### PR TITLE
chore: add Maestro E2E testing structure for mobile app

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -34,6 +34,10 @@ yarn-error.*
 .env
 .env*.local
 
+# Maestro
+.maestro/.env
+.maestro/test-results/
+
 # typescript
 *.tsbuildinfo
 

--- a/mobile/.maestro/README.md
+++ b/mobile/.maestro/README.md
@@ -1,0 +1,78 @@
+# Maestro E2E Tests — Zeta Finance
+
+Tests E2E para la app móvil usando [Maestro](https://maestro.dev/).
+
+## Estructura
+
+```
+.maestro/
+├── config.yaml              # Configuración global
+├── .env.example             # Variables de entorno (template)
+├── helpers/                 # Flows reutilizables
+│   ├── login.yaml
+│   └── logout.yaml
+└── flows/                   # Tests organizados por feature
+    ├── auth/
+    │   ├── login-success.yaml
+    │   ├── login-invalid-credentials.yaml
+    │   └── signup.yaml
+    ├── accounts/
+    │   ├── view-accounts.yaml
+    │   └── account-detail.yaml
+    ├── transactions/
+    │   ├── view-transactions.yaml
+    │   └── search-transactions.yaml
+    └── import/
+        └── import-pdf-wizard.yaml
+```
+
+## Setup local
+
+```bash
+# 1. Instalar Maestro CLI
+curl -Ls "https://get.maestro.mobile.dev" | bash
+
+# 2. (iOS) Instalar IDB
+brew tap facebook/fb
+brew install facebook/fb/idb-companion
+
+# 3. Configurar variables de entorno
+cp .maestro/.env.example .maestro/.env
+# Editar .env con credenciales de test
+
+# 4. Iniciar emulador/simulador y la app
+pnpm ios   # o pnpm android
+
+# 5. Ejecutar tests
+maestro test .maestro/flows/                           # Todos
+maestro test .maestro/flows/auth/login-success.yaml    # Uno específico
+maestro test --include-tags=smoke .maestro/flows/      # Solo smoke tests
+maestro test --env-file=.maestro/.env .maestro/flows/  # Con env file
+```
+
+## Maestro Studio (inspector visual)
+
+```bash
+maestro studio
+```
+
+Abre un inspector interactivo para explorar la UI y generar comandos YAML.
+
+## Tags
+
+| Tag | Descripción |
+|-----|-------------|
+| `smoke` | Tests mínimos para verificar que la app funciona |
+| `auth` | Flujos de autenticación |
+| `accounts` | Gestión de cuentas |
+| `transactions` | Transacciones y búsqueda |
+| `import` | Importación de PDFs |
+| `regression` | Suite completa de regresión |
+
+## Convenciones
+
+- **testID**: Todos los componentes testeados deben tener `testID` con formato `{screen}-{element}-{type}`
+  - Ejemplos: `login-email-input`, `dashboard-balance-card`, `tab-accounts`
+- **Helpers**: Flows reutilizables van en `helpers/` y se invocan con `runFlow`
+- **Variables**: Usar `${VARIABLE}` para datos dinámicos, definir en `.env`
+- **Idioma**: Comentarios y nombres de archivo en español, comandos YAML en inglés

--- a/mobile/.maestro/TODO.md
+++ b/mobile/.maestro/TODO.md
@@ -1,0 +1,71 @@
+# TODO: Implementación Maestro E2E — Zeta Finance
+
+## Fase 1: Setup local (Prioridad Alta)
+- [ ] Instalar Maestro CLI en máquina local
+- [ ] Instalar IDB companion (para iOS simulator)
+- [ ] Crear archivo `.maestro/.env` con credenciales de test
+- [ ] Verificar que Maestro detecta el emulador/simulador: `maestro hierarchy`
+
+## Fase 2: Agregar testID a componentes (Prioridad Alta)
+- [ ] **Auth screens**
+  - [ ] `login.tsx`: `login-screen`, `login-email-input`, `login-password-input`, `login-submit-button`, `login-error-message`, `login-signup-link`, `login-biometric-button`
+  - [ ] `signup.tsx`: `signup-screen`, `signup-name-input`, `signup-email-input`, `signup-password-input`, `signup-submit-button`, `signup-success-message`
+  - [ ] `forgot-password.tsx`: `forgot-password-screen`, `forgot-password-email-input`, `forgot-password-submit-button`
+- [ ] **Tab navigation**
+  - [ ] `_layout.tsx`: `tab-dashboard`, `tab-accounts`, `tab-transactions`, `tab-budgets`, `tab-import`, `tab-settings`
+- [ ] **Dashboard**
+  - [ ] `(tabs)/index.tsx`: `dashboard-screen`
+  - [ ] `BalanceCard.tsx`: `balance-card`
+  - [ ] `MonthSummary.tsx`: `month-summary-card`
+  - [ ] `CategoryBreakdown.tsx`: `category-breakdown`
+- [ ] **Accounts**
+  - [ ] `(tabs)/accounts.tsx`: `accounts-screen`
+  - [ ] `AccountCard.tsx`: `account-card`
+  - [ ] `account/[id].tsx`: `account-detail-screen`, `account-balance`
+  - [ ] `account/create.tsx`: `account-create-screen`, `account-create-submit`
+- [ ] **Transactions**
+  - [ ] `(tabs)/transactions.tsx`: `transactions-screen`, `transaction-list`
+  - [ ] `TransactionRow.tsx`: `transaction-row`
+  - [ ] `SearchBar.tsx`: `transactions-search-input`
+  - [ ] `transaction/[id].tsx`: `transaction-detail-screen`
+- [ ] **Import**
+  - [ ] `(tabs)/import.tsx`: `import-screen`, `import-upload-button`
+- [ ] **Settings**
+  - [ ] `(tabs)/settings.tsx`: `settings-screen`, `settings-logout-button`
+
+## Fase 3: Validar flows existentes (Prioridad Alta)
+- [ ] Ejecutar `login-success.yaml` — verificar que pasa
+- [ ] Ejecutar `login-invalid-credentials.yaml` — verificar que pasa
+- [ ] Ejecutar `signup.yaml` — ajustar según UI real
+- [ ] Ejecutar `view-accounts.yaml` — verificar navegación
+- [ ] Ejecutar `account-detail.yaml` — verificar modal/sheet
+- [ ] Ejecutar `view-transactions.yaml` — verificar lista
+- [ ] Ejecutar `search-transactions.yaml` — verificar filtrado
+- [ ] Ejecutar `import-pdf-wizard.yaml` — verificar wizard
+- [ ] Ajustar selectores y timeouts según comportamiento real
+
+## Fase 4: Expandir cobertura (Prioridad Media)
+- [ ] Flow: Crear cuenta nueva (formulario completo)
+- [ ] Flow: Editar cuenta existente
+- [ ] Flow: Ver detalle de transacción
+- [ ] Flow: Captura rápida de gasto (FloatingCaptureButton → modal)
+- [ ] Flow: Cambiar mes en dashboard (MonthSelector)
+- [ ] Flow: Onboarding de usuario nuevo
+- [ ] Flow: Desbloqueo biométrico (BiometricLockScreen)
+- [ ] Flow: Modo demo (login sin credenciales)
+- [ ] Flow: Navegación completa entre todos los tabs
+
+## Fase 5: CI/CD (Prioridad Media)
+- [ ] Agregar script `test:e2e` en `mobile/package.json`
+- [ ] Crear GitHub Action workflow para Maestro tests
+- [ ] Configurar EAS Workflows para E2E en builds
+- [ ] Generar reportes JUnit: `maestro test --format junit --output results.xml`
+- [ ] Evaluar Maestro Cloud vs self-hosted para CI
+
+## Fase 6: Mejoras (Prioridad Baja)
+- [ ] Agregar screenshots automáticos en puntos clave
+- [ ] Crear flow de regresión visual (snapshot comparisons)
+- [ ] Documentar proceso de escritura de nuevos tests
+- [ ] Agregar `testID` a componentes de `@zeta/shared` si aplica
+- [ ] Explorar Maestro para testing de deep links (`zeta://`)
+- [ ] Evaluar testing de notificaciones push

--- a/mobile/.maestro/config.yaml
+++ b/mobile/.maestro/config.yaml
@@ -1,0 +1,17 @@
+# Maestro Configuration for Zeta Finance App
+# Docs: https://docs.maestro.dev
+
+appId: com.zetafinance.app
+
+# Tags allow filtering which tests to run
+# Usage: maestro test --include-tags=smoke .maestro/
+tags:
+  - smoke
+  - regression
+
+# Default execution order
+executionOrder:
+  continueOnFailure: false
+
+# Status bar configuration (hides dynamic content for screenshots)
+statusBar: dark

--- a/mobile/.maestro/flows/accounts/account-detail.yaml
+++ b/mobile/.maestro/flows/accounts/account-detail.yaml
@@ -1,0 +1,38 @@
+# Test: Ver detalle de una cuenta
+# Tags: accounts
+# Precondición: Usuario autenticado con al menos 1 cuenta
+
+appId: com.zetafinance.app
+tags:
+  - accounts
+env:
+  EMAIL: ${EMAIL}
+  PASSWORD: ${PASSWORD}
+---
+- launchApp:
+    clearState: true
+
+# Login
+- runFlow:
+    file: ../../helpers/login.yaml
+    env:
+      EMAIL: ${EMAIL}
+      PASSWORD: ${PASSWORD}
+
+# Navegar a cuentas
+- tapOn:
+    id: "tab-accounts"
+- assertVisible:
+    id: "accounts-screen"
+
+# Abrir primera cuenta
+- tapOn:
+    id: "account-card"
+    index: 0
+
+# Verificar detalle de cuenta
+- assertVisible:
+    id: "account-detail-screen"
+    timeout: 5000
+- assertVisible:
+    id: "account-balance"

--- a/mobile/.maestro/flows/accounts/view-accounts.yaml
+++ b/mobile/.maestro/flows/accounts/view-accounts.yaml
@@ -1,0 +1,34 @@
+# Test: Ver lista de cuentas
+# Tags: smoke, accounts
+# Precondición: Usuario autenticado con al menos 1 cuenta
+
+appId: com.zetafinance.app
+tags:
+  - smoke
+  - accounts
+env:
+  EMAIL: ${EMAIL}
+  PASSWORD: ${PASSWORD}
+---
+- launchApp:
+    clearState: true
+
+# Login
+- runFlow:
+    file: ../../helpers/login.yaml
+    env:
+      EMAIL: ${EMAIL}
+      PASSWORD: ${PASSWORD}
+
+# Navegar a cuentas
+- tapOn:
+    id: "tab-accounts"
+
+# Verificar pantalla de cuentas
+- assertVisible:
+    id: "accounts-screen"
+
+# Verificar que existe al menos una cuenta
+- assertVisible:
+    id: "account-card"
+    timeout: 5000

--- a/mobile/.maestro/flows/auth/login-invalid-credentials.yaml
+++ b/mobile/.maestro/flows/auth/login-invalid-credentials.yaml
@@ -1,0 +1,34 @@
+# Test: Login con credenciales inválidas muestra error
+# Tags: smoke, auth
+
+appId: com.zetafinance.app
+tags:
+  - smoke
+  - auth
+---
+- launchApp:
+    clearState: true
+
+- assertVisible:
+    id: "login-screen"
+
+# Ingresar credenciales inválidas
+- tapOn:
+    id: "login-email-input"
+- inputText: "invalid@test.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "wrongpassword"
+
+# Enviar formulario
+- tapOn:
+    id: "login-submit-button"
+
+# Verificar mensaje de error
+- assertVisible:
+    id: "login-error-message"
+    timeout: 5000
+
+# Verificar que seguimos en login
+- assertVisible:
+    id: "login-screen"

--- a/mobile/.maestro/flows/auth/login-success.yaml
+++ b/mobile/.maestro/flows/auth/login-success.yaml
@@ -1,0 +1,37 @@
+# Test: Login exitoso con credenciales válidas
+# Tags: smoke, auth
+# Precondición: Usuario registrado en el sistema
+
+appId: com.zetafinance.app
+tags:
+  - smoke
+  - auth
+---
+- launchApp:
+    clearState: true
+
+# Pantalla de login visible
+- assertVisible:
+    id: "login-screen"
+- assertVisible: "Iniciar sesión"
+
+# Ingresar credenciales
+- tapOn:
+    id: "login-email-input"
+- inputText: ${EMAIL}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${PASSWORD}
+
+# Enviar formulario
+- tapOn:
+    id: "login-submit-button"
+
+# Verificar navegación al dashboard
+- assertVisible:
+    id: "dashboard-screen"
+    timeout: 10000
+
+# Verificar elementos clave del dashboard
+- assertVisible:
+    id: "balance-card"

--- a/mobile/.maestro/flows/auth/signup.yaml
+++ b/mobile/.maestro/flows/auth/signup.yaml
@@ -1,0 +1,41 @@
+# Test: Flujo de registro de usuario
+# Tags: auth
+# Nota: Requiere email único por ejecución
+
+appId: com.zetafinance.app
+tags:
+  - auth
+---
+- launchApp:
+    clearState: true
+
+- assertVisible:
+    id: "login-screen"
+
+# Navegar a signup
+- tapOn:
+    id: "login-signup-link"
+
+# Pantalla de registro visible
+- assertVisible:
+    id: "signup-screen"
+
+# Llenar formulario
+- tapOn:
+    id: "signup-name-input"
+- inputText: "Test User"
+- tapOn:
+    id: "signup-email-input"
+- inputText: "test+${TIMESTAMP}@example.com"
+- tapOn:
+    id: "signup-password-input"
+- inputText: "TestPassword123!"
+
+# Enviar registro
+- tapOn:
+    id: "signup-submit-button"
+
+# Verificar feedback (puede ser confirmación de email o dashboard)
+- assertVisible:
+    id: "signup-success-message"
+    timeout: 10000

--- a/mobile/.maestro/flows/import/import-pdf-wizard.yaml
+++ b/mobile/.maestro/flows/import/import-pdf-wizard.yaml
@@ -1,0 +1,34 @@
+# Test: Flujo de importación PDF (navegación del wizard)
+# Tags: import
+# Precondición: Usuario autenticado
+# Nota: Este test verifica la navegación del wizard, no la importación real
+
+appId: com.zetafinance.app
+tags:
+  - import
+env:
+  EMAIL: ${EMAIL}
+  PASSWORD: ${PASSWORD}
+---
+- launchApp:
+    clearState: true
+
+# Login
+- runFlow:
+    file: ../../helpers/login.yaml
+    env:
+      EMAIL: ${EMAIL}
+      PASSWORD: ${PASSWORD}
+
+# Navegar a importar
+- tapOn:
+    id: "tab-import"
+
+# Verificar pantalla de import
+- assertVisible:
+    id: "import-screen"
+    timeout: 5000
+
+# Verificar que el botón de subir PDF existe
+- assertVisible:
+    id: "import-upload-button"

--- a/mobile/.maestro/flows/transactions/search-transactions.yaml
+++ b/mobile/.maestro/flows/transactions/search-transactions.yaml
@@ -1,0 +1,36 @@
+# Test: Buscar transacciones
+# Tags: transactions
+# Precondición: Usuario autenticado con transacciones
+
+appId: com.zetafinance.app
+tags:
+  - transactions
+env:
+  EMAIL: ${EMAIL}
+  PASSWORD: ${PASSWORD}
+---
+- launchApp:
+    clearState: true
+
+# Login
+- runFlow:
+    file: ../../helpers/login.yaml
+    env:
+      EMAIL: ${EMAIL}
+      PASSWORD: ${PASSWORD}
+
+# Navegar a transacciones
+- tapOn:
+    id: "tab-transactions"
+- assertVisible:
+    id: "transactions-screen"
+
+# Buscar
+- tapOn:
+    id: "transactions-search-input"
+- inputText: "mercado"
+
+# Verificar que los resultados se filtran
+- assertVisible:
+    id: "transaction-list"
+    timeout: 5000

--- a/mobile/.maestro/flows/transactions/view-transactions.yaml
+++ b/mobile/.maestro/flows/transactions/view-transactions.yaml
@@ -1,0 +1,34 @@
+# Test: Ver lista de transacciones
+# Tags: smoke, transactions
+# Precondición: Usuario autenticado
+
+appId: com.zetafinance.app
+tags:
+  - smoke
+  - transactions
+env:
+  EMAIL: ${EMAIL}
+  PASSWORD: ${PASSWORD}
+---
+- launchApp:
+    clearState: true
+
+# Login
+- runFlow:
+    file: ../../helpers/login.yaml
+    env:
+      EMAIL: ${EMAIL}
+      PASSWORD: ${PASSWORD}
+
+# Navegar a transacciones
+- tapOn:
+    id: "tab-transactions"
+
+# Verificar pantalla
+- assertVisible:
+    id: "transactions-screen"
+    timeout: 5000
+
+# Verificar que la lista carga
+- assertVisible:
+    id: "transaction-list"

--- a/mobile/.maestro/helpers/login.yaml
+++ b/mobile/.maestro/helpers/login.yaml
@@ -1,0 +1,16 @@
+# Helper: Login flow reutilizable
+# Uso: - runFlow: ../helpers/login.yaml
+
+appId: com.zetafinance.app
+---
+- tapOn:
+    id: "login-email-input"
+- inputText: ${EMAIL}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- assertVisible:
+    id: "dashboard-screen"
+    timeout: 10000

--- a/mobile/.maestro/helpers/logout.yaml
+++ b/mobile/.maestro/helpers/logout.yaml
@@ -1,0 +1,18 @@
+# Helper: Logout flow reutilizable
+# Uso: - runFlow: ../helpers/logout.yaml
+
+appId: com.zetafinance.app
+---
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+- scrollUntilVisible:
+    element:
+      id: "settings-logout-button"
+    direction: DOWN
+- tapOn:
+    id: "settings-logout-button"
+- assertVisible:
+    id: "login-screen"
+    timeout: 5000


### PR DESCRIPTION
Initial scaffolding for Maestro-based E2E tests on the Zeta mobile app
(Expo/React Native). Includes config, reusable helpers (login/logout),
flow templates for auth, accounts, transactions and import features,
plus a detailed TODO for phased implementation.

https://claude.ai/code/session_01Uk4oEFJoYPitN5pn5LEhPm