### PR TITLE
fix: agregar checkout antes de dorny/paths-filter en job changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,9 @@ jobs:
       parser_changed: ${{ steps.set-outputs.outputs.parser_changed }}
       any_deploy: ${{ steps.set-outputs.outputs.any_deploy }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Detect changed areas
         id: filter
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
Para eventos push, paths-filter necesita un repositorio git local. Con el trigger pull_request usaba la API de GitHub y no lo requería, pero al cambiar a push hay que hacer checkout explícitamente primero.

https://claude.ai/code/session_01H77WmmWxCj1Ndo2cpMxy8B