### PR TITLE
fix: correct inverted debt values on debt dashboard and main dashboard

### DIFF
--- a/services/pdf_parser/parsers/bancolombia_credit_card.py
+++ b/services/pdf_parser/parsers/bancolombia_credit_card.py
@@ -282,18 +282,20 @@ def _extract_metadata(
                 if m:
                     summary["interest_charged"] = _parse_colombian_number(m.group(1))
 
-            # Interest rate table rows (US-format numbers: 1.8311%)
+            # Interest rate table rows (US-format numbers: monthly% annual%)
+            # e.g. "Compra 2 - 36 cuotas 1.8311% 24.3269%"
+            # group(1)=monthly, group(2)=annual — we store the annual (EA) rate
             if not meta.get("interest_rate"):
                 m = TASA_COMPRA_RE.search(stripped)
                 if m:
-                    rate = float(m.group(1))
-                    if rate > 0:
-                        meta["interest_rate"] = rate
+                    annual_rate = float(m.group(2))
+                    if annual_rate > 0:
+                        meta["interest_rate"] = annual_rate
 
             if not meta.get("late_interest_rate"):
                 m = TASA_MORA_RE.search(stripped)
                 if m:
-                    meta["late_interest_rate"] = float(m.group(1))
+                    meta["late_interest_rate"] = float(m.group(2))
 
             # --- State-machine: values on the line AFTER their label ---
 

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -148,7 +148,12 @@ export async function importTransactions(
         const cc = meta.creditCardMetadata;
         if (cc.credit_limit != null) accountUpdate.credit_limit = cc.credit_limit;
         if (cc.interest_rate != null) accountUpdate.interest_rate = cc.interest_rate;
-        if (cc.total_payment_due != null) accountUpdate.current_balance = cc.total_payment_due;
+        if (cc.total_payment_due != null) {
+          accountUpdate.current_balance = cc.total_payment_due;
+        } else if (cc.credit_limit != null && cc.available_credit != null) {
+          // Fallback: derive debt from limit − available credit
+          accountUpdate.current_balance = Math.max(cc.credit_limit - cc.available_credit, 0);
+        }
         if (cc.available_credit != null) accountUpdate.available_balance = cc.available_credit;
         if (cc.payment_due_date) {
           accountUpdate.payment_day = new Date(cc.payment_due_date).getUTCDate();

--- a/webapp/src/app/(dashboard)/dashboard/page.tsx
+++ b/webapp/src/app/(dashboard)/dashboard/page.tsx
@@ -28,6 +28,7 @@ import { InteractiveMetricCard } from "@/components/dashboard/interactive-metric
 import { MonthSelector } from "@/components/month-selector";
 import { UpcomingRecurringCard } from "@/components/recurring/upcoming-recurring-card";
 import { getUpcomingRecurrences } from "@/actions/recurring-templates";
+import { computeDebtBalance } from "@/lib/utils/debt";
 
 export default async function DashboardPage({
   searchParams,
@@ -96,7 +97,10 @@ export default async function DashboardPage({
   );
 
   const totalAssets = assetAccounts.reduce((sum, a) => sum + a.current_balance, 0);
-  const totalLiabilities = liabilityAccounts.reduce((sum, a) => sum + a.current_balance, 0);
+  const totalLiabilities = liabilityAccounts.reduce(
+    (sum, a) => sum + computeDebtBalance(a),
+    0
+  );
   const netWorth = totalAssets - totalLiabilities;
 
   const monthIncome = monthTx

--- a/webapp/src/components/debt/utilization-gauge.tsx
+++ b/webapp/src/components/debt/utilization-gauge.tsx
@@ -30,12 +30,14 @@ export function UtilizationGauge({
   totalUsed: number;
   totalLimit: number;
 }) {
-  const color = getUtilizationColor(utilization);
-  const label = getUtilizationLabel(utilization);
+  // Clamp to 0-100 to prevent rendering issues with negative/overflow values
+  const safeUtilization = Math.max(0, Math.min(utilization, 100));
+  const color = getUtilizationColor(safeUtilization);
+  const label = getUtilizationLabel(safeUtilization);
 
   const data = [
-    { name: "used", value: utilization },
-    { name: "available", value: Math.max(100 - utilization, 0) },
+    { name: "used", value: safeUtilization },
+    { name: "available", value: 100 - safeUtilization },
   ];
 
   return (
@@ -69,7 +71,7 @@ export function UtilizationGauge({
             </ResponsiveContainer>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
               <span className="text-2xl font-bold" style={{ color }}>
-                {utilization.toFixed(0)}%
+                {safeUtilization.toFixed(0)}%
               </span>
               <span className="text-xs text-muted-foreground">{label}</span>
             </div>


### PR DESCRIPTION
The debt dashboard was showing inverted values for credit card utilization
when current_balance contained the available credit (instead of debt owed)
or was stored as a negative number.

Changes:
- Add computeDebtBalance() that prefers (credit_limit − available_balance)
  for credit cards, falling back to |current_balance| for robustness
- calcUtilization() now uses Math.abs to handle negative balances
- UtilizationGauge clamps utilization to 0-100 to prevent rendering issues
- Main dashboard uses computeDebtBalance() for liability/net-worth calc
- Import adds fallback: derives current_balance from limit − available
  credit when total_payment_due is null
- Parser now extracts annual (EA) interest rate instead of monthly rate

https://claude.ai/code/session_01WBr3YKyN2GWjL1Pc4XxWSG