### PR TITLE
feat(mobile): transaction edit + exclude toggle

### DIFF
--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -5,15 +5,27 @@ import {
   ActivityIndicator,
   Pressable,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Switch,
+  TextInput,
+  Modal,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useEffect, useState } from "react";
-import { X, Trash2 } from "lucide-react-native";
+import { useEffect, useRef, useState } from "react";
+import { Calendar, Pencil, Tag, Trash2, X } from "lucide-react-native";
+import DateTimePicker from "@react-native-community/datetimepicker";
 import {
-  getTransactionById,
   deleteTransaction,
+  getTransactionById,
+  updateTransaction,
 } from "../../lib/repositories/transactions";
-import { formatCurrency, formatDate, type CurrencyCode } from "@venti5/shared";
+import { getAllCategories } from "../../lib/repositories/categories";
+import {
+  CategoryPicker,
+  type CategoryRow,
+} from "../../components/transactions/CategoryPicker";
+import { formatCurrency, type CurrencyCode } from "@venti5/shared";
 
 type TransactionDetail = {
   id: string;
@@ -32,6 +44,8 @@ type TransactionDetail = {
   account_name: string | null;
   account_icon: string | null;
   account_color: string | null;
+  notes: string | null;
+  is_excluded: number; // SQLite stores boolean as 0/1
 };
 
 function DetailRow({
@@ -52,13 +66,66 @@ function DetailRow({
   );
 }
 
+function FormField({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <View className="mb-4">
+      <Text className="text-gray-700 font-inter-medium text-sm mb-1.5">
+        {label}
+        {required && <Text className="text-red-500"> *</Text>}
+      </Text>
+      {children}
+    </View>
+  );
+}
+
+function parseLocalDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d, 12, 0, 0);
+}
+
+function toDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 export default function TransactionDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
-  const [transaction, setTransaction] = useState<TransactionDetail | null>(
-    null
-  );
+
+  // Data state
+  const [transaction, setTransaction] = useState<TransactionDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState<CategoryRow[]>([]);
+
+  // UI state
+  const [isEditing, setIsEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [successVisible, setSuccessVisible] = useState(false);
+  const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Picker visibility
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  // Edit form state
+  const [editMerchantName, setEditMerchantName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editAmount, setEditAmount] = useState("");
+  const [editDate, setEditDate] = useState(new Date());
+  const [editCategoryId, setEditCategoryId] = useState<string | null>(null);
+  const [editCategoryName, setEditCategoryName] = useState<string | null>(null);
+  const [editNotes, setEditNotes] = useState("");
+  const [editIsExcluded, setEditIsExcluded] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -66,13 +133,93 @@ export default function TransactionDetailScreen() {
       try {
         const result = (await getTransactionById(id)) as TransactionDetail;
         setTransaction(result);
-      } catch (error) {
-        console.error("Failed to load transaction:", error);
+      } catch (err) {
+        console.error("Failed to load transaction:", err);
       } finally {
         setLoading(false);
       }
     })();
   }, [id]);
