### PR TITLE
feat: add recurring transactions (core)

### DIFF
--- a/supabase/migrations/20260215180000_create_recurring_transaction_templates.sql
+++ b/supabase/migrations/20260215180000_create_recurring_transaction_templates.sql
@@ -1,0 +1,50 @@
+-- Enum for recurrence frequency
+CREATE TYPE recurrence_frequency AS ENUM (
+  'WEEKLY',
+  'BIWEEKLY',
+  'MONTHLY',
+  'QUARTERLY',
+  'ANNUAL'
+);
+
+-- Recurring transaction templates
+CREATE TABLE recurring_transaction_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  category_id UUID REFERENCES categories(id) ON DELETE SET NULL,
+
+  -- Transaction template data
+  amount NUMERIC(15,2) NOT NULL CHECK (amount > 0),
+  currency_code currency_code NOT NULL DEFAULT 'COP',
+  direction transaction_direction NOT NULL,
+  merchant_name TEXT,
+  description TEXT,
+
+  -- Schedule
+  frequency recurrence_frequency NOT NULL,
+  day_of_month INT CHECK (day_of_month BETWEEN 1 AND 31),
+  day_of_week INT CHECK (day_of_week BETWEEN 0 AND 6), -- 0=Sunday
+
+  -- Lifecycle
+  start_date DATE NOT NULL,
+  end_date DATE,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS
+ALTER TABLE recurring_transaction_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own recurring templates"
+  ON recurring_transaction_templates
+  FOR ALL
+  USING ((SELECT auth.uid()) = user_id);
+
+-- Auto-update updated_at via moddatetime (extension enabled by default on Supabase)
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON recurring_transaction_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION moddatetime(updated_at);

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -1,0 +1,283 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { recurringTemplateSchema } from "@/lib/validators/recurring-template";
+import { getNextOccurrence, getOccurrencesBetween } from "@/lib/utils/recurrence";
+import { addDays } from "date-fns";
+import type { ActionResult } from "@/types/actions";
+import type {
+  RecurringTemplate,
+  RecurringTemplateWithRelations,
+  UpcomingRecurrence,
+} from "@/types/domain";
+
+const TEMPLATE_SELECT = `
+  *,
+  account:accounts!recurring_transaction_templates_account_id_fkey(id, name, icon, color),
+  category:categories!recurring_transaction_templates_category_id_fkey(id, name, name_es, icon, color)
+`;
+
+export async function getRecurringTemplates(): Promise<
+  ActionResult<RecurringTemplateWithRelations[]>
+> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const { data, error } = await supabase
+    .from("recurring_transaction_templates")
+    .select(TEMPLATE_SELECT)
+    .order("is_active", { ascending: false })
+    .order("merchant_name");
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: (data ?? []) as RecurringTemplateWithRelations[] };
+}
+
+export async function getRecurringTemplate(
+  id: string
+): Promise<ActionResult<RecurringTemplateWithRelations>> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("recurring_transaction_templates")
+    .select(TEMPLATE_SELECT)
+    .eq("id", id)
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as RecurringTemplateWithRelations };
+}
+
+export async function createRecurringTemplate(
+  _prevState: ActionResult<RecurringTemplate>,
+  formData: FormData
+): Promise<ActionResult<RecurringTemplate>> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = recurringTemplateSchema.safeParse({
+    account_id: formData.get("account_id"),
+    amount: formData.get("amount"),
+    currency_code: formData.get("currency_code"),
+    direction: formData.get("direction"),
+    frequency: formData.get("frequency"),
+    merchant_name: formData.get("merchant_name"),
+    description: formData.get("description") || undefined,
+    category_id: formData.get("category_id") || undefined,
+    day_of_month: formData.get("day_of_month") || undefined,
+    day_of_week: formData.get("day_of_week") || undefined,
+    start_date: formData.get("start_date"),
+    end_date: formData.get("end_date") || undefined,
+  });
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const { data, error } = await supabase
+    .from("recurring_transaction_templates")
+    .insert({
+      user_id: user.id,
+      ...parsed.data,
+    })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath("/recurrentes");
+  revalidatePath("/dashboard");
+  return { success: true, data };
+}
+
+export async function updateRecurringTemplate(
+  id: string,
+  _prevState: ActionResult<RecurringTemplate>,
+  formData: FormData
+): Promise<ActionResult<RecurringTemplate>> {
+  const supabase = await createClient();
+
+  const parsed = recurringTemplateSchema.safeParse({
+    account_id: formData.get("account_id"),
+    amount: formData.get("amount"),
+    currency_code: formData.get("currency_code"),
+    direction: formData.get("direction"),
+    frequency: formData.get("frequency"),
+    merchant_name: formData.get("merchant_name"),
+    description: formData.get("description") || undefined,
+    category_id: formData.get("category_id") || undefined,
+    day_of_month: formData.get("day_of_month") || undefined,
+    day_of_week: formData.get("day_of_week") || undefined,
+    start_date: formData.get("start_date"),
+    end_date: formData.get("end_date") || undefined,
+  });
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const { data, error } = await supabase
+    .from("recurring_transaction_templates")
+    .update(parsed.data)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath("/recurrentes");
+  revalidatePath("/dashboard");
+  return { success: true, data };
+}
+
+export async function deleteRecurringTemplate(
+  id: string
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("recurring_transaction_templates")
+    .delete()
+    .eq("id", id);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath("/recurrentes");
+  revalidatePath("/dashboard");
+  return { success: true, data: undefined };
+}
+
+export async function toggleRecurringTemplate(
+  id: string,
+  isActive: boolean
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("recurring_transaction_templates")
+    .update({ is_active: isActive })
+    .eq("id", id);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath("/recurrentes");
+  revalidatePath("/dashboard");
+  return { success: true, data: undefined };
+}
+
+/**
+ * Get upcoming recurring payments for the next N days.
+ * Computes occurrences on the fly from active templates.
+ */
+export async function getUpcomingRecurrences(
+  days: number = 30
+): Promise<UpcomingRecurrence[]> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return [];
+
+  const { data: templates } = await supabase
+    .from("recurring_transaction_templates")
+    .select(TEMPLATE_SELECT)
+    .eq("is_active", true);
+
+  if (!templates || templates.length === 0) return [];
+
+  const now = new Date();
+  const rangeEnd = addDays(now, days);
+
+  const upcoming: UpcomingRecurrence[] = [];
+
+  for (const template of templates as RecurringTemplateWithRelations[]) {
+    const dates = getOccurrencesBetween(
+      template.start_date,
+      template.frequency,
+      template.end_date,
+      now,
+      rangeEnd
+    );
+
+    for (const date of dates) {
+      upcoming.push({ template, next_date: date });
+    }
+  }
+
+  // Sort by date ascending
+  upcoming.sort((a, b) => a.next_date.localeCompare(b.next_date));
+
+  return upcoming;
+}
+
+/**
+ * Get monthly totals for active recurring templates.
+ */
+export async function getRecurringSummary(): Promise<{
+  totalMonthlyExpenses: number;
+  totalMonthlyIncome: number;
+  activeCount: number;
+}> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user)
+    return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
+
+  const { data: templates } = await supabase
+    .from("recurring_transaction_templates")
+    .select("amount, direction, frequency")
+    .eq("is_active", true);
+
+  if (!templates)
+    return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
+
+  let totalMonthlyExpenses = 0;
+  let totalMonthlyIncome = 0;
+
+  for (const t of templates) {
+    // Normalize to monthly equivalent
+    const monthlyAmount = toMonthlyAmount(t.amount, t.frequency);
+    if (t.direction === "OUTFLOW") {
+      totalMonthlyExpenses += monthlyAmount;
+    } else {
+      totalMonthlyIncome += monthlyAmount;
+    }
+  }
+
+  return {
+    totalMonthlyExpenses,
+    totalMonthlyIncome,
+    activeCount: templates.length,
+  };
+}
+
+function toMonthlyAmount(
+  amount: number,
+  frequency: string
+): number {
+  switch (frequency) {
+    case "WEEKLY":
+      return amount * 4.33;
+    case "BIWEEKLY":
+      return amount * 2.17;
+    case "MONTHLY":
+      return amount;
+    case "QUARTERLY":
+      return amount / 3;
+    case "ANNUAL":
+      return amount / 12;
+    default:
+      return amount;
+  }
+}

