### PR TITLE
feat: budget redesign, design tokens & mobile polish

### DIFF
--- a/docs/agent/PROJECT_CONTEXT.md
+++ b/docs/agent/PROJECT_CONTEXT.md
@@ -1,25 +1,25 @@
 # PROJECT_CONTEXT
 
 Auto-generated project intelligence for fast onboarding and safe edits.
-Treat this as a durable snapshot; prefer jcodemunch for live structure and symbol queries.
 
-- Generated (UTC): `2026-03-31T17:46:08.962729+00:00`
+- Generated (UTC): `2026-04-04T13:35:37.087527+00:00`
 - Project root: `/Users/cristian/Documents/developing/current-projects/zeta`
 
 ## Stack Snapshot
-- Node.js
-- Docker
+- Next.js
+- Expo/React Native
+- FastAPI
+- Supabase
 - pnpm workspace
-- pnpm
 
 ## File/Lang Distribution
-- Text files scanned: 1086
-- TypeScript/React: 296
+- Text files scanned: 1186
+- TypeScript/React: 328
 - JSON: 285
-- Markdown: 186
-- TypeScript: 174
-- HTML: 50
-- SQL: 38
+- Markdown: 205
+- TypeScript: 189
+- HTML: 73
+- SQL: 49
 - Python: 24
 - YAML: 12
 - Shell: 11
@@ -28,12 +28,12 @@ Treat this as a durable snapshot; prefer jcodemunch for live structure and symbo
 - TOML: 2
 
 ## Top-level Areas
-- webapp: 378 files
+- webapp: 425 files
 - mobile: 354 files
-- .planning: 90 files
-- docs: 66 files
-- supabase: 40 files
-- .superpowers: 37 files
+- .planning: 91 files
+- docs: 84 files
+- .superpowers: 60 files
+- supabase: 51 files
 - packages: 32 files
 - services: 24 files
 - (root): 17 files
@@ -45,7 +45,19 @@ Treat this as a durable snapshot; prefer jcodemunch for live structure and symbo
 - mockups: 2 files
 
 ## Key Commands
-### mobile (package.json)
+### root_scripts
+- `start`: `pnpm --filter mobile start`
+- `web`: `pnpm --filter webapp dev`
+- `mobile`: `pnpm --filter mobile start`
+- `ios`: `pnpm --filter mobile ios`
+- `android`: `pnpm --filter mobile android`
+- `build:web`: `pnpm --filter webapp build`
+### webapp_scripts
+- `dev`: `next dev`
+- `build`: `next build`
+- `start`: `next start`
+- `lint`: `eslint`
+### mobile_scripts
 - `start`: `expo start`
 - `android`: `expo run:android`
 - `ios`: `expo run:ios`
@@ -58,65 +70,43 @@ Treat this as a durable snapshot; prefer jcodemunch for live structure and symbo
 - `build:ios:simulator:device`: `eas build --platform ios --profile preview-ios-simulator-device`
 - `build:ios:device`: `eas build --platform ios --profile preview-ios-device`
 - `build:ios:production`: `eas build --platform ios --profile production-ios`
-### (root) (package.json)
-- `start`: `pnpm --filter mobile start`
-- `web`: `pnpm --filter webapp dev`
-- `mobile`: `pnpm --filter mobile start`
-- `ios`: `pnpm --filter mobile ios`
-- `android`: `pnpm --filter mobile android`
-- `build:web`: `pnpm --filter webapp build`
-### packages/mcp-server (package.json)
-- `build`: `tsc`
-- `dev`: `tsx src/index.ts`
-### packages/shared (package.json)
-- `test`: `vitest run`
-- `test:watch`: `vitest`
-### webapp (package.json)
-- `dev`: `next dev`
-- `build`: `next build`
-- `start`: `next start`
-- `lint`: `eslint`
 
 ## Patterns Detected
-- `app-router` (15 files): App-router style entrypoints
+- `supabase-integration` (15 files): Supabase clients/services in app code
+  - e.g. `webapp/middleware.ts`
   - e.g. `webapp/src/app/auth/callback/route.ts`
-  - e.g. `webapp/src/app/api/save-unrecognized/route.ts`
   - e.g. `webapp/src/app/api/capture/route.ts`
-- `ui-components` (15 files): Reusable UI component modules
-  - e.g. `webapp/src/components/month-selector.tsx`
-  - e.g. `webapp/src/components/ui/tabs.tsx`
-  - e.g. `webapp/src/components/ui/card.tsx`
-- `server-actions` (15 files): Server-side action modules
+- `next-app-router` (15 files): Next.js App Router pages/layouts
+  - e.g. `webapp/src/app/layout.tsx`
+  - e.g. `webapp/src/app/page.tsx`
+  - e.g. `webapp/src/app/global-error.tsx`
+- `zod-validators` (15 files): Validation layer using Zod
+  - e.g. `webapp/src/components/categories/category-zone-picker.tsx`
+  - e.g. `webapp/src/actions/recurring-templates.ts`
+  - e.g. `webapp/src/actions/profile.ts`
+- `server-actions` (15 files): Server Action handlers under webapp/src/actions
   - e.g. `webapp/src/actions/statement-snapshots.ts`
+  - e.g. `webapp/src/actions/impact-events.ts`
   - e.g. `webapp/src/actions/dashboard-config.ts`
-  - e.g. `webapp/src/actions/interest-paid.ts`
-- `data-layer` (15 files): Schemas, migrations, or database-related code
-  - e.g. `supabase/migrations/20260329050657_create_capture_tokens.sql`
-  - e.g. `supabase/migrations/20260214100003_add_transaction_is_excluded.sql`
-  - e.g. `supabase/migrations/20260227000001_add_updated_at_to_statement_snapshots.sql`
-- `tests` (14 files): Unit, integration, or e2e tests
-  - e.g. `webapp/e2e/security.spec.ts`
-  - e.g. `webapp/e2e/ux-audit.spec.ts`
-  - e.g. `webapp/e2e/auth.setup.ts`
-- `api-routes` (13 files): HTTP or API route handlers
-  - e.g. `webapp/src/app/api/save-unrecognized/route.ts`
-  - e.g. `webapp/src/app/api/capture/route.ts`
-  - e.g. `webapp/src/app/api/mcp/debts/route.ts`
-- `cli-scripts` (4 files): CLI or automation scripts
-  - e.g. `.agents/skills/codebase-context/scripts/install_git_hook.sh`
-  - e.g. `.agents/skills/codebase-context/scripts/build_context.py`
-  - e.g. `.claude/skills/codebase-context/scripts/install_git_hook.sh`
+- `expo-router` (15 files): Expo Router file-based routes
+  - e.g. `mobile/app/subscriptions.tsx`
+  - e.g. `mobile/app/annotate-screenshot.tsx`
+  - e.g. `mobile/app/purchase-decision.tsx`
+- `fastapi-service` (15 files): FastAPI service modules
+  - e.g. `services/pdf_parser/test_parser.py`
+  - e.g. `services/pdf_parser/models.py`
+  - e.g. `services/pdf_parser/storage.py`
+- `repository-pattern` (4 files): Repository pattern in mobile/lib/repositories
+  - e.g. `mobile/lib/repositories/budgets.ts`
+  - e.g. `mobile/lib/repositories/categories.ts`
+  - e.g. `mobile/lib/repositories/transactions.ts`
 
 ## Entrypoints
-- `.agents/skills/codebase-context/scripts/build_context.py`
-- `.agents/skills/codebase-context/scripts/install_git_hook.sh`
-- `.claude/skills/codebase-context/scripts/build_context.py`
-- `.claude/skills/codebase-context/scripts/install_git_hook.sh`
-- `mobile/app/(tabs)/index.tsx`
-- `packages/mcp-server/src/index.ts`
-- `packages/shared/src/index.ts`
+- `mobile/app/(auth)/_layout.tsx`
+- `mobile/app/(tabs)/_layout.tsx`
+- `mobile/app/_layout.tsx`
+- `packages/shared/src/types/domain.ts`
 - `services/pdf_parser/main.py`
-- `supabase/functions/notify-bug-report/index.ts`
 - `webapp/src/app/(auth)/forgot-password/page.tsx`
 - `webapp/src/app/(auth)/layout.tsx`
 - `webapp/src/app/(auth)/login/page.tsx`
@@ -127,6 +117,7 @@ Treat this as a durable snapshot; prefer jcodemunch for live structure and symbo
 - `webapp/src/app/(dashboard)/categories/page.tsx`
 - `webapp/src/app/(dashboard)/categorizar/page.tsx`
 - `webapp/src/app/(dashboard)/dashboard/page.tsx`
+- `webapp/src/app/(dashboard)/deseos/page.tsx`
 - `webapp/src/app/(dashboard)/destinatarios/[id]/page.tsx`
 - `webapp/src/app/(dashboard)/destinatarios/page.tsx`
 - `webapp/src/app/(dashboard)/deudas/page.tsx`
@@ -135,20 +126,44 @@ Treat this as a durable snapshot; prefer jcodemunch for live structure and symbo
 - `webapp/src/app/(dashboard)/gestionar/page.tsx`
 - `webapp/src/app/(dashboard)/import/page.tsx`
 - `webapp/src/app/(dashboard)/layout.tsx`
+- `webapp/src/app/(dashboard)/pendientes/page.tsx`
 - `webapp/src/app/(dashboard)/plan/page.tsx`
 - `webapp/src/app/(dashboard)/presupuesto/page.tsx`
 - `webapp/src/app/(dashboard)/recurrentes/page.tsx`
+- `webapp/src/app/(dashboard)/settings/analytics/page.tsx`
+- `webapp/src/app/(dashboard)/settings/page.tsx`
 
 ## Dependency Signals (Folder-level)
-- `webapp` -> `webapp` (1264)
+- `webapp` -> `webapp` (1462)
 - `mobile` -> `mobile` (1)
 
 ## Recent Changes (git status)
-- `webapp/src/app/page.tsx`
-- `MANUAL_TODOS.md`
-- `webapp/src/components/marketing/`
+- `docs/agent/PROJECT_CONTEXT.md`
+- `docs/agent/project_context.json`
+- `webapp/src/app/(dashboard)/categorizar/page.tsx`
+- `webapp/src/app/(dashboard)/deseos/page.tsx`
+- `webapp/src/app/(dashboard)/etiquetas/page.tsx`
+- `webapp/src/app/(dashboard)/gestionar/page.tsx`
+- `webapp/src/app/(dashboard)/pendientes/page.tsx`
+- `webapp/src/app/(dashboard)/plan/page.tsx`
+- `webapp/src/app/(dashboard)/transactions/page.tsx`
+- `webapp/src/components/budget/budget-page-client.tsx`
+- `webapp/src/components/budget/budget-treemap.tsx`
+- `webapp/src/components/mobile/cards/mobile-budget-ring.tsx`
+- `webapp/src/components/mobile/cards/mobile-hero-card.tsx`
+- `webapp/src/components/mobile/cards/mobile-recent-txns.tsx`
+- `webapp/src/components/mobile/cards/mobile-spending-pace.tsx`
+- `webapp/src/components/mobile/cards/mobile-upcoming-payments.tsx`
+- `webapp/src/components/mobile/mobile-dashboard-v2.tsx`
+- `webapp/src/components/mobile/mobile-page-header.tsx`
+- `webapp/src/components/tags/tag-manager.tsx`
+- `webapp/src/lib/constants/styles.ts`
+- `.planning/quick/260403-o20-design-system-audit-mobile-foundation/`
+- `docs/audios_ideas/`
+- `docs/design-system-audit-2026-04-03.md`
+- `webapp/src/components/ui/section-eyebrow.tsx`
 
 ## Agent Playbook
-- Read this file first, then use jcodemunch for live repo outline, tree, and symbol lookups.
+- Read this file first, then open only relevant folders/files.
 - Prefer paths listed under Patterns and Entrypoints for feature work.
 - Regenerate this file after non-trivial code changes.

