### PR TITLE
feat(dev): enable design review system in production with mobile-responsive UI

### DIFF
--- a/webapp/src/app/(dashboard)/layout.tsx
+++ b/webapp/src/app/(dashboard)/layout.tsx
@@ -18,7 +18,6 @@ const DevOverlay = dynamic(
   () => import("@/components/dev/dev-overlay").then((m) => ({ default: m.DevOverlay })),
 );
 
-const IS_DEV = process.env.NODE_ENV === "development";
 
 export default async function DashboardLayout({
   children,
@@ -88,7 +87,7 @@ export default async function DashboardLayout({
           </MobileShellProvider>
         </KeyboardInsetProvider>
       </div>
-      {IS_DEV && <DevOverlay />}
+      <DevOverlay />
     </div>
   );
 }

--- a/webapp/src/components/dev/annotate-canvas.tsx
+++ b/webapp/src/components/dev/annotate-canvas.tsx
@@ -184,8 +184,8 @@ export function AnnotateCanvas({
   return (
     <div className="fixed inset-0 z-[9999] flex flex-col bg-black">
       {/* Toolbar */}
-      <div className="flex items-center justify-between border-b border-white/6 bg-z-surface px-4 py-2">
-        <span className="text-sm font-medium text-z-sage-light">
+      <div className="flex flex-wrap items-center gap-2 border-b border-white/6 bg-z-surface px-4 py-2">
+        <span className="w-full text-sm font-medium text-z-sage-light lg:w-auto">
           {screenshotDataUrl ? "Anotar captura" : "Lienzo libre"}
           {componentHint && (
             <span className="ml-2 text-z-brass">· {componentHint}</span>
@@ -196,19 +196,19 @@ export function AnnotateCanvas({
             <SketchWorkspaceToolbar onImportImage={handleImportImage} />
           </div>
         )}
-        <div className="flex items-center gap-2">
+        <div className="ml-auto flex items-center gap-2">
           <button
             onClick={handleSave}
-            className="flex items-center gap-1.5 rounded-lg bg-z-brass px-3 py-1.5 text-xs font-semibold text-z-ink"
+            className="flex min-h-[44px] items-center gap-1.5 rounded-lg bg-z-brass px-4 py-2.5 text-sm font-semibold text-z-ink lg:min-h-0 lg:px-3 lg:py-1.5 lg:text-xs"
           >
-            <Save className="size-3.5" />
+            <Save className="size-4 lg:size-3.5" />
             Guardar
           </button>
           <button
             onClick={onClose}
-            className="flex items-center gap-1.5 rounded-lg border border-white/6 bg-z-surface-3 px-3 py-1.5 text-xs text-z-sage-light"
+            className="flex min-h-[44px] items-center gap-1.5 rounded-lg border border-white/6 bg-z-surface-3 px-4 py-2.5 text-sm text-z-sage-light lg:min-h-0 lg:px-3 lg:py-1.5 lg:text-xs"
           >
-            <X className="size-3.5" />
+            <X className="size-4 lg:size-3.5" />
             Cerrar
           </button>
         </div>

--- a/webapp/src/components/dev/dev-fab.tsx
+++ b/webapp/src/components/dev/dev-fab.tsx
@@ -25,10 +25,10 @@ export function DevFAB({ onAction, activeAction }: DevFABProps) {
   if (!enabled) return null;
 
   return (
-    <div className="fixed bottom-24 left-4 z-[9999] lg:bottom-6">
+    <div className="fixed bottom-28 left-4 z-[9999] lg:bottom-6">
       {/* Radial menu */}
       {menuOpen && (
-        <div className="absolute bottom-14 left-0 flex flex-col gap-2">
+        <div className="absolute bottom-14 left-0 flex flex-col gap-3 lg:gap-2">
           {actions.map((action) => (
             <button
               key={action.id}
@@ -37,7 +37,7 @@ export function DevFAB({ onAction, activeAction }: DevFABProps) {
                 setMenuOpen(false);
               }}
               className={cn(
-                "flex items-center gap-2 rounded-full px-3 py-2 text-xs font-medium shadow-lg transition-all",
+                "flex min-h-[44px] items-center gap-2 rounded-full px-4 py-3 text-sm font-medium shadow-lg transition-all lg:min-h-0 lg:px-3 lg:py-2 lg:text-xs",
                 activeAction === action.id
                   ? "bg-z-brass text-z-ink"
                   : "bg-z-surface-3 text-z-sage-light border border-white/6 hover:bg-white/5"

--- a/webapp/src/components/dev/inspect-overlay.tsx
+++ b/webapp/src/components/dev/inspect-overlay.tsx
@@ -110,8 +110,15 @@ export function InspectOverlay({ onSelectComponent, onClose }: InspectOverlayPro
   return (
     <div ref={overlayRef} className="fixed inset-0 z-[9998] cursor-crosshair">
       {/* Instruction bar */}
-      <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] rounded-full bg-z-surface-3 border border-white/6 px-4 py-2 text-xs text-z-sage-light shadow-lg">
-        Inspeccionar — haz clic en un componente · <kbd className="text-z-brass">Esc</kbd> para salir
+      <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 rounded-full bg-z-surface-3 border border-white/6 px-4 py-2 text-xs text-z-sage-light shadow-lg">
+        <span>Inspeccionar — toca un componente</span>
+        <kbd className="hidden text-z-brass lg:inline">Esc</kbd>
+        <button
+          className="ml-1 flex size-6 items-center justify-center rounded-full bg-white/10 text-z-sage-light lg:hidden"
+          onClick={onClose}
+        >
+          ✕
+        </button>
       </div>
 
       {/* Highlight box */}
@@ -148,14 +155,17 @@ export function InspectOverlay({ onSelectComponent, onClose }: InspectOverlayPro
       {contextMenu && (
         <div
           className="fixed z-[10000] rounded-xl border border-white/6 bg-z-surface-2 p-1.5 shadow-xl"
-          style={{ top: contextMenu.y, left: contextMenu.x }}
+          style={{
+            top: Math.min(contextMenu.y, window.innerHeight - 180),
+            left: Math.min(contextMenu.x, window.innerWidth - 200),
+          }}
         >
-          <p className="px-2 py-1 text-[11px] font-semibold text-z-brass">{contextMenu.info.componentName}</p>
+          <p className="px-3 py-1.5 text-xs font-semibold text-z-brass lg:px-2 lg:py-1 lg:text-[11px]">{contextMenu.info.componentName}</p>
           {([
-            { id: "annotate" as const, label: "Anotar componente", emoji: "✏️" },
-            { id: "storybook" as const, label: "Abrir en Storybook", emoji: "🧩" },
-            { id: "copy" as const, label: "Copiar ruta", emoji: "📋" },
-          ]).map((action) => (
+            { id: "annotate" as const, label: "Anotar componente", emoji: "✏️", needsSource: false },
+            { id: "storybook" as const, label: "Abrir en Storybook", emoji: "🧩", needsSource: true },
+            { id: "copy" as const, label: "Copiar ruta", emoji: "📋", needsSource: true },
+          ]).filter((action) => !action.needsSource || contextMenu.info.filePath).map((action) => (
             <button
               key={action.id}
               onClick={() => {
@@ -171,7 +181,7 @@ export function InspectOverlay({ onSelectComponent, onClose }: InspectOverlayPro
                   setContextMenu(null);
                 }
               }}
-              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-xs text-z-sage-light hover:bg-white/5"
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-sm text-z-sage-light hover:bg-white/5 lg:px-2 lg:py-1.5 lg:text-xs"
             >
               <span>{action.emoji}</span> {action.label}
             </button>

--- a/webapp/src/components/dev/review-save-dialog.tsx
+++ b/webapp/src/components/dev/review-save-dialog.tsx
@@ -97,8 +97,8 @@ export function ReviewSaveDialog({
   }
 
   return (
-    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-sm rounded-2xl border border-white/6 bg-z-surface p-5 shadow-xl">
+    <div className="fixed inset-0 z-[10000] flex items-end justify-center bg-black/60 lg:items-center">
+      <div className="w-full max-w-none rounded-t-2xl border border-white/6 bg-z-surface p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] shadow-xl lg:max-w-sm lg:rounded-2xl lg:pb-5">
         <h3 className="text-base font-semibold text-z-white">
           Guardar revisión
         </h3>
@@ -114,7 +114,7 @@ export function ReviewSaveDialog({
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="¿Qué hay que arreglar?"
-          className="mt-3 w-full rounded-lg border border-white/6 bg-z-surface-2 px-3 py-2 text-sm text-z-white placeholder:text-z-sage-dark outline-none focus:border-z-brass"
+          className="mt-3 w-full rounded-lg border border-white/6 bg-z-surface-2 px-3 py-3 text-base text-z-white placeholder:text-z-sage-dark outline-none focus:border-z-brass lg:py-2 lg:text-sm"
           maxLength={160}
         />
 
@@ -123,7 +123,7 @@ export function ReviewSaveDialog({
             <button
               key={opt.value}
               onClick={() => setSeverity(opt.value)}
-              className={`flex-1 rounded-lg border px-2 py-1.5 text-xs font-medium transition-colors ${
+              className={`flex-1 min-h-[44px] rounded-lg border px-2 py-2.5 text-sm font-medium transition-colors lg:min-h-0 lg:py-1.5 lg:text-xs ${
                 severity === opt.value
                   ? "border-z-brass bg-z-brass/10 text-z-brass"
                   : "border-white/6 text-z-sage-light hover:bg-white/5"
@@ -139,16 +139,16 @@ export function ReviewSaveDialog({
         <div className="mt-4 flex gap-2">
           <button
             onClick={onCancel}
-            className="flex-1 rounded-lg border border-white/6 bg-z-surface-3 py-2 text-xs text-z-sage-light"
+            className="flex-1 min-h-[44px] rounded-lg border border-white/6 bg-z-surface-3 py-3 text-sm text-z-sage-light lg:min-h-0 lg:py-2 lg:text-xs"
           >
             Cancelar
           </button>
           <button
             onClick={handleSave}
             disabled={!title.trim() || saving}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-z-brass py-2 text-xs font-semibold text-z-ink disabled:opacity-50"
+            className="flex flex-1 min-h-[44px] items-center justify-center gap-1.5 rounded-lg bg-z-brass py-3 text-sm font-semibold text-z-ink disabled:opacity-50 lg:min-h-0 lg:py-2 lg:text-xs"
           >
-            <Save className="size-3.5" />
+            <Save className="size-4 lg:size-3.5" />
             {saving ? "Guardando..." : "Guardar"}
           </button>
         </div>

--- a/webapp/src/components/dev/sketch-workspace.tsx
+++ b/webapp/src/components/dev/sketch-workspace.tsx
@@ -90,23 +90,23 @@ export function SketchWorkspaceToolbar({ onImportImage }: SketchWorkspaceToolbar
     <div className="flex items-center gap-2">
       <button
         onClick={handleFileImport}
-        className="flex items-center gap-1.5 rounded-lg border border-white/6 bg-z-surface-3 px-3 py-1.5 text-xs text-z-sage-light hover:bg-white/5"
+        className="flex min-h-[44px] items-center gap-1.5 rounded-lg border border-white/6 bg-z-surface-3 px-4 py-2.5 text-sm text-z-sage-light hover:bg-white/5 lg:min-h-0 lg:px-3 lg:py-1.5 lg:text-xs"
       >
-        <ImagePlus className="size-3.5" />
+        <ImagePlus className="size-4 lg:size-3.5" />
         Importar imagen
       </button>
 
       <button
         onClick={handleLoadReviews}
         disabled={loadingReviews}
-        className="flex items-center gap-1.5 rounded-lg border border-white/6 bg-z-surface-3 px-3 py-1.5 text-xs text-z-sage-light hover:bg-white/5"
+        className="flex min-h-[44px] items-center gap-1.5 rounded-lg border border-white/6 bg-z-surface-3 px-4 py-2.5 text-sm text-z-sage-light hover:bg-white/5 lg:min-h-0 lg:px-3 lg:py-1.5 lg:text-xs"
       >
-        <FolderOpen className="size-3.5" />
+        <FolderOpen className="size-4 lg:size-3.5" />
         {loadingReviews ? "Cargando..." : "Revisiones previas"}
       </button>
 
       {showPreviousReviews && (
-        <div className="absolute top-12 left-0 z-10 max-h-64 w-72 overflow-y-auto rounded-xl border border-white/6 bg-z-surface-2 p-2 shadow-xl">
+        <div className="absolute top-12 left-0 right-0 z-10 max-h-[50vh] w-auto overflow-y-auto rounded-xl border border-white/6 bg-z-surface-2 p-2 shadow-xl lg:right-auto lg:w-72">
           {reviews.length === 0 ? (
             <p className="p-2 text-xs text-z-sage-dark">No hay revisiones</p>
           ) : (

--- a/webapp/src/components/settings/review-mode-toggle.tsx
+++ b/webapp/src/components/settings/review-mode-toggle.tsx
@@ -5,8 +5,6 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 
 export function ReviewModeToggle() {
-  if (process.env.NODE_ENV !== "development") return null;
-
   const { enabled, toggle } = useReviewMode();
 
   return (


### PR DESCRIPTION
Remove NODE_ENV === "development" gates so the Excalidraw-based design review
system works in production. The overlay remains opt-in via ?review=true URL
param or the Settings toggle. Adapt all UI components (FAB, toolbar, save
dialog, inspect overlay) for touch-friendly mobile web usage with 44px minimum
tap targets, responsive layouts, and bottom-sheet save dialog.

https://claude.ai/code/session_01QwZfVQ3gdftLDbkxV8RiJ1