--- a/webapp/src/app/(dashboard)/dashboard/page.tsx
+++ b/webapp/src/app/(dashboard)/dashboard/page.tsx
@@ -26,6 +26,8 @@ import { DailySpendingChart } from "@/components/charts/daily-spending-chart";
 import { EnhancedCashflowChart } from "@/components/charts/enhanced-cashflow-chart";
 import { InteractiveMetricCard } from "@/components/dashboard/interactive-metric-card";
 import { MonthSelector } from "@/components/month-selector";
+import { UpcomingRecurringCard } from "@/components/recurring/upcoming-recurring-card";
+import { getUpcomingRecurrences } from "@/actions/recurring-templates";
 
 export default async function DashboardPage({
   searchParams,
@@ -71,14 +73,15 @@ export default async function DashboardPage({
   // Fetch previous month param for trend calculation
   const prevMonthParam = formatMonthParam(subMonths(target, 1));
 
-  // Fetch chart data + previous month metrics in parallel
-  const [categoryData, cashflowData, dailyData, dailyCashflowData, prevMetrics] =
+  // Fetch chart data + previous month metrics + upcoming recurring in parallel
+  const [categoryData, cashflowData, dailyData, dailyCashflowData, prevMetrics, upcomingRecurrences] =
     await Promise.all([
       getCategorySpending(month),
       getMonthlyCashflow(month),
       getDailySpending(month),
       getDailyCashflow(month),
       getMonthMetrics(prevMonthParam),
+      getUpcomingRecurrences(30),
     ]);
 
   const allAccounts = accounts ?? [];
@@ -239,6 +242,9 @@ export default async function DashboardPage({
           </CardContent>
         </Card>
       )}
+
+      {/* Upcoming recurring payments */}
+      <UpcomingRecurringCard upcoming={upcomingRecurrences} />
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Accounts Summary */}

--- a/webapp/src/app/(dashboard)/recurrentes/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/page.tsx
@@ -1,0 +1,101 @@
+import { getRecurringTemplates, getRecurringSummary } from "@/actions/recurring-templates";
+import { getAccounts } from "@/actions/accounts";
+import { getCategories } from "@/actions/categories";
+import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
+import { RecurringList } from "@/components/recurring/recurring-list";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils/currency";
+import { ArrowUpRight, ArrowDownLeft, Repeat2 } from "lucide-react";
+
+export default async function RecurrentesPage() {
+  const [templatesResult, accountsResult, categoriesResult, summary] =
+    await Promise.all([
+      getRecurringTemplates(),
+      getAccounts(),
+      getCategories(),
+      getRecurringSummary(),
+    ]);
+
+  const templates = templatesResult.success ? templatesResult.data : [];
+  const accounts = accountsResult.success ? accountsResult.data : [];
+  const categories = categoriesResult.success
+    ? categoriesResult.data.flatMap((c) => [c, ...c.children])
+    : [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Transacciones Recurrentes</h1>
+          <p className="text-muted-foreground">
+            {summary.activeCount} recurrente{summary.activeCount !== 1 ? "s" : ""} activa{summary.activeCount !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <RecurringFormDialog accounts={accounts} categories={categories} />
+      </div>
+
+      {/* Summary cards */}
+      {summary.activeCount > 0 && (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-lg bg-orange-500/10">
+                  <ArrowUpRight className="h-5 w-5 text-orange-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">
+                    Gastos fijos mensuales
+                  </p>
+                  <p className="text-xl font-bold">
+                    {formatCurrency(summary.totalMonthlyExpenses)}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-lg bg-green-500/10">
+                  <ArrowDownLeft className="h-5 w-5 text-green-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">
+                    Ingresos fijos mensuales
+                  </p>
+                  <p className="text-xl font-bold">
+                    {formatCurrency(summary.totalMonthlyIncome)}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-lg bg-primary/10">
+                  <Repeat2 className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">
+                    Recurrentes activas
+                  </p>
+                  <p className="text-xl font-bold">{summary.activeCount}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <RecurringList
+        templates={templates}
+        accounts={accounts}
+        categories={categories}
+      />
+    </div>
+  );
+}

--- a/webapp/src/components/recurring/recurring-form-dialog.tsx
+++ b/webapp/src/components/recurring/recurring-form-dialog.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { RecurringForm } from "./recurring-form";
+import { Plus } from "lucide-react";
+import type { Account, Category, RecurringTemplate } from "@/types/domain";
+
+export function RecurringFormDialog({
+  template,
+  accounts,
+  categories,
+  trigger,
+}: {
+  template?: RecurringTemplate;
+  accounts: Account[];
+  categories: Category[];
+  trigger?: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button>
+            <Plus className="h-4 w-4 mr-2" />
+            Nueva recurrente
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {template ? "Editar recurrente" : "Nueva transacción recurrente"}
+          </DialogTitle>
+        </DialogHeader>
+        <RecurringForm
+          template={template}
+          accounts={accounts}
+          categories={categories}
+          onSuccess={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  createRecurringTemplate,
+  updateRecurringTemplate,
+} from "@/actions/recurring-templates";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ActionResult } from "@/types/actions";
+import type { Account, Category, RecurringTemplate } from "@/types/domain";
+
+const FREQUENCY_OPTIONS = [
+  { value: "WEEKLY", label: "Semanal" },
+  { value: "BIWEEKLY", label: "Quincenal" },
+  { value: "MONTHLY", label: "Mensual" },
+  { value: "QUARTERLY", label: "Trimestral" },
+  { value: "ANNUAL", label: "Anual" },
+] as const;
+
+export function RecurringForm({
+  template,
+  accounts,
+  categories,
+  onSuccess,
+}: {
+  template?: RecurringTemplate;
+  accounts: Account[];
+  categories: Category[];
+  onSuccess?: () => void;
+}) {
+  const action = template
+    ? updateRecurringTemplate.bind(null, template.id)
+    : createRecurringTemplate;
+
+  const [state, formAction, pending] = useActionState<
+    ActionResult<RecurringTemplate>,
+    FormData
+  >(
+    async (prevState, formData) => {
+      const result = await action(prevState, formData);
+      if (result.success) onSuccess?.();
+      return result;
+    },
+    { success: false, error: "" }
+  );
+
+  const defaultAccount = accounts[0];
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {!state.success && state.error && (
+        <div className="bg-destructive/10 text-destructive text-sm rounded-md p-3">
+          {state.error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="merchant_name">Nombre / Comercio</Label>
+        <Input
+          id="merchant_name"
+          name="merchant_name"
+          defaultValue={template?.merchant_name ?? ""}
+          placeholder="Ej: Netflix, Arriendo, Salario"
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="direction">Tipo</Label>
+          <Select
+            name="direction"
+            defaultValue={template?.direction ?? "OUTFLOW"}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="OUTFLOW">Gasto</SelectItem>
+              <SelectItem value="INFLOW">Ingreso</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="amount">Monto</Label>
+          <Input
+            id="amount"
+            name="amount"
+            type="number"
+            step="0.01"
+            min="0.01"
+            defaultValue={template?.amount}
+            placeholder="0.00"
+            required
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="account_id">Cuenta</Label>
+          <Select
+            name="account_id"
+            defaultValue={template?.account_id ?? defaultAccount?.id}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Seleccionar cuenta" />
+            </SelectTrigger>
+            <SelectContent>
+              {accounts.map((acc) => (
+                <SelectItem key={acc.id} value={acc.id}>
+                  {acc.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="frequency">Frecuencia</Label>
+          <Select
+            name="frequency"
+            defaultValue={template?.frequency ?? "MONTHLY"}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FREQUENCY_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <input
+        type="hidden"
+        name="currency_code"
+        value={
+          template?.currency_code ?? defaultAccount?.currency_code ?? "COP"
+        }
+      />
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="start_date">Fecha de inicio</Label>
+          <Input
+            id="start_date"
+            name="start_date"
+            type="date"
+            defaultValue={
+              template?.start_date ??
+              new Date().toISOString().split("T")[0]
+            }
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="end_date">Fecha fin (opcional)</Label>
+          <Input
+            id="end_date"
+            name="end_date"
+            type="date"
+            defaultValue={template?.end_date ?? ""}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="category_id">Categoría</Label>
+        <Select
+          name="category_id"
+          defaultValue={template?.category_id ?? ""}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Sin categoría" />
+          </SelectTrigger>
+          <SelectContent>
+            {categories.map((cat) => (
+              <SelectItem key={cat.id} value={cat.id}>
+                {cat.name_es || cat.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="description">Notas</Label>
+        <Input
+          id="description"
+          name="description"
+          defaultValue={template?.description ?? ""}
+          placeholder="Nota opcional"
+        />
+      </div>
+
+      <Button type="submit" className="w-full" disabled={pending}>
+        {pending
+          ? "Guardando..."
+          : template
+            ? "Actualizar"
+            : "Crear recurrente"}
+      </Button>
+    </form>
+  );
+}

--- a/webapp/src/components/recurring/recurring-list.tsx
+++ b/webapp/src/components/recurring/recurring-list.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useTransition } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  deleteRecurringTemplate,
+  toggleRecurringTemplate,
+} from "@/actions/recurring-templates";
+import { formatCurrency } from "@/lib/utils/currency";
+import { frequencyLabel } from "@/lib/utils/recurrence";
+import { getNextOccurrence } from "@/lib/utils/recurrence";
+import { formatDate } from "@/lib/utils/date";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  MoreVertical,
+  Pause,
+  Play,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+import { RecurringFormDialog } from "./recurring-form-dialog";
+import type {
+  Account,
+  Category,
+  CurrencyCode,
+  RecurringTemplateWithRelations,
+} from "@/types/domain";
+
+export function RecurringList({
+  templates,
+  accounts,
+  categories,
+}: {
+  templates: RecurringTemplateWithRelations[];
+  accounts: Account[];
+  categories: Category[];
+}) {
+  if (templates.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <p className="text-muted-foreground mb-2">
+          No tienes transacciones recurrentes configuradas.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Crea una para rastrear pagos y cobros automáticos.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {templates.map((template) => (
+        <RecurringCard
+          key={template.id}
+          template={template}
+          accounts={accounts}
+          categories={categories}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RecurringCard({
+  template,
+  accounts,
+  categories,
+}: {
+  template: RecurringTemplateWithRelations;
+  accounts: Account[];
+  categories: Category[];
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const nextDate = getNextOccurrence(
+    template.start_date,
+    template.frequency,
+    template.end_date
+  );
+
+  const handleToggle = () => {
+    startTransition(() => {
+      toggleRecurringTemplate(template.id, !template.is_active);
+    });
+  };
+
+  const handleDelete = () => {
+    startTransition(() => {
+      deleteRecurringTemplate(template.id);
+    });
+  };
+
+  return (
+    <Card className={!template.is_active ? "opacity-60" : undefined}>
+      <CardContent className="pt-6">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            {template.direction === "INFLOW" ? (
+              <div className="p-2 rounded-lg bg-green-500/10">
+                <ArrowDownLeft className="h-5 w-5 text-green-600" />
+              </div>
+            ) : (
+              <div className="p-2 rounded-lg bg-orange-500/10">
+                <ArrowUpRight className="h-5 w-5 text-orange-600" />
+              </div>
+            )}
+            <div>
+              <p className="font-medium">{template.merchant_name}</p>
+              <p className="text-sm text-muted-foreground">
+                {template.account.name}
+              </p>
+            </div>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8" disabled={isPending}>
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <RecurringFormDialog
+                template={template}
+                accounts={accounts}
+                categories={categories}
+                trigger={
+                  <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                    <Pencil className="h-4 w-4 mr-2" />
+                    Editar
+                  </DropdownMenuItem>
+                }
+              />
+              <DropdownMenuItem onClick={handleToggle}>
+                {template.is_active ? (
+                  <>
+                    <Pause className="h-4 w-4 mr-2" />
+                    Pausar
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-4 w-4 mr-2" />
+                    Activar
+                  </>
+                )}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={handleDelete}
+                className="text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Eliminar
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        <div className="mt-4 flex items-baseline justify-between">
+          <span
+            className={`text-xl font-bold ${
+              template.direction === "INFLOW" ? "text-green-600" : ""
+            }`}
+          >
+            {template.direction === "INFLOW" ? "+" : "-"}
+            {formatCurrency(template.amount, template.currency_code as CurrencyCode)}
+          </span>
+          <Badge variant="secondary">{frequencyLabel(template.frequency)}</Badge>
+        </div>
+
+        <div className="mt-3 flex items-center justify-between text-sm text-muted-foreground">
+          {template.category && (
+            <span>
+              {template.category.name_es || template.category.name}
+            </span>
+          )}
+          {nextDate ? (
+            <span>Próximo: {formatDate(nextDate)}</span>
+          ) : (
+            <span>Finalizado</span>
+          )}
+        </div>
+
+        {!template.is_active && (
+          <Badge variant="outline" className="mt-2">
+            Pausada
+          </Badge>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/webapp/src/components/recurring/upcoming-recurring-card.tsx
+++ b/webapp/src/components/recurring/upcoming-recurring-card.tsx
@@ -1,0 +1,75 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { frequencyLabel } from "@/lib/utils/recurrence";
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+import type { CurrencyCode, UpcomingRecurrence } from "@/types/domain";
+
+export function UpcomingRecurringCard({
+  upcoming,
+}: {
+  upcoming: UpcomingRecurrence[];
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-lg">Próximos recurrentes</CardTitle>
+        <Link
+          href="/recurrentes"
+          className="text-sm text-primary hover:underline"
+        >
+          Ver todos
+        </Link>
+      </CardHeader>
+      <CardContent>
+        {upcoming.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No hay pagos recurrentes próximos.{" "}
+            <Link href="/recurrentes" className="text-primary hover:underline">
+              Crear uno
+            </Link>
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {upcoming.slice(0, 5).map((item, i) => (
+              <div
+                key={`${item.template.id}-${item.next_date}-${i}`}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center gap-3">
+                  {item.template.direction === "INFLOW" ? (
+                    <ArrowDownLeft className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <ArrowUpRight className="h-4 w-4 text-orange-500" />
+                  )}
+                  <div>
+                    <p className="text-sm font-medium">
+                      {item.template.merchant_name}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatDate(item.next_date)} &middot;{" "}
+                      {frequencyLabel(item.template.frequency)}
+                    </p>
+                  </div>
+                </div>
+                <span
+                  className={`text-sm font-medium ${
+                    item.template.direction === "INFLOW" ? "text-green-600" : ""
+                  }`}
+                >
+                  {item.template.direction === "INFLOW" ? "+" : "-"}
+                  {formatCurrency(
+                    item.template.amount,
+                    item.template.currency_code as CurrencyCode
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/webapp/src/lib/constants/navigation.ts
+++ b/webapp/src/lib/constants/navigation.ts
@@ -5,6 +5,7 @@ import {
   Wallet,
   Tag,
   Landmark,
+  Repeat2,
   Settings,
   type LucideIcon,
 } from "lucide-react";
@@ -21,6 +22,7 @@ export const MAIN_NAV: NavItem[] = [
   { title: "Importar", href: "/import", icon: FileUp },
   { title: "Cuentas", href: "/accounts", icon: Wallet },
   { title: "Deudas", href: "/deudas", icon: Landmark },
+  { title: "Recurrentes", href: "/recurrentes", icon: Repeat2 },
   { title: "Categorías", href: "/categories", icon: Tag },
 ];
 

--- a/webapp/src/lib/utils/recurrence.ts
+++ b/webapp/src/lib/utils/recurrence.ts
@@ -1,0 +1,97 @@
+import { addDays, addWeeks, addMonths, addYears, parseISO, isBefore, isAfter, startOfDay } from "date-fns";
+import type { RecurrenceFrequency } from "@/types/domain";
+
+/**
+ * Advance a date by one period of the given frequency.
+ */
+function advanceByFrequency(date: Date, frequency: RecurrenceFrequency): Date {
+  switch (frequency) {
+    case "WEEKLY":
+      return addWeeks(date, 1);
+    case "BIWEEKLY":
+      return addWeeks(date, 2);
+    case "MONTHLY":
+      return addMonths(date, 1);
+    case "QUARTERLY":
+      return addMonths(date, 3);
+    case "ANNUAL":
+      return addYears(date, 1);
+  }
+}
+
+/**
+ * Given a recurring template's schedule data, find the next occurrence
+ * on or after `fromDate`. Returns null if the template has ended.
+ */
+export function getNextOccurrence(
+  startDate: string,
+  frequency: RecurrenceFrequency,
+  endDate: string | null,
+  fromDate: Date = new Date()
+): string | null {
+  const from = startOfDay(fromDate);
+  const start = startOfDay(parseISO(startDate));
+  const end = endDate ? startOfDay(parseISO(endDate)) : null;
+
+  // If end date has passed, no more occurrences
+  if (end && isBefore(end, from)) return null;
+
+  let current = start;
+
+  // Advance until we reach or pass fromDate
+  while (isBefore(current, from)) {
+    current = advanceByFrequency(current, frequency);
+  }
+
+  // Check if this occurrence is past the end date
+  if (end && isAfter(current, end)) return null;
+
+  return current.toISOString().split("T")[0];
+}
+
+/**
+ * Get all occurrences between two dates for a recurring template.
+ */
+export function getOccurrencesBetween(
+  startDate: string,
+  frequency: RecurrenceFrequency,
+  endDate: string | null,
+  rangeStart: Date,
+  rangeEnd: Date
+): string[] {
+  const dates: string[] = [];
+  const start = startOfDay(parseISO(startDate));
+  const end = endDate ? startOfDay(parseISO(endDate)) : null;
+  const from = startOfDay(rangeStart);
+  const to = startOfDay(rangeEnd);
+
+  let current = start;
+
+  // Advance to first occurrence on or after rangeStart
+  while (isBefore(current, from)) {
+    current = advanceByFrequency(current, frequency);
+  }
+
+  // Collect all dates within range
+  while (!isAfter(current, to)) {
+    if (end && isAfter(current, end)) break;
+    dates.push(current.toISOString().split("T")[0]);
+    current = advanceByFrequency(current, frequency);
+  }
+
+  return dates;
+}
+
+/**
+ * Human-readable frequency label in Spanish.
+ */
+export function frequencyLabel(frequency: RecurrenceFrequency): string {
+  const labels: Record<RecurrenceFrequency, string> = {
+    WEEKLY: "Semanal",
+    BIWEEKLY: "Quincenal",
+    MONTHLY: "Mensual",
+    QUARTERLY: "Trimestral",
+    ANNUAL: "Anual",
+  };
+  return labels[frequency];
+}

--- a/webapp/src/lib/validators/recurring-template.ts
+++ b/webapp/src/lib/validators/recurring-template.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uuidStr = (msg = "UUID inválido") => z.string().regex(UUID_RE, msg);
+
+export const recurringTemplateSchema = z.object({
+  account_id: uuidStr("Cuenta inválida"),
+  amount: z.coerce.number().positive("El monto debe ser mayor a 0"),
+  currency_code: z.enum(["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"]),
+  direction: z.enum(["INFLOW", "OUTFLOW"]),
+  frequency: z.enum(["WEEKLY", "BIWEEKLY", "MONTHLY", "QUARTERLY", "ANNUAL"]),
+  merchant_name: z.string().min(1, "El nombre es requerido"),
+  description: z.string().optional(),
+  category_id: z.preprocess(
+    (val) => (val === "" || val === null ? undefined : val),
+    uuidStr().optional().nullable()
+  ),
+  day_of_month: z.preprocess(
+    (val) => (val === "" || val === null ? undefined : val),
+    z.coerce.number().int().min(1).max(31).optional().nullable()
+  ),
+  day_of_week: z.preprocess(
+    (val) => (val === "" || val === null ? undefined : val),
+    z.coerce.number().int().min(0).max(6).optional().nullable()
+  ),
+  start_date: z.string().min(1, "La fecha de inicio es requerida"),
+  end_date: z.preprocess(
+    (val) => (val === "" || val === null ? undefined : val),
+    z.string().optional().nullable()
+  ),
+});
+
+export type RecurringTemplateFormData = z.infer<typeof recurringTemplateSchema>;

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -194,6 +194,88 @@ export type Database = {
           },
         ]
       }
+      recurring_transaction_templates: {
+        Row: {
+          account_id: string
+          amount: number
+          category_id: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          day_of_month: number | null
+          day_of_week: number | null
+          description: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id: string
+          is_active: boolean
+          merchant_name: string | null
+          start_date: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null
@@ -482,6 +564,12 @@ export type Database = {
         | "ML_MODEL"
         | "USER_OVERRIDE"
       connection_status: "CONNECTED" | "DISCONNECTED" | "ERROR" | "PENDING"
+      recurrence_frequency:
+        | "WEEKLY"
+        | "BIWEEKLY"
+        | "MONTHLY"
+        | "QUARTERLY"
+        | "ANNUAL"
       currency_code:
         | "COP"
         | "BRL"
@@ -643,6 +731,13 @@ export const Constants = {
         "USER_OVERRIDE",
       ],
       connection_status: ["CONNECTED", "DISCONNECTED", "ERROR", "PENDING"],
+      recurrence_frequency: [
+        "WEEKLY",
+        "BIWEEKLY",
+        "MONTHLY",
+        "QUARTERLY",
+        "ANNUAL",
+      ],
       currency_code: ["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"],
       data_provider: [
         "MANUAL",

--- a/webapp/src/types/domain.ts
+++ b/webapp/src/types/domain.ts
@@ -6,6 +6,8 @@ export type Account = Tables<"accounts">;
 export type Transaction = Tables<"transactions">;
 export type Category = Tables<"categories">;
 
+export type RecurringTemplate = Tables<"recurring_transaction_templates">;
+
 // Enum types
 export type TransactionDirection = Enums<"transaction_direction">;
 export type CurrencyCode = Enums<"currency_code">;
@@ -14,6 +16,7 @@ export type ConnectionStatus = Enums<"connection_status">;
 export type CategorizationSource = Enums<"categorization_source">;
 export type TransactionStatus = Enums<"transaction_status">;
 export type DataProvider = Enums<"data_provider">;
+export type RecurrenceFrequency = Enums<"recurrence_frequency">;
 
 // Category with children for tree views
 export type CategoryWithChildren = Category & {
@@ -31,4 +34,16 @@ export type AccountWithSummary = Account & {
   transaction_count: number;
   total_inflow: number;
   total_outflow: number;
+};
+
+// Recurring template with joined relations
+export type RecurringTemplateWithRelations = RecurringTemplate & {
+  account: Pick<Account, "id" | "name" | "icon" | "color">;
+  category: Pick<Category, "id" | "name" | "name_es" | "icon" | "color"> | null;
+};
+
+// Computed upcoming occurrence from a template
+export type UpcomingRecurrence = {
+  template: RecurringTemplateWithRelations;
+  next_date: string;
 };


### PR DESCRIPTION
- New table: recurring_transaction_templates with RLS + frequency enum
- Compute-on-the-fly approach: upcoming dates calculated at render time
- CRUD server actions + getUpcomingRecurrences + getRecurringSummary
- /recurrentes page with summary cards, template list, create/edit dialog
- Dashboard integration: upcoming recurring payments card (next 30 days)
- Utility: recurrence date calculation + Spanish frequency labels
- Navigation: "Recurrentes" item with Repeat2 icon

Future: auto-match on PDF import, payment reminders

https://claude.ai/code/session_019gK9jvn7Rv7Nzah9pZkxX4