### PR TITLE
fix: corregir pipeline de deploy para que corra desde main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
-name: Deploy After PR Merge
+name: Build and Deploy
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
     paths:
       - '.github/workflows/deploy.yml'
@@ -24,13 +23,11 @@ env:
 
 jobs:
   changes:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
-      webapp_changed: ${{ steps.filter.outputs.webapp }}
-      parser_changed: ${{ steps.filter.outputs.parser }}
-      deploy_changed: ${{ steps.filter.outputs.deploy }}
-      any_deploy: ${{ steps.any.outputs.any_deploy }}
+      webapp_changed: ${{ steps.set-outputs.outputs.webapp_changed }}
+      parser_changed: ${{ steps.set-outputs.outputs.parser_changed }}
+      any_deploy: ${{ steps.set-outputs.outputs.any_deploy }}
     steps:
       - name: Detect changed areas
         id: filter
@@ -51,112 +48,39 @@ jobs:
               - '.github/workflows/deploy.yml'
               - '.github/workflows/pr-build-images.yml'
 
-      - name: Compute deploy flag
-        id: any
+      - name: Set outputs
+        id: set-outputs
         run: |
-          if [ "${{ steps.filter.outputs.webapp }}" = "true" ] || \
-             [ "${{ steps.filter.outputs.parser }}" = "true" ] || \
-             [ "${{ steps.filter.outputs.deploy }}" = "true" ]; then
+          IS_DISPATCH="${{ github.event_name == 'workflow_dispatch' }}"
+          WEBAPP="${{ steps.filter.outputs.webapp }}"
+          PARSER="${{ steps.filter.outputs.parser }}"
+          DEPLOY_FILES="${{ steps.filter.outputs.deploy }}"
+
+          if [ "$IS_DISPATCH" = "true" ] || [ "$WEBAPP" = "true" ]; then
+            echo "webapp_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "webapp_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$IS_DISPATCH" = "true" ] || [ "$PARSER" = "true" ]; then
+            echo "parser_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "parser_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$IS_DISPATCH" = "true" ] || \
+             [ "$WEBAPP" = "true" ] || \
+             [ "$PARSER" = "true" ] || \
+             [ "$DEPLOY_FILES" = "true" ]; then
             echo "any_deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "any_deploy=false" >> "$GITHUB_OUTPUT"
           fi
 
-  promote-webapp:
-    if: github.event_name == 'pull_request' && needs.changes.outputs.webapp_changed == 'true'
+  build-webapp:
+    if: needs.changes.outputs.webapp_changed == 'true'
     runs-on: ubuntu-latest
     needs: [changes]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_PAT_WRITE }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Promote webapp PR image to production tag
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.REPO }}:webapp-latest \
-            ${{ env.REGISTRY }}/${{ env.REPO }}:webapp-pr-${{ github.event.pull_request.number }}-latest
-
-  promote-parser:
-    if: github.event_name == 'pull_request' && needs.changes.outputs.parser_changed == 'true'
-    runs-on: ubuntu-latest
-    needs: [changes]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_PAT_WRITE }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Promote parser PR image to production tag
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.REPO }}:parser-latest \
-            ${{ env.REGISTRY }}/${{ env.REPO }}:parser-pr-${{ github.event.pull_request.number }}-latest
-
-  deploy:
-    if: |
-      github.event_name == 'pull_request' &&
-      always() &&
-      needs.changes.result != 'skipped' &&
-      needs.changes.outputs.any_deploy == 'true' &&
-      needs.promote-webapp.result != 'failure' &&
-      needs.promote-parser.result != 'failure'
-    runs-on: ubuntu-latest
-    needs: [changes, promote-webapp, promote-parser]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate GHCR token can read images
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_PAT_READ }}
-
-      - name: Verify images are pullable from GHCR
-        run: |
-          docker manifest inspect ${{ env.REGISTRY }}/${{ env.REPO }}:webapp-latest > /dev/null
-          docker manifest inspect ${{ env.REGISTRY }}/${{ env.REPO }}:parser-latest > /dev/null
-
-      - name: Deploy to Hostinger VPS
-        uses: hostinger/deploy-on-vps@v2
-        with:
-          api-key: ${{ secrets.HOSTINGER_API_KEY }}
-          virtual-machine: ${{ vars.HOSTINGER_VM_ID }}
-          project-name: personal-finance-manager
-          docker-compose-path: docker-compose.prod.yml
-          environment-variables: |
-            GITHUB_REPO=${{ env.REPO }}
-            NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-            NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
-            SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-            SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-            DOMAIN=${{ vars.DOMAIN }}
-            GHCR_USERNAME=${{ env.GHCR_USERNAME }}
-            GHCR_TOKEN=${{ secrets.GHCR_PAT_READ }}
-
-  manual-build-webapp:
-    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -174,7 +98,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build & push webapp latest image from main
+      - name: Build & push webapp latest image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -191,9 +115,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  manual-build-parser:
-    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
+  build-parser:
+    if: needs.changes.outputs.parser_changed == 'true'
     runs-on: ubuntu-latest
+    needs: [changes]
     permissions:
       contents: read
       packages: write
@@ -211,7 +136,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build & push parser latest image from main
+      - name: Build & push parser latest image
         uses: docker/build-push-action@v6
         with:
           context: ./services/pdf_parser
@@ -221,10 +146,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-manual:
-    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
+  deploy:
+    if: |
+      always() &&
+      needs.changes.outputs.any_deploy == 'true' &&
+      needs.build-webapp.result != 'failure' &&
+      needs.build-parser.result != 'failure'
     runs-on: ubuntu-latest
-    needs: [manual-build-webapp, manual-build-parser]
+    needs: [changes, build-webapp, build-parser]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Cambiar trigger de `pull_request: types: [closed]` a `push: branches: [main]`
  para que el workflow siempre corra en el contexto de main, no del PR
- Reemplazar jobs de "promote" (promote-webapp, promote-parser) con builds
  directos desde main (build-webapp, build-parser), unificando el flujo
  automático y manual en los mismos jobs
- Manejar workflow_dispatch correctamente en la detección de cambios:
  cuando se dispara manualmente, se fuerza any_deploy=true para garantizar
  que el deploy siempre se ejecute
- Eliminar manual-build-webapp, manual-build-parser y deploy-manual como
  jobs separados; ahora el mismo flujo cubre ambos triggers

https://claude.ai/code/session_01H77WmmWxCj1Ndo2cpMxy8B