### PR TITLE
perf: eliminate waterfalls, dynamic imports, defense-in-depth

### DIFF
--- a/webapp/src/actions/accounts.ts
+++ b/webapp/src/actions/accounts.ts
@@ -561,6 +561,5 @@ export async function registerPayment(
   revalidateTag("dashboard:accounts", "zeta");
   revalidateTag("dashboard:hero", "zeta");
   revalidateTag("debt", "zeta");
-  revalidateTag("zeta", "zeta");
   return { success: true, data: null };
 }

--- a/webapp/src/actions/charts.ts
+++ b/webapp/src/actions/charts.ts
@@ -487,26 +487,17 @@ async function getDashboardAccountsCached(userId: string): Promise<{
 
   const supabase = createAdminClient();
 
-  const [{ data: dashboardAccounts, error: dashboardError }, { data: allActiveAccounts, error: allError }] =
-    await Promise.all([
-      supabase
-        .from("accounts")
-        .select("id, name, account_type, current_balance, currency_code, updated_at")
-        .eq("user_id", userId)
-        .eq("is_active", true),
-      supabase
-        .from("accounts")
-        .select("currency_code")
-        .eq("user_id", userId)
-        .eq("is_active", true),
-    ]);
+  const { data: dashboardAccounts, error: dashboardError } = await supabase
+    .from("accounts")
+    .select("id, name, account_type, current_balance, currency_code, updated_at")
+    .eq("user_id", userId)
+    .eq("is_active", true);
 
   if (dashboardError) throw dashboardError;
-  if (allError) throw allError;
 
   return {
     dashboardAccounts: dashboardAccounts ?? [],
-    allActiveAccounts: allActiveAccounts ?? [],
+    allActiveAccounts: dashboardAccounts ?? [],
   };
 }
 

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -125,7 +125,6 @@ export async function createTagGroup(
   if (error) return { success: false, error: error.message };
 
   revalidateTag("tags", "zeta");
-  revalidateTag("zeta", "zeta");
   return { success: true, data: { id: data.id } };
 }
 

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -463,6 +463,7 @@ export async function getTransactions(
     let query = supabase
       .from("transactions")
       .select("*", { count: "exact" })
+      .eq("user_id", user.id)
       .order("transaction_date", { ascending: false })
       .order("created_at", { ascending: false })
       .range(from, to);

--- a/webapp/src/actions/wishlist.ts
+++ b/webapp/src/actions/wishlist.ts
@@ -77,7 +77,6 @@ function getNearestDays(dates: string[]): number | null {
 
 function invalidateWishlist() {
   revalidateTag("wishlist", "zeta");
-  revalidateTag("zeta", "zeta");
 }
 
 // ─── Section 1: CRUD Queries & Mutations ─────────────────────────────────────

--- a/webapp/src/app/(dashboard)/categories/page.tsx
+++ b/webapp/src/app/(dashboard)/categories/page.tsx
@@ -37,14 +37,14 @@ export default async function CategoriesPage({
   // Normalize old tab parameter
   const activeTab = tab === "gestionar" ? "configurar" : (tab ?? "presupuesto");
 
-  const [currency, manageResult, uncategorized, categoryTreeResult, attentionSnapshot] = await Promise.all([
-    getPreferredCurrency(),
+  const currency = await getPreferredCurrency();
+  const [manageResult, uncategorized, categoryTreeResult, attentionSnapshot, result] = await Promise.all([
     getAllCategoriesForManagement(),
     getUncategorizedTransactions(),
     getCategories(),
     getAttentionSnapshot(),
+    getCategoriesWithBudgetData(month, currency),
   ]);
-  const result = await getCategoriesWithBudgetData(month, currency);
   const categories = result.success ? result.data : [];
   const outflowCategories = categories.filter((c) => c.direction === "OUTFLOW");
   const allCategories = manageResult.success ? manageResult.data : [];

--- a/webapp/src/app/(dashboard)/deudas/planificador/page.tsx
+++ b/webapp/src/app/(dashboard)/deudas/planificador/page.tsx
@@ -5,7 +5,12 @@ import { getDebtOverview } from "@/actions/debt";
 import { getEstimatedIncome } from "@/actions/income";
 import { getPreferredCurrency } from "@/actions/profile";
 import { getScenarios } from "@/actions/scenarios";
-import { ScenarioPlanner } from "@/components/debt/scenario-planner";
+import dynamic from "next/dynamic";
+
+const ScenarioPlanner = dynamic(
+  () => import("@/components/debt/scenario-planner").then((m) => ({ default: m.ScenarioPlanner })),
+  { loading: () => <div className="h-64 rounded-xl bg-muted animate-pulse" /> }
+);
 import { MobilePageHeader } from "@/components/mobile/mobile-page-header";
 import { PageHero, HeroAccentPill } from "@/components/ui/page-hero";
 import { StatCard } from "@/components/ui/stat-card";

--- a/webapp/src/app/(dashboard)/layout.tsx
+++ b/webapp/src/app/(dashboard)/layout.tsx
@@ -1,10 +1,11 @@
-import { Suspense } from "react";
+import dynamic from "next/dynamic";
 import { redirect } from "next/navigation";
 import { connection } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getUserSafely } from "@/lib/supabase/auth";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Topbar } from "@/components/layout/topbar";
+import { getProfile } from "@/actions/profile";
 import { getAttentionSnapshot } from "@/actions/attention";
 import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
@@ -12,7 +13,10 @@ import { MobileTabBar } from "@/components/mobile/v2/mobile-tab-bar";
 import { MobileShellProvider } from "@/components/mobile/v2/mobile-shell-provider";
 import { PageTransition } from "@/components/ui/page-transition";
 import { KeyboardInsetProvider } from "@/hooks/use-keyboard-inset";
-import { DevOverlay } from "@/components/dev/dev-overlay";
+
+const DevOverlay = dynamic(
+  () => import("@/components/dev/dev-overlay").then((m) => ({ default: m.DevOverlay })),
+);
 
 const IS_DEV = process.env.NODE_ENV === "development";
 
@@ -29,11 +33,14 @@ export default async function DashboardLayout({
     redirect("/login");
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("*")
-    .eq("id", user.id)
-    .single();
+  const [profileResult, attentionSnapshot, accountsResult, categoriesResult] = await Promise.all([
+    getProfile(),
+    getAttentionSnapshot(),
+    getAccounts(),
+    getCategories(),
+  ]);
+
+  const profile = profileResult.success ? profileResult.data : null;
 
   if (!profile) {
     redirect("/login");
@@ -42,12 +49,6 @@ export default async function DashboardLayout({
   if (!profile.onboarding_completed) {
     redirect("/onboarding");
   }
-
-  const [attentionSnapshot, accountsResult, categoriesResult] = await Promise.all([
-    getAttentionSnapshot(),
-    getAccounts(),
-    getCategories(),
-  ]);
 
   const accounts = accountsResult.success ? accountsResult.data : [];
   const categories = categoriesResult.success ? categoriesResult.data : [];
@@ -78,11 +79,9 @@ export default async function DashboardLayout({
             }}
           >
             <main className="flex-1 overflow-x-hidden p-4 pb-20 lg:p-6 lg:pb-6">
-              <Suspense>
-                <PageTransition>
-                  {children}
-                </PageTransition>
-              </Suspense>
+              <PageTransition>
+                {children}
+              </PageTransition>
             </main>
 
             <MobileTabBar accounts={accounts} categories={categories} />

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -9,14 +9,12 @@ import { PlanBudgetToggle } from "@/components/plan/plan-budget-toggle";
 import { PlanDecisionRail } from "@/components/plan/plan-decision-rail";
 import { PlanDebtSection } from "@/components/plan/plan-debt-section";
 import { PlanHero } from "@/components/plan/plan-hero";
-import { PlanFlowTimeline } from "@/components/plan/plan-flow-timeline";
 import { PlanRecurringSection } from "@/components/plan/plan-recurring-section";
 import { PlanScenarioPreview } from "@/components/plan/plan-scenario-preview";
 import { SectionEyebrow } from "@/components/ui/section-eyebrow";
-import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { PlanRoot } from "@/components/mobile/v2/plan/plan-root";
-import { get503020Allocation } from "@/actions/allocation";
 import { getCategoriesWithBudgetData } from "@/actions/categories";
+import { getPreferredCurrency } from "@/actions/profile";
 import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 import { formatMonthLabel, parseMonth } from "@/lib/utils/date";
 
@@ -29,15 +27,14 @@ export default async function PlanPage({
   const params = await searchParams;
   const month = params.month;
   const monthLabel = formatMonthLabel(parseMonth(month));
-  const [planData, wishlistSummary] = await Promise.all([
-    getPlanPageData(month),
+  const currency = await getPreferredCurrency();
+  const [planData, wishlistSummary, rhythmResult, categoryBudgetResult] = await Promise.all([
+    getPlanPageData(month, currency),
     getWishlistItemsForDashboard(),
+    getCategoriesByRhythm(month, currency),
+    getCategoriesWithBudgetData(month, currency),
   ]);
-  const [rhythmResult, allocationData, categoryBudgetResult] = await Promise.all([
-    getCategoriesByRhythm(month, planData.currency),
-    get503020Allocation(month, planData.currency),
-    getCategoriesWithBudgetData(month, planData.currency),
-  ]);
+  const allocationData = planData.budget.allocation;
   const rhythmData = rhythmResult.success ? rhythmResult.data : [];
   const categoryBudgetData = categoryBudgetResult.success ? categoryBudgetResult.data : [];
   const isStable = planData.heroSummary.pressure === "stable";

--- a/webapp/src/app/(dashboard)/presupuesto/page.tsx
+++ b/webapp/src/app/(dashboard)/presupuesto/page.tsx
@@ -1,13 +1,21 @@
 import { connection } from "next/server";
+import dynamic from "next/dynamic";
 import { getBudgetMode } from "@/actions/budget";
 import { getEstimatedIncome } from "@/actions/income";
 import { getCategoriesWithBudgetData } from "@/actions/categories";
 import { get503020Allocation } from "@/actions/allocation";
-import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { BudgetWizard } from "@/components/budget/budget-wizard";
-import { BudgetPageClient } from "@/components/budget/budget-page-client";
+import { getPreferredCurrency } from "@/actions/profile";
 import { parseMonth, formatMonthLabel, getDaysRemainingInMonth } from "@/lib/utils/date";
-import type { CurrencyCode } from "@/types/domain";
+
+const BudgetWizard = dynamic(
+  () => import("@/components/budget/budget-wizard").then((m) => ({ default: m.BudgetWizard })),
+  { loading: () => <div className="h-64 rounded-xl bg-muted animate-pulse" /> }
+);
+
+const BudgetPageClient = dynamic(
+  () => import("@/components/budget/budget-page-client").then((m) => ({ default: m.BudgetPageClient })),
+  { loading: () => <div className="h-96 rounded-xl bg-muted animate-pulse" /> }
+);
 
 export default async function PresupuestoPage({
   searchParams,
@@ -18,11 +26,7 @@ export default async function PresupuestoPage({
   const params = await searchParams;
   const month = params.month;
 
-  const { supabase, user } = await getAuthenticatedClient();
-  const { data: profile } = user
-    ? await supabase.from("profiles").select("preferred_currency").eq("id", user.id).single()
-    : { data: null };
-  const currency = (profile?.preferred_currency ?? "COP") as CurrencyCode;
+  const currency = await getPreferredCurrency();
 
   const [modeResult, incomeEstimate, categoriesResult, allocationData] = await Promise.all([
     getBudgetMode(),

--- a/webapp/src/components/dashboard/actividad-heatmap.tsx
+++ b/webapp/src/components/dashboard/actividad-heatmap.tsx
@@ -1,5 +1,10 @@
+import dynamic from "next/dynamic";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { SpendingHeatmap } from "@/components/charts/spending-heatmap";
+
+const SpendingHeatmap = dynamic(
+  () => import("@/components/charts/spending-heatmap").then((m) => ({ default: m.SpendingHeatmap })),
+  { loading: () => <div className="h-[200px] w-full rounded-md bg-muted animate-pulse" /> }
+);
 import { getSpendingHeatmap } from "@/actions/spending-heatmap";
 import type { CurrencyCode } from "@/types/domain";
 

--- a/webapp/src/components/dashboard/flujo-waterfall.tsx
+++ b/webapp/src/components/dashboard/flujo-waterfall.tsx
@@ -1,5 +1,10 @@
+import dynamic from "next/dynamic";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { WaterfallChart } from "@/components/charts/waterfall-chart";
+
+const WaterfallChart = dynamic(
+  () => import("@/components/charts/waterfall-chart").then((m) => ({ default: m.WaterfallChart })),
+  { loading: () => <div className="h-[320px] w-full rounded-md bg-muted animate-pulse" /> }
+);
 import { getMonthlyCashflow, getCategorySpending } from "@/actions/charts";
 import type { CurrencyCode } from "@/types/domain";
 

--- a/webapp/src/components/dev/dev-overlay.tsx
+++ b/webapp/src/components/dev/dev-overlay.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import html2canvas from "html2canvas";
 import { DevFAB } from "./dev-fab";
 import { InspectOverlay } from "./inspect-overlay";
 import { AnnotateCanvas } from "./annotate-canvas";
@@ -26,6 +25,7 @@ export function DevOverlay() {
   } | null>(null);
 
   const captureScreenshot = useCallback(async () => {
+    const { default: html2canvas } = await import("html2canvas");
     const overlay = document.getElementById("dev-overlay-root");
     if (overlay) overlay.style.display = "none";
 

--- a/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
+++ b/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useKeyboardInset } from "@/hooks/use-keyboard-inset";
@@ -14,8 +15,14 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import { MobileTransactionForm } from "@/components/mobile/mobile-transaction-form";
 import type { Account, CategoryWithChildren } from "@/types/domain";
+
+const MobileTransactionForm = dynamic(
+  () => import("@/components/mobile/mobile-transaction-form").then((m) => ({
+    default: m.MobileTransactionForm,
+  })),
+  { ssr: false, loading: () => null }
+);
 
 interface MobileTabBarProps {
   accounts: Account[];


### PR DESCRIPTION
## Summary

Performance audit across 3 dimensions (DB, rendering/caching, bundle) found 5 critical + 10 high-priority issues. This PR fixes the top 14.

### Critical fixes
- **Layout sequential profile fetch** → cached `getProfile()` in `Promise.all` (-50–150ms on every page)
- **`plan/page.tsx` double waterfall** → collapsed into single `Promise.all`, removed redundant fetches (-100–300ms)
- **`categories/page.tsx` waterfall** → parallelized `getCategoriesWithBudgetData` (-150–400ms)
- **Defense-in-depth on `getTransactions`** → added `.eq("user_id")` to the most-used read query
- **`MobileTransactionForm` in tab bar** → `next/dynamic` removes ~1,200 lines from every mobile page bundle

### High-priority fixes
- **`presupuesto/page.tsx`** → cached `getPreferredCurrency()` + dynamic imports for `BudgetWizard` (718 lines) and `BudgetPageClient` (806 lines)
- **Nuclear `revalidateTag("zeta")`** → removed from `tags.ts`, `wishlist.ts`, `accounts.ts`
- **Layout Suspense** → removed no-fallback `<Suspense>` wrapping `{children}`
- **`DevOverlay`** → dynamic import + lazy `html2canvas` (250KB off production)
- **`ScenarioPlanner`**, **`SpendingHeatmap`**, **`WaterfallChart`** → dynamic imports
- **`getDashboardAccountsCached`** → eliminated redundant duplicate query

### Estimated total impact
- **Every page:** -50–150ms (layout waterfall)
- **`/plan`:** -100–300ms
- **`/categories`:** -150–400ms
- **Mobile bundle:** ~1,200+ lines removed from initial load
- **Cache coherence:** no more full-app cache busts on tag/wishlist/account mutations

## Test plan
- [x] `pnpm build` passes clean
- [ ] Verify dashboard loads correctly (profile, sidebar, topbar)
- [ ] Verify `/plan` page renders allocation and budget data
- [ ] Verify `/categories` page renders budget categories
- [ ] Verify `/presupuesto` budget wizard and budget page render
- [ ] Verify mobile tab bar + transaction form drawer works
- [ ] Verify tag creation, wishlist mutations, account payment recording still invalidate correct caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)