--- a/docs/agent/project_context.json
+++ b/docs/agent/project_context.json
@@ -1,21 +1,22 @@
 {
-  "generated_at_utc": "2026-03-31T17:46:08.962729+00:00",
+  "generated_at_utc": "2026-04-04T13:35:37.087527+00:00",
   "project_root": "/Users/cristian/Documents/developing/current-projects/zeta",
   "technologies": [
-    "Node.js",
-    "Docker",
-    "pnpm workspace",
-    "pnpm"
+    "Next.js",
+    "Expo/React Native",
+    "FastAPI",
+    "Supabase",
+    "pnpm workspace"
   ],
   "totals": {
-    "text_files_scanned": 1086,
+    "text_files_scanned": 1186,
     "languages": {
-      "TypeScript/React": 296,
+      "TypeScript/React": 328,
       "JSON": 285,
-      "Markdown": 186,
-      "TypeScript": 174,
-      "HTML": 50,
-      "SQL": 38,
+      "Markdown": 205,
+      "TypeScript": 189,
+      "HTML": 73,
+      "SQL": 49,
       "Python": 24,
       "YAML": 12,
       "Shell": 11,
@@ -25,12 +26,12 @@
     }
   },
   "top_level_directories": {
-    "webapp": 378,
+    "webapp": 425,
     "mobile": 354,
-    ".planning": 90,
-    "docs": 66,
-    "supabase": 40,
-    ".superpowers": 37,
+    ".planning": 91,
+    "docs": 84,
+    ".superpowers": 60,
+    "supabase": 51,
     "packages": 32,
     "services": 24,
     "(root)": 17,
@@ -43,180 +44,44 @@
     "brand": 1,
     "test-results": 1
   },
-  "commands": [
-    {
-      "scope": "mobile",
-      "kind": "package.json",
-      "scripts": {
-        "start": "expo start",
-        "android": "expo run:android",
-        "ios": "expo run:ios",
-        "web": "expo start --web",
-        "build:aab:local": "cd android && ./gradlew bundleRelease",
-        "build:apk:local": "eas build --platform android --profile preview-local",
-        "build:apk:device": "eas build --platform android --profile preview-device",
-        "build:aab:production": "eas build --platform android --profile production-android",
-        "build:ios:simulator:local": "eas build --platform ios --profile preview-ios-simulator-local",
-        "build:ios:simulator:device": "eas build --platform ios --profile preview-ios-simulator-device",
-        "build:ios:device": "eas build --platform ios --profile preview-ios-device",
-        "build:ios:production": "eas build --platform ios --profile production-ios"
-      }
+  "commands": {
+    "root_scripts": {
+      "start": "pnpm --filter mobile start",
+      "web": "pnpm --filter webapp dev",
+      "mobile": "pnpm --filter mobile start",
+      "ios": "pnpm --filter mobile ios",
+      "android": "pnpm --filter mobile android",
+      "build:web": "pnpm --filter webapp build"
     },
-    {
-      "scope": "(root)",
-      "kind": "package.json",
-      "scripts": {
-        "start": "pnpm --filter mobile start",
-        "web": "pnpm --filter webapp dev",
-        "mobile": "pnpm --filter mobile start",
-        "ios": "pnpm --filter mobile ios",
-        "android": "pnpm --filter mobile android",
-        "build:web": "pnpm --filter webapp build"
-      }
+    "webapp_scripts": {
+      "dev": "next dev",
+      "build": "next build",
+      "start": "next start",
+      "lint": "eslint"
     },
-    {
-      "scope": "packages/mcp-server",
-      "kind": "package.json",
-      "scripts": {
-        "build": "tsc",
-        "dev": "tsx src/index.ts"
-      }
-    },
-    {
-      "scope": "packages/shared",
-      "kind": "package.json",
-      "scripts": {
-        "test": "vitest run",
-        "test:watch": "vitest"
-      }
-    },
-    {
-      "scope": "webapp",
-      "kind": "package.json",
-      "scripts": {
-        "dev": "next dev",
-        "build": "next build",
-        "start": "next start",
-        "lint": "eslint"
-      }
+    "mobile_scripts": {
+      "start": "expo start",
+      "android": "expo run:android",
+      "ios": "expo run:ios",
+      "web": "expo start --web",
+      "build:aab:local": "cd android && ./gradlew bundleRelease",
+      "build:apk:local": "eas build --platform android --profile preview-local",
+      "build:apk:device": "eas build --platform android --profile preview-device",
+      "build:aab:production": "eas build --platform android --profile production-android",
+      "build:ios:simulator:local": "eas build --platform ios --profile preview-ios-simulator-local",
+      "build:ios:simulator:device": "eas build --platform ios --profile preview-ios-simulator-device",
+      "build:ios:device": "eas build --platform ios --profile preview-ios-device",
+      "build:ios:production": "eas build --platform ios --profile production-ios"
     }
-  ],
+  },
   "patterns": [
     {
-      "name": "app-router",
-      "description": "App-router style entrypoints",
+      "name": "supabase-integration",
+      "description": "Supabase clients/services in app code",
       "matched_files": 15,
       "examples": [
+        "webapp/middleware.ts",
         "webapp/src/app/auth/callback/route.ts",
-        "webapp/src/app/api/save-unrecognized/route.ts",
-        "webapp/src/app/api/capture/route.ts",
-        "webapp/src/app/api/mcp/debts/route.ts",
-        "webapp/src/app/api/mcp/transactions/route.ts",
-        "webapp/src/app/api/mcp/accounts/route.ts",
-        "webapp/src/app/api/mcp/budgets/route.ts",
-        "webapp/src/app/api/mcp/summary/route.ts",
-        "webapp/src/app/api/bug-reports/route.ts",
-        "webapp/src/app/api/parse-statement/route.ts",
-        "webapp/src/app/api/webhooks/telegram/route.ts",
-        "webapp/src/app/api/webhooks/telegram/setup/route.ts",
-        "webapp/src/app/(auth)/layout.tsx",
-        "webapp/src/app/(auth)/signup/page.tsx",
-        "webapp/src/app/(auth)/forgot-password/page.tsx"
-      ]
-    },
-    {
-      "name": "ui-components",
-      "description": "Reusable UI component modules",
-      "matched_files": 15,
-      "examples": [
-        "webapp/src/components/month-selector.tsx",
-        "webapp/src/components/ui/tabs.tsx",
-        "webapp/src/components/ui/card.tsx",
-        "webapp/src/components/ui/popover.tsx",
-        "webapp/src/components/ui/progress.tsx",
-        "webapp/src/components/ui/chart.tsx",
-        "webapp/src/components/ui/sheet.tsx",
-        "webapp/src/components/ui/prefetch-link.tsx",
-        "webapp/src/components/ui/summary-card.tsx",
-        "webapp/src/components/ui/label.tsx",
-        "webapp/src/components/ui/sonner.tsx",
-        "webapp/src/components/ui/drawer.tsx",
-        "webapp/src/components/ui/tooltip.tsx",
-        "webapp/src/components/ui/alert.tsx",
-        "webapp/src/components/ui/switch.tsx"
-      ]
-    },
-    {
-      "name": "server-actions",
-      "description": "Server-side action modules",
-      "matched_files": 15,
-      "examples": [
-        "webapp/src/actions/statement-snapshots.ts",
-        "webapp/src/actions/dashboard-config.ts",
-        "webapp/src/actions/interest-paid.ts",
-        "webapp/src/actions/recurring-templates.ts",
-        "webapp/src/actions/debt.ts",
-        "webapp/src/actions/categorize.ts",
-        "webapp/src/actions/product-events.ts",
-        "webapp/src/actions/budgets.ts",
-        "webapp/src/actions/allocation.ts",
-        "webapp/src/actions/payment-reminders.ts",
-        "webapp/src/actions/exchange-rate.ts",
-        "webapp/src/actions/quick-view.ts",
-        "webapp/src/actions/debt-snapshots.ts",
-        "webapp/src/actions/spending-heatmap.ts",
-        "webapp/src/actions/import-transactions.ts"
-      ]
-    },
-    {
-      "name": "data-layer",
-      "description": "Schemas, migrations, or database-related code",
-      "matched_files": 15,
-      "examples": [
-        "supabase/migrations/20260329050657_create_capture_tokens.sql",
-        "supabase/migrations/20260214100003_add_transaction_is_excluded.sql",
-        "supabase/migrations/20260227000001_add_updated_at_to_statement_snapshots.sql",
-        "supabase/migrations/20260214100001_seed_categories.sql",
-        "supabase/migrations/20260223030329_create_category_rules.sql",
-        "supabase/migrations/20260220222726_add_onboarding_fields.sql",
-        "supabase/migrations/20260214034921_add_account_specialized_fields.sql",
-        "supabase/migrations/20260227100000_add_github_issue_url_to_bug_reports.sql",
-        "supabase/migrations/20260318113717_fix_budgets_rls_parenthesized.sql",
-        "supabase/migrations/20260330002608_add_budget_mode.sql",
-        "supabase/migrations/20260223232146_add_installment_columns.sql",
-        "supabase/migrations/20260225204500_create_product_event_analytics_views.sql",
-        "supabase/migrations/20260227000000_enable_rls_core_tables.sql",
-        "supabase/migrations/20260223030254_reorganize_category_groups.sql",
-        "supabase/migrations/20260220211240_create_budgets.sql"
-      ]
-    },
-    {
-      "name": "tests",
-      "description": "Unit, integration, or e2e tests",
-      "matched_files": 14,
-      "examples": [
-        "webapp/e2e/security.spec.ts",
-        "webapp/e2e/ux-audit.spec.ts",
-        "webapp/e2e/auth.setup.ts",
-        "webapp/e2e/mobile-keyboard.spec.ts",
-        "webapp/e2e/mobile-redesign.spec.ts",
-        "webapp/src/lib/utils/__tests__/zone-colors.test.ts",
-        "webapp/src/lib/utils/__tests__/dashboard.test.ts",
-        "webapp/src/lib/utils/__tests__/account-balance.test.ts",
-        "webapp/src/lib/utils/__tests__/category-suggestion.test.ts",
-        "packages/shared/src/utils/__tests__/helpers.ts",
-        "packages/shared/src/utils/__tests__/auto-categorize.test.ts",
-        "packages/shared/src/utils/__tests__/debt.test.ts",
-        "packages/shared/src/utils/__tests__/scenario-engine.test.ts",
-        "packages/shared/src/utils/__tests__/debt-simulator.test.ts"
-      ]
-    },
-    {
-      "name": "api-routes",
-      "description": "HTTP or API route handlers",
-      "matched_files": 13,
-      "examples": [
-        "webapp/src/app/api/save-unrecognized/route.ts",
         "webapp/src/app/api/capture/route.ts",
         "webapp/src/app/api/mcp/debts/route.ts",
         "webapp/src/app/api/mcp/transactions/route.ts",
@@ -227,32 +92,139 @@
         "webapp/src/app/api/_shared/capture-auth.ts",
         "webapp/src/app/api/_shared/auth.ts",
         "webapp/src/app/api/parse-statement/route.ts",
+        "webapp/src/app/api/webhooks/email-ingest/route.ts",
         "webapp/src/app/api/webhooks/telegram/route.ts",
-        "webapp/src/app/api/webhooks/telegram/setup/route.ts"
+        "webapp/src/app/(dashboard)/layout.tsx"
       ]
     },
     {
-      "name": "cli-scripts",
-      "description": "CLI or automation scripts",
+      "name": "next-app-router",
+      "description": "Next.js App Router pages/layouts",
+      "matched_files": 15,
+      "examples": [
+        "webapp/src/app/layout.tsx",
+        "webapp/src/app/page.tsx",
+        "webapp/src/app/global-error.tsx",
+        "webapp/src/app/not-found.tsx",
+        "webapp/src/app/auth/callback/route.ts",
+        "webapp/src/app/api/save-unrecognized/route.ts",
+        "webapp/src/app/api/capture/route.ts",
+        "webapp/src/app/api/mcp/debts/route.ts",
+        "webapp/src/app/api/mcp/transactions/route.ts",
+        "webapp/src/app/api/mcp/accounts/route.ts",
+        "webapp/src/app/api/mcp/budgets/route.ts",
+        "webapp/src/app/api/mcp/summary/route.ts",
+        "webapp/src/app/api/bug-reports/route.ts",
+        "webapp/src/app/api/_shared/capture-auth.ts",
+        "webapp/src/app/api/_shared/auth.ts"
+      ]
+    },
+    {
+      "name": "zod-validators",
+      "description": "Validation layer using Zod",
+      "matched_files": 15,
+      "examples": [
+        "webapp/src/components/categories/category-zone-picker.tsx",
+        "webapp/src/actions/recurring-templates.ts",
+        "webapp/src/actions/profile.ts",
+        "webapp/src/actions/purchase-decision.ts",
+        "webapp/src/lib/validators/account.ts",
+        "webapp/src/lib/validators/dashboard-config.ts",
+        "webapp/src/lib/validators/category.ts",
+        "webapp/src/lib/validators/scenario.ts",
+        "webapp/src/lib/validators/shared.ts",
+        "webapp/src/lib/validators/wishlist.ts",
+        "webapp/src/lib/validators/reminders.ts",
+        "webapp/src/lib/validators/destinatario.ts",
+        "webapp/src/lib/validators/transaction.ts",
+        "webapp/src/lib/validators/budget.ts",
+        "webapp/src/lib/validators/recurring-template.ts"
+      ]
+    },
+    {
+      "name": "server-actions",
+      "description": "Server Action handlers under webapp/src/actions",
+      "matched_files": 15,
+      "examples": [
+        "webapp/src/actions/statement-snapshots.ts",
+        "webapp/src/actions/impact-events.ts",
+        "webapp/src/actions/dashboard-config.ts",
+        "webapp/src/actions/interest-paid.ts",
+        "webapp/src/actions/email-ingest.ts",
+        "webapp/src/actions/recurring-templates.ts",
+        "webapp/src/actions/debt.ts",
+        "webapp/src/actions/categorize.ts",
+        "webapp/src/actions/product-events.ts",
+        "webapp/src/actions/budgets.ts",
+        "webapp/src/actions/allocation.ts",
+        "webapp/src/actions/payment-reminders.ts",
+        "webapp/src/actions/exchange-rate.ts",
+        "webapp/src/actions/quick-view.ts",
+        "webapp/src/actions/debt-snapshots.ts"
+      ]
+    },
+    {
+      "name": "expo-router",
+      "description": "Expo Router file-based routes",
+      "matched_files": 15,
+      "examples": [
+        "mobile/app/subscriptions.tsx",
+        "mobile/app/annotate-screenshot.tsx",
+        "mobile/app/purchase-decision.tsx",
+        "mobile/app/+not-found.tsx",
+        "mobile/app/onboarding.tsx",
+        "mobile/app/_layout.tsx",
+        "mobile/app/bug-report.tsx",
+        "mobile/app/modal.tsx",
+        "mobile/app/+html.tsx",
+        "mobile/app/capture.tsx",
+        "mobile/app/transaction/[id].tsx",
+        "mobile/app/(tabs)/settings.tsx",
+        "mobile/app/(tabs)/index.tsx",
+        "mobile/app/(tabs)/import.tsx",
+        "mobile/app/(tabs)/transactions.tsx"
+      ]
+    },
+    {
+      "name": "fastapi-service",
+      "description": "FastAPI service modules",
+      "matched_files": 15,
+      "examples": [
+        "services/pdf_parser/test_parser.py",
+        "services/pdf_parser/models.py",
+        "services/pdf_parser/storage.py",
+        "services/pdf_parser/main.py",
+        "services/pdf_parser/parsers/davivienda_loan.py",
+        "services/pdf_parser/parsers/nequi_savings.py",
+        "services/pdf_parser/parsers/lulo_loan.py",
+        "services/pdf_parser/parsers/bogota_loan.py",
+        "services/pdf_parser/parsers/bancolombia_loan.py",
+        "services/pdf_parser/parsers/falabella_credit_card.py",
+        "services/pdf_parser/parsers/opendataloader_fallback.py",
+        "services/pdf_parser/parsers/popular_credit_card.py",
+        "services/pdf_parser/parsers/__init__.py",
+        "services/pdf_parser/parsers/bancolombia_savings.py",
+        "services/pdf_parser/parsers/utils.py"
+      ]
+    },
+    {
+      "name": "repository-pattern",
+      "description": "Repository pattern in mobile/lib/repositories",
       "matched_files": 4,
       "examples": [
-        ".agents/skills/codebase-context/scripts/install_git_hook.sh",
-        ".agents/skills/codebase-context/scripts/build_context.py",
-        ".claude/skills/codebase-context/scripts/install_git_hook.sh",
-        ".claude/skills/codebase-context/scripts/build_context.py"
+        "mobile/lib/repositories/budgets.ts",
+        "mobile/lib/repositories/categories.ts",
+        "mobile/lib/repositories/transactions.ts",
+        "mobile/lib/repositories/accounts.ts"
       ]
     }
   ],
   "entrypoints": [
-    ".agents/skills/codebase-context/scripts/build_context.py",
-    ".agents/skills/codebase-context/scripts/install_git_hook.sh",
-    ".claude/skills/codebase-context/scripts/build_context.py",
-    ".claude/skills/codebase-context/scripts/install_git_hook.sh",
-    "mobile/app/(tabs)/index.tsx",
-    "packages/mcp-server/src/index.ts",
-    "packages/shared/src/index.ts",
+    "mobile/app/(auth)/_layout.tsx",
+    "mobile/app/(tabs)/_layout.tsx",
+    "mobile/app/_layout.tsx",
+    "packages/shared/src/types/domain.ts",
     "services/pdf_parser/main.py",
-    "supabase/functions/notify-bug-report/index.ts",
     "webapp/src/app/(auth)/forgot-password/page.tsx",
     "webapp/src/app/(auth)/layout.tsx",
     "webapp/src/app/(auth)/login/page.tsx",
@@ -263,6 +235,7 @@
     "webapp/src/app/(dashboard)/categories/page.tsx",
     "webapp/src/app/(dashboard)/categorizar/page.tsx",
     "webapp/src/app/(dashboard)/dashboard/page.tsx",
+    "webapp/src/app/(dashboard)/deseos/page.tsx",
     "webapp/src/app/(dashboard)/destinatarios/[id]/page.tsx",
     "webapp/src/app/(dashboard)/destinatarios/page.tsx",
     "webapp/src/app/(dashboard)/deudas/page.tsx",
@@ -271,6 +244,7 @@
     "webapp/src/app/(dashboard)/gestionar/page.tsx",
     "webapp/src/app/(dashboard)/import/page.tsx",
     "webapp/src/app/(dashboard)/layout.tsx",
+    "webapp/src/app/(dashboard)/pendientes/page.tsx",
     "webapp/src/app/(dashboard)/plan/page.tsx",
     "webapp/src/app/(dashboard)/presupuesto/page.tsx",
     "webapp/src/app/(dashboard)/recurrentes/page.tsx",
@@ -278,8 +252,6 @@
     "webapp/src/app/(dashboard)/settings/page.tsx",
     "webapp/src/app/(dashboard)/transactions/[id]/page.tsx",
     "webapp/src/app/(dashboard)/transactions/page.tsx",
-    "webapp/src/app/api/_shared/auth.ts",
-    "webapp/src/app/api/_shared/capture-auth.ts",
     "webapp/src/app/api/bug-reports/route.ts",
     "webapp/src/app/api/capture/route.ts",
     "webapp/src/app/api/mcp/accounts/route.ts",
@@ -289,18 +261,22 @@
     "webapp/src/app/api/mcp/transactions/route.ts",
     "webapp/src/app/api/parse-statement/route.ts",
     "webapp/src/app/api/save-unrecognized/route.ts",
+    "webapp/src/app/api/webhooks/email-ingest/route.ts",
     "webapp/src/app/api/webhooks/telegram/route.ts",
     "webapp/src/app/api/webhooks/telegram/setup/route.ts",
     "webapp/src/app/auth/callback/route.ts",
+    "webapp/src/app/layout.tsx",
     "webapp/src/app/onboarding/layout.tsx",
     "webapp/src/app/onboarding/page.tsx",
-    "webapp/src/lib/supabase/server.ts"
+    "webapp/src/app/page.tsx",
+    "webapp/src/components/marketing/landing-page.tsx",
+    "webapp/src/types/domain.ts"
   ],
   "dependency_edges": [
     {
       "from": "webapp",
       "to": "webapp",
-      "count": 1264
+      "count": 1462
     },
     {
       "from": "mobile",
@@ -309,8 +285,29 @@
     }
   ],
   "recent_changes": [
-    "webapp/src/app/page.tsx",
-    "MANUAL_TODOS.md",
-    "webapp/src/components/marketing/"
+    "docs/agent/PROJECT_CONTEXT.md",
+    "docs/agent/project_context.json",
+    "webapp/src/app/(dashboard)/categorizar/page.tsx",
+    "webapp/src/app/(dashboard)/deseos/page.tsx",
+    "webapp/src/app/(dashboard)/etiquetas/page.tsx",
+    "webapp/src/app/(dashboard)/gestionar/page.tsx",
+    "webapp/src/app/(dashboard)/pendientes/page.tsx",
+    "webapp/src/app/(dashboard)/plan/page.tsx",
+    "webapp/src/app/(dashboard)/transactions/page.tsx",
+    "webapp/src/components/budget/budget-page-client.tsx",
+    "webapp/src/components/budget/budget-treemap.tsx",
+    "webapp/src/components/mobile/cards/mobile-budget-ring.tsx",
+    "webapp/src/components/mobile/cards/mobile-hero-card.tsx",
+    "webapp/src/components/mobile/cards/mobile-recent-txns.tsx",
+    "webapp/src/components/mobile/cards/mobile-spending-pace.tsx",
+    "webapp/src/components/mobile/cards/mobile-upcoming-payments.tsx",
+    "webapp/src/components/mobile/mobile-dashboard-v2.tsx",
+    "webapp/src/components/mobile/mobile-page-header.tsx",
+    "webapp/src/components/tags/tag-manager.tsx",
+    "webapp/src/lib/constants/styles.ts",
+    ".planning/quick/260403-o20-design-system-audit-mobile-foundation/",
+    "docs/audios_ideas/",
+    "docs/design-system-audit-2026-04-03.md",
+    "webapp/src/components/ui/section-eyebrow.tsx"
   ]
 }

--- a/docs/design-system-audit-2026-04-03.md
+++ b/docs/design-system-audit-2026-04-03.md
@@ -1,0 +1,78 @@
+# Design System Audit - 2026-04-03
+
+## Reference
+
+- Primary benchmark: the debt redesign merged on `origin/main`
+- Use it for: page hierarchy, section eyebrows, condensed summary cards, panel surfaces, spacing rhythm, and token discipline
+- Do not copy: the debt page expanded-detail interaction or its heavier reveal pattern
+
+## Shared Primitives
+
+- `PAGE_STACK_CLASS`: consistent vertical rhythm for page shells
+- `SECTION_EYEBROW_CLASS` + `SectionEyebrow`: one eyebrow style across dashboard pages
+- `PANEL_SURFACE_CLASS`: standard elevated summary surface
+- `PANEL_SURFACE_SUBTLE_CLASS`: lighter elevated surface for nested/hero-adjacent content
+- `PANEL_INSET_CLASS`: compact inset tile surface
+- `PANEL_INSET_INTERACTIVE_CLASS`: hoverable inset tile surface
+- `GHOST_BUTTON_CLASS` and `BRASS_BUTTON_CLASS`: standardized secondary and primary actions
+
+## Audit Snapshot
+
+### Strong Reference Pages
+
+- `/deudas`
+- `/deudas/planificador`
+- `/import`
+- `/transactions/[id]`
+- `/accounts/[id]`
+- `/settings/analytics`
+
+These already carry the clearest version of the current system: strong headers, cleaner information density, and better desktop/mobile translation.
+
+### Normalized In This Pass
+
+- `/plan`
+- `/categorizar`
+- `/deseos`
+- `/etiquetas`
+- `/pendientes`
+- `/gestionar`
+- `webapp/src/components/tags/tag-manager.tsx`
+- budget/mobile shell surfaces in:
+  - `webapp/src/components/budget/budget-page-client.tsx`
+  - `webapp/src/components/budget/budget-treemap.tsx`
+  - `webapp/src/components/mobile/cards/*`
+
+Changes focused on shell consistency, not feature rewrites:
+
+- unified eyebrow and title rhythm
+- tokenized panel surfaces instead of page-local backgrounds
+- standardized mobile page header treatment
+- reduced one-off utility styling in small cards and management panels
+
+### Partial Alignment / Next Candidates
+
+- `/dashboard`
+- `/accounts`
+- `/categories`
+- `/transactions`
+- `/destinatarios`
+- `/recurrentes`
+
+These are already closer to the target system, but they still contain page-local surfaces or older secondary card treatments that should be folded into the same primitives over time.
+
+## Mobile Findings
+
+- Fixed undefined token usage:
+  - `text-z-sage-lightest`
+  - `bg-z-bg`
+- Replaced multiple ad-hoc mobile surfaces with shared inset or elevated panels
+- Tightened the mobile page-header pattern so deeper routes no longer invent their own top spacing or back-button styling
+
+## Design Rules Going Forward
+
+1. Every page needs a clear eyebrow, title, and one-sentence framing before detail.
+2. Summary state should be compact and scannable; detail state should stay quieter than the debt-page expansion.
+3. Mobile surfaces should come from shared tokens first, not page-local `bg-*` or hardcoded hex values.
+4. Deep utility pages should use `MobilePageHeader` plus the same shell rhythm as strategic pages.
+5. New dashboard work should reuse the shared panel classes before adding another custom card treatment.

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -43,7 +43,7 @@ export type TransactionPreview = {
 
 export interface PatternTestResult {
   matchCount: number;
-  samples: { id: string; rawDescription: string; date: string; amount: number }[];
+  samples: { id: string; rawDescription: string; date: string; amount: number; currencyCode: string }[];
 }
 
 export async function testDestinatarioPattern(
@@ -56,7 +56,7 @@ export async function testDestinatarioPattern(
   // Use server-side filtering via ilike instead of fetching 1000 rows
   let query = supabase
     .from("transactions")
-    .select("id, raw_description, transaction_date, amount")
+    .select("id, raw_description, transaction_date, amount, currency_code")
     .eq("user_id", user.id)
     .is("destinatario_id", null)
     .not("raw_description", "is", null);
@@ -84,6 +84,7 @@ export async function testDestinatarioPattern(
         rawDescription: tx.raw_description!,
         date: tx.transaction_date,
         amount: tx.amount,
+        currencyCode: tx.currency_code,
       })),
     },
   };

--- a/webapp/src/app/(dashboard)/categorizar/page.tsx
+++ b/webapp/src/app/(dashboard)/categorizar/page.tsx
@@ -145,7 +145,7 @@ export default async function CategorizarPage() {
               </p>
             </CardHeader>
             <CardContent className="grid gap-3 sm:grid-cols-3">
-              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <div className={`${PANEL_INSET_CLASS} p-4`}>
                 <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   <Inbox className="size-4 text-z-alert" />
                   Sin categoría
@@ -153,7 +153,7 @@ export default async function CategorizarPage() {
                 <p className="mt-2 text-2xl font-semibold">{uncategorizedCount}</p>
                 <p className="mt-1 text-xs text-muted-foreground">movimientos pendientes</p>
               </div>
-              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <div className={`${PANEL_INSET_CLASS} p-4`}>
                 <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   <ShieldCheck className="size-4 text-z-brass" />
                   Auto-review
@@ -161,7 +161,7 @@ export default async function CategorizarPage() {
                 <p className="mt-2 text-2xl font-semibold">{autoReviewCount}</p>
                 <p className="mt-1 text-xs text-muted-foreground">sugerencias por validar</p>
               </div>
-              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <div className={`${PANEL_INSET_CLASS} p-4`}>
                 <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   <Tags className="size-4 text-z-sage-dark" />
                   Reglas activas
@@ -179,7 +179,7 @@ export default async function CategorizarPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <p className="text-sm leading-6 text-muted-foreground">{actionCard.body}</p>
-              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <div className={`${PANEL_INSET_CLASS} p-4`}>
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Qué cuida esta bandeja</p>
                 <p className="mt-2 text-sm text-muted-foreground">
                   Si limpias esta cola, el presupuesto deja de subestimar ruido, Plan deja de reaccionar tarde y las reglas automáticas aprenden con menos fricción.

--- a/webapp/src/app/(dashboard)/categorizar/page.tsx
+++ b/webapp/src/app/(dashboard)/categorizar/page.tsx
@@ -5,10 +5,17 @@ import { getCategories } from "@/actions/categories";
 import { getTagGroups } from "@/actions/tags";
 import { MobilePageHeader } from "@/components/mobile/mobile-page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ArrowRight, Inbox, ShieldCheck, Tags } from "lucide-react";
-import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import {
+  BRASS_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+  PAGE_STACK_CLASS,
+  PANEL_INSET_CLASS,
+  PANEL_SURFACE_CLASS,
+} from "@/lib/constants/styles";
 
 const CategoryInbox = dynamic(
   () => import("@/components/categorize/category-inbox").then((m) => ({ default: m.CategoryInbox })),
@@ -55,14 +62,12 @@ export default async function CategorizarPage() {
         };
 
   return (
-    <div className="space-y-6">
+    <div className={PAGE_STACK_CLASS}>
       <MobilePageHeader title="Categorizar" backHref="/gestionar" />
 
       <div className="space-y-4 lg:hidden">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-            Categorizar
-          </p>
+          <SectionEyebrow>Categorizar</SectionEyebrow>
           <div>
             <h1 className="text-2xl font-semibold">Tu bandeja de orden operativo</h1>
             <p className="text-sm text-muted-foreground">
@@ -71,25 +76,23 @@ export default async function CategorizarPage() {
           </div>
         </div>
 
-        <Card className="border-white/6 bg-z-surface-2/80 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+        <Card className={PANEL_SURFACE_CLASS}>
           <CardHeader className="space-y-2 pb-3">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-              {actionCard.eyebrow}
-            </p>
+            <SectionEyebrow>{actionCard.eyebrow}</SectionEyebrow>
             <CardTitle className="text-lg leading-tight">{actionCard.title}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <p className="text-sm leading-6 text-muted-foreground">{actionCard.body}</p>
             <div className="grid grid-cols-3 gap-2 text-center">
-              <div className="rounded-xl border border-white/6 bg-black/10 px-3 py-3">
+              <div className={`${PANEL_INSET_CLASS} px-3 py-3`}>
                 <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Inbox</p>
                 <p className="mt-1 text-lg font-semibold">{uncategorizedCount}</p>
               </div>
-              <div className="rounded-xl border border-white/6 bg-black/10 px-3 py-3">
+              <div className={`${PANEL_INSET_CLASS} px-3 py-3`}>
                 <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Auto</p>
                 <p className="mt-1 text-lg font-semibold">{autoReviewCount}</p>
               </div>
-              <div className="rounded-xl border border-white/6 bg-black/10 px-3 py-3">
+              <div className={`${PANEL_INSET_CLASS} px-3 py-3`}>
                 <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Reglas</p>
                 <p className="mt-1 text-lg font-semibold">{suggestedRulesCount}</p>
               </div>
@@ -107,9 +110,7 @@ export default async function CategorizarPage() {
       <div className="hidden lg:block space-y-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="max-w-2xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-              Categorizar
-            </p>
+            <SectionEyebrow>Categorizar</SectionEyebrow>
             <h1 className="text-3xl font-semibold tracking-tight">Tu bandeja de orden operativo</h1>
             <p className="text-muted-foreground">
               Asigna criterio al detalle crudo para que presupuesto, destinatarios y plan partan de una base confiable.
@@ -133,11 +134,9 @@ export default async function CategorizarPage() {
         </div>
 
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_24rem]">
-          <Card className="border-white/6 bg-z-surface-2/80 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <Card className={PANEL_SURFACE_CLASS}>
             <CardHeader className="space-y-2">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                Vista actual
-              </p>
+              <SectionEyebrow>Vista actual</SectionEyebrow>
               <CardTitle className="text-2xl leading-tight">
                 La categoría correcta vale más que otro gráfico bonito
               </CardTitle>
@@ -146,7 +145,7 @@ export default async function CategorizarPage() {
               </p>
             </CardHeader>
             <CardContent className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
+              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
                 <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   <Inbox className="size-4 text-z-alert" />
                   Sin categoría
@@ -154,7 +153,7 @@ export default async function CategorizarPage() {
                 <p className="mt-2 text-2xl font-semibold">{uncategorizedCount}</p>
                 <p className="mt-1 text-xs text-muted-foreground">movimientos pendientes</p>
               </div>
-              <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
+              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
                 <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   <ShieldCheck className="size-4 text-z-brass" />
                   Auto-review
@@ -162,7 +161,7 @@ export default async function CategorizarPage() {
                 <p className="mt-2 text-2xl font-semibold">{autoReviewCount}</p>
                 <p className="mt-1 text-xs text-muted-foreground">sugerencias por validar</p>
               </div>
-              <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
+              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
                 <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   <Tags className="size-4 text-z-sage-dark" />
                   Reglas activas
@@ -173,16 +172,14 @@ export default async function CategorizarPage() {
             </CardContent>
           </Card>
 
-          <Card className="border-white/6 bg-z-surface-2/80 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <Card className={PANEL_SURFACE_CLASS}>
             <CardHeader className="space-y-2 pb-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                {actionCard.eyebrow}
-              </p>
+              <SectionEyebrow>{actionCard.eyebrow}</SectionEyebrow>
               <CardTitle className="text-xl leading-tight">{actionCard.title}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <p className="text-sm leading-6 text-muted-foreground">{actionCard.body}</p>
-              <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
+              <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Qué cuida esta bandeja</p>
                 <p className="mt-2 text-sm text-muted-foreground">
                   Si limpias esta cola, el presupuesto deja de subestimar ruido, Plan deja de reaccionar tarde y las reglas automáticas aprenden con menos fricción.

--- a/webapp/src/app/(dashboard)/deseos/page.tsx
+++ b/webapp/src/app/(dashboard)/deseos/page.tsx
@@ -8,6 +8,9 @@ import {
 import { getAccounts } from "@/actions/accounts";
 import { getPreferredCurrency } from "@/actions/profile";
 import { DeseosList } from "@/components/deseos/deseos-list";
+import { MobilePageHeader } from "@/components/mobile/mobile-page-header";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 
 export default async function DeseosPage() {
   await connection();
@@ -25,20 +28,29 @@ export default async function DeseosPage() {
   const accounts = accountsResult.success ? accountsResult.data : [];
 
   return (
-    <div className="space-y-6">
-      <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-          Plan
-        </p>
+    <div className={PAGE_STACK_CLASS}>
+      <MobilePageHeader title="Deseos" backHref="/plan" />
+
+      <div className="space-y-1 lg:hidden">
+        <SectionEyebrow>Plan</SectionEyebrow>
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight lg:text-3xl">
-            Deseos
-          </h1>
-          <p className="text-sm text-muted-foreground lg:text-base">
+          <h1 className="text-2xl font-semibold tracking-tight">Deseos</h1>
+          <p className="text-sm text-muted-foreground">
             Lo que quieres comprar, evaluado contra tu realidad financiera
           </p>
         </div>
       </div>
+
+      <div className="hidden lg:block space-y-1">
+        <SectionEyebrow>Plan</SectionEyebrow>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Deseos</h1>
+          <p className="text-muted-foreground">
+            Lo que quieres comprar, evaluado contra tu realidad financiera
+          </p>
+        </div>
+      </div>
+
       <DeseosList
         items={items}
         nudges={nudges}

--- a/webapp/src/app/(dashboard)/etiquetas/page.tsx
+++ b/webapp/src/app/(dashboard)/etiquetas/page.tsx
@@ -1,23 +1,52 @@
 import { connection } from "next/server";
 import { getTagGroups } from "@/actions/tags";
+import { MobilePageHeader } from "@/components/mobile/mobile-page-header";
 import { TagManager } from "@/components/tags/tag-manager";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 
 export default async function EtiquetasPage() {
   await connection();
   const result = await getTagGroups();
 
+  const pageHeader = (
+    <>
+      <MobilePageHeader title="Etiquetas" backHref="/gestionar" />
+
+      <div className="space-y-1 lg:hidden">
+        <SectionEyebrow>Etiquetas</SectionEyebrow>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Ordena tu lenguaje común</h1>
+          <p className="text-sm text-muted-foreground">
+            Organiza etiquetas en grupos para anotar transacciones, destinatarios y categorías.
+          </p>
+        </div>
+      </div>
+
+      <div className="hidden lg:block space-y-1">
+        <SectionEyebrow>Etiquetas</SectionEyebrow>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Ordena tu lenguaje común</h1>
+          <p className="text-muted-foreground">
+            Organiza etiquetas en grupos para anotar transacciones, destinatarios y categorías.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+
   if (!result.success) {
-    return <p className="p-6 text-destructive">{result.error}</p>;
+    return (
+      <div className={`mx-auto max-w-2xl ${PAGE_STACK_CLASS}`}>
+        {pageHeader}
+        <p className="text-destructive">{result.error}</p>
+      </div>
+    );
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 p-6">
-      <div>
-        <h1 className="text-2xl font-bold">Etiquetas</h1>
-        <p className="text-sm text-muted-foreground">
-          Organiza etiquetas en grupos para anotar transacciones, destinatarios y categorías.
-        </p>
-      </div>
+    <div className={`mx-auto max-w-2xl ${PAGE_STACK_CLASS}`}>
+      {pageHeader}
       <TagManager tagGroups={result.data} />
     </div>
   );

--- a/webapp/src/app/(dashboard)/gestionar/page.tsx
+++ b/webapp/src/app/(dashboard)/gestionar/page.tsx
@@ -1,30 +1,35 @@
 import { connection } from "next/server";
 import { getAttentionSnapshot } from "@/actions/attention";
 import { PageHeaderRow } from "@/components/ui/page-header-row";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { AttentionHub } from "@/components/gestionar/attention-hub";
 import { MobileLinkGrid } from "@/components/mobile/mobile-link-grid";
 import { MobilePageHeader } from "@/components/mobile/mobile-page-header";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 
 export default async function BandejaPage() {
   await connection();
   const snapshot = await getAttentionSnapshot();
 
   return (
-    <div className="space-y-6">
+    <div className={PAGE_STACK_CLASS}>
       <MobilePageHeader title="Bandeja" />
 
       {/* Desktop */}
       <div className="hidden lg:block space-y-6">
-        <PageHeaderRow
-          title="Bandeja"
-          subtitle={
-            snapshot.totalAction > 0
-              ? `${snapshot.totalAction} pendientes`
-              : snapshot.totalSuggestion > 0
-                ? `${snapshot.totalSuggestion} sugerencias`
-                : "Todo al día"
-          }
-        />
+        <div className="space-y-1">
+          <SectionEyebrow>Gestionar</SectionEyebrow>
+          <PageHeaderRow
+            title="Bandeja"
+            subtitle={
+              snapshot.totalAction > 0
+                ? `${snapshot.totalAction} pendientes`
+                : snapshot.totalSuggestion > 0
+                  ? `${snapshot.totalSuggestion} sugerencias`
+                  : "Todo al día"
+            }
+          />
+        </div>
         <AttentionHub signals={snapshot.signals} />
       </div>
 
@@ -32,9 +37,7 @@ export default async function BandejaPage() {
       <div className="lg:hidden space-y-6">
         <AttentionHub signals={snapshot.signals} />
         <div className="space-y-3">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            Ir a
-          </p>
+          <SectionEyebrow>Ir a</SectionEyebrow>
           <MobileLinkGrid />
         </div>
       </div>

--- a/webapp/src/app/(dashboard)/pendientes/page.tsx
+++ b/webapp/src/app/(dashboard)/pendientes/page.tsx
@@ -2,6 +2,8 @@ import { connection } from "next/server";
 import { getReminders } from "@/actions/reminders";
 import { RemindersList } from "@/components/reminders/reminders-list";
 import { MobilePageHeader } from "@/components/mobile/mobile-page-header";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 
 export default async function PendientesPage() {
   await connection();
@@ -13,13 +15,11 @@ export default async function PendientesPage() {
   const recentCompleted = completed.slice(0, 10);
 
   return (
-    <div className="space-y-6">
+    <div className={PAGE_STACK_CLASS}>
       <MobilePageHeader title="Pendientes" backHref="/dashboard" />
 
       <div className="hidden lg:block space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-          Pendientes
-        </p>
+        <SectionEyebrow>Pendientes</SectionEyebrow>
         <h1 className="text-3xl font-semibold tracking-tight">
           Tu lista de pendientes financieros
         </h1>
@@ -29,9 +29,7 @@ export default async function PendientesPage() {
       </div>
 
       <div className="lg:hidden space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-          Pendientes
-        </p>
+        <SectionEyebrow>Pendientes</SectionEyebrow>
         <h1 className="text-2xl font-semibold">Tus pendientes financieros</h1>
         <p className="text-sm text-muted-foreground">
           Tareas puntuales que debes pagar o resolver.

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -12,6 +12,8 @@ import { PlanDebtSection } from "@/components/plan/plan-debt-section";
 import { PlanHero } from "@/components/plan/plan-hero";
 import { PlanRecurringSection } from "@/components/plan/plan-recurring-section";
 import { PlanScenarioPreview } from "@/components/plan/plan-scenario-preview";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 import { formatMonthLabel, parseMonth } from "@/lib/utils/date";
 
 export default async function PlanPage({
@@ -31,12 +33,10 @@ export default async function PlanPage({
   const rhythmData = rhythmResult.success ? rhythmResult.data : [];
 
   return (
-    <div className="space-y-6">
+    <div className={PAGE_STACK_CLASS}>
       <div className="space-y-3 lg:hidden">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-            Plan
-          </p>
+          <SectionEyebrow>Plan</SectionEyebrow>
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Tu capa estratégica</h1>
             <p className="text-sm text-muted-foreground">
@@ -54,9 +54,7 @@ export default async function PlanPage({
 
       <div className="hidden lg:flex lg:items-center lg:justify-between lg:gap-4">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-            Plan
-          </p>
+          <SectionEyebrow>Plan</SectionEyebrow>
           <div>
             <h1 className="text-3xl font-semibold tracking-tight">Tu capa estratégica</h1>
             <p className="text-muted-foreground">

--- a/webapp/src/app/(dashboard)/transactions/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/page.tsx
@@ -113,19 +113,19 @@ export default async function TransactionsPage({
           }
         >
           <div className="grid grid-cols-3 gap-2">
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-3`}>
+            <div className={`${PANEL_INSET_CLASS} p-3`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Vista</p>
               <p className="mt-2 text-2xl font-semibold tracking-tight">{transactionsResult.count}</p>
               <p className="mt-1 text-[11px] text-muted-foreground">{scopeLabel}</p>
             </div>
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-3`}>
+            <div className={`${PANEL_INSET_CLASS} p-3`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Ingresos</p>
               <p className="mt-2 text-lg font-semibold tracking-tight text-z-income">
                 {formatCurrency(inflowVisible, summaryCurrency)}
               </p>
               <p className="mt-1 text-[11px] text-muted-foreground">en la vista</p>
             </div>
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-3`}>
+            <div className={`${PANEL_INSET_CLASS} p-3`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Gastos</p>
               <p className="mt-2 text-lg font-semibold tracking-tight text-z-alert">
                 {formatCurrency(outflowVisible, summaryCurrency)}
@@ -167,26 +167,26 @@ export default async function TransactionsPage({
           }
         >
           <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-4">
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+            <div className={`${PANEL_INSET_CLASS} p-4`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Vista</p>
               <p className="mt-2 text-3xl font-semibold tracking-tight">{transactionsResult.count}</p>
               <p className="mt-1 text-xs text-muted-foreground">{scopeLabel}</p>
             </div>
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+            <div className={`${PANEL_INSET_CLASS} p-4`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Ingresos</p>
               <p className="mt-2 text-2xl font-semibold tracking-tight text-z-income">
                 {formatCurrency(inflowVisible, summaryCurrency)}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">en la vista</p>
             </div>
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+            <div className={`${PANEL_INSET_CLASS} p-4`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Gastos</p>
               <p className="mt-2 text-2xl font-semibold tracking-tight text-z-alert">
                 {formatCurrency(outflowVisible, summaryCurrency)}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">en la vista</p>
             </div>
-            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+            <div className={`${PANEL_INSET_CLASS} p-4`}>
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Sin categoría</p>
               <p className="mt-2 text-3xl font-semibold tracking-tight">
                 {uncategorizedVisible}

--- a/webapp/src/app/(dashboard)/transactions/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/page.tsx
@@ -5,10 +5,8 @@ import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getAllTags } from "@/actions/tags";
 import { getPendingEmailTransactions } from "@/actions/email-ingest";
-import { Button } from "@/components/ui/button";
-import { PageHeaderRow } from "@/components/ui/page-header-row";
-import { SummaryCard } from "@/components/ui/summary-card";
 import { AttentionCard } from "@/components/ui/attention-card";
+import { HeroAccentPill, HeroPill, PageHero } from "@/components/ui/page-hero";
 import { TransactionTable } from "@/components/transactions/transaction-table";
 import { PendingEmailTransactions } from "@/components/transactions/pending-email-transactions";
 import { TransactionFilters } from "@/components/transactions/transaction-filters";
@@ -19,31 +17,13 @@ import { MonthSelector } from "@/components/month-selector";
 import { MobileMovimientos } from "@/components/mobile/mobile-movimientos";
 import { parseMonth, formatMonthParam, formatMonthLabel } from "@/lib/utils/date";
 import { formatCurrency } from "@/lib/utils/currency";
-import Link from "next/link";
 import dynamic from "next/dynamic";
-import { ArrowRight, Tags } from "lucide-react";
+import { PAGE_STACK_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
 
 const PurchaseDecisionCard = dynamic(
   () => import("@/components/dashboard/purchase-decision-card").then((m) => ({ default: m.PurchaseDecisionCard })),
   { loading: () => <div className="h-64 rounded-xl bg-muted animate-pulse" /> }
 );
-
-function buildFiltersHref(params: Record<string, string | undefined>, keepMonthOnly = false) {
-  const next = new URLSearchParams();
-  if (params.month) {
-    next.set("month", params.month);
-  }
-
-  if (!keepMonthOnly) {
-    for (const [key, value] of Object.entries(params)) {
-      if (!value || key === "month" || key === "page") continue;
-      next.set(key, value);
-    }
-  }
-
-  const query = next.toString();
-  return query ? `/transactions?${query}` : "/transactions";
-}
 
 export default async function TransactionsPage({
   searchParams,
@@ -101,33 +81,28 @@ export default async function TransactionsPage({
       : hasActiveFilters
         ? "en esta vista"
         : "visibles";
-  const clearHref = buildFiltersHref(params, true);
+  const description = hasActiveFilters
+    ? `Estás viendo ${transactionsResult.count} movimientos filtrados ${scopeLabel}. Úsalos para limpiar ruido y corregir criterio antes de que afecten presupuesto y plan.`
+    : `${monthLabel} en una sola vista: ingresos, gastos y excepciones para leer rápido qué pasó antes de bajar al detalle.`;
 
   return (
-    <div className="space-y-6">
+    <div className={PAGE_STACK_CLASS}>
       {/* Mobile: compact header + controls + date-grouped feed */}
-      <div className="lg:hidden">
-        <div className="space-y-4">
-          <div className="flex items-start justify-between gap-3">
-            <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                Movimientos
-              </p>
-              <h1 className="text-2xl font-semibold">Movimientos</h1>
-            </div>
-            <div className="rounded-full border border-white/6 bg-z-surface-2 px-3 py-1 text-xs text-muted-foreground">
-              {monthLabel}
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between rounded-xl border border-white/6 bg-black/10 px-4 py-3 text-sm">
-            <div>
-              <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Vista actual</p>
-              <p className="font-medium">
-                {transactionsResult.count} movimientos {scopeLabel}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
+      <div className="space-y-4 lg:hidden">
+        <PageHero
+          pills={
+            <>
+              <HeroPill>Movimientos</HeroPill>
+              {hasActiveFilters && (
+                <HeroAccentPill>{activeFilterCount} filtros activos</HeroAccentPill>
+              )}
+              <HeroPill>{monthLabel}</HeroPill>
+            </>
+          }
+          title="Movimientos"
+          description={description}
+          actions={
+            <div className="flex flex-wrap items-center gap-2">
               <Suspense>
                 <TransactionFilters accounts={accounts} tags={allTags} />
               </Suspense>
@@ -135,8 +110,30 @@ export default async function TransactionsPage({
                 <MonthSelector />
               </Suspense>
             </div>
+          }
+        >
+          <div className="grid grid-cols-3 gap-2">
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-3`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Vista</p>
+              <p className="mt-2 text-2xl font-semibold tracking-tight">{transactionsResult.count}</p>
+              <p className="mt-1 text-[11px] text-muted-foreground">{scopeLabel}</p>
+            </div>
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-3`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Ingresos</p>
+              <p className="mt-2 text-lg font-semibold tracking-tight text-z-income">
+                {formatCurrency(inflowVisible, summaryCurrency)}
+              </p>
+              <p className="mt-1 text-[11px] text-muted-foreground">en la vista</p>
+            </div>
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-3`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Gastos</p>
+              <p className="mt-2 text-lg font-semibold tracking-tight text-z-alert">
+                {formatCurrency(outflowVisible, summaryCurrency)}
+              </p>
+              <p className="mt-1 text-[11px] text-muted-foreground">en la vista</p>
+            </div>
           </div>
-        </div>
+        </PageHero>
 
         <PendingEmailTransactions transactions={pendingTransactions} accounts={accounts} />
 
@@ -148,42 +145,73 @@ export default async function TransactionsPage({
 
       {/* Desktop: action-first layout with two-card zone */}
       <div className="hidden lg:block space-y-6">
-        <PageHeaderRow
-          title="Movimientos"
-          subtitle={`${monthLabel} · ${transactionsResult.count} ${scopeLabel}`}
-          actions={
+        <PageHero
+          pills={
             <>
+              <HeroPill>Movimientos</HeroPill>
+              {hasActiveFilters && (
+                <HeroAccentPill>{activeFilterCount} filtros activos</HeroAccentPill>
+              )}
+              <HeroPill>{monthLabel}</HeroPill>
+            </>
+          }
+          title="Movimientos"
+          description={description}
+          actions={
+            <div className="flex flex-wrap gap-3">
               <Suspense>
                 <MonthSelector />
               </Suspense>
               <TransactionFormDialog accounts={accounts} categories={categories} tags={allTags} />
-            </>
+            </div>
+          }
+        >
+          <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-4">
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Vista</p>
+              <p className="mt-2 text-3xl font-semibold tracking-tight">{transactionsResult.count}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{scopeLabel}</p>
+            </div>
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Ingresos</p>
+              <p className="mt-2 text-2xl font-semibold tracking-tight text-z-income">
+                {formatCurrency(inflowVisible, summaryCurrency)}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">en la vista</p>
+            </div>
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Gastos</p>
+              <p className="mt-2 text-2xl font-semibold tracking-tight text-z-alert">
+                {formatCurrency(outflowVisible, summaryCurrency)}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">en la vista</p>
+            </div>
+            <div className={`${PANEL_INSET_CLASS} rounded-2xl p-4`}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Sin categoría</p>
+              <p className="mt-2 text-3xl font-semibold tracking-tight">
+                {uncategorizedVisible}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {uncategorizedVisible > 0 ? "requieren criterio" : "todo limpio"}
+              </p>
+            </div>
+          </div>
+        </PageHero>
+
+        <AttentionCard
+          signals={
+            uncategorizedVisible > 0
+              ? [{
+                  page: "transactions",
+                  key: "uncategorized_visible",
+                  count: uncategorizedVisible,
+                  label: "sin categoría en pantalla",
+                  priority: "action" as const,
+                  actionHref: "/categorizar",
+                }]
+              : []
           }
         />
-
-        <div className="grid gap-4 lg:grid-cols-2">
-          <SummaryCard
-            metrics={[
-              { label: "Movimientos", value: transactionsResult.count, context: scopeLabel },
-              { label: "Ingresos", value: formatCurrency(inflowVisible, summaryCurrency), context: "en la vista" },
-              { label: "Gastos", value: formatCurrency(outflowVisible, summaryCurrency), context: "en la vista" },
-            ]}
-          />
-          <AttentionCard
-            signals={
-              uncategorizedVisible > 0
-                ? [{
-                    page: "transactions",
-                    key: "uncategorized_visible",
-                    count: uncategorizedVisible,
-                    label: "sin categoría en pantalla",
-                    priority: "action" as const,
-                    actionHref: "/categorizar",
-                  }]
-                : []
-            }
-          />
-        </div>
 
         <Suspense>
           <TransactionFilters accounts={accounts} tags={allTags} />

--- a/webapp/src/components/budget/budget-page-client.tsx
+++ b/webapp/src/components/budget/budget-page-client.tsx
@@ -572,7 +572,7 @@ function SummaryCard({
   negative?: boolean;
 }) {
   return (
-    <div className={cn(PANEL_INSET_CLASS, "rounded-2xl bg-black/15 p-4 lg:p-5")}>
+    <div className={cn(PANEL_INSET_CLASS, "bg-black/15 p-4 lg:p-5")}>
       <SectionEyebrow>{label}</SectionEyebrow>
       <p
         className={cn(

--- a/webapp/src/components/budget/budget-page-client.tsx
+++ b/webapp/src/components/budget/budget-page-client.tsx
@@ -15,7 +15,8 @@ import { CategoryIcon } from "@/components/categories/category-icon";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { MonthSelector } from "@/components/month-selector";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { HeroAccentPill, HeroPill, PageHero } from "@/components/ui/page-hero";
 import {
   Popover,
   PopoverContent,
@@ -27,6 +28,13 @@ import {
   upsertBudgetForCategory,
 } from "@/actions/budget";
 import { cn } from "@/lib/utils";
+import {
+  GHOST_BUTTON_CLASS,
+  PAGE_STACK_CLASS,
+  PANEL_INSET_CLASS,
+  PANEL_SURFACE_CLASS,
+  PANEL_SURFACE_SUBTLE_CLASS,
+} from "@/lib/constants/styles";
 import { BudgetTreemap } from "./budget-treemap";
 import type { BudgetMode, CategoryBudgetData, CurrencyCode } from "@/types/domain";
 import type { AllocationData } from "@/actions/allocation";
@@ -125,66 +133,89 @@ export function BudgetPageClient({
   const otherStyleLabel = isStrict ? "Flexible" : "Estricto";
   const StyleIcon = isStrict ? Gauge : Feather;
   const thirdCardLabel = isStrict ? "Por asignar" : "Libre";
+  const heroDescription = remaining < 0
+    ? `Tu plan del mes quedó sobre-asignado por ${formatCurrency(Math.abs(remaining), currency)}. Ajusta antes de bajar al detalle.`
+    : isStrict
+      ? `Cada peso necesita destino. ${formatCurrency(remaining, currency)} siguen esperando una decisión para cerrar ${monthLabel}.`
+      : `Tu marco mensual ya está armado. Revisa qué categorías sostienen el plan y cuáles empiezan a desordenarlo.`;
 
   return (
-    <div className="space-y-6">
-      {/* ── Header ── */}
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-            Presupuesto
-          </p>
-          <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-semibold tracking-tight lg:text-3xl">
-              Tu plan mensual
-            </h1>
-            <Badge variant="secondary" className="gap-1.5 text-xs">
-              <StyleIcon className="size-3.5" />
-              {styleLabel}
-            </Badge>
-          </div>
-          <p className="text-sm text-muted-foreground">
-            {monthLabel} · {daysRemaining} días restantes
-          </p>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <Suspense>
-            <MonthSelector />
-          </Suspense>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button variant="outline" size="sm" disabled={isPending}>
-                <Settings2 className="size-4 mr-2" />
-                Ajustes
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-64 space-y-3">
-              <div>
-                <p className="text-sm font-medium">Estilo</p>
-                <p className="text-xs text-muted-foreground mb-2">
-                  Actualmente: {styleLabel}
-                </p>
+    <div className={PAGE_STACK_CLASS}>
+      <PageHero
+        variant={remaining < 0 ? "brass" : "sage"}
+        pills={
+          <>
+            <HeroPill>Presupuesto</HeroPill>
+            <HeroAccentPill>
+              <span className="inline-flex items-center gap-1.5">
+                <StyleIcon className="size-3.5" />
+                {styleLabel}
+              </span>
+            </HeroAccentPill>
+            <HeroPill>{monthLabel}</HeroPill>
+          </>
+        }
+        title="Tu plan mensual"
+        description={heroDescription}
+        actions={
+          <div className="flex flex-wrap items-center gap-3">
+            <Suspense>
+              <MonthSelector />
+            </Suspense>
+            <Popover>
+              <PopoverTrigger asChild>
                 <Button
                   variant="outline"
                   size="sm"
-                  className="w-full"
-                  onClick={handleModeSwitch}
                   disabled={isPending}
+                  className={GHOST_BUTTON_CLASS}
                 >
-                  Cambiar a {otherStyleLabel}
+                  <Settings2 className="size-4 mr-2" />
+                  Ajustes
                 </Button>
-              </div>
-              <IncomeEditor
-                currentIncome={income}
-                currency={currency}
-                onSave={handleIncomeUpdate}
-                isPending={isPending}
-              />
-            </PopoverContent>
-          </Popover>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-64 space-y-3">
+                <div>
+                  <p className="text-sm font-medium">Estilo</p>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Actualmente: {styleLabel}
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={handleModeSwitch}
+                    disabled={isPending}
+                  >
+                    Cambiar a {otherStyleLabel}
+                  </Button>
+                </div>
+                <IncomeEditor
+                  currentIncome={income}
+                  currency={currency}
+                  onSave={handleIncomeUpdate}
+                  isPending={isPending}
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+        }
+      >
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <SummaryCard label="Ingreso" value={income} currency={currency} />
+          <SummaryCard label="Asignado" value={assigned} currency={currency} />
+          <SummaryCard
+            label={thirdCardLabel}
+            value={remaining}
+            currency={currency}
+            negative={remaining < 0}
+          />
         </div>
-      </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="h-2 w-2 rounded-full bg-z-brass" />
+          <span>{daysRemaining} días restantes para cerrar {monthLabel}</span>
+        </div>
+      </PageHero>
 
       {/* ── Strict mode: Sticky remaining-to-assign bar ── */}
       {isStrict && (
@@ -195,18 +226,6 @@ export function BudgetPageClient({
           currency={currency}
         />
       )}
-
-      {/* ── Summary cards ── */}
-      <div className="grid grid-cols-3 gap-3">
-        <SummaryCard label="Ingreso" value={income} currency={currency} />
-        <SummaryCard label="Asignado" value={assigned} currency={currency} />
-        <SummaryCard
-          label={thirdCardLabel}
-          value={remaining}
-          currency={currency}
-          negative={remaining < 0}
-        />
-      </div>
 
       {/* ── 50/30/20 Allocation Reference ── */}
       {allocationData && (
@@ -257,10 +276,11 @@ export function BudgetPageClient({
             <div
               key={cat.id}
               className={cn(
-                "rounded-2xl border bg-card transition-colors",
+                PANEL_SURFACE_CLASS,
+                "transition-colors",
                 unbudgetedStrict
-                  ? "border-amber-500/20 bg-amber-500/[0.03]"
-                  : "border-white/6",
+                  ? "border-z-alert/25 bg-z-alert/[0.06]"
+                  : undefined,
               )}
               style={{ borderLeft: `4px solid ${cat.color}` }}
             >
@@ -500,8 +520,8 @@ function StickyAssignmentBar({
         : "bg-emerald-500";
 
   return (
-    <div className="sticky top-0 z-10 bg-z-bg pb-2">
-      <div className="rounded-2xl border border-white/6 bg-z-surface-2/80 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+    <div className="sticky top-0 z-10 bg-background pb-2">
+      <div className={cn(PANEL_SURFACE_CLASS, "p-4")}>
         <div className="flex items-center gap-3">
           <div className="h-2 flex-1 rounded-full bg-z-surface-3">
             <div
@@ -552,14 +572,12 @@ function SummaryCard({
   negative?: boolean;
 }) {
   return (
-    <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-        {label}
-      </p>
+    <div className={cn(PANEL_INSET_CLASS, "rounded-2xl bg-black/15 p-4 lg:p-5")}>
+      <SectionEyebrow>{label}</SectionEyebrow>
       <p
         className={cn(
-          "mt-1 text-lg font-semibold tabular-nums",
-          negative && "text-red-500",
+          "mt-2 text-2xl font-semibold tracking-tight tabular-nums lg:text-[2rem]",
+          negative && "text-z-debt",
         )}
       >
         {formatCurrency(value, currency)}
@@ -593,10 +611,10 @@ function AllocationReference({ data }: { data: AllocationData }) {
   ];
 
   return (
-    <div className="rounded-xl border border-white/6 bg-z-surface-2 p-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground mb-3">
+    <div className={cn(PANEL_SURFACE_SUBTLE_CLASS, "p-4")}>
+      <SectionEyebrow className="mb-3 text-muted-foreground">
         Distribución 50/30/20
-      </p>
+      </SectionEyebrow>
 
       {bars.map((bar) => (
         <div key={bar.label} className="mb-4 last:mb-0">

--- a/webapp/src/components/budget/budget-treemap.tsx
+++ b/webapp/src/components/budget/budget-treemap.tsx
@@ -4,6 +4,10 @@ import { useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { CategoryIcon } from "@/components/categories/category-icon";
+import {
+  PANEL_INSET_CLASS,
+  PANEL_SURFACE_SUBTLE_CLASS,
+} from "@/lib/constants/styles";
 import type { CategoryBudgetData, CurrencyCode } from "@/types/domain";
 
 interface BudgetTreemapProps {
@@ -52,7 +56,7 @@ export function BudgetTreemap({
   }
 
   return (
-    <div className="rounded-2xl border border-white/6 bg-[#111411] p-1.5 overflow-hidden">
+    <div className={cn(PANEL_SURFACE_SUBTLE_CLASS, "overflow-hidden p-1.5")}>
       <div className="flex flex-col gap-1.5">
         {/* Top row — large categories with subcategories */}
         {bigCats.length > 0 && (
@@ -91,7 +95,10 @@ export function BudgetTreemap({
             ))}
             {smallCats.length > 6 && (
               <div
-                className="flex items-center justify-center rounded-xl bg-white/[0.02] border border-white/6 text-xs text-muted-foreground"
+                className={cn(
+                  PANEL_INSET_CLASS,
+                  "flex items-center justify-center bg-white/[0.03] text-xs text-muted-foreground"
+                )}
                 style={{ flex: smallCats.slice(6).reduce((s, c) => s + c._budget, 0) }}
               >
                 +{smallCats.length - 6}

--- a/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
+++ b/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
@@ -22,7 +22,7 @@ import { Label } from "@/components/ui/label";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
 import { formatCurrency } from "@/lib/utils/currency";
 import type { ActionResult } from "@/types/actions";
-import type { CategoryWithChildren } from "@/types/domain";
+import type { CategoryWithChildren, CurrencyCode } from "@/types/domain";
 
 export function CreateDestinatarioDialog({
   categories,
@@ -63,7 +63,14 @@ export function CreateDestinatarioDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={(next) => {
+      setOpen(next);
+      if (!next) {
+        setCategoryId(null);
+        setPatterns("");
+        setTestResult(null);
+      }
+    }}>
       <DialogTrigger asChild>
         {trigger ?? (
           <Button>
@@ -100,7 +107,7 @@ export function CreateDestinatarioDialog({
               categories={categories}
               value={categoryId}
               onValueChange={setCategoryId}
-              direction="OUTFLOW"
+              variant="popover"
               name="default_category_id"
               placeholder="Sin categoría"
               triggerClassName="w-full"
@@ -117,7 +124,7 @@ export function CreateDestinatarioDialog({
                 value={patterns}
                 onChange={(e) => {
                   setPatterns(e.target.value);
-                  setTestResult(null);
+                  if (testResult) setTestResult(null);
                 }}
                 className="flex-1"
               />
@@ -152,7 +159,7 @@ export function CreateDestinatarioDialog({
                       <li key={s.id} className="text-xs text-muted-foreground flex justify-between gap-2">
                         <span className="truncate">{s.rawDescription}</span>
                         <span className="shrink-0 tabular-nums">
-                          {formatCurrency(s.amount, "COP")}
+                          {formatCurrency(s.amount, s.currencyCode as CurrencyCode)}
                         </span>
                       </li>
                     ))}

--- a/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
+++ b/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useActionState, useEffect, useMemo, useState } from "react";
+import { useActionState, useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Plus } from "lucide-react";
-import { createDestinatario, type CreateDestinatarioResult } from "@/actions/destinatarios";
+import { Plus, Search, Loader2 } from "lucide-react";
+import {
+  createDestinatario,
+  testDestinatarioPattern,
+  type CreateDestinatarioResult,
+  type PatternTestResult,
+} from "@/actions/destinatarios";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -14,18 +19,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import { formatCurrency } from "@/lib/utils/currency";
 import type { ActionResult } from "@/types/actions";
 import type { CategoryWithChildren } from "@/types/domain";
-import type { Database } from "@/types/database";
-
-type Destinatario = Database["public"]["Tables"]["destinatarios"]["Row"];
 
 export function CreateDestinatarioDialog({
   categories,
@@ -36,35 +33,34 @@ export function CreateDestinatarioDialog({
 }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [categoryId, setCategoryId] = useState("none");
+  const [categoryId, setCategoryId] = useState<string | null>(null);
   const [isActive, setIsActive] = useState(true);
+  const [patterns, setPatterns] = useState("");
+  const [testResult, setTestResult] = useState<PatternTestResult | null>(null);
+  const [isTesting, startTestTransition] = useTransition();
   const [state, formAction, pending] = useActionState<ActionResult<CreateDestinatarioResult>, FormData>(
     createDestinatario,
     { success: false, error: "" }
-  );
-
-  const categoryOptions = useMemo(
-    () =>
-      categories.flatMap((category) => [
-        {
-          id: category.id,
-          label: category.name_es ?? category.name,
-        },
-        ...category.children.map((child) => ({
-          id: child.id,
-          label: `${category.name_es ?? category.name} / ${child.name_es ?? child.name}`,
-        })),
-      ]),
-    [categories]
   );
 
   useEffect(() => {
     if (!state.success) return;
     router.refresh();
     setOpen(false);
-    setCategoryId("none");
+    setCategoryId(null);
     setIsActive(true);
+    setPatterns("");
+    setTestResult(null);
   }, [router, state.success]);
+
+  function handleTestPatterns() {
+    const firstPattern = patterns.split(",")[0]?.trim();
+    if (!firstPattern) return;
+    startTestTransition(async () => {
+      const result = await testDestinatarioPattern(firstPattern, "contains");
+      if (result.success) setTestResult(result.data);
+    });
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -99,37 +95,71 @@ export function CreateDestinatarioDialog({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="dest-category">Categoría por defecto</Label>
-            <Select value={categoryId} onValueChange={setCategoryId}>
-              <SelectTrigger id="dest-category">
-                <SelectValue placeholder="Sin categoría" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">Sin categoría</SelectItem>
-                {categoryOptions.map((category) => (
-                  <SelectItem key={category.id} value={category.id}>
-                    {category.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <input
-              type="hidden"
+            <Label>Categoría por defecto</Label>
+            <CategoryZonePicker
+              categories={categories}
+              value={categoryId}
+              onValueChange={setCategoryId}
+              direction="OUTFLOW"
               name="default_category_id"
-              value={categoryId === "none" ? "" : categoryId}
+              placeholder="Sin categoría"
+              triggerClassName="w-full"
             />
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="dest-patterns">Patrones</Label>
-            <Input
-              id="dest-patterns"
-              name="patterns"
-              placeholder="Ej: nequi pago, rappi, spotify"
-            />
+            <div className="flex gap-2">
+              <Input
+                id="dest-patterns"
+                name="patterns"
+                placeholder="Ej: nequi pago, rappi, spotify"
+                value={patterns}
+                onChange={(e) => {
+                  setPatterns(e.target.value);
+                  setTestResult(null);
+                }}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleTestPatterns}
+                disabled={!patterns.trim() || isTesting}
+                title="Probar patrón"
+              >
+                {isTesting ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Search className="size-4" />
+                )}
+              </Button>
+            </div>
             <p className="text-xs text-muted-foreground">
               Separa varios patrones con comas para crear reglas iniciales de asociación.
             </p>
+            {testResult && (
+              <div className="rounded-lg border border-z-border-strong bg-z-surface-2 p-3 space-y-2">
+                <p className="text-xs font-medium">
+                  {testResult.matchCount === 0
+                    ? "Sin coincidencias en transacciones sin asignar"
+                    : `${testResult.matchCount} transaccion${testResult.matchCount === 1 ? "" : "es"} coinciden`}
+                </p>
+                {testResult.samples.length > 0 && (
+                  <ul className="space-y-1">
+                    {testResult.samples.map((s) => (
+                      <li key={s.id} className="text-xs text-muted-foreground flex justify-between gap-2">
+                        <span className="truncate">{s.rawDescription}</span>
+                        <span className="shrink-0 tabular-nums">
+                          {formatCurrency(s.amount, "COP")}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/webapp/src/components/mobile/cards/mobile-budget-ring.tsx
+++ b/webapp/src/components/mobile/cards/mobile-budget-ring.tsx
@@ -3,6 +3,9 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
+import {
+  PANEL_INSET_CLASS,
+} from "@/lib/constants/styles";
 
 export interface TopCategory {
   name: string;
@@ -20,31 +23,67 @@ export interface MobileBudgetTileProps {
 
 export function BudgetTile({
   progress,
-  active,
-  onClick,
+  totalTarget,
+  totalSpent,
+  topCategories,
 }: {
   progress: number;
-  active: boolean;
-  onClick: () => void;
+  totalTarget: number;
+  totalSpent: number;
+  topCategories: TopCategory[];
 }) {
+  const isOver = progress >= 100;
+  const isHigh = progress >= 80;
+  const stateCopy = isOver
+    ? "Sobre el límite"
+    : isHigh
+      ? "Último tramo"
+      : "Con margen";
+  const topCategory = topCategories[0]?.name;
+
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex w-full flex-col items-center rounded-xl border bg-[#111] p-2.5 text-center transition-colors",
-        active ? "border-z-sage-light/25" : "border-white/6"
-      )}
-      aria-expanded={active}
+    <Link
+      href="/plan"
+      className={`${PANEL_INSET_CLASS} flex h-full flex-col justify-between p-3`}
     >
-      <ProgressRing progress={progress} />
-      <span className={cn(
-        "mt-1 text-[10px] font-semibold uppercase tracking-[0.18em]",
-        active ? "text-z-sage-light" : "text-muted-foreground"
-      )}>
-        Presupuesto
-      </span>
-    </button>
+      <div className="space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Presupuesto
+          </span>
+          <span
+            className={
+              isOver
+                ? "text-[10px] font-medium text-z-debt"
+                : isHigh
+                  ? "text-[10px] font-medium text-z-brass"
+                  : "text-[10px] font-medium text-z-sage-light"
+            }
+          >
+            {stateCopy}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <ProgressRing progress={progress} />
+          <div className="min-w-0 flex-1 text-right">
+            <p className="text-[28px] font-extrabold leading-none text-z-white">
+              {Math.round(progress)}%
+            </p>
+            <p className="mt-1 text-[11px] leading-5 text-muted-foreground">
+              {topCategory ? `${topCategory} lidera el gasto` : "Sin categorías fuertes todavía"}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between text-[11px] font-semibold text-z-sage-light">
+        <span>
+          {totalTarget > 0 ? `${Math.round((totalSpent / totalTarget) * 100)}% usado` : "Ver plan"}
+        </span>
+        <ChevronRight className="h-3 w-3" />
+      </div>
+    </Link>
   );
 }
 
@@ -52,7 +91,7 @@ export function BudgetTile({
 
 export function BudgetDetail({ topCategories }: { topCategories: TopCategory[] }) {
   return (
-    <div className="rounded-xl border border-white/6 bg-[#111] p-3">
+    <div className={cn(PANEL_INSET_CLASS, "p-3")}>
       <p className="mb-2 text-[10px] font-semibold text-z-sage-light">Categorías con más gasto</p>
       {topCategories.length > 0 ? (
         <div className="space-y-2">
@@ -79,7 +118,7 @@ export function BudgetDetail({ topCategories }: { topCategories: TopCategory[] }
       )}
       <Link
         href="/plan"
-        className="mt-2 flex w-full items-center justify-center gap-1 rounded-lg border border-white/8 bg-white/3 px-3 py-1.5 text-[11px] font-semibold text-z-sage-light transition-colors hover:bg-white/5"
+        className="mt-2 flex w-full items-center justify-center gap-1 rounded-lg border border-white/8 bg-white/[0.03] px-3 py-1.5 text-[11px] font-semibold text-z-sage-light transition-colors hover:bg-white/5"
       >
         Ir a presupuesto <ChevronRight className="h-3 w-3" />
       </Link>
@@ -109,7 +148,7 @@ function ProgressRing({ progress, size = 38 }: { progress: number; size?: number
         />
       </svg>
       <div className="absolute inset-0 flex items-center justify-center">
-        <span className={cn("text-[9px] font-bold", isOver ? "text-z-debt" : "text-z-sage-lightest")}>
+        <span className={cn("text-[9px] font-bold", isOver ? "text-z-debt" : "text-z-white")}>
           {Math.round(progress)}%
         </span>
       </div>

--- a/webapp/src/components/mobile/cards/mobile-hero-card.tsx
+++ b/webapp/src/components/mobile/cards/mobile-hero-card.tsx
@@ -7,6 +7,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { ChevronRight } from "lucide-react";
 import {
+  HERO_CARD_GRADIENT_CLASS,
   PANEL_INSET_CLASS,
   PANEL_SURFACE_SUBTLE_CLASS,
 } from "@/lib/constants/styles";
@@ -78,7 +79,8 @@ export function MobileHeroCard({
     <div
       className={cn(
         PANEL_SURFACE_SUBTLE_CLASS,
-        "bg-[radial-gradient(circle_at_top_left,rgba(63,70,50,0.22),transparent_42%),linear-gradient(180deg,rgba(27,30,27,0.96),rgba(18,20,18,0.98))] p-3.5"
+        HERO_CARD_GRADIENT_CLASS,
+        "p-3.5"
       )}
     >
       {/* Hero number — tappable for math */}

--- a/webapp/src/components/mobile/cards/mobile-hero-card.tsx
+++ b/webapp/src/components/mobile/cards/mobile-hero-card.tsx
@@ -6,6 +6,10 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { ChevronRight } from "lucide-react";
+import {
+  PANEL_INSET_CLASS,
+  PANEL_SURFACE_SUBTLE_CLASS,
+} from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 
 type ExpandedSection = "math" | "saldo" | "fijos" | "proximo" | null;
@@ -71,7 +75,12 @@ export function MobileHeroCard({
   const isNegative = availableToSpend < 0;
 
   return (
-    <div className="rounded-2xl border border-white/6 bg-[linear-gradient(160deg,#1a2518,#0d1117)] p-3.5">
+    <div
+      className={cn(
+        PANEL_SURFACE_SUBTLE_CLASS,
+        "bg-[radial-gradient(circle_at_top_left,rgba(63,70,50,0.22),transparent_42%),linear-gradient(180deg,rgba(27,30,27,0.96),rgba(18,20,18,0.98))] p-3.5"
+      )}
+    >
       {/* Hero number — tappable for math */}
       <button
         type="button"
@@ -85,7 +94,7 @@ export function MobileHeroCard({
         <p
           className={cn(
             "mt-0.5 text-[32px] font-extrabold leading-tight tracking-tight",
-            isNegative ? "text-z-debt" : "text-z-sage-lightest"
+            isNegative ? "text-z-debt" : "text-z-white"
           )}
         >
           {formatCurrency(availableToSpend, currency)}
@@ -94,7 +103,7 @@ export function MobileHeroCard({
 
       {/* Math expansion */}
       <CollapsePanel visible={expanded === "math"}>
-        <div className="rounded-xl bg-black/20 p-3 text-xs">
+        <div className={cn(PANEL_INSET_CLASS, "border-white/8 bg-black/20 p-3 text-xs")}>
           <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
             Cómo se calcula
           </p>
@@ -111,7 +120,7 @@ export function MobileHeroCard({
               <span>− Ya gastado</span>
               <span>{formatCurrency(totalSpent, currency)}</span>
             </div>
-            <div className="flex justify-between border-t border-white/10 pt-1.5 font-semibold text-z-sage-lightest">
+            <div className="flex justify-between border-t border-white/10 pt-1.5 font-semibold text-z-white">
               <span>= Disponible</span>
               <span>{formatCurrency(availableToSpend, currency)}</span>
             </div>
@@ -149,7 +158,7 @@ export function MobileHeroCard({
 
       {/* Saldo expansion */}
       <CollapsePanel visible={expanded === "saldo"}>
-        <div className="rounded-xl bg-black/20 p-3">
+        <div className={cn(PANEL_INSET_CLASS, "border-white/8 bg-black/20 p-3")}>
           <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
             Saldo por cuenta
           </p>
@@ -170,7 +179,7 @@ export function MobileHeroCard({
 
       {/* Fijos expansion */}
       <CollapsePanel visible={expanded === "fijos"}>
-        <div className="rounded-xl bg-black/20 p-3">
+        <div className={cn(PANEL_INSET_CLASS, "border-white/8 bg-black/20 p-3")}>
           <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
             Gastos fijos del período
           </p>
@@ -184,7 +193,7 @@ export function MobileHeroCard({
                   </div>
                 ))}
               </div>
-              <div className="mt-1.5 flex justify-between border-t border-white/10 pt-1.5 text-xs font-semibold text-z-sage-lightest">
+              <div className="mt-1.5 flex justify-between border-t border-white/10 pt-1.5 text-xs font-semibold text-z-white">
                 <span>Total fijos</span>
                 <span>{formatCurrency(pendingFixed, currency)}</span>
               </div>
@@ -197,7 +206,7 @@ export function MobileHeroCard({
 
       {/* Próximo expansion */}
       <CollapsePanel visible={expanded === "proximo"}>
-        <div className="rounded-xl bg-black/20 p-3">
+        <div className={cn(PANEL_INSET_CLASS, "border-white/8 bg-black/20 p-3")}>
           <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
             Próximo pago
           </p>

--- a/webapp/src/components/mobile/cards/mobile-recent-txns.tsx
+++ b/webapp/src/components/mobile/cards/mobile-recent-txns.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 
 interface RecentTransaction {
@@ -19,7 +20,7 @@ export function MobileRecentTxns({ transactions }: { transactions: RecentTransac
   if (visible.length === 0) return null;
 
   return (
-    <div className="rounded-xl border border-white/6 bg-[#111] px-3 py-2">
+    <div className={cn(PANEL_INSET_CLASS, "px-3 py-2")}>
       <div className="mb-1 flex items-center justify-between">
         <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
           Recientes

--- a/webapp/src/components/mobile/cards/mobile-spending-pace.tsx
+++ b/webapp/src/components/mobile/cards/mobile-spending-pace.tsx
@@ -4,66 +4,77 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { ChevronRight } from "lucide-react";
+import {
+  PANEL_INSET_CLASS,
+} from "@/lib/constants/styles";
 import type { BurnRateResponse } from "@/actions/burn-rate";
 
-// ─── Tile (compact, for the side-by-side row) ────────────────────────────────
+// ─── Tile (summary-first, without expanded state) ────────────────────────────
 
 export function SpendingPaceTile({
   data,
-  active,
-  onClick,
 }: {
   data: BurnRateResponse;
-  active: boolean;
-  onClick: () => void;
 }) {
   const { runwayDays } = data.discretionary;
   const now = new Date();
   const dayOfMonth = now.getDate();
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  const progress = Math.min((dayOfMonth / daysInMonth) * 100, 100);
   const daysRemaining = daysInMonth - dayOfMonth;
   const isCritical = runwayDays < daysRemaining * 0.5;
   const isWarning = runwayDays < daysRemaining;
+  const stateCopy = isCritical
+    ? "No llegas al cierre"
+    : isWarning
+      ? "Ajusta para cerrar"
+      : "Ritmo bajo control";
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex w-full flex-col items-center rounded-xl border bg-[#111] p-2.5 text-center transition-colors",
-        active
-          ? (isCritical ? "border-z-debt/25" : isWarning ? "border-z-brass/25" : "border-z-sage-light/25")
-          : "border-white/6"
-      )}
-      aria-expanded={active}
+    <Link
+      href="/dashboard#burn-rate"
+      className={`${PANEL_INSET_CLASS} flex h-full flex-col justify-between p-3`}
     >
-      <span className={cn(
-        "text-[22px] font-extrabold leading-none",
-        isCritical ? "text-z-debt" : isWarning ? "text-z-brass" : "text-z-sage-light"
-      )}>
-        {Math.round(runwayDays)}d
-      </span>
-      <div className="mx-auto mt-1.5 h-2 w-3/4 overflow-hidden rounded-full bg-white/5">
-        <div
-          className={cn(
-            "h-full rounded-full",
-            isCritical
-              ? "bg-gradient-to-r from-z-brass to-z-debt"
-              : isWarning
-                ? "bg-gradient-to-r from-z-sage-light to-z-brass"
-                : "bg-z-sage-light"
-          )}
-          style={{ width: `${progress}%` }}
-        />
+      <div className="space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Ritmo
+          </span>
+          <span
+            className={
+              isCritical
+                ? "text-[10px] font-medium text-z-debt"
+                : isWarning
+                  ? "text-[10px] font-medium text-z-brass"
+                  : "text-[10px] font-medium text-z-sage-light"
+            }
+          >
+            {stateCopy}
+          </span>
+        </div>
+
+        <div className="space-y-1">
+          <span
+            className={
+              isCritical
+                ? "text-[28px] font-extrabold leading-none text-z-debt"
+                : isWarning
+                  ? "text-[28px] font-extrabold leading-none text-z-brass"
+                  : "text-[28px] font-extrabold leading-none text-z-sage-light"
+            }
+          >
+            {Math.round(runwayDays)}d
+          </span>
+          <p className="text-[11px] leading-5 text-muted-foreground">
+            {formatCurrency(data.discretionary.dailyAverage, data.currency)}/día al ritmo actual
+          </p>
+        </div>
       </div>
-      <span className={cn(
-        "mt-1 text-[10px] font-semibold uppercase tracking-[0.18em]",
-        active ? (isCritical ? "text-z-debt" : isWarning ? "text-z-brass" : "text-z-sage-light") : "text-muted-foreground"
-      )}>
-        Ritmo
-      </span>
-    </button>
+
+      <div className="mt-3 flex items-center justify-between text-[11px] font-semibold text-z-brass">
+        <span>Ver análisis</span>
+        <ChevronRight className="h-3 w-3" />
+      </div>
+    </Link>
   );
 }
 
@@ -80,7 +91,7 @@ export function SpendingPaceDetail({ data }: { data: BurnRateResponse }) {
   const isWarning = runwayDays < daysRemaining;
 
   return (
-    <div className="rounded-xl border border-white/6 bg-[#111] p-3">
+    <div className={cn(PANEL_INSET_CLASS, "p-3")}>
       <p className="mb-2 text-[10px] font-semibold text-z-brass">Proyección de gasto</p>
       <RunwayChart
         dataPoints={dataPoints}
@@ -141,7 +152,7 @@ function RunwayChart({
 
   if (monthPoints.length < 2) {
     return (
-      <div className="flex h-14 items-center justify-center rounded-lg bg-black/20 text-[11px] text-muted-foreground">
+      <div className="flex h-14 items-center justify-center rounded-lg border border-white/8 bg-black/20 text-[11px] text-muted-foreground">
         Datos insuficientes
       </div>
     );
@@ -162,21 +173,21 @@ function RunwayChart({
   const projectedEndDay = Math.min(lastDay + runwayDays, daysInMonth + 2);
 
   return (
-    <div className="rounded-lg bg-black/20 p-2">
+    <div className="rounded-lg border border-white/8 bg-black/20 p-2">
       <svg viewBox={`0 0 ${W} ${H}`} className="w-full" aria-label="Proyección de gasto">
         {[0.25, 0.5, 0.75].map((pct) => (
-          <line key={pct} x1={PAD.left} y1={scaleY(maxBalance * pct)} x2={W - PAD.right} y2={scaleY(maxBalance * pct)} stroke="#222" strokeWidth="0.5" />
+          <line key={pct} x1={PAD.left} y1={scaleY(maxBalance * pct)} x2={W - PAD.right} y2={scaleY(maxBalance * pct)} stroke="var(--z-surface-3)" strokeWidth="0.5" />
         ))}
-        <line x1={scaleX(1)} y1={scaleY(maxBalance)} x2={scaleX(daysInMonth)} y2={scaleY(0)} stroke="#2a3a22" strokeWidth="1.5" strokeDasharray="4,3" />
+        <line x1={scaleX(1)} y1={scaleY(maxBalance)} x2={scaleX(daysInMonth)} y2={scaleY(0)} stroke="var(--z-olive-deep)" strokeWidth="1.5" strokeDasharray="4,3" />
         <path d={actualPath} fill="none" stroke="var(--z-brass)" strokeWidth="2" strokeLinejoin="round" />
         <circle cx={cx} cy={cy} r="3.5" fill="var(--z-brass)" />
         <circle cx={cx} cy={cy} r="5.5" fill="var(--z-brass)" fillOpacity="0.15" />
         {runwayDays < daysInMonth - dayOfMonth && (
           <path d={`M${cx},${cy} L${scaleX(projectedEndDay)},${scaleY(0)}`} fill="none" stroke="var(--z-debt)" strokeWidth="1.5" strokeDasharray="3,2" />
         )}
-        <text x={PAD.left} y={H - 2} fill="#555" fontSize="9" fontFamily="system-ui">Día 1</text>
-        <text x={scaleX(dayOfMonth)} y={H - 2} fill="#888" fontSize="9" fontFamily="system-ui" textAnchor="middle">Hoy</text>
-        <text x={W - PAD.right} y={H - 2} fill="#555" fontSize="9" fontFamily="system-ui" textAnchor="end">{daysInMonth}</text>
+        <text x={PAD.left} y={H - 2} fill="var(--z-sage-dark)" fontSize="9" fontFamily="system-ui">Día 1</text>
+        <text x={scaleX(dayOfMonth)} y={H - 2} fill="var(--z-sage-light)" fontSize="9" fontFamily="system-ui" textAnchor="middle">Hoy</text>
+        <text x={W - PAD.right} y={H - 2} fill="var(--z-sage-dark)" fontSize="9" fontFamily="system-ui" textAnchor="end">{daysInMonth}</text>
       </svg>
     </div>
   );

--- a/webapp/src/components/mobile/cards/mobile-upcoming-payments.tsx
+++ b/webapp/src/components/mobile/cards/mobile-upcoming-payments.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate, toISODateString } from "@/lib/utils/date";
 import { ChevronRight } from "lucide-react";
+import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 
 interface Payment {
@@ -52,7 +53,7 @@ export function MobileUpcomingPayments({ payments }: { payments: Payment[] }) {
   if (visible.length === 0) return null;
 
   return (
-    <div className="rounded-xl border border-white/6 bg-[#111] px-3 py-2">
+    <div className={cn(PANEL_INSET_CLASS, "px-3 py-2")}>
       <div className="mb-1 flex items-center justify-between">
         <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
           Pagos
@@ -81,7 +82,7 @@ export function MobileUpcomingPayments({ payments }: { payments: Payment[] }) {
                   <span className="truncate text-[10px] text-z-sage-light">{shortName(payment.name)}</span>
                 </div>
                 <div className="flex items-center gap-1.5 shrink-0 ml-2">
-                  <span className="text-[10px] font-semibold text-z-sage-lightest">
+                  <span className="text-[10px] font-semibold text-z-white">
                     {formatCurrency(payment.amount, payment.currencyCode as CurrencyCode)}
                   </span>
                   <span className={cn(
@@ -99,7 +100,7 @@ export function MobileUpcomingPayments({ payments }: { payments: Payment[] }) {
                 style={{ gridTemplateRows: isExpanded ? "1fr" : "0fr" }}
               >
                 <div className="overflow-hidden">
-                  <div className={cn("rounded-lg bg-black/20 p-2.5 mb-1 transition-opacity duration-150", isExpanded ? "opacity-100 delay-75" : "opacity-0")}>
+                  <div className={cn("mb-1 rounded-lg border border-white/8 bg-black/20 p-2.5 transition-opacity duration-150", isExpanded ? "opacity-100 delay-75" : "opacity-0")}>
                     <div className="space-y-0.5 text-[10px] text-z-sage-light">
                       <div className="flex justify-between">
                         <span className="text-muted-foreground">Monto</span>
@@ -112,7 +113,7 @@ export function MobileUpcomingPayments({ payments }: { payments: Payment[] }) {
                     </div>
                     <Link
                       href="/recurrentes"
-                      className="mt-2 flex w-full items-center justify-center gap-1 rounded-lg border border-white/8 bg-white/3 px-3 py-1 text-[10px] font-semibold text-z-sage-light transition-colors hover:bg-white/5"
+                      className="mt-2 flex w-full items-center justify-center gap-1 rounded-lg border border-white/8 bg-white/[0.03] px-3 py-1 text-[10px] font-semibold text-z-sage-light transition-colors hover:bg-white/5"
                     >
                       Ver detalles <ChevronRight className="h-3 w-3" />
                     </Link>

--- a/webapp/src/components/mobile/mobile-dashboard-v2.tsx
+++ b/webapp/src/components/mobile/mobile-dashboard-v2.tsx
@@ -1,18 +1,14 @@
 "use client";
 
-import { useState } from "react";
-import { cn } from "@/lib/utils";
 import type { AttentionSignal } from "@/types/attention";
 import type { BurnRateResponse } from "@/actions/burn-rate";
 import type { CurrencyCode } from "@/types/domain";
 import { MobileAlertCard } from "./cards/mobile-alert-card";
 import { MobileHeroCard, type MobileHeroCardProps } from "./cards/mobile-hero-card";
-import { SpendingPaceTile, SpendingPaceDetail } from "./cards/mobile-spending-pace";
-import { BudgetTile, BudgetDetail, type TopCategory } from "./cards/mobile-budget-ring";
+import { SpendingPaceTile } from "./cards/mobile-spending-pace";
+import { BudgetTile, type TopCategory } from "./cards/mobile-budget-ring";
 import { MobileUpcomingPayments } from "./cards/mobile-upcoming-payments";
 import { MobileRecentTxns } from "./cards/mobile-recent-txns";
-
-type InsightPanel = "pace" | "budget" | null;
 
 export interface MobileDashboardV2Props {
   attentionSignals: AttentionSignal[];
@@ -51,14 +47,8 @@ export function MobileDashboardV2({
   upcomingPayments,
   recentTransactions,
 }: MobileDashboardV2Props) {
-  const [activePanel, setActivePanel] = useState<InsightPanel>(null);
-
   const hasPace = !!burnRateData;
   const hasBudget = !!budget && budget.totalTarget > 0;
-
-  function togglePanel(panel: InsightPanel) {
-    setActivePanel((prev) => (prev === panel ? null : panel));
-  }
 
   return (
     <div className="space-y-2">
@@ -68,50 +58,20 @@ export function MobileDashboardV2({
       {/* ② Hero */}
       <MobileHeroCard {...hero} />
 
-      {/* ③ Insight tiles — side by side, detail expands full-width below */}
+      {/* ③ Insight tiles — summary first, no debt-style expanded state */}
       {(hasPace || hasBudget) && (
-        <div>
-          {/* Tile row */}
-          <div className="flex gap-1.5">
+        <div className="grid grid-cols-2 gap-1.5">
             {hasPace && (
-              <div className="flex-1">
-                <SpendingPaceTile
-                  data={burnRateData}
-                  active={activePanel === "pace"}
-                  onClick={() => togglePanel("pace")}
-                />
-              </div>
+              <SpendingPaceTile data={burnRateData} />
             )}
             {hasBudget && (
-              <div className="flex-1">
-                <BudgetTile
-                  progress={budget.progress}
-                  active={activePanel === "budget"}
-                  onClick={() => togglePanel("budget")}
-                />
-              </div>
+              <BudgetTile
+                progress={budget.progress}
+                totalTarget={budget.totalTarget}
+                totalSpent={budget.totalSpent}
+                topCategories={budget.topCategories}
+              />
             )}
-          </div>
-
-          {/* Expanded detail — full width below tiles */}
-          <div
-            className="grid transition-[grid-template-rows] duration-200 ease-out"
-            style={{ gridTemplateRows: activePanel ? "1fr" : "0fr" }}
-          >
-            <div className="overflow-hidden">
-              <div className={cn(
-                "mt-2 transition-opacity duration-150",
-                activePanel ? "opacity-100 delay-75" : "opacity-0"
-              )}>
-                {activePanel === "pace" && burnRateData && (
-                  <SpendingPaceDetail data={burnRateData} />
-                )}
-                {activePanel === "budget" && budget && (
-                  <BudgetDetail topCategories={budget.topCategories} />
-                )}
-              </div>
-            </div>
-          </div>
         </div>
       )}
 

--- a/webapp/src/components/mobile/mobile-page-header.tsx
+++ b/webapp/src/components/mobile/mobile-page-header.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 
 interface MobilePageHeaderProps {
   title: string;
@@ -18,17 +20,22 @@ export function MobilePageHeader({
   const router = useRouter();
 
   return (
-    <div className="flex items-center gap-3 mb-4 lg:hidden">
+    <div className="mb-5 flex items-center gap-3 lg:hidden">
       <Button
         variant="ghost"
         size="icon"
-        className="size-8 shrink-0"
+        className={cn(
+          "size-9 shrink-0 rounded-full",
+          GHOST_BUTTON_CLASS
+        )}
         onClick={() => (backHref ? router.push(backHref) : router.back())}
       >
         <ArrowLeft className="size-4" />
         <span className="sr-only">Volver</span>
       </Button>
-      <h1 className="text-lg font-semibold flex-1 truncate">{title}</h1>
+      <h1 className="flex-1 truncate text-base font-semibold tracking-tight text-z-white">
+        {title}
+      </h1>
       {children}
     </div>
   );

--- a/webapp/src/components/tags/tag-manager.tsx
+++ b/webapp/src/components/tags/tag-manager.tsx
@@ -7,6 +7,11 @@ import { createTagGroup, deleteTagGroup, createTag, deleteTag } from "@/actions/
 import { TagChip } from "./tag-chip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  GHOST_BUTTON_CLASS,
+  PANEL_INSET_CLASS,
+  PANEL_SURFACE_CLASS,
+} from "@/lib/constants/styles";
 import type { TagGroupWithTags } from "@/types/domain";
 
 interface TagManagerProps {
@@ -64,12 +69,12 @@ export function TagManager({ tagGroups }: TagManagerProps) {
   function renderGroup(group: TagGroupWithTags, editable: boolean) {
     const key = group.id;
     return (
-      <div key={group.id} className="rounded-xl border border-white/10 p-4">
+      <div key={group.id} className={`${PANEL_SURFACE_CLASS} p-4`}>
         <div className="mb-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <h3 className="font-semibold">{group.name}</h3>
             {group.is_system && (
-              <span className="rounded-full bg-white/5 px-2 py-0.5 text-[0.65rem] text-muted-foreground">
+              <span className="rounded-full border border-white/6 bg-black/10 px-2 py-0.5 text-[0.65rem] text-muted-foreground">
                 sistema
               </span>
             )}
@@ -108,7 +113,7 @@ export function TagManager({ tagGroups }: TagManagerProps) {
                 value={newTagInputs[key] ?? ""}
                 onChange={(e) => setNewTagInputs((prev) => ({ ...prev, [key]: e.target.value }))}
                 placeholder="+ agregar"
-                className="h-7 w-28 border-dashed text-xs"
+                className={`h-8 w-28 border-dashed text-xs ${PANEL_INSET_CLASS}`}
                 disabled={isPending}
               />
             </form>
@@ -127,16 +132,22 @@ export function TagManager({ tagGroups }: TagManagerProps) {
           e.preventDefault();
           handleCreateGroup();
         }}
-        className="flex gap-2"
+        className="flex flex-col gap-2 sm:flex-row"
       >
         <Input
           value={newGroupName}
           onChange={(e) => setNewGroupName(e.target.value)}
           placeholder="Nuevo grupo de etiquetas..."
-          className="flex-1"
+          className={`flex-1 ${PANEL_INSET_CLASS}`}
           disabled={isPending}
         />
-        <Button type="submit" variant="outline" size="sm" disabled={isPending || !newGroupName.trim()}>
+        <Button
+          type="submit"
+          variant="outline"
+          size="sm"
+          className={GHOST_BUTTON_CLASS}
+          disabled={isPending || !newGroupName.trim()}
+        >
           <Plus className="mr-1 size-4" />
           Crear grupo
         </Button>

--- a/webapp/src/components/ui/section-eyebrow.tsx
+++ b/webapp/src/components/ui/section-eyebrow.tsx
@@ -1,0 +1,22 @@
+import { SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+interface SectionEyebrowProps extends React.ComponentProps<"p"> {
+  children: React.ReactNode;
+}
+
+export function SectionEyebrow({
+  className,
+  children,
+  ...props
+}: SectionEyebrowProps) {
+  return (
+    <p
+      data-slot="section-eyebrow"
+      className={cn(SECTION_EYEBROW_CLASS, className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}

--- a/webapp/src/lib/constants/styles.ts
+++ b/webapp/src/lib/constants/styles.ts
@@ -4,3 +4,25 @@ export const BRASS_BUTTON_CLASS = "bg-z-brass text-z-ink hover:bg-z-brass/90";
 /** Obsidian & Brass design token: secondary/ghost button */
 export const GHOST_BUTTON_CLASS =
   "border-white/8 bg-black/10 text-z-sage-light hover:bg-white/5 hover:text-z-sage-light";
+
+/** Shared page shell spacing */
+export const PAGE_STACK_CLASS = "space-y-6 lg:space-y-8";
+
+/** Shared eyebrow label for page/section headers */
+export const SECTION_EYEBROW_CLASS =
+  "text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark";
+
+/** Standard elevated panel used by page summaries and hero-adjacent surfaces */
+export const PANEL_SURFACE_CLASS =
+  "rounded-2xl border border-white/6 bg-z-surface-2/80 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]";
+
+/** Lighter elevated panel used inside hero sections and stacked layouts */
+export const PANEL_SURFACE_SUBTLE_CLASS =
+  "rounded-2xl border border-white/6 bg-z-surface-2/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]";
+
+/** Compact inset surface for tiles, pills, and mobile secondary cards */
+export const PANEL_INSET_CLASS = "rounded-xl border border-white/6 bg-black/10";
+
+/** Compact inset surface with a softer hover state for interactive tiles */
+export const PANEL_INSET_INTERACTIVE_CLASS =
+  "rounded-xl border border-white/6 bg-black/10 transition-colors hover:bg-white/[0.03]";

--- a/webapp/src/lib/constants/styles.ts
+++ b/webapp/src/lib/constants/styles.ts
@@ -20,9 +20,13 @@ export const PANEL_SURFACE_CLASS =
 export const PANEL_SURFACE_SUBTLE_CLASS =
   "rounded-2xl border border-white/6 bg-z-surface-2/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]";
 
+/** Hero card gradient for mobile dashboard cards */
+export const HERO_CARD_GRADIENT_CLASS =
+  "bg-[radial-gradient(circle_at_top_left,rgba(63,70,50,0.22),transparent_42%),linear-gradient(180deg,rgba(27,30,27,0.96),rgba(18,20,18,0.98))]";
+
 /** Compact inset surface for tiles, pills, and mobile secondary cards */
-export const PANEL_INSET_CLASS = "rounded-xl border border-white/6 bg-black/10";
+export const PANEL_INSET_CLASS = "rounded-2xl border border-white/6 bg-black/10";
 
 /** Compact inset surface with a softer hover state for interactive tiles */
 export const PANEL_INSET_INTERACTIVE_CLASS =
-  "rounded-xl border border-white/6 bg-black/10 transition-colors hover:bg-white/[0.03]";
+  "rounded-2xl border border-white/6 bg-black/10 transition-colors hover:bg-white/[0.03]";


### PR DESCRIPTION
## Summary

Consolidates the remaining mobile UX work from the budget redesign branch:

- **Budget redesign (continued from PR #76)**: expandable category cards, subcategory spending breakdown with progress bars, glass depth treemap visualization
- **Design token standardization**: canonical eyebrow labels, panel surfaces, and page layouts applied across 7 pages (categorizar, deseos, etiquetas, gestionar, pendientes, plan, transactions)
- **Mobile card polish**: budget-ring, spending-pace, hero-card, upcoming-payments, recent-txns — updated to use consistent design tokens
- **New components**: `SectionEyebrow` reusable component, updated `styles.ts` constants
- **Cleanup**: simplified mobile-dashboard-v2 orchestrator, tag-manager and page-header polish

Builds on top of:
- PR #75 (mobile dashboard redesign)
- PR #76 (budget unified view + wizard)
- PR #77 (debt page redesign)

## Test plan

- [ ] Budget page: verify expandable category cards work, subcategory breakdown renders
- [ ] Budget treemap: glass depth visualization renders correctly
- [ ] Mobile dashboard: all cards render with consistent design tokens
- [ ] Pages (categorizar, deseos, etiquetas, gestionar, pendientes): eyebrow labels and panel surfaces consistent
- [ ] Transactions page: layout and token standardization intact
- [ ] `pnpm build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)