### PR TITLE
feat: add inline destinatario creation from transaction detail view

### DIFF
--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -59,32 +59,36 @@ export async function testDestinatarioPattern(
   if (!user) return { success: false, error: "No autenticado" };
 
   // Use server-side filtering via ilike instead of fetching 1000 rows
-  let query = supabase
-    .from("transactions")
-    .select("id, raw_description, transaction_date, amount, currency_code")
-    .eq("user_id", user.id)
-    .is("destinatario_id", null)
-    .not("raw_description", "is", null);
+  const ilikePattern = matchType === "exact" ? pattern : `%${pattern}%`;
 
-  if (matchType === "exact") {
-    query = query.ilike("raw_description", pattern);
-  } else {
-    query = query.ilike("raw_description", `%${pattern}%`);
-  }
+  // Count query (exact total) + sample query (5 rows) in parallel
+  const [countResult, samplesResult] = await Promise.all([
+    supabase
+      .from("transactions")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", user.id)
+      .is("destinatario_id", null)
+      .not("raw_description", "is", null)
+      .ilike("raw_description", ilikePattern),
+    supabase
+      .from("transactions")
+      .select("id, raw_description, transaction_date, amount, currency_code")
+      .eq("user_id", user.id)
+      .is("destinatario_id", null)
+      .not("raw_description", "is", null)
+      .ilike("raw_description", ilikePattern)
+      .order("transaction_date", { ascending: false })
+      .limit(5),
+  ]);
 
-  const { data, error } = await query
-    .order("transaction_date", { ascending: false })
-    .limit(5);
-
-  if (error) return { success: false, error: error.message };
-
-  const matches = data ?? [];
+  if (countResult.error) return { success: false, error: countResult.error.message };
+  if (samplesResult.error) return { success: false, error: samplesResult.error.message };
 
   return {
     success: true,
     data: {
-      matchCount: matches.length,
-      samples: matches.map((tx) => ({
+      matchCount: countResult.count ?? 0,
+      samples: (samplesResult.data ?? []).map((tx) => ({
         id: tx.id,
         rawDescription: tx.raw_description!,
         date: tx.transaction_date,

--- a/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
@@ -180,6 +180,8 @@ export default async function TransactionDetailPage({
                 transactionId={tx.id}
                 currentDestinatarioId={tx.destinatario_id}
                 destinatarios={destinatarios}
+                rawDescription={tx.raw_description}
+                categories={categories}
               />
             </CardContent>
           </Card>

--- a/webapp/src/components/transactions/destinatario-picker.tsx
+++ b/webapp/src/components/transactions/destinatario-picker.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { Check, ChevronsUpDown, X, Loader2 } from "lucide-react";
+import {
+  Check,
+  ChevronsUpDown,
+  X,
+  Loader2,
+  Plus,
+  Search,
+} from "lucide-react";
 import Link from "next/link";
 
 import { cn } from "@/lib/utils";
@@ -14,6 +21,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/components/ui/command";
 import {
   Popover,
@@ -21,9 +29,27 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import {
   assignDestinatario,
   removeDestinatarioFromTransaction,
 } from "@/actions/categorize";
+import {
+  createDestinatario,
+  testDestinatarioPattern,
+  type CreateDestinatarioResult,
+  type PatternTestResult,
+} from "@/actions/destinatarios";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { ActionResult } from "@/types/actions";
+import type { CategoryWithChildren, CurrencyCode } from "@/types/domain";
 
 type DestinatarioOption = {
   id: string;
@@ -35,16 +61,21 @@ interface DestinatarioPickerProps {
   transactionId: string;
   currentDestinatarioId: string | null;
   destinatarios: DestinatarioOption[];
+  rawDescription?: string | null;
+  categories?: CategoryWithChildren[];
 }
 
 export function DestinatarioPicker({
   transactionId,
   currentDestinatarioId,
   destinatarios,
+  rawDescription,
+  categories,
 }: DestinatarioPickerProps) {
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [selectedId, setSelectedId] = React.useState(currentDestinatarioId);
+  const [showCreateDialog, setShowCreateDialog] = React.useState(false);
 
   const activeDestinatarios = destinatarios.filter((d) => d.is_active);
   const selected = destinatarios.find((d) => d.id === selectedId);
@@ -68,6 +99,24 @@ export function DestinatarioPicker({
       const result = await removeDestinatarioFromTransaction(transactionId);
       if (result.success) {
         setSelectedId(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleCreateNew() {
+    setOpen(false);
+    setShowCreateDialog(true);
+  }
+
+  async function handleCreated(destinatarioId: string) {
+    setShowCreateDialog(false);
+    setLoading(true);
+    try {
+      const result = await assignDestinatario(transactionId, destinatarioId);
+      if (result.success) {
+        setSelectedId(destinatarioId);
       }
     } finally {
       setLoading(false);
@@ -109,7 +158,8 @@ export function DestinatarioPicker({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
             variant="outline"
@@ -144,9 +194,223 @@ export function DestinatarioPicker({
                   </CommandItem>
                 ))}
               </CommandGroup>
+              {categories && (
+                <>
+                  <CommandSeparator />
+                  <CommandGroup>
+                    <CommandItem onSelect={handleCreateNew}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Crear nuevo destinatario
+                    </CommandItem>
+                  </CommandGroup>
+                </>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>
-    </Popover>
+      </Popover>
+
+      {categories && (
+        <InlineCreateDestinatarioDialog
+          open={showCreateDialog}
+          onOpenChange={setShowCreateDialog}
+          categories={categories}
+          rawDescription={rawDescription}
+          onCreated={handleCreated}
+        />
+      )}
+    </>
+  );
+}
+
+// ─── Inline Create Dialog ────────────────────────────────────────────────────
+
+function InlineCreateDestinatarioDialog({
+  open,
+  onOpenChange,
+  categories,
+  rawDescription,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  categories: CategoryWithChildren[];
+  rawDescription?: string | null;
+  onCreated: (destinatarioId: string) => void;
+}) {
+  const [categoryId, setCategoryId] = React.useState<string | null>(null);
+  const [patterns, setPatterns] = React.useState("");
+  const [testResult, setTestResult] = React.useState<PatternTestResult | null>(
+    null
+  );
+  const [isTesting, startTestTransition] = React.useTransition();
+  const [state, formAction, pending] = React.useActionState<
+    ActionResult<CreateDestinatarioResult>,
+    FormData
+  >(createDestinatario, { success: false, error: "" });
+
+  // Pre-fill pattern from raw description when opening
+  React.useEffect(() => {
+    if (open && rawDescription) {
+      setPatterns(rawDescription);
+      setTestResult(null);
+    }
+  }, [open, rawDescription]);
+
+  // Handle successful creation
+  React.useEffect(() => {
+    if (!state.success) return;
+    const createdId = state.data.id;
+    setCategoryId(null);
+    setPatterns("");
+    setTestResult(null);
+    onCreated(createdId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  // Reset form when closing
+  function handleOpenChange(next: boolean) {
+    onOpenChange(next);
+    if (!next) {
+      setCategoryId(null);
+      setPatterns("");
+      setTestResult(null);
+    }
+  }
+
+  function handleTestPatterns() {
+    const firstPattern = patterns.split(",")[0]?.trim();
+    if (!firstPattern) return;
+    startTestTransition(async () => {
+      const result = await testDestinatarioPattern(firstPattern, "contains");
+      if (result.success) setTestResult(result.data);
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Crear destinatario</DialogTitle>
+          <p className="text-sm text-muted-foreground">
+            Crea un destinatario a partir de esta transacción. Prueba los
+            patrones antes de guardar.
+          </p>
+        </DialogHeader>
+
+        <form action={formAction} className="space-y-4">
+          {!state.success && state.error && (
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {state.error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="inline-dest-name">Nombre</Label>
+            <Input
+              id="inline-dest-name"
+              name="name"
+              placeholder="Ej: Nequi, Spotify, Rappi"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Categoría por defecto</Label>
+            <CategoryZonePicker
+              categories={categories}
+              value={categoryId}
+              onValueChange={setCategoryId}
+              variant="popover"
+              name="default_category_id"
+              placeholder="Sin categoría"
+              triggerClassName="w-full"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="inline-dest-patterns">Patrones</Label>
+            <div className="flex gap-2">
+              <Input
+                id="inline-dest-patterns"
+                name="patterns"
+                placeholder="Ej: nequi pago, rappi, spotify"
+                value={patterns}
+                onChange={(e) => {
+                  setPatterns(e.target.value);
+                  if (testResult) setTestResult(null);
+                }}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleTestPatterns}
+                disabled={!patterns.trim() || isTesting}
+                title="Probar patrón"
+              >
+                {isTesting ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Search className="size-4" />
+                )}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Pre-llenado con la descripción de esta transacción. Ajusta o
+              separa con comas para crear varias reglas.
+            </p>
+            {testResult && (
+              <div className="rounded-lg border border-z-border-strong bg-z-surface-2 p-3 space-y-2">
+                <p className="text-xs font-medium">
+                  {testResult.matchCount === 0
+                    ? "Sin coincidencias en transacciones sin asignar"
+                    : `${testResult.matchCount} transaccion${testResult.matchCount === 1 ? "" : "es"} coinciden`}
+                </p>
+                {testResult.samples.length > 0 && (
+                  <ul className="space-y-1">
+                    {testResult.samples.map((s) => (
+                      <li
+                        key={s.id}
+                        className="text-xs text-muted-foreground flex justify-between gap-2"
+                      >
+                        <span className="truncate">{s.rawDescription}</span>
+                        <span className="shrink-0 tabular-nums">
+                          {formatCurrency(
+                            s.amount,
+                            s.currencyCode as CurrencyCode
+                          )}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+
+          <input type="hidden" name="is_active" value="true" />
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => handleOpenChange(false)}
+              disabled={pending}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              className="bg-z-brass text-z-ink hover:bg-z-brass/90"
+              disabled={pending}
+            >
+              {pending ? "Creando..." : "Crear y asignar"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/webapp/src/components/transactions/destinatario-picker.tsx
+++ b/webapp/src/components/transactions/destinatario-picker.tsx
@@ -210,7 +210,7 @@ export function DestinatarioPicker({
         </PopoverContent>
       </Popover>
 
-      {categories && (
+      {categories && showCreateDialog && (
         <InlineCreateDestinatarioDialog
           open={showCreateDialog}
           onOpenChange={setShowCreateDialog}
@@ -279,11 +279,31 @@ function InlineCreateDestinatarioDialog({
   }
 
   function handleTestPatterns() {
-    const firstPattern = patterns.split(",")[0]?.trim();
-    if (!firstPattern) return;
+    const allPatterns = patterns
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (allPatterns.length === 0) return;
     startTestTransition(async () => {
-      const result = await testDestinatarioPattern(firstPattern, "contains");
-      if (result.success) setTestResult(result.data);
+      // Test all patterns and aggregate results
+      const results = await Promise.all(
+        allPatterns.map((p) => testDestinatarioPattern(p, "contains"))
+      );
+      const combined: PatternTestResult = { matchCount: 0, samples: [] };
+      const seenIds = new Set<string>();
+      for (const r of results) {
+        if (!r.success) continue;
+        combined.matchCount += r.data.matchCount;
+        for (const s of r.data.samples) {
+          if (!seenIds.has(s.id)) {
+            seenIds.add(s.id);
+            combined.samples.push(s);
+          }
+        }
+      }
+      // Limit displayed samples to 5
+      combined.samples = combined.samples.slice(0, 5);
+      setTestResult(combined);
     });
   }
 


### PR DESCRIPTION
Adds a "Crear nuevo destinatario" option in the destinatario picker dropdown
that opens a modal pre-filled with the transaction's raw description as a
pattern. Users can test the pattern against unmatched transactions before
creating, and the new destinatario is auto-assigned to the current transaction.

https://claude.ai/code/session_01KP6Q8DqB7CGz8VHddEXsE2