### PR TITLE
fix: improve duplicate review detail, fix off-brand colors, restore email retry

### DIFF
--- a/webapp/src/components/import/import-wizard.tsx
+++ b/webapp/src/components/import/import-wizard.tsx
@@ -301,6 +301,7 @@ export function ImportWizard({
             transactions={preparedTransactions}
             statementMeta={preparedStatementMeta}
             preview={reconciliationPreview}
+            currency={(parseResult?.statements[0]?.currency ?? "COP") as CurrencyCode}
             onComplete={handleImportComplete}
             onBack={() => setStep("confirm")}
           />

--- a/webapp/src/components/import/reconciliation-step.tsx
+++ b/webapp/src/components/import/reconciliation-step.tsx
@@ -4,7 +4,10 @@ import { useActionState, useMemo, useState } from "react";
 import { CheckCircle2, GitMerge, Loader2, SplitSquareVertical } from "lucide-react";
 import { importTransactions } from "@/actions/import-transactions";
 import { trackClientEvent } from "@/lib/utils/analytics";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -12,9 +15,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { ActionResult } from "@/types/actions";
+import type { CurrencyCode } from "@/types/domain";
 import type {
   ImportResult,
   ReconciliationDecisionInput,
+  ReconciliationPreviewItem,
   ReconciliationPreviewResult,
   StatementMetaForImport,
   TransactionToImport,
@@ -22,16 +27,59 @@ import type {
 
 type ReviewChoice = "MERGE" | "KEEP_BOTH";
 
+function ReconciliationPairCard({
+  item,
+  currency,
+}: {
+  item: ReconciliationPreviewItem;
+  currency: CurrencyCode;
+}) {
+  const imported = item.importedTransaction;
+  const candidate = item.candidate;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between">
+        <div className="grid flex-1 grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Extracto</p>
+            <p className="text-sm font-medium leading-tight">{imported.raw_description}</p>
+            <p className="text-xs text-muted-foreground">{formatDate(imported.transaction_date)}</p>
+            <p className={`text-sm font-semibold ${imported.direction === "INFLOW" ? "text-z-income" : "text-z-debt"}`}>
+              {imported.direction === "OUTFLOW" ? "−" : "+"}{formatCurrency(imported.amount, currency)}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Existente</p>
+            <p className="text-sm font-medium leading-tight">
+              {candidate.raw_description ?? candidate.merchant_name}
+            </p>
+            <p className="text-xs text-muted-foreground">{formatDate(candidate.transaction_date)}</p>
+            <p className="text-sm font-semibold">
+              {formatCurrency(candidate.amount, currency)}
+            </p>
+          </div>
+        </div>
+        <Badge variant="outline" className="ml-2 shrink-0 text-xs">
+          {Math.round(item.candidate.score * 100)}%
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
 export function ReconciliationStep({
   transactions,
   statementMeta,
   preview,
+  currency,
   onComplete,
   onBack,
 }: {
   transactions: TransactionToImport[];
   statementMeta: StatementMetaForImport[];
   preview: ReconciliationPreviewResult;
+  currency: CurrencyCode;
   onComplete: (result: ImportResult) => void;
   onBack: () => void;
 }) {
@@ -141,13 +189,7 @@ export function ReconciliationStep({
           <CardContent className="space-y-3">
             {preview.autoMerge.map((item) => (
               <div key={`${item.statementIndex}:${item.transactionIndex}`} className="rounded-lg border p-3">
-                <p className="text-sm font-medium">{item.importedTransaction.raw_description}</p>
-                <p className="text-xs text-muted-foreground">
-                  Se fusionará con: {item.candidate.raw_description ?? item.candidate.merchant_name}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Score {Math.round(item.candidate.score * 100)}%
-                </p>
+                <ReconciliationPairCard item={item} currency={currency} />
               </div>
             ))}
           </CardContent>
@@ -165,15 +207,7 @@ export function ReconciliationStep({
               const choice = reviewChoices[key] ?? "KEEP_BOTH";
               return (
                 <div key={key} className="rounded-lg border p-4">
-                  <div className="space-y-1">
-                    <p className="text-sm font-medium">{item.importedTransaction.raw_description}</p>
-                    <p className="text-xs text-muted-foreground">
-                      Posible duplicado: {item.candidate.raw_description ?? item.candidate.merchant_name}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      Score {Math.round(item.candidate.score * 100)}%
-                    </p>
-                  </div>
+                  <ReconciliationPairCard item={item} currency={currency} />
                   <div className="mt-3 flex gap-2">
                     <Button
                       type="button"

--- a/webapp/src/components/import/step-results.tsx
+++ b/webapp/src/components/import/step-results.tsx
@@ -144,7 +144,7 @@ export function StepResults({
             {result.autoMerged > 0 && (
               <div className="rounded-lg border p-3">
                 <div className="flex items-center gap-2 mb-1">
-                  <CheckCircle className="h-4 w-4 text-blue-600" />
+                  <CheckCircle className="h-4 w-4 text-z-brass" />
                   <span className="text-2xl font-bold">{result.autoMerged}</span>
                 </div>
                 <p className="text-xs text-muted-foreground">
@@ -155,7 +155,7 @@ export function StepResults({
             {result.manualMerged > 0 && (
               <div className="rounded-lg border p-3">
                 <div className="flex items-center gap-2 mb-1">
-                  <RefreshCw className="h-4 w-4 text-sky-600" />
+                  <RefreshCw className="h-4 w-4 text-z-brass" />
                   <span className="text-2xl font-bold">{result.manualMerged}</span>
                 </div>
                 <p className="text-xs text-muted-foreground">
@@ -179,7 +179,7 @@ export function StepResults({
       )}
 
       {result.adjustmentsExcluded != null && result.adjustmentsExcluded > 0 && (
-        <div className="rounded-md bg-blue-50 dark:bg-blue-950/30 text-blue-800 dark:text-blue-200 text-sm p-3">
+        <div className="rounded-md border border-z-alert/20 bg-z-alert/5 text-z-alert text-sm p-3">
           Se excluyeron {result.adjustmentsExcluded} ajuste(s) manual(es) de saldo que fueron reemplazados por las transacciones del extracto.
         </div>
       )}
@@ -188,7 +188,7 @@ export function StepResults({
         <div className="rounded-md border p-3 space-y-1">
           <p className="text-sm font-medium">Detalles:</p>
           {result.details.map((d, i) => (
-            <p key={i} className="text-xs text-destructive">
+            <p key={i} className="text-xs text-muted-foreground">
               {d}
             </p>
           ))}

--- a/webapp/src/components/settings/unrecognized-emails-card.tsx
+++ b/webapp/src/components/settings/unrecognized-emails-card.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { AlertTriangle, ChevronDown, ChevronUp, X, Loader2 } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronUp, Loader2, RefreshCw, X } from "lucide-react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { dismissUnrecognizedEmail } from "@/actions/email-ingest";
+import { dismissUnrecognizedEmail, retryUnrecognizedEmail } from "@/actions/email-ingest";
 import { formatDate } from "@/lib/utils/date";
 import type { UnrecognizedEmail } from "@/types/domain";
 
@@ -16,6 +17,7 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
   const [emails, setEmails] = useState(initialEmails);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [isPending, startTransition] = useTransition();
+  const [retryingId, setRetryingId] = useState<string | null>(null);
 
   if (emails.length === 0) return null;
 
@@ -35,6 +37,26 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
         setEmails((prev) => prev.filter((e) => e.id !== id));
       }
     });
+  }
+
+  async function handleRetry(id: string) {
+    setRetryingId(id);
+    try {
+      const result = await retryUnrecognizedEmail(id);
+      if (result.success) {
+        const messages: Record<string, string> = {
+          imported: "Transacción importada correctamente",
+          queued: "Transacción en cola para revisión",
+          duplicate: "La transacción ya existía",
+        };
+        toast.success(messages[result.data] ?? "Procesado correctamente");
+        setEmails((prev) => prev.filter((e) => e.id !== id));
+      } else {
+        toast.error(result.error || "No se pudo reprocesar el correo");
+      }
+    } finally {
+      setRetryingId(null);
+    }
   }
 
   return (
@@ -84,20 +106,36 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
                       </p>
                     </div>
                   </button>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
-                    onClick={() => handleDismiss(email.id)}
-                    disabled={isPending}
-                    aria-label="Descartar"
-                  >
-                    {isPending ? (
-                      <Loader2 className="size-4 animate-spin" />
-                    ) : (
-                      <X className="size-4" />
-                    )}
-                  </Button>
+                  <div className="flex shrink-0 gap-1">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-8 text-muted-foreground hover:text-z-brass"
+                      onClick={() => handleRetry(email.id)}
+                      disabled={retryingId === email.id || isPending}
+                      aria-label="Reintentar"
+                    >
+                      {retryingId === email.id ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <RefreshCw className="size-4" />
+                      )}
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-8 text-muted-foreground hover:text-destructive"
+                      onClick={() => handleDismiss(email.id)}
+                      disabled={isPending || retryingId === email.id}
+                      aria-label="Descartar"
+                    >
+                      {isPending ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <X className="size-4" />
+                      )}
+                    </Button>
+                  </div>
                 </div>
 
                 {isExpanded && (


### PR DESCRIPTION
- Reconciliation review cards now show side-by-side comparison with date,
  description, and colored amount for both imported and existing transactions
- Results page: replace blue alerts with z-alert tokens, red details text
  with muted-foreground, merge stat icons now use z-brass
- Restore retry button on unrecognized emails card (retryUnrecognizedEmail
  server action was orphaned — now wired to UI with toast feedback)

https://claude.ai/code/session_01Wkg95Q5qgU5VMcbhg1Y594