### PR TITLE
fix(email-ingest): case-insensitive address_key lookup for Resend inb…

### DIFF
--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -123,7 +123,7 @@ export async function generateIngestAddress(): Promise<ActionResult<EmailIngestA
     .eq("user_id", user.id)
     .eq("is_active", true);
 
-  const addressKey = `u_${nanoid(8)}`;
+  const addressKey = `u_${nanoid(8)}`.toLowerCase();
 
   const { data, error } = await supabase
     .from("email_ingest_addresses")

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -194,6 +194,8 @@ export async function POST(request: NextRequest) {
   const rawBodyPreview = emailBody?.slice(0, 500) ?? null;
 
   // 3. Extract address key from recipient (e.g. "u_abc123@domain.com" → "u_abc123")
+  //    Resend lowercases the `to` on direct inbound emails, so normalize here
+  //    and use case-insensitive lookup below.
   const recipientEmail = to?.[0] ?? "";
   const addressKey = recipientEmail.split("@")[0] ?? "";
 
@@ -212,10 +214,12 @@ export async function POST(request: NextRequest) {
   const admin = createAdminClient();
 
   // 4. Look up email_ingest_addresses by address_key + is_active = true
+  //    Use case-insensitive match: Resend may lowercase the recipient address
+  //    on direct inbound delivery while the stored key retains mixed case.
   const { data: ingestAddress } = await admin
     .from("email_ingest_addresses")
     .select("id, user_id, account_id, auto_import, allowed_sender")
-    .eq("address_key", addressKey)
+    .filter("address_key", "ilike", addressKey.replace(/%/g, "\\%").replace(/_/g, "\\_"))
     .eq("is_active", true)
     .single();
 


### PR DESCRIPTION
…ound emails

Resend lowercases the `to` address on direct inbound delivery (e.g. auto-forwarded from Gmail), but preserves original case on manually forwarded emails. The webhook handler was using a case-sensitive `.eq()` lookup, so `u_zxh9weim` wouldn't match the stored `u_ZXh9weIM`.

Switch to `.filter("address_key", "ilike", ...)` with escaped wildcards for the DB lookup, and generate new address keys as lowercase to prevent the mismatch going forward.

https://claude.ai/code/session_01RUb9dZz5o35vsZqiM6duzs