### PR TITLE
ci: split PR workflow into verify + publish

### DIFF
--- a/.github/workflows/pr-build-images.yml
+++ b/.github/workflows/pr-build-images.yml
@@ -1,8 +1,12 @@
-name: PR Build Images
+name: PR Build & Verify
+
+# Two concerns:
+# 1. VERIFY (every push): build check + audit — catches errors early, no GHCR push
+# 2. PUBLISH (on-demand): build + push image — only when labeled or ready for review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
     branches: [main]
     paths:
       - '.github/workflows/pr-build-images.yml'
@@ -13,6 +17,10 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'services/pdf_parser/**'
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -25,6 +33,7 @@ jobs:
     outputs:
       webapp_changed: ${{ steps.filter.outputs.webapp }}
       parser_changed: ${{ steps.filter.outputs.parser }}
+      should_publish: ${{ steps.publish-gate.outputs.should_publish }}
     steps:
       - name: Detect changed areas
         id: filter
@@ -40,10 +49,79 @@ jobs:
             parser:
               - 'services/pdf_parser/**'
 
-  build-and-push-webapp:
+      - name: Check publish gate
+        id: publish-gate
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          if echo "$PR_LABELS" | grep -q "build-image"; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_ACTION" = "ready_for_review" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─── VERIFY: runs on every push, no GHCR interaction ────────────────────────
+
+  verify-webapp:
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.webapp_changed == 'true' && github.event.pull_request.head.repo.fork == false
+    if: needs.changes.outputs.webapp_changed == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build webapp
+        run: pnpm --filter webapp build
+
+      - name: Audit (high/critical only)
+        run: pnpm audit --audit-level high || true
+
+  verify-parser:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.parser_changed == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Check parser builds
+        working-directory: services/pdf_parser
+        run: |
+          uv sync
+          uv run python -c "from main import app; print('Parser imports OK')"
+
+  # ─── PUBLISH: only when labeled or ready for review ─────────────────────────
+
+  build-and-push-webapp:
+    runs-on: ubuntu-latest
+    needs: [changes, verify-webapp]
+    if: |
+      needs.changes.outputs.should_publish == 'true' &&
+      needs.changes.outputs.webapp_changed == 'true' &&
+      github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       packages: write
@@ -97,8 +175,11 @@ jobs:
 
   build-and-push-parser:
     runs-on: ubuntu-latest
-    needs: [changes]
-    if: needs.changes.outputs.parser_changed == 'true' && github.event.pull_request.head.repo.fork == false
+    needs: [changes, verify-parser]
+    if: |
+      needs.changes.outputs.should_publish == 'true' &&
+      needs.changes.outputs.parser_changed == 'true' &&
+      github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       packages: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "zeta",
+  "packageManager": "pnpm@10.30.3",
   "engines": {
     "node": ">=20"
   },

--- a/webapp/src/app/(dashboard)/dashboard/page.tsx
+++ b/webapp/src/app/(dashboard)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+// ci: trigger verify-webapp job
 import { connection } from "next/server";
 import { Suspense } from "react";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";


### PR DESCRIPTION
## Summary

- **verify-webapp** (every PR push): `pnpm install` → `pnpm build` → `pnpm audit` — catches errors fast, zero GHCR usage
- **verify-parser** (every PR push): `uv sync` → import check
- **build-and-push-*** (on-demand only): Docker build + push to GHCR — only when `build-image` label added or PR marked ready for review
- **Concurrency group**: cancels in-progress builds for same PR

### Before
Every PR push → full Docker build + GHCR push. 5 fix pushes = 5 wasted images = egress drain.

### After
Every PR push → lightweight build check (~2 min, no GHCR). Image push only when explicitly triggered (1x per PR).

## Test plan

- [ ] Push a commit to this PR — verify `verify-webapp` runs (build + audit) but no image push
- [ ] Add `build-image` label — verify `build-and-push-webapp` runs after verify passes
- [ ] Remove label and push again — verify only verify runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)