+
+  useEffect(() => {
+    return () => {
+      if (successTimer.current) clearTimeout(successTimer.current);
+    };
+  }, []);
+
+  const loadCategories = async () => {
+    try {
+      const cats = await getAllCategories();
+      setCategories(cats as CategoryRow[]);
+    } catch (err) {
+      console.error("Failed to load categories:", err);
+    }
+  };
+
+  const showSuccess = () => {
+    setSuccessVisible(true);
+    if (successTimer.current) clearTimeout(successTimer.current);
+    successTimer.current = setTimeout(() => setSuccessVisible(false), 3000);
+  };
+
+  const enterEditMode = () => {
+    if (!transaction) return;
+    setEditMerchantName(transaction.merchant_name ?? "");
+    setEditDescription(transaction.description ?? "");
+    setEditAmount(String(Math.abs(transaction.amount)));
+    setEditDate(parseLocalDate(transaction.transaction_date));
+    setEditCategoryId(transaction.category_id);
+    setEditCategoryName(transaction.category_name_es);
+    setEditNotes(transaction.notes ?? "");
+    setEditIsExcluded(!!transaction.is_excluded);
+    setIsEditing(true);
+    if (categories.length === 0) loadCategories();
+  };
+
+  const cancelEdit = () => setIsEditing(false);
+
+  const handleSave = async () => {
+    if (!id) return;
+    const amountNum = parseFloat(editAmount.replace(",", "."));
+    if (isNaN(amountNum) || amountNum <= 0) {
+      Alert.alert("Error", "El monto debe ser un número positivo.");
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateTransaction(id, {
+        merchant_name: editMerchantName.trim() || null,
+        description: editDescription.trim() || null,
+        amount: amountNum,
+        transaction_date: toDateString(editDate),
+        category_id: editCategoryId,
+        notes: editNotes.trim() || null,
+        is_excluded: editIsExcluded,
+      });
+      // Reload from DB to get fresh joined data (category_name_es, etc.)
+      const updated = (await getTransactionById(id)) as TransactionDetail;
+      setTransaction(updated);
+      setIsEditing(false);
+      showSuccess();
+    } catch (err) {
+      console.error("Update transaction error:", err);
+      Alert.alert("Error", "No se pudo guardar los cambios.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleExclude = async () => {
+    if (!transaction || !id) return;
+    const isExcluded = !!transaction.is_excluded;
+    try {
+      await updateTransaction(id, { is_excluded: !isExcluded });
+      setTransaction({ ...transaction, is_excluded: isExcluded ? 0 : 1 });
+    } catch (err) {
+      console.error("Toggle exclude error:", err);
+      Alert.alert("Error", "No se pudo actualizar la transaccion.");
+    }
+  };
 
   const handleDelete = () => {
     if (!id) return;
@@ -88,8 +235,8 @@ export default function TransactionDetailScreen() {
             try {
               await deleteTransaction(id);
               router.back();
-            } catch (error) {
-              console.error("Delete failed:", error);
+            } catch (err) {
+              console.error("Delete failed:", err);
               Alert.alert("Error", "No se pudo eliminar la transaccion.");
             }
           },
@@ -131,6 +278,7 @@ export default function TransactionDetailScreen() {
   }
 
   const isInflow = transaction.direction === "INFLOW";
+  const isExcluded = !!transaction.is_excluded;
   const statusLabel =
     transaction.status === "CLEARED"
       ? "Confirmada"
@@ -138,73 +286,328 @@ export default function TransactionDetailScreen() {
         ? "Pendiente"
         : transaction.status === "POSTED"
           ? "Registrada"
-          : transaction.status ?? "Desconocido";
+          : (transaction.status ?? "Desconocido");
 
   return (
     <View className="flex-1 bg-white">
-      {/* Header with close + delete */}
+      {/* Header */}
       <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
-        <Pressable
-          onPress={() => router.back()}
-          className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
-        >
-          <X size={18} color="#6B7280" />
-        </Pressable>
-        <Text className="text-gray-900 font-inter-bold text-base">
-          Detalle
-        </Text>
-        <Pressable
-          onPress={handleDelete}
-          className="w-8 h-8 items-center justify-center rounded-full bg-red-50 active:bg-red-100"
-        >
-          <Trash2 size={16} color="#EF4444" />
-        </Pressable>
+        {isEditing ? (
+          <>
+            <Pressable
+              onPress={cancelEdit}
+              className="h-8 px-2 items-center justify-center"
+              disabled={saving}
+            >
+              <Text className="text-gray-500 font-inter-medium text-sm">
+                Cancelar
+              </Text>
+            </Pressable>
+            <Text className="text-gray-900 font-inter-bold text-base">
+              Editar transacción
+            </Text>
+            <Pressable
+              onPress={handleSave}
+              className="h-8 px-2 items-center justify-center"
+              disabled={saving}
+            >
+              {saving ? (
+                <ActivityIndicator size="small" color="#10B981" />
+              ) : (
+                <Text className="text-primary font-inter-bold text-sm">
+                  Guardar
+                </Text>
+              )}
+            </Pressable>
+          </>
+        ) : (
+          <>
+            <Pressable
+              onPress={() => router.back()}
+              className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+            >
+              <X size={18} color="#6B7280" />
+            </Pressable>
+            <Text className="text-gray-900 font-inter-bold text-base">
+              Detalle
+            </Text>
+            <View className="flex-row gap-2">
+              <Pressable
+                onPress={enterEditMode}
+                className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+              >
+                <Pencil size={16} color="#6B7280" />
+              </Pressable>
+              <Pressable
+                onPress={handleDelete}
+                className="w-8 h-8 items-center justify-center rounded-full bg-red-50 active:bg-red-100"
+              >
+                <Trash2 size={16} color="#EF4444" />
+              </Pressable>
+            </View>
+          </>
+        )}
       </View>
 
-      <ScrollView className="flex-1">
-        {/* Amount header */}
-        <View className="items-center pt-6 pb-5 border-b border-gray-100 mx-4">
-          <Text className="text-gray-500 font-inter text-sm mb-1">
-            {isInflow ? "Ingreso" : "Gasto"}
+      {/* Success banner */}
+      {successVisible && (
+        <View className="mx-4 mb-2 bg-green-50 rounded-xl px-4 py-2.5">
+          <Text className="text-green-700 font-inter-medium text-sm">
+            Cambios guardados correctamente
           </Text>
-          <Text
-            className={`font-inter-bold text-4xl ${
-              isInflow ? "text-green-600" : "text-gray-900"
-            }`}
-          >
-            {isInflow ? "+" : "-"}
-            {formatCurrency(
-              Math.abs(transaction.amount),
-              (transaction.currency_code as CurrencyCode) || "COP"
-            )}
-          </Text>
-          {transaction.merchant_name && (
-            <Text className="text-gray-700 font-inter-medium text-base mt-2">
-              {transaction.merchant_name}
-            </Text>
-          )}
         </View>
+      )}
 
-        {/* Details */}
-        <View className="px-4 pt-2 pb-8">
-          <DetailRow
-            label="Fecha"
-            value={
-              transaction.transaction_date
-                ? formatDate(transaction.transaction_date, "dd MMM yyyy")
-                : null
-            }
-          />
-          <DetailRow label="Cuenta" value={transaction.account_name} />
-          <DetailRow label="Categoria" value={transaction.category_name_es} />
-          <DetailRow label="Estado" value={statusLabel} />
-          <DetailRow label="Descripcion" value={transaction.description} />
-          <DetailRow
-            label="Descripcion original"
-            value={transaction.raw_description}
-          />
-        </View>
-      </ScrollView>
+      {isEditing ? (
+        /* ── Edit form ── */
+        <KeyboardAvoidingView
+          className="flex-1"
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
+          <ScrollView
+            className="flex-1"
+            contentContainerStyle={{ padding: 16, paddingBottom: 40 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* Merchant */}
+            <FormField label="Comercio">
+              <TextInput
+                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                value={editMerchantName}
+                onChangeText={setEditMerchantName}
+                placeholder="Nombre del comercio"
+                placeholderTextColor="#9CA3AF"
+                autoCapitalize="words"
+              />
+            </FormField>
+
+            {/* Description */}
+            <FormField label="Descripción">
+              <TextInput
+                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                value={editDescription}
+                onChangeText={setEditDescription}
+                placeholder="Descripción de la transacción"
+                placeholderTextColor="#9CA3AF"
+              />
+            </FormField>
+
+            {/* Amount */}
+            <FormField label="Monto" required>
+              <TextInput
+                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                value={editAmount}
+                onChangeText={setEditAmount}
+                placeholder="0"
+                placeholderTextColor="#9CA3AF"
+                keyboardType="decimal-pad"
+              />
+            </FormField>
+
+            {/* Date */}
+            <FormField label="Fecha" required>
+              <Pressable
+                onPress={() => setShowDatePicker(true)}
+                className="bg-white border border-gray-200 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-gray-50"
+              >
+                <Text className="text-gray-900 font-inter text-sm">
+                  {editDate.toLocaleDateString("es-CO", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </Text>
+                <Calendar size={16} color="#9CA3AF" />
+              </Pressable>
+            </FormField>
+
+            {/* Category */}
+            <FormField label="Categoría">
+              <Pressable
+                onPress={() => setShowCategoryPicker(true)}
+                className="bg-white border border-gray-200 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-gray-50"
+              >
+                <Text
+                  className={`font-inter text-sm ${
+                    editCategoryName ? "text-gray-900" : "text-gray-400"
+                  }`}
+                >
+                  {editCategoryName ?? "Sin categoría"}
+                </Text>
+                <Tag size={16} color="#9CA3AF" />
+              </Pressable>
+            </FormField>
+
+            {/* Notes */}
+            <FormField label="Notas">
+              <TextInput
+                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                value={editNotes}
+                onChangeText={setEditNotes}
+                placeholder="Agregar nota..."
+                placeholderTextColor="#9CA3AF"
+                multiline
+                style={{ minHeight: 72, textAlignVertical: "top" }}
+              />
+            </FormField>
+
+            {/* Exclude from totals */}
+            <View className="flex-row items-center justify-between bg-white border border-gray-200 rounded-xl px-4 py-3 mb-4">
+              <View className="flex-1 mr-4">
+                <Text className="text-gray-700 font-inter-medium text-sm">
+                  Excluir de totales
+                </Text>
+                <Text className="text-gray-500 font-inter text-xs mt-0.5">
+                  No contabilizar en estadísticas
+                </Text>
+              </View>
+              <Switch
+                value={editIsExcluded}
+                onValueChange={setEditIsExcluded}
+                trackColor={{ false: "#E5E7EB", true: "#10B981" }}
+                thumbColor="#FFFFFF"
+                ios_backgroundColor="#E5E7EB"
+              />
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      ) : (
+        /* ── Read-only view ── */
+        <ScrollView className="flex-1">
+          {/* Amount hero */}
+          <View className="items-center pt-6 pb-5 border-b border-gray-100 mx-4">
+            <Text className="text-gray-500 font-inter text-sm mb-1">
+              {isInflow ? "Ingreso" : "Gasto"}
+            </Text>
+            {isExcluded && (
+              <View className="flex-row items-center bg-amber-50 px-3 py-1 rounded-full mb-2">
+                <Text className="text-amber-600 font-inter-medium text-xs">
+                  Excluido de totales
+                </Text>
+              </View>
+            )}
+            <Text
+              className={`font-inter-bold text-4xl ${
+                isExcluded
+                  ? "text-gray-300"
+                  : isInflow
+                    ? "text-green-600"
+                    : "text-gray-900"
+              }`}
+              style={isExcluded ? { textDecorationLine: "line-through" } : undefined}
+            >
+              {isInflow ? "+" : "-"}
+              {formatCurrency(
+                Math.abs(transaction.amount),
+                (transaction.currency_code as CurrencyCode) || "COP"
+              )}
+            </Text>
+            {transaction.merchant_name && (
+              <Text
+                className={`font-inter-medium text-base mt-2 ${
+                  isExcluded ? "text-gray-400" : "text-gray-700"
+                }`}
+              >
+                {transaction.merchant_name}
+              </Text>
+            )}
+          </View>
+
+          {/* Details */}
+          <View className="px-4 pt-2 pb-8">
+            <DetailRow
+              label="Fecha"
+              value={
+                transaction.transaction_date
+                  ? parseLocalDate(transaction.transaction_date).toLocaleDateString(
+                      "es-CO",
+                      { year: "numeric", month: "short", day: "numeric" }
+                    )
+                  : null
+              }
+            />
+            <DetailRow label="Cuenta" value={transaction.account_name} />
+            <DetailRow label="Categoria" value={transaction.category_name_es} />
+            <DetailRow label="Estado" value={statusLabel} />
+            <DetailRow label="Descripcion" value={transaction.description} />
+            <DetailRow
+              label="Descripcion original"
+              value={transaction.raw_description}
+            />
+            <DetailRow label="Notas" value={transaction.notes} />
+
+            {/* Exclude toggle */}
+            <View className="flex-row items-center justify-between py-3 border-b border-gray-100">
+              <View>
+                <Text className="text-gray-500 font-inter text-sm">
+                  Excluir de totales
+                </Text>
+                <Text className="text-gray-400 font-inter text-xs mt-0.5">
+                  No afecta estadísticas ni presupuestos
+                </Text>
+              </View>
+              <Switch
+                value={isExcluded}
+                onValueChange={handleToggleExclude}
+                trackColor={{ false: "#E5E7EB", true: "#10B981" }}
+                thumbColor="#FFFFFF"
+                ios_backgroundColor="#E5E7EB"
+              />
+            </View>
+          </View>
+        </ScrollView>
+      )}
+
+      {/* Category picker */}
+      <CategoryPicker
+        visible={showCategoryPicker}
+        onClose={() => setShowCategoryPicker(false)}
+        onSelect={(catId, catName) => {
+          setEditCategoryId(catId);
+          setEditCategoryName(catName);
+        }}
+        selectedId={editCategoryId}
+        categories={categories}
+      />
+
+      {/* Date picker — iOS: spinner in bottom sheet; Android: native dialog */}
+      {showDatePicker && Platform.OS === "ios" ? (
+        <Modal transparent animationType="slide">
+          <View className="flex-1 justify-end bg-black/40">
+            <View className="bg-white rounded-t-2xl pt-2 pb-6">
+              <View className="flex-row justify-end px-4 pb-2">
+                <Pressable
+                  onPress={() => setShowDatePicker(false)}
+                  className="h-8 px-3 items-center justify-center"
+                >
+                  <Text className="text-primary font-inter-bold text-sm">
+                    Listo
+                  </Text>
+                </Pressable>
+              </View>
+              <DateTimePicker
+                value={editDate}
+                mode="date"
+                display="spinner"
+                locale="es-CO"
+                onChange={(_, date) => {
+                  if (date) setEditDate(date);
+                }}
+              />
+            </View>
+          </View>
+        </Modal>
+      ) : showDatePicker ? (
+        <DateTimePicker
+          value={editDate}
+          mode="date"
+          display="default"
+          onChange={(_, date) => {
+            setShowDatePicker(false);
+            if (date) setEditDate(date);
+          }}
+        />
+      ) : null}
     </View>
   );
 }

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from "react";
+import {
+  FlatList,
+  Modal,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Check, X } from "lucide-react-native";
+
+export type CategoryRow = {
+  id: string;
+  name: string;
+  name_es: string | null;
+  color: string | null;
+  parent_id: string | null;
+};
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (id: string | null, name: string | null) => void;
+  selectedId: string | null;
+  categories: CategoryRow[];
+};
+
+type ListItem =
+  | { type: "header"; item: CategoryRow }
+  | { type: "row"; item: CategoryRow; indented: boolean };
+
+function displayName(cat: CategoryRow): string {
+  return cat.name_es ?? cat.name;
+}
+
+export function CategoryPicker({
+  visible,
+  onClose,
+  onSelect,
+  selectedId,
+  categories,
+}: Props) {
+  const [search, setSearch] = useState("");
+
+  const listItems = useMemo((): ListItem[] => {
+    const query = search.toLowerCase().trim();
+
+    if (query) {
+      // Flat filtered list — all matching categories are selectable rows
+      return categories
+        .filter((c) => displayName(c).toLowerCase().includes(query))
+        .map((item) => ({ type: "row" as const, item, indented: false }));
+    }
+
+    // Hierarchical view: roots first, then their children
+    const rootIds = new Set(
+      categories.filter((c) => !c.parent_id).map((c) => c.id)
+    );
+    const childrenByParent = new Map<string, CategoryRow[]>();
+    for (const cat of categories) {
+      if (cat.parent_id && rootIds.has(cat.parent_id)) {
+        const arr = childrenByParent.get(cat.parent_id) ?? [];
+        arr.push(cat);
+        childrenByParent.set(cat.parent_id, arr);
+      }
+    }
+
+    const result: ListItem[] = [];
+    for (const cat of categories.filter((c) => !c.parent_id)) {
+      const children = childrenByParent.get(cat.id) ?? [];
+      if (children.length > 0) {
+        // Show as non-selectable section header
+        result.push({ type: "header", item: cat });
+        for (const child of children) {
+          result.push({ type: "row", item: child, indented: true });
+        }
+      } else {
+        // No children — show as a normal selectable row
+        result.push({ type: "row", item: cat, indented: false });
+      }
+    }
+
+    // Orphaned children (parent not in root list)
+    for (const cat of categories) {
+      if (cat.parent_id && !rootIds.has(cat.parent_id)) {
+        result.push({ type: "row", item: cat, indented: false });
+      }
+    }
+
+    return result;
+  }, [categories, search]);
+
+  const handleClose = () => {
+    setSearch("");
+    onClose();
+  };
+
+  const handleSelect = (id: string | null, name: string | null) => {
+    setSearch("");
+    onSelect(id, name);
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={handleClose}
+    >
+      <View className="flex-1 bg-white">
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-gray-100">
+          <Text className="text-gray-900 font-inter-bold text-base">
+            Categoría
+          </Text>
+          <Pressable
+            onPress={handleClose}
+            className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+          >
+            <X size={18} color="#6B7280" />
+          </Pressable>
+        </View>
+
+        {/* Search */}
+        <View className="px-4 py-3 border-b border-gray-100">
+          <TextInput
+            className="bg-gray-100 rounded-xl px-4 py-2.5 text-gray-900 font-inter text-sm"
+            placeholder="Buscar categoría..."
+            placeholderTextColor="#9CA3AF"
+            value={search}
+            onChangeText={setSearch}
+            autoCorrect={false}
+            autoCapitalize="none"
+          />
+        </View>
+
+        {/* "None" option */}
+        <Pressable
+          onPress={() => handleSelect(null, null)}
+          className="flex-row items-center px-4 py-3.5 border-b border-gray-100 active:bg-gray-50"
+        >
+          <View className="w-3 h-3 rounded-full bg-gray-300 mr-3" />
+          <Text className="text-gray-500 font-inter text-sm flex-1">
+            Sin categoría
+          </Text>
+          {selectedId === null && <Check size={16} color="#10B981" />}
+        </Pressable>
+
+        <FlatList
+          data={listItems}
+          keyExtractor={(item) => item.item.id}
+          keyboardShouldPersistTaps="handled"
+          renderItem={({ item }) => {
+            if (item.type === "header") {
+              return (
+                <View className="px-4 pt-4 pb-1.5 bg-gray-50">
+                  <Text className="text-gray-400 font-inter-semibold text-xs uppercase tracking-wide">
+                    {displayName(item.item)}
+                  </Text>
+                </View>
+              );
+            }
+
+            const isSelected = item.item.id === selectedId;
+            const paddingLeft = item.indented ? "pl-8" : "pl-4";
+
+            return (
+              <Pressable
+                onPress={() =>
+                  handleSelect(item.item.id, displayName(item.item))
+                }
+                className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-gray-50`}
+              >
+                {item.item.color ? (
+                  <View
+                    className="w-3 h-3 rounded-full mr-3"
+                    style={{ backgroundColor: item.item.color }}
+                  />
+                ) : (
+                  <View className="w-3 h-3 rounded-full bg-gray-200 mr-3" />
+                )}
+                <Text
+                  className={`font-inter text-sm flex-1 ${
+                    isSelected ? "text-primary font-inter-medium" : "text-gray-900"
+                  }`}
+                >
+                  {displayName(item.item)}
+                </Text>
+                {isSelected && <Check size={16} color="#10B981" />}
+              </Pressable>
+            );
+          }}
+          ItemSeparatorComponent={() => (
+            <View className="h-px bg-gray-50 ml-4" />
+          )}
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -48,27 +48,148 @@ export async function getTransactions(options?: {
 export async function deleteTransaction(id: string) {
   const db = await getDatabase();
 
-  // Check if there's a pending INSERT that hasn't synced yet
-  const pendingInsert = await db.getFirstAsync<{ id: number }>(
-    `SELECT id FROM sync_queue
-     WHERE table_name = 'transactions' AND record_id = ? AND operation = 'INSERT' AND synced_at IS NULL`,
-    [id]
-  );
-
-  await db.runAsync("DELETE FROM transactions WHERE id = ?", [id]);
-
-  if (pendingInsert) {
-    // Never synced — just remove the pending INSERT from the queue
-    await db.runAsync("DELETE FROM sync_queue WHERE id = ?", [pendingInsert.id]);
-  } else {
-    // Already synced — queue a DELETE so Supabase removes it too
-    const now = new Date().toISOString();
-    await db.runAsync(
-      `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
-       VALUES ('transactions', ?, 'DELETE', ?, ?)`,
-      [id, JSON.stringify({ id }), now]
+  await db.withTransactionAsync(async () => {
+    // Check if this record was never synced (has a pending INSERT)
+    const pendingInsert = await db.getFirstAsync<{ id: number }>(
+      `SELECT id FROM sync_queue
+       WHERE table_name = 'transactions' AND record_id = ? AND operation = 'INSERT' AND synced_at IS NULL`,
+      [id]
     );
+
+    await db.runAsync("DELETE FROM transactions WHERE id = ?", [id]);
+
+    if (pendingInsert) {
+      // Never reached Supabase — remove all pending queue entries for this record
+      await db.runAsync(
+        `DELETE FROM sync_queue WHERE table_name = 'transactions' AND record_id = ? AND synced_at IS NULL`,
+        [id]
+      );
+    } else {
+      // Already in Supabase — clean up pending UPDATEs and queue a DELETE
+      await db.runAsync(
+        `DELETE FROM sync_queue WHERE table_name = 'transactions' AND record_id = ? AND operation = 'UPDATE' AND synced_at IS NULL`,
+        [id]
+      );
+      const now = new Date().toISOString();
+      await db.runAsync(
+        `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+         VALUES ('transactions', ?, 'DELETE', ?, ?)`,
+        [id, JSON.stringify({ id }), now]
+      );
+    }
+  });
+}
+
+export type UpdateTransactionParams = {
+  description?: string | null;
+  merchant_name?: string | null;
+  amount?: number;
+  transaction_date?: string; // "YYYY-MM-DD"
+  category_id?: string | null;
+  notes?: string | null;
+  is_excluded?: boolean;
+};
+
+export async function updateTransaction(
+  id: string,
+  params: UpdateTransactionParams
+): Promise<void> {
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+
+  const setClauses: string[] = [];
+  const values: (string | number | null)[] = [];
+
+  if (params.description !== undefined) {
+    setClauses.push("description = ?");
+    values.push(params.description ?? null);
   }
+  if (params.merchant_name !== undefined) {
+    setClauses.push("merchant_name = ?");
+    values.push(params.merchant_name ?? null);
+  }
+  if (params.amount !== undefined) {
+    setClauses.push("amount = ?");
+    values.push(params.amount);
+  }
+  if (params.transaction_date !== undefined) {
+    setClauses.push("transaction_date = ?");
+    values.push(params.transaction_date);
+  }
+  if (params.category_id !== undefined) {
+    setClauses.push("category_id = ?");
+    values.push(params.category_id ?? null);
+  }
+  if (params.notes !== undefined) {
+    setClauses.push("notes = ?");
+    values.push(params.notes ?? null);
+  }
+  if (params.is_excluded !== undefined) {
+    setClauses.push("is_excluded = ?");
+    values.push(params.is_excluded ? 1 : 0);
+  }
+
+  if (setClauses.length === 0) return;
+
+  setClauses.push("updated_at = ?");
+  values.push(now);
+  values.push(id);
+
+  // Build sync payload — Supabase expects boolean for is_excluded, not integer
+  const syncPayload: Record<string, unknown> = { updated_at: now };
+  if (params.description !== undefined) syncPayload.description = params.description ?? null;
+  if (params.merchant_name !== undefined) syncPayload.merchant_name = params.merchant_name ?? null;
+  if (params.amount !== undefined) syncPayload.amount = params.amount;
+  if (params.transaction_date !== undefined) syncPayload.transaction_date = params.transaction_date;
+  if (params.category_id !== undefined) syncPayload.category_id = params.category_id ?? null;
+  if (params.notes !== undefined) syncPayload.notes = params.notes ?? null;
+  if (params.is_excluded !== undefined) syncPayload.is_excluded = params.is_excluded;
+
+  await db.withTransactionAsync(async () => {
+    await db.runAsync(
+      `UPDATE transactions SET ${setClauses.join(", ")} WHERE id = ?`,
+      values
+    );
+
+    const pendingInsert = await db.getFirstAsync<{ id: number; payload: string }>(
+      `SELECT id, payload FROM sync_queue
+       WHERE table_name = 'transactions' AND record_id = ? AND operation = 'INSERT' AND synced_at IS NULL`,
+      [id]
+    );
+
+    if (pendingInsert) {
+      // Merge into the existing INSERT so Supabase receives the final state
+      const existing = JSON.parse(pendingInsert.payload);
+      const merged = { ...existing, ...syncPayload };
+      await db.runAsync(
+        "UPDATE sync_queue SET payload = ? WHERE id = ?",
+        [JSON.stringify(merged), pendingInsert.id]
+      );
+    } else {
+      // Check for an existing pending UPDATE — merge rather than accumulate
+      const pendingUpdate = await db.getFirstAsync<{ id: number; payload: string }>(
+        `SELECT id, payload FROM sync_queue
+         WHERE table_name = 'transactions' AND record_id = ? AND operation = 'UPDATE' AND synced_at IS NULL`,
+        [id]
+      );
+
+      if (pendingUpdate) {
+        const existing = JSON.parse(pendingUpdate.payload);
+        const merged = { ...existing, ...syncPayload };
+        await db.runAsync(
+          "UPDATE sync_queue SET payload = ? WHERE id = ?",
+          [JSON.stringify(merged), pendingUpdate.id]
+        );
+      } else {
+        // Queue a new UPDATE
+        await db.runAsync(
+          `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+           VALUES ('transactions', ?, 'UPDATE', ?, ?)`,
+          [id, JSON.stringify(syncPayload), now]
+        );
+      }
+    }
+  });
 }
 
 export async function getTransactionById(id: string) {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,6 +17,7 @@
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-crypto": "^15.0.8",
+    "@react-native-community/datetimepicker": "8.4.4",
     "expo-document-picker": "^14.0.8",
     "expo-font": "~14.0.11",
     "expo-linking": "~8.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-native-community/datetimepicker':
+        specifier: 8.4.4
+        version: 8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native':
         specifier: ^7.1.8
         version: 7.1.28(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -2070,6 +2073,19 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@react-native-community/datetimepicker@8.4.4':
+    resolution: {integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
@@ -8932,6 +8948,14 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   '@react-native/assets-registry@0.81.5': {}
 


### PR DESCRIPTION
## Summary

- **Inline transaction edit form**: tap the pencil icon in the transaction detail header to enter edit mode. Editable fields: merchant name, description, amount, date (platform-native DateTimePicker), category (CategoryPicker), and notes. Tap "Guardar" to save or "Cancelar" to discard.
- **Exclude from totals toggle**: shown in the read-only view and in the edit form. Toggling in view mode writes immediately (offline-first). Excluded transactions display a muted strikethrough amount and an amber "Excluido de totales" badge.
- **CategoryPicker**: new reusable modal (`mobile/components/transactions/CategoryPicker.tsx`) with a searchable list of categories grouped by parent. Returns `category_id` + `category_name` to the caller.

## Offline-first data flow

All writes follow the existing pattern:
1. Update SQLite immediately (atomic via `withTransactionAsync`)
2. Merge into any pending `INSERT` or `UPDATE` in `sync_queue` to avoid accumulation
3. Background sync engine pushes to Supabase on next sync

## Bug fixes included

- `updateTransaction` and `deleteTransaction` now wrapped in `withTransactionAsync` — the SQLite write and sync_queue operation are atomic
- `deleteTransaction` now cleans up orphaned pending `UPDATE` rows before queuing a `DELETE`
- Date display uses `parseLocalDate` (local noon) instead of `parseISO` (UTC midnight) to prevent off-by-one day on devices in UTC-5 (Bogotá)
- Repeated offline edits no longer accumulate `UPDATE` rows — payloads are merged in place

## Test plan

- [ ] Open a transaction → tap pencil icon → verify all fields are pre-populated
- [ ] Edit description, amount, date, category, notes → tap Guardar → verify detail view refreshes
- [ ] Tap pencil → make changes → tap Cancelar → verify no changes saved
- [ ] Toggle "Excluir de totales" in view mode → verify amount shows strikethrough + amber badge
- [ ] Toggle "Excluir de totales" in edit form → save → verify is_excluded persists
- [ ] Edit while offline → sync later → verify Supabase reflects final state (no duplicate queue rows)
- [ ] Edit a transaction twice while offline → verify sync_queue has exactly one UPDATE row

Closes P0 items 3 from MIGRATION_STATUS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)