### PR TITLE
feat: performance audit + encryption caching + mobile polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ node_modules/
 # Bank PDF examples and unrecognized uploads (sensitive financial data)
 bank_pdf_examples/
 services/pdf_parser/unrecognized/
+image_transaction_samples/
+
+# Audit artifacts
+audit/
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@
 ## Supabase
 - Project ID: `tgkhaxipfgskxydotdtu` (sa-east-1, org: zybaordjrezdjajzwisk)
 - See `~/.claude/rules/supabase.md` for RLS, auth, migration patterns
+- **Envelope encryption**: Tables with PII use `_enc` suffix (real table) + view (original name) + INSTEAD OF triggers. When adding a column to any `_enc` table, you MUST also update the view SELECT and the INSTEAD OF INSERT/UPDATE trigger functions. See `docs/superpowers/specs/2026-04-07-envelope-encryption-design.md` for full spec.
 
 ## Income & Metrics Rules
 - **Debt inflows are NOT income**: INFLOW to `CREDIT_CARD` or `LOAN` accounts are debt payments. They must NEVER count in income/ingresos metrics. Always filter: `tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id)` where `debtAccountIds` comes from `accounts.filter(a => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN")`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,17 @@
 - Dates: Spanish locale via `formatDate()` from `src/lib/utils/date.ts`
 - Idempotency: `computeIdempotencyKey()` from `src/lib/utils/idempotency.ts` for dedup
 
+## Performance Rules
+- **Cache stable data**: Accounts, categories, destinatarios, profiles, recurring templates, and other slowly-changing data MUST use `"use cache"` with `cacheTag()` + `cacheLife("zeta")`. Transactions are also cached. Mutations invalidate via `revalidateTag()`. Never add a DB query to a page render path without caching unless the data is truly per-request.
+- **Don't add joins or queries without justification**: Before adding PostgREST joins, extra SELECT columns, or new DB calls to a page, consider: (1) is this data already available from a parent component? (2) can it be deferred via Suspense? (3) does it need to load eagerly or only on interaction? Every new query adds latency — explain the trade-off.
+- **Suspense for non-critical data**: Data only needed for interactive elements (edit forms, pickers, dialogs) should be deferred behind `<Suspense>`, not fetched eagerly in the page's main `Promise.all`.
+- **Cached client pattern**: `"use cache"` functions use `createCachedClient(accessToken)` from `@/lib/supabase/cached`. The `accessToken` comes from `getAuthenticatedClient()`. See Gotchas for details.
+
+## UI Rules
+- **No hardcoded colors**: Never use raw hex values, `rgb()`, or arbitrary Tailwind colors (`bg-[#xxx]`). Always use the design tokens defined in `docs/design-system/TOKENS.md` — e.g., `text-z-brass`, `bg-z-surface-2`, `border-white/6`, `text-z-sage-dark`. If a needed token doesn't exist, propose adding it to TOKENS.md first.
+- **No hardcoded styles for layout/spacing**: Prefer existing utility patterns and component props. Check existing components for established patterns before creating new styling approaches.
+- **Reuse existing components**: Before building a new card, badge, stat display, or layout pattern, check `webapp/src/components/ui/` for existing primitives (StatCard, PageHero, Card, Badge, etc.).
+
 ## Supabase
 - Project ID: `tgkhaxipfgskxydotdtu` (sa-east-1, org: zybaordjrezdjajzwisk)
 - See `~/.claude/rules/supabase.md` for RLS, auth, migration patterns
@@ -35,6 +46,8 @@
 - shadcn/ui Checkbox: use `checked="indeterminate"`, not an `indeterminate` prop
 - Radix Select sends empty string (not null/undefined) when no value — use `z.preprocess` to normalize
 - Shell `compdef` warning leaks into stdout redirects — always strip first line if piping to file
+- **PostgREST joins through encrypted views**: FK constraints live on `_enc` tables, so PostgREST can't auto-detect relationships through the views. Always use explicit FK hint syntax: `account:accounts!transactions_account_id_fkey(id, name)` — never plain `account:accounts(id, name)`. Without the `!fk_name` hint, the join silently fails and returns empty results.
+- **`"use cache"` + encryption**: Cached functions that query encrypted views must use `createCachedClient(accessToken)` from `@/lib/supabase/cached`, never `createAdminClient()`. The admin client has no JWT, so `zeta_decrypt()` returns NULL for all encrypted columns. The `accessToken` comes from `getAuthenticatedClient()` which returns `{ supabase, user, accessToken }`.
 
 <!-- GSD:project-start source:PROJECT.md -->
 ## Project

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,111 +1,84 @@
-# HANDOVER — Mobile v2 Full Redesign (2026-04-04/05)
+# HANDOVER — 2026-04-08 (Performance Audit)
 
 ## 1. Session Summary
 
-Complete mobile redesign for all 4 root tabs (Inicio, Movimientos, Plan, Deudas) on branch `feat/mobile-v2-redesign`. Built ~30 new React components with zone-based layouts, custom heroes per root, expandable chip patterns, and Zeta-branded data visualizations (brass dotted expected lines, sage solid actual lines). Design was iterated through HTML mockup previews → component catalog review → user approval → React implementation → Playwright visual testing. Core UX pattern: "expand inline, never navigate directly" — everything shows a preview first, navigation is secondary.
+Performance audit triggered by slow "Ver detalle" navigation on the movimientos page. Traced root cause to missing loading states, eager data fetching, and a critical encryption compatibility bug where `createAdminClient()` in `"use cache"` functions returned NULL for all encrypted columns post-envelope-encryption. Fixed all 14 affected action files, introduced `createCachedClient(accessToken)` pattern, optimized `zeta_decrypt()` with DEK session caching, added Suspense splitting to the transaction detail page, and cached transaction queries. Also fixed a broken PostgREST join and updated the transaction row expanded view to use icon-only action buttons.
 
 ## 2. Changes Made
 
-### Shared primitives (`webapp/src/components/mobile/v2/`)
-- `mobile-zone.tsx` — Zone layout (eyebrow + heading + children)
-- `state-chip.tsx` — Colored state pill (sage/brass/warn/danger)
-- `use-expandable-zone.ts` — Accordion hook (one zone expanded at a time)
-- `linked-metric-detail-panel.tsx` — Chip row + full-width expandable detail panel
-- `mobile-header.tsx` — Added `chip?: string` prop to page variant
+### Infrastructure — Cached client pattern
+- **`webapp/src/lib/supabase/cached.ts`** — Created. New `createCachedClient(accessToken)` that creates a Supabase client with user JWT for use inside `"use cache"` functions.
+- **`webapp/src/lib/supabase/auth.ts`** — Modified. `getAuthenticatedClient()` now returns `{ supabase, user, accessToken }` (backward-compatible addition). Fast path extracts token from `getSession()`.
 
-### Inicio (`webapp/src/components/mobile/v2/inicio/`) — 7 files
-- `inicio-hero.tsx` — Daily amount ($X/día), expandable math breakdown, controlled from parent accordion
-- `inicio-metrics-grid.tsx` — SVG arc ring (% inside) + próximo ingreso
-- `inicio-focus.tsx` — Single attention signal row
-- `inicio-burndown.tsx` — Copilot-style: "$X restante" centered, brass/sage chart, badge on point
-- `inicio-discovery.tsx` — Two cards, expand FULL WIDTH panel below both (not per-column)
-- `inicio-activity.tsx` — Transaction rows expand inline with quick view (not navigate)
-- `inicio-root.tsx` — Orchestrator with page-level `useExpandableZone`
+### DB optimization — DEK caching
+- **`supabase/migrations/20260408143011_optimize_zeta_decrypt_dek_cache.sql`** — Created. `zeta_decrypt()`, `zeta_encrypt()`, and `zeta_hmac()` now cache the decrypted DEK in a transaction-local session variable via `set_config('zeta.cached_dek', ...)`. First call does vault+DEK lookup; subsequent calls skip it. Benchmarked: accounts query 17.3ms → 8.4ms (-52%).
 
-### Movimientos (`webapp/src/components/mobile/v2/movimientos/`) — 5 files
-- `movimientos-lectura.tsx` — 3-col stats, expandable dual-line chart (REAL data aggregated by week)
-- `movimientos-herramientas.tsx` — 3-col tools (Categorizar/Destinatarios/Importar), expand inline
-- `movimientos-transaction-row.tsx` — Expandable rows with action pills
-- `movimientos-utilidades.tsx` — Pill buttons opening drawers
-- `movimientos-root.tsx` — Orchestrator with page-level accordion
+### Encryption compatibility — 14 action files fixed
+All `"use cache"` functions that query encrypted views switched from `createAdminClient()` to `createCachedClient(accessToken)`:
+- **`webapp/src/actions/accounts.ts`** — Restored `"use cache"` with token-based client
+- **`webapp/src/actions/destinatarios.ts`** — Restored `"use cache"` for main reads; `fetchDestinatarioRules()` exported for shared use
+- **`webapp/src/actions/categorize.ts`** — All 5 cached functions + `getDestinatarioSuggestionsForInbox()` updated
+- **`webapp/src/actions/debt.ts`** — `getDebtOverviewCached` updated
+- **`webapp/src/actions/recurring-templates.ts`** — All 4 cached functions updated
+- **`webapp/src/actions/statement-snapshots.ts`** — Both cached functions updated
+- **`webapp/src/actions/profile.ts`** — Both cached functions updated
+- **`webapp/src/actions/debt-countdown.ts`** — `getDebtFreeCountdownCached` updated
+- **`webapp/src/actions/cashflow-planner.ts`** — All cached functions updated
+- **`webapp/src/actions/scenarios.ts`** — `getScenariosCached` updated
+- **`webapp/src/actions/attention-items.ts`** — `getAttentionItemsCached` updated
+- **`webapp/src/actions/payment-reminders.ts`** — `getUpcomingPaymentsCached` updated
+- **`webapp/src/actions/income.ts`** — `getEstimatedIncomeCached` updated
 
-### Plan (`webapp/src/components/mobile/v2/plan/`) — 5 files
-- `plan-budget-hero.tsx` — % hero with progress bar + pace marker, expandable per-category breakdown
-- `plan-action-cta.tsx` — "Planificar" multi-option CTA
-- `plan-flow-chart.tsx` — Bar chart: income up / expense down by day (real recurring data)
-- `plan-distribution.tsx` — 50/30/20 bars, budget-type aware
-- `plan-root.tsx` — Orchestrator with page-level accordion
+### Transaction detail page — Suspense + loading
+- **`webapp/src/app/(dashboard)/transactions/[id]/loading.tsx`** — Created. Skeleton matching page structure.
+- **`webapp/src/app/(dashboard)/transactions/[id]/page.tsx`** — Rewritten. Only `getTransaction(id)` blocks initial render. Edit button (`TransactionEditAction`) and sidebar (`TransactionSidebar`) deferred via `<Suspense>`. Page now renders as PPR.
 
-### Deudas (`webapp/src/components/mobile/v2/deudas/`) — 7 files
-- `deudas-hero.tsx` — Split bar (capital vs interest), pressure chip
-- `deudas-grid.tsx` — Two matching SVG rings (uso del cupo + próxima salida)
-- `deudas-focus.tsx` — Dominant debt card
-- `deudas-loans-chips.tsx` — Expandable chips with ALL credits' progress bars
-- `deudas-accounts-accordion.tsx` — One account open at a time, tighter spacing
-- `deudas-salary-bar.tsx` — Collapsed bar only, expandable legend
-- `deudas-root.tsx` — Orchestrator with page-level accordion
+### Transaction caching + PostgREST fix
+- **`webapp/src/actions/transactions.ts`** — `getTransactions()` and `getTransaction()` now use `"use cache"` with `cacheTag("transactions")`. Added `"transactions"` to `revalidateFinancialViews()`. PostgREST join fixed with explicit FK hints: `accounts!transactions_account_id_fkey`, `categories!transactions_category_id_fkey`, `destinatarios!transactions_destinatario_id_fkey`.
 
-### Page wiring (modified)
-- `dashboard/page.tsx` — `MobileDashboardV2` → `InicioRoot`
-- `transactions/page.tsx` — Inline mobile section → `MovimientosRoot`
-- `plan/page.tsx` — Desktop reuse → `PlanRoot`, added `get503020Allocation` + `getCategoriesWithBudgetData`
-- `deudas/page.tsx` — `MobileDebtSection` → `DeudasRoot`
+### UI — Transaction row expanded view
+- **`webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx`** — Expanded view now uses icon-only action buttons (`UserRound`, `Hash`, `Pencil`) matching CategorizarDetail style. Category/destinatario shown as chips when present, as action links when missing.
+- **`webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx`** — CategorizarDetail expanded view updated to same flat chip layout: `[Categoría picker] [👤] [#] ——— [✏️]`. CategoryZonePicker placeholder changed to "Categoría".
 
-### HTML previews (`ui-showcases/`)
-- `mobile-zeta-v2-components.html` — Approved component catalog (visual reference)
-- 4 per-root previews + 1 overview
-
-### Tests
-- `webapp/e2e/mobile-v2-visual.spec.ts` — Visual layout tests
+### CLAUDE.md rules
+- **`CLAUDE.md`** — Added three new sections: **Performance Rules** (cache stable data, justify new queries, Suspense for non-critical data), **UI Rules** (no hardcoded colors, reuse design tokens from TOKENS.md, reuse existing components), and two Gotchas (PostgREST FK hints through encrypted views, `"use cache"` + encryption pattern).
 
 ## 3. Key Decisions
 
-- **Expand inline, never navigate** — All interactive elements expand a preview first. Navigation is secondary inside the panel. Saved as memory: `feedback_expand_not_navigate.md`
-- **Page-level accordion** — Each root owns ONE `useExpandableZone`. Expanding hero collapses burndown, etc. Saved as memory: `feedback_one_expand_per_page.md`
-- **Burndown/salary bar = hover, NOT expand** — Chart point interactions, not click-to-expand sections
-- **Hero = big daily number** ($X/día), not total available
-- **Ritmo = arc ring with % inside** (not text state like "Bajo control")
-- **Plan flow = bar chart** (day-by-day, forward-looking), **Movimientos flow = line chart** (dancing lines, backward-looking)
-- **Tools grid 3rd card = "Importar"** (email pending) replaces "Detecciones"
-- **Zeta palette for charts**: brass dotted expected, sage solid actual
-- **Distribution adapts to budget type** (50/30/20, YNAB, custom)
-- **Custom SVG icons** for discovery (not emoji)
-- **Deudas loan chips show ALL credits' progress bars** when expanded
+- **`createCachedClient(accessToken)` over alternatives**: Considered (a) removing all caching, (b) passing supabase client directly, (c) impersonation via admin client. Chose token-based client because it preserves `"use cache"` cross-request caching while providing `auth.uid()` for decryption. Cache entries auto-expire with JWT rotation (~1h).
+- **Explicit FK hints over schema reload**: PostgREST can't auto-detect FK relationships through `security_invoker` encrypted views. `NOTIFY pgrst, 'reload schema'` was tried but didn't help. Explicit `!fk_name` syntax is the reliable solution.
+- **Suspense split over full page cache**: Transaction detail page defers accounts/categories/destinatarios/tags behind `<Suspense>` rather than loading everything eagerly. The hero renders with just `getTransaction()` (~3ms).
+- **Icon-only action buttons**: User explicitly requested no text labels for Destinatario (👤) and Etiquetar (#). Pencil icon (✏️) pushed to the right with `flex-1` spacer.
+- **Inline pickers deferred**: User wants 👤, #, and ✏️ to open drawer pickers inline instead of navigating to `/transactions/[id]`. Agreed to implement as follow-up.
 
 ## 4. Current State
 
-- **Build**: Passes clean (`pnpm build` in webapp/)
-- **Branch**: `feat/mobile-v2-redesign`
-- **Git**: ~30 new files, ~10 modified, all uncommitted
-- **Playwright**: Auth works (`TEST_PASSWORD` in `.env.local`). Plan + Deudas visual tests pass. Inicio passes. Movimientos has selector issues (sidebar text match).
-- **Screenshots**: `webapp/test-results/mobile-v2-*.png` — actual rendered layouts
+- **Build**: `pnpm build` passes clean
+- **Branch**: `feat/mobile-polish`
+- **Migration**: `20260408143011_optimize_zeta_decrypt_dek_cache.sql` deployed to Supabase
+- **Uncommitted changes**: ~30 files modified (this session + another agent's parallel work on plan/landing page)
+- **Another agent** was working on plan page and landing page changes simultaneously — those files are also modified but untouched by this session
 
 ## 5. Open Issues & Gotchas
 
-1. **Deudas grid rings should be expandable chips** — User's latest request. Currently static rings, should behave like loan chips with expand panel.
-2. **Movimientos Playwright selectors** — `getByText('HERRAMIENTAS')` matches sidebar link. Need `.lg\\:hidden` scoping.
-3. **Next income data is null** — `inicio-metrics-grid` shows "Sin datos" because no action fetches upcoming INFLOW recurring templates. Need to derive from `planData.recurring.upcoming`.
-4. **Burndown chart not interactive** — Should show tooltip on day tap. Currently static SVG.
-5. **Salary bar not hoverable** — User wants segment-tap tooltips, not expand toggle.
-6. **Legacy components to delete** — `mobile-dashboard-v2.tsx`, `burndown-expandable.tsx`, `inicio-discovery-rail.tsx`, `movimientos-tools-rail.tsx`, `movimientos-utility-sheet.tsx`, `loan-metric-linked-detail.tsx`
-7. **`plan-root.tsx` is `"use client"`** — Added by agent for accordion hook. May cause unnecessary client-side rendering of server-safe children.
+- **Remaining `createAdminClient` users are safe**: `charts.ts`, `categories.ts`, `budgets.ts`, `burn-rate.ts`, `exchange-rate.ts`, `attention.ts`, `email-pdf-ingest.ts`, `product-events.ts`, `plan-timeline.ts` still use `createAdminClient()` but only query non-encrypted columns. No action needed unless they start selecting encrypted fields.
+- **PostgREST FK hints required everywhere**: Any new PostgREST join through an encrypted view MUST use `!fk_name` syntax. This is documented in CLAUDE.md Gotchas but easy to forget.
+- **Transaction row actions are Links, not drawers**: The 👤, #, and ✏️ icon buttons currently navigate to `/transactions/[id]` instead of opening inline pickers. User explicitly requested inline drawers as follow-up.
+- **`TransactionWithAccount` type may need update**: The `getTransactions` query now joins `category` and `destinatario`, but the `TransactionWithAccount` type in `domain.ts` may not reflect these new fields. The data arrives via `as unknown as TransactionWithAccount` cast. Check `webapp/src/types/domain.ts` for the type definition.
+- **`plan-timeline.ts`** uses `createAdminClient()` outside `"use cache"` — it's a read helper, not cached. If it queries encrypted columns, it needs the same fix but with the authenticated client directly (no cache needed).
 
 ## 6. Suggested Next Steps
 
-1. **Make deudas grid rings expandable** — Convert to `LinkedMetricDetailPanel` chip pattern
-2. **Wire next income data** — Query upcoming INFLOW templates for Inicio metrics
-3. **Add burndown chart interactivity** — SVG touch targets with day-level tooltips
-4. **Delete unused legacy components** — 6 files no longer imported
-5. **Commit** — Large changeset, clear commit message
-6. **Fix Movimientos test selectors** — Scope to mobile container
+1. **Inline drawer pickers** — Create `LazyDestinatarioPicker` and `LazyTagPicker` that fetch data on open via server actions, render in a `<Drawer>`. Wire to the 👤 and # icon buttons in both `movimientos-transaction-row.tsx` and `movimientos-herramientas.tsx`. Consider a drawer edit form for ✏️ too.
+2. **Update `TransactionWithAccount` type** — Add `category` and `destinatario` optional fields to match the new PostgREST join in `getTransactions()`.
+3. **Verify movimientos page works** — The PostgREST FK hint fix + schema reload should restore the transaction list. Confirm visually that transactions load and the expanded row chips render correctly.
+4. **Commit this work** — Large changeset across 30+ files. Consider splitting into 2-3 commits: (a) encryption compat + caching infra, (b) transaction detail perf, (c) UI polish.
+5. **Audit other pages for eager loading** — The Suspense pattern used on `/transactions/[id]` could benefit other pages that load edit-form data eagerly (accounts detail, destinatario detail, etc.).
 
 ## 7. Context for Claude
 
-- **Component catalog**: `ui-showcases/mobile-zeta-v2-components.html` — open in browser for visual reference
-- **Memory files**: `project_mobile_v2_redesign.md`, `feedback_expand_not_navigate.md`, `feedback_one_expand_per_page.md`
-- **`DebtAccount`** from `@zeta/shared` has `monthlyPayment` (not `minPayment`), nullable `creditLimit`/`interestRate`
-- **`AllocationData`** exported from `@/actions/allocation`, not `@/types/domain`
-- **`getAllTags()`** returns `Tag[]`, not `TagWithGroup[]`
-- **Playwright auth**: `TEST_PASSWORD` in `webapp/.env.local`, email hardcoded as `giraldo.0302@gmail.com`
-- **Page-level accordion pattern**: Root owns `useExpandableZone<string>`, passes `expanded: boolean` + `onToggle` to children. Components with internal sub-state (loan chips) accept `sectionActive: boolean` + `onActivate` from root.
-- **Plan page** now fetches `get503020Allocation` and `getCategoriesWithBudgetData` (added this session)
+- **Migration already deployed**: `20260408143011` is live on Supabase `tgkhaxipfgskxydotdtu`. Don't re-push.
+- **`accessToken` is backward-compatible**: Adding it to `getAuthenticatedClient()` return type doesn't break existing `const { supabase, user } = ...` destructuring — the new field is simply ignored.
+- **`"use cache"` key includes all args**: The `accessToken` (~1h JWT) becomes part of the cache key, so cache entries auto-expire on token refresh. This is intentional — not a bug.
+- **`fetchDestinatarioRules`** is now exported from `destinatarios.ts` (was private `getDestinatarioRulesCached`). It accepts a `supabase` client parameter and is used by both `destinatarios.ts` and `categorize.ts`.
+- **Design tokens**: `docs/design-system/TOKENS.md` is the canonical reference for all colors and spacing. CLAUDE.md now enforces this.

--- a/docs/superpowers/plans/2026-04-07-mobile-polish.md
+++ b/docs/superpowers/plans/2026-04-07-mobile-polish.md
@@ -1,0 +1,1023 @@
+# Mobile Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 4 mobile UX issues — Categorizar card-based redesign, accounts badge clipping, Plan tab bar overflow, Settings accordion sections.
+
+**Architecture:** Mobile extraction for Categorizar (new `MobileCategoryInbox` + `MobileCategoryDrawer` components). Inline responsive fixes for the other 3 items. All use `lg:` (1024px) as the mobile/desktop breakpoint, consistent with the app.
+
+**Tech Stack:** Next.js 15, Tailwind v4, shadcn/ui (Drawer, Collapsible), Radix primitives, existing mobile/v2 components (MCardTight, MListRow)
+
+**Spec:** `docs/superpowers/specs/2026-04-07-mobile-polish-design.md`
+
+---
+
+### Task 1: Accounts badge clipping fix
+
+**Files:**
+- Modify: `webapp/src/components/accounts/account-card.tsx:63-117`
+
+This is the smallest, most self-contained fix. Remove the "Inicio" badge entirely and add proper flex constraints so the type badge + action button never clip.
+
+- [ ] **Step 1: Remove Inicio badge and fix flex layout**
+
+In `webapp/src/components/accounts/account-card.tsx`, replace the header section (lines 63-117):
+
+```tsx
+        <CardHeader className="space-y-4 pb-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <div
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-white/6"
+                style={{ backgroundColor: accentSurface }}
+              >
+                <Icon className="h-5 w-5" style={{ color: accentColor }} />
+              </div>
+              <div className="min-w-0">
+                <CardTitle className="truncate text-base font-semibold">{account.name}</CardTitle>
+                {account.institution_name && (
+                  <p className="truncate text-xs text-muted-foreground">
+                    {account.institution_name}
+                    {account.mask && ` ••${account.mask}`}
+                  </p>
+                )}
+                {!account.institution_name && account.mask ? (
+                  <p className="text-xs text-muted-foreground">Terminación ••{account.mask}</p>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Badge variant="secondary" className="border-white/6 bg-black/15 text-[11px] text-z-white">
+                {ACCOUNT_TYPE_SHORT_LABELS[account.account_type]}
+              </Badge>
+              {allAccounts && allAccounts.length > 0 && (
+                <div
+                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                  className="shrink-0"
+                >
+                  <QuickPaymentDialog
+                    accountId={account.id}
+                    accountName={account.name}
+                    accountType={account.account_type}
+                    currentBalance={account.current_balance}
+                    currencyCode={account.currency_code}
+                    accounts={allAccounts}
+                    trigger={
+                      <Button variant="ghost" size="icon" className="size-8 rounded-full">
+                        <HandCoins className="size-4" />
+                      </Button>
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+```
+
+Key changes from current code:
+- Remove the `flex-wrap justify-end` wrapper around badges — no longer needed with single badge
+- Remove the `show_in_dashboard` / "Inicio" badge entirely
+- Add `shrink-0` to the right-side container so badge + button never compress
+- Left side already has `min-w-0` for truncation — keep it
+
+- [ ] **Step 2: Verify at mobile width**
+
+Run: `cd webapp && pnpm build`
+Expected: Clean build, no type errors.
+
+Then visually verify at 390px and 320px widths that:
+- Type badge stays visible next to action button
+- Account name truncates with ellipsis when space is tight
+- No overflow or clipping
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/accounts/account-card.tsx
+git commit -m "fix: remove Inicio badge and fix account card badge clipping on mobile"
+```
+
+---
+
+### Task 2: Plan tab bar — bottom list on mobile
+
+**Files:**
+- Create: `webapp/src/components/plan/plan-mobile-nav-list.tsx`
+- Modify: `webapp/src/components/plan/plan-tab-nav.tsx:18-35`
+- Modify: `webapp/src/app/(dashboard)/plan/page.tsx:160-186`
+
+- [ ] **Step 1: Create PlanMobileNavList component**
+
+Create `webapp/src/components/plan/plan-mobile-nav-list.tsx`:
+
+```tsx
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { MCardTight, MListRow } from "@/components/mobile/v2/mobile-card";
+import { MOBILE_EYEBROW_CLASS } from "@/lib/constants/styles";
+import type { PlanTab } from "@/components/plan/plan-tab-nav";
+
+const PLAN_TABS: { key: PlanTab; label: string }[] = [
+  { key: "resumen", label: "Resumen" },
+  { key: "presupuesto", label: "Presupuesto" },
+  { key: "periodo", label: "Periodo" },
+  { key: "recurrentes", label: "Recurrentes" },
+  { key: "deseos", label: "Deseos" },
+];
+
+export function PlanMobileNavList({ activeTab }: { activeTab: PlanTab }) {
+  const otherTabs = PLAN_TABS.filter((t) => t.key !== activeTab);
+
+  return (
+    <div className="mt-6 space-y-2 lg:hidden">
+      <p className={MOBILE_EYEBROW_CLASS}>Más en Plan</p>
+      <MCardTight>
+        {otherTabs.map((tab) => (
+          <Link key={tab.key} href={tab.key === "resumen" ? "/plan" : `/plan?tab=${tab.key}`}>
+            <MListRow>
+              <span className="text-sm font-medium">{tab.label}</span>
+              <ChevronRight className="size-4 text-muted-foreground" />
+            </MListRow>
+          </Link>
+        ))}
+      </MCardTight>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Hide top pill bar on mobile**
+
+In `webapp/src/components/plan/plan-tab-nav.tsx`, add `hidden lg:flex` to the nav:
+
+```tsx
+// Change line 19 from:
+    <nav className="flex gap-1 overflow-x-auto scrollbar-none rounded-xl border border-white/6 bg-black/10 p-1">
+// To:
+    <nav className="hidden gap-1 overflow-x-auto scrollbar-none rounded-xl border border-white/6 bg-black/10 p-1 lg:flex">
+```
+
+- [ ] **Step 3: Add bottom nav list to Plan page mobile section**
+
+In `webapp/src/app/(dashboard)/plan/page.tsx`, add the import at the top:
+
+```tsx
+import { PlanMobileNavList } from "@/components/plan/plan-mobile-nav-list";
+```
+
+Then in the mobile section (around line 160-186), add `PlanMobileNavList` after the tab content. Replace the mobile `<div>` block:
+
+```tsx
+      {/* ── Mobile ── */}
+      <div className="lg:hidden">
+        {/* Tab header — always visible on mobile */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">Plan</p>
+              <h1 className="text-xl font-semibold">{activeTab === "resumen" ? "Tu plan" : ""}</h1>
+            </div>
+            {isResumen && (
+              <Suspense fallback={<span className="text-xs capitalize text-muted-foreground">{monthLabel}</span>}>
+                <MonthSelector />
+              </Suspense>
+            )}
+          </div>
+        </div>
+
+        {/* Mobile tab content */}
+        {mobileContent}
+        {tabContent && (
+          <div className="mt-4">
+            <Suspense fallback={<div className="h-64 rounded-xl bg-muted animate-pulse" />}>
+              {tabContent}
+            </Suspense>
+          </div>
+        )}
+
+        {/* Bottom navigation to other Plan tabs */}
+        <PlanMobileNavList activeTab={activeTab} />
+      </div>
+```
+
+Note: The only change from existing code is removing `<PlanTabNav activeTab={activeTab} />` from the mobile header (line 174) and adding `<PlanMobileNavList activeTab={activeTab} />` after the tab content.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd webapp && pnpm build`
+Expected: Clean build.
+
+Verify at 390px: top pill bar is hidden, bottom list shows remaining tabs, tapping a tab navigates correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/components/plan/plan-mobile-nav-list.tsx webapp/src/components/plan/plan-tab-nav.tsx webapp/src/app/\(dashboard\)/plan/page.tsx
+git commit -m "feat: replace Plan tab pill bar with bottom nav list on mobile"
+```
+
+---
+
+### Task 3: Settings accordion on mobile
+
+**Files:**
+- Modify: `webapp/src/app/(dashboard)/settings/page.tsx`
+
+Uses the existing `Collapsible` component from Radix (already installed at `components/ui/collapsible.tsx`). No need to add shadcn Accordion.
+
+- [ ] **Step 1: Add Collapsible imports and create mobile wrapper**
+
+In `webapp/src/app/(dashboard)/settings/page.tsx`, add imports:
+
+```tsx
+import { SettingsMobileAccordion } from "@/components/settings/settings-mobile-accordion";
+```
+
+Create `webapp/src/components/settings/settings-mobile-accordion.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface SettingsSection {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function SettingsMobileAccordion({ sections }: { sections: SettingsSection[] }) {
+  const [openId, setOpenId] = useState<string>(sections[0]?.id ?? "");
+
+  return (
+    <div className="space-y-2">
+      {sections.map((section) => {
+        const isOpen = openId === section.id;
+        return (
+          <Collapsible
+            key={section.id}
+            open={isOpen}
+            onOpenChange={(open) => setOpenId(open ? section.id : "")}
+          >
+            <div className="rounded-xl border border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+              <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 p-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+                    {section.icon}
+                  </div>
+                  <span className="font-semibold">{section.title}</span>
+                </div>
+                <ChevronDown
+                  className={cn(
+                    "size-4 text-muted-foreground transition-transform duration-200",
+                    isOpen && "rotate-180"
+                  )}
+                />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="border-t border-white/6 px-4 pb-4 pt-3">
+                  {section.children}
+                </div>
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Refactor Settings page with mobile/desktop split**
+
+In `webapp/src/app/(dashboard)/settings/page.tsx`, restructure the return to use a mobile accordion and desktop cards:
+
+After the `<PageHeaderRow>` and summary/attention grid (which stay the same), replace the card sections with:
+
+```tsx
+      {/* ── Mobile: Accordion ── */}
+      <div className="lg:hidden">
+        <SettingsMobileAccordion
+          sections={[
+            {
+              id: "perfil",
+              title: "Perfil",
+              icon: <UserRound className="size-4 text-z-brass" />,
+              children: <ProfileForm profile={profile} />,
+            },
+            {
+              id: "integraciones",
+              title: "Integraciones",
+              icon: <Activity className="size-4 text-z-brass" />,
+              children: (
+                <IntegrationsCard
+                  accounts={(accounts ?? []) as Account[]}
+                  tokens={tokens}
+                  headless
+                />
+              ),
+            },
+            {
+              id: "email",
+              title: "Email",
+              icon: <Activity className="size-4 text-z-brass" />,
+              children: (
+                <>
+                  <EmailIngestCard
+                    accounts={(accounts ?? []) as Account[]}
+                    initialAddress={emailIngestAddress}
+                    headless
+                  />
+                  {unrecognizedEmails.length > 0 && (
+                    <div className="mt-4">
+                      <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} headless />
+                    </div>
+                  )}
+                </>
+              ),
+            },
+            {
+              id: "etiquetas",
+              title: "Etiquetas",
+              icon: <Tag className="size-4 text-z-brass" />,
+              children: tagGroupsResult.success ? (
+                <TagManager tagGroups={tagGroupsResult.data} />
+              ) : (
+                <p className="text-sm text-destructive">{tagGroupsResult.error}</p>
+              ),
+            },
+            {
+              id: "bug",
+              title: "Reportar bug",
+              icon: <Bug className="size-4 text-z-brass" />,
+              children: <BugReportForm />,
+            },
+          ]}
+        />
+        <div className="mt-4 space-y-4">
+          <BuildInfo />
+          <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+            <CardHeader>
+              <CardTitle className="text-base">Herramientas de Desarrollo</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ReviewModeToggle />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* ── Desktop: Cards ── */}
+      <div className="hidden lg:block space-y-6">
+        {/* ... existing card sections unchanged ... */}
+      </div>
+```
+
+**Important:** The existing card components (`IntegrationsCard`, `EmailIngestCard`, `UnrecognizedEmailsCard`) currently render their own `<Card>` wrapper. For the accordion, we need them without the wrapper. Add a `headless` prop to these components that skips the Card/CardHeader wrapper and renders just the content. If this is too invasive, an alternative is to keep the cards as-is inside the accordion (card-inside-accordion is fine visually since the accordion item already has the card styling).
+
+**Simpler approach (recommended):** Skip the `headless` prop. Just render the existing card components directly inside the accordion content. The double border is minimal and can be polished later. This keeps the task small:
+
+```tsx
+            {
+              id: "integraciones",
+              title: "Integraciones",
+              icon: <Activity className="size-4 text-z-brass" />,
+              children: (
+                <IntegrationsCard
+                  accounts={(accounts ?? []) as Account[]}
+                  tokens={tokens}
+                />
+              ),
+            },
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd webapp && pnpm build`
+Expected: Clean build.
+
+Verify at 390px: accordion shows with Perfil expanded by default, tapping another section closes current and opens new one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/components/settings/settings-mobile-accordion.tsx webapp/src/app/\(dashboard\)/settings/page.tsx
+git commit -m "feat: wrap Settings sections in accordion on mobile"
+```
+
+---
+
+### Task 4: Mobile Categorizar — card feed + action sheet
+
+**Files:**
+- Create: `webapp/src/components/categorize/mobile-category-inbox.tsx`
+- Create: `webapp/src/components/categorize/mobile-category-drawer.tsx`
+- Modify: `webapp/src/app/(dashboard)/categorizar/page.tsx:194-201`
+
+This is the largest task. The mobile component manages its own state (selection, tab, drawer open/close) and calls the same server actions as the desktop `CategoryInbox`.
+
+- [ ] **Step 1: Create MobileCategoryDrawer**
+
+Create `webapp/src/components/categorize/mobile-category-drawer.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import type { TransactionWithRelations, CategoryWithChildren } from "@/types/domain";
+import type { CategorizationResult } from "@zeta/shared";
+
+interface MobileCategoryDrawerProps {
+  transaction: TransactionWithRelations | null;
+  suggestion: CategorizationResult | null;
+  categories: CategoryWithChildren[];
+  similarCount: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (categoryId: string, applySimilar: boolean) => void;
+  isPending: boolean;
+  destinatarioSuggestion?: {
+    destinatario_id: string;
+    destinatario_name: string;
+    category_id: string | null;
+  } | null;
+}
+
+export function MobileCategoryDrawer({
+  transaction: tx,
+  suggestion,
+  categories,
+  similarCount,
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+  destinatarioSuggestion,
+}: MobileCategoryDrawerProps) {
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
+    suggestion?.categoryId ?? null
+  );
+  const [applySimilar, setApplySimilar] = useState(false);
+  const [expandedParent, setExpandedParent] = useState<string | null>(null);
+
+  // Reset state when transaction changes
+  const txId = tx?.id;
+  const [prevTxId, setPrevTxId] = useState(txId);
+  if (txId !== prevTxId) {
+    setPrevTxId(txId);
+    setSelectedCategoryId(suggestion?.categoryId ?? null);
+    setApplySimilar(false);
+    setExpandedParent(null);
+  }
+
+  if (!tx) return null;
+
+  const merchant = tx.merchant_name ?? tx.clean_description ?? tx.raw_description ?? "Sin descripción";
+  const isOutflow = tx.direction === "OUTFLOW";
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[85dvh]">
+        <DrawerHeader className="text-left">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <DrawerTitle className="text-base">{merchant}</DrawerTitle>
+              <p className="text-xs text-muted-foreground">
+                {tx.account?.name ?? "—"} · {formatDate(tx.transaction_date)}
+              </p>
+            </div>
+            <p className={`text-base font-semibold ${isOutflow ? "text-z-debt" : "text-z-sage-light"}`}>
+              {isOutflow ? "-" : "+"}
+              {formatCurrency(Math.abs(tx.amount), tx.currency_code)}
+            </p>
+          </div>
+        </DrawerHeader>
+
+        <div className="overflow-y-auto px-4 pb-4">
+          {/* Category picker grid */}
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Categoría
+          </p>
+          <div className="grid grid-cols-3 gap-1.5">
+            {categories.map((cat) => {
+              const isExpanded = expandedParent === cat.id;
+              const isSelected = selectedCategoryId === cat.id;
+              const hasSelectedChild = cat.children.some((c) => c.id === selectedCategoryId);
+
+              return (
+                <button
+                  key={cat.id}
+                  type="button"
+                  onClick={() => {
+                    if (cat.children.length > 0) {
+                      setExpandedParent(isExpanded ? null : cat.id);
+                    } else {
+                      setSelectedCategoryId(cat.id);
+                      setExpandedParent(null);
+                    }
+                  }}
+                  className={`rounded-lg border px-2 py-2 text-center text-xs font-medium transition-colors ${
+                    isSelected || hasSelectedChild
+                      ? "border-z-brass/40 bg-z-brass/15 text-z-brass"
+                      : "border-white/6 bg-black/10 text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {cat.name_es ?? cat.name}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Subcategory expansion */}
+          {expandedParent && (() => {
+            const parent = categories.find((c) => c.id === expandedParent);
+            if (!parent || parent.children.length === 0) return null;
+            return (
+              <div className="mt-2 grid grid-cols-3 gap-1.5">
+                {parent.children.map((child) => (
+                  <button
+                    key={child.id}
+                    type="button"
+                    onClick={() => {
+                      setSelectedCategoryId(child.id);
+                      setExpandedParent(null);
+                    }}
+                    className={`rounded-lg border px-2 py-1.5 text-center text-[11px] font-medium transition-colors ${
+                      selectedCategoryId === child.id
+                        ? "border-z-brass/40 bg-z-brass/15 text-z-brass"
+                        : "border-white/6 bg-black/10 text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {child.name_es ?? child.name}
+                  </button>
+                ))}
+              </div>
+            );
+          })()}
+
+          {/* Apply to similar */}
+          {similarCount > 0 && (
+            <div className="mt-4 flex items-center justify-between rounded-xl border border-white/6 bg-black/10 p-3">
+              <div>
+                <p className="text-sm font-medium">Aplicar a {similarCount} similares</p>
+                <p className="text-[11px] text-muted-foreground">
+                  Todas las transacciones de {merchant}
+                </p>
+              </div>
+              <Switch checked={applySimilar} onCheckedChange={setApplySimilar} />
+            </div>
+          )}
+
+          {/* Destinatario suggestion */}
+          {destinatarioSuggestion && (
+            <div className="mt-3 rounded-xl border border-z-brass/20 bg-z-brass/5 p-3">
+              <p className="text-xs text-z-brass">
+                Vincular con <strong>{destinatarioSuggestion.destinatario_name}</strong>
+              </p>
+            </div>
+          )}
+
+          {/* Confirm */}
+          <Button
+            className={`mt-4 w-full ${BRASS_BUTTON_CLASS}`}
+            disabled={!selectedCategoryId || isPending}
+            onClick={() => {
+              if (selectedCategoryId) {
+                onConfirm(selectedCategoryId, applySimilar);
+              }
+            }}
+          >
+            {isPending ? "Aplicando..." : "Confirmar"}
+          </Button>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+```
+
+- [ ] **Step 2: Build check (drawer compiles)**
+
+Run: `cd webapp && pnpm build`
+Expected: Clean build (component is created but not imported anywhere yet — tree-shaking won't include it, but tsc will check types).
+
+- [ ] **Step 3: Create MobileCategoryInbox**
+
+Create `webapp/src/components/categorize/mobile-category-inbox.tsx`:
+
+```tsx
+"use client";
+
+import { useState, useMemo, useTransition, useCallback } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { MobileCategoryDrawer } from "./mobile-category-drawer";
+import { BulkActionBar } from "./bulk-action-bar";
+import { autoCategorize, extractPattern } from "@zeta/shared";
+import {
+  categorizeTransaction,
+  bulkCategorize,
+  confirmAutoCategory,
+  bulkConfirmAutoCategory,
+} from "@/actions/categorize";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { BRASS_BUTTON_CLASS, MOBILE_EYEBROW_CLASS } from "@/lib/constants/styles";
+import type { TransactionWithRelations, CategoryWithChildren } from "@/types/domain";
+import type { UserRule, CategorizationResult } from "@zeta/shared";
+
+type ActiveTab = "uncategorized" | "auto-review";
+
+interface MobileCategoryInboxProps {
+  initialTransactions: TransactionWithRelations[];
+  autoCategorizedTransactions?: TransactionWithRelations[];
+  categories: CategoryWithChildren[];
+  userRules: UserRule[];
+  destinatarioSuggestions?: Record<string, {
+    destinatario_id: string;
+    destinatario_name: string;
+    category_id: string | null;
+  }>;
+}
+
+function groupByDate(txs: TransactionWithRelations[]) {
+  const groups = new Map<string, TransactionWithRelations[]>();
+  const sorted = [...txs].sort((a, b) => b.transaction_date.localeCompare(a.transaction_date));
+  for (const tx of sorted) {
+    const date = tx.transaction_date;
+    if (!groups.has(date)) groups.set(date, []);
+    groups.get(date)!.push(tx);
+  }
+  return groups;
+}
+
+export function MobileCategoryInbox({
+  initialTransactions,
+  autoCategorizedTransactions = [],
+  categories,
+  userRules,
+  destinatarioSuggestions = {},
+}: MobileCategoryInboxProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>("uncategorized");
+  const [transactions, setTransactions] = useState(initialTransactions);
+  const [autoTransactions, setAutoTransactions] = useState(autoCategorizedTransactions);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectMode, setSelectMode] = useState(false);
+  const [drawerTx, setDrawerTx] = useState<TransactionWithRelations | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const currentList = activeTab === "uncategorized" ? transactions : autoTransactions;
+  const dateGroups = useMemo(() => groupByDate(currentList), [currentList]);
+
+  // Compute auto-categorize suggestions
+  const suggestions = useMemo(() => {
+    const map = new Map<string, CategorizationResult>();
+    for (const tx of transactions) {
+      if (tx.categorization_source === "USER_OVERRIDE" || tx.categorization_source === "USER_CREATED") continue;
+      const desc = tx.merchant_name ?? tx.clean_description ?? tx.raw_description ?? "";
+      const result = autoCategorize(desc, userRules);
+      if (result) map.set(tx.id, result);
+    }
+    return map;
+  }, [transactions, userRules]);
+
+  // Count similar transactions by merchant pattern
+  const similarCounts = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const tx of transactions) {
+      const desc = tx.merchant_name ?? tx.clean_description ?? tx.raw_description ?? "";
+      const pattern = extractPattern(desc);
+      if (!map.has(pattern)) map.set(pattern, []);
+      map.get(pattern)!.push(tx.id);
+    }
+    return map;
+  }, [transactions]);
+
+  function getSimilarIds(tx: TransactionWithRelations): string[] {
+    const desc = tx.merchant_name ?? tx.clean_description ?? tx.raw_description ?? "";
+    const pattern = extractPattern(desc);
+    const ids = similarCounts.get(pattern) ?? [];
+    return ids.filter((id) => id !== tx.id);
+  }
+
+  const handleTapCard = useCallback((tx: TransactionWithRelations) => {
+    if (selectMode) {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(tx.id)) next.delete(tx.id);
+        else next.add(tx.id);
+        return next;
+      });
+    } else {
+      setDrawerTx(tx);
+      setDrawerOpen(true);
+    }
+  }, [selectMode]);
+
+  const handleLongPress = useCallback((tx: TransactionWithRelations) => {
+    setSelectMode(true);
+    setSelected(new Set([tx.id]));
+  }, []);
+
+  const handleConfirm = useCallback(
+    (categoryId: string, applySimilar: boolean) => {
+      if (!drawerTx) return;
+      const similarIds = applySimilar ? getSimilarIds(drawerTx) : [];
+      const allIds = [drawerTx.id, ...similarIds];
+
+      startTransition(async () => {
+        if (activeTab === "auto-review") {
+          await confirmAutoCategory(drawerTx.id, categoryId);
+        } else if (allIds.length > 1) {
+          await bulkCategorize(allIds, categoryId);
+        } else {
+          await categorizeTransaction(drawerTx.id, categoryId);
+        }
+
+        // Remove categorized transactions from local state
+        if (activeTab === "uncategorized") {
+          setTransactions((prev) => prev.filter((t) => !allIds.includes(t.id)));
+        } else {
+          setAutoTransactions((prev) => prev.filter((t) => t.id !== drawerTx.id));
+        }
+
+        setDrawerOpen(false);
+        setDrawerTx(null);
+        toast.success(
+          allIds.length > 1
+            ? `${allIds.length} transacciones categorizadas`
+            : "Transacción categorizada"
+        );
+      });
+    },
+    [drawerTx, activeTab, transactions]
+  );
+
+  const handleBulkAssign = useCallback(
+    (categoryId: string) => {
+      const ids = Array.from(selected);
+      startTransition(async () => {
+        if (activeTab === "auto-review") {
+          await bulkConfirmAutoCategory(ids, categoryId);
+          setAutoTransactions((prev) => prev.filter((t) => !selected.has(t.id)));
+        } else {
+          await bulkCategorize(ids, categoryId);
+          setTransactions((prev) => prev.filter((t) => !selected.has(t.id)));
+        }
+        setSelected(new Set());
+        setSelectMode(false);
+        toast.success(`${ids.length} transacciones categorizadas`);
+      });
+    },
+    [selected, activeTab]
+  );
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelected(new Set());
+  }, []);
+
+  // Empty state
+  if (transactions.length === 0 && autoTransactions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center lg:hidden">
+        <p className="text-lg font-semibold">Bandeja limpia</p>
+        <p className="mt-1 text-sm text-muted-foreground">No hay transacciones pendientes</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 lg:hidden">
+      {/* Tab pills */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => { setActiveTab("uncategorized"); exitSelectMode(); }}
+          className={cn(
+            "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+            activeTab === "uncategorized"
+              ? "bg-z-brass/15 text-z-brass"
+              : "bg-black/10 text-muted-foreground"
+          )}
+        >
+          {transactions.length} sin categoría
+        </button>
+        <button
+          type="button"
+          onClick={() => { setActiveTab("auto-review"); exitSelectMode(); }}
+          className={cn(
+            "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+            activeTab === "auto-review"
+              ? "bg-z-brass/15 text-z-brass"
+              : "bg-black/10 text-muted-foreground"
+          )}
+        >
+          {autoTransactions.length} auto-categorizadas
+        </button>
+      </div>
+
+      {/* Card feed grouped by date */}
+      {Array.from(dateGroups.entries()).map(([date, txs]) => (
+        <div key={date}>
+          <p className={cn(MOBILE_EYEBROW_CLASS, "sticky top-0 z-10 bg-background/80 py-1 backdrop-blur-sm")}>
+            {formatDate(date)}
+          </p>
+          <div className="space-y-1.5">
+            {txs.map((tx) => {
+              const merchant = tx.merchant_name ?? tx.clean_description ?? tx.raw_description ?? "—";
+              const isOutflow = tx.direction === "OUTFLOW";
+              const suggestion = suggestions.get(tx.id);
+              const isSelected = selected.has(tx.id);
+
+              return (
+                <button
+                  key={tx.id}
+                  type="button"
+                  onClick={() => handleTapCard(tx)}
+                  onContextMenu={(e) => { e.preventDefault(); handleLongPress(tx); }}
+                  className={cn(
+                    "flex w-full items-start justify-between gap-3 rounded-xl border p-3 text-left transition-colors",
+                    isSelected
+                      ? "border-z-brass/30 bg-z-brass/10"
+                      : "border-white/6 bg-z-surface-2/70"
+                  )}
+                >
+                  <div className="flex min-w-0 gap-2.5">
+                    {selectMode && (
+                      <Checkbox
+                        checked={isSelected}
+                        className="mt-0.5 shrink-0"
+                        onCheckedChange={() => handleTapCard(tx)}
+                      />
+                    )}
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold">{merchant}</p>
+                      <div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                        {tx.account && (
+                          <>
+                            <span
+                              className="inline-block size-1.5 rounded-full"
+                              style={{ backgroundColor: tx.account.color ?? "var(--z-sage-dark)" }}
+                            />
+                            <span className="truncate">{tx.account.name}</span>
+                            <span>·</span>
+                          </>
+                        )}
+                        <span>{formatDate(tx.transaction_date)}</span>
+                        {suggestion && (
+                          <>
+                            <span>·</span>
+                            <span className="rounded-full bg-z-brass/10 px-1.5 py-0.5 text-z-brass">
+                              💡 {suggestion.categoryName}
+                            </span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <span className={cn(
+                    "shrink-0 text-sm font-semibold",
+                    isOutflow ? "text-z-debt" : "text-z-sage-light"
+                  )}>
+                    {isOutflow ? "-" : "+"}
+                    {formatCurrency(Math.abs(tx.amount), tx.currency_code)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      {/* Bulk action bar */}
+      {selectMode && selected.size > 0 && (
+        <BulkActionBar
+          selectedCount={selected.size}
+          categories={categories}
+          onAssign={handleBulkAssign}
+          onClearSelection={exitSelectMode}
+          isPending={isPending}
+        />
+      )}
+
+      {/* Category drawer */}
+      <MobileCategoryDrawer
+        transaction={drawerTx}
+        suggestion={drawerTx ? suggestions.get(drawerTx.id) ?? null : null}
+        categories={categories}
+        similarCount={drawerTx ? getSimilarIds(drawerTx).length : 0}
+        open={drawerOpen}
+        onOpenChange={(open) => {
+          setDrawerOpen(open);
+          if (!open) setDrawerTx(null);
+        }}
+        onConfirm={handleConfirm}
+        isPending={isPending}
+        destinatarioSuggestion={drawerTx ? destinatarioSuggestions[drawerTx.id] ?? null : null}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire into Categorizar page**
+
+In `webapp/src/app/(dashboard)/categorizar/page.tsx`, add the dynamic import after the existing `CategoryInbox` import (line 20-23):
+
+```tsx
+const MobileCategoryInbox = dynamic(
+  () => import("@/components/categorize/mobile-category-inbox").then((m) => ({ default: m.MobileCategoryInbox })),
+  { loading: () => <div className="h-64 rounded-xl bg-muted animate-pulse lg:hidden" /> }
+);
+```
+
+Then replace lines 194-201 (the `CategoryInbox` render) with:
+
+```tsx
+      {/* Mobile */}
+      <MobileCategoryInbox
+        initialTransactions={transactions}
+        autoCategorizedTransactions={unreviewedAutoTransactions}
+        categories={categories}
+        userRules={userRules}
+        destinatarioSuggestions={destinatarioSuggestions}
+      />
+
+      {/* Desktop */}
+      <div className="hidden lg:block">
+        <CategoryInbox
+          initialTransactions={transactions}
+          autoCategorizedTransactions={unreviewedAutoTransactions}
+          categories={categories}
+          userRules={userRules}
+          tagGroups={tagGroups}
+          destinatarioSuggestions={destinatarioSuggestions}
+        />
+      </div>
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd webapp && pnpm build`
+Expected: Clean build, no type errors.
+
+Verify at 390px:
+- Card feed renders with date-grouped transactions
+- Tapping a card opens the drawer with category grid
+- Selecting a category and confirming removes the transaction from the feed
+- Long-press enters select mode with checkboxes
+- Bulk action bar appears with selection count
+- Tab pills toggle between uncategorized and auto-review
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webapp/src/components/categorize/mobile-category-inbox.tsx webapp/src/components/categorize/mobile-category-drawer.tsx webapp/src/app/\(dashboard\)/categorizar/page.tsx
+git commit -m "feat: add mobile card feed + drawer for Categorizar page"
+```
+
+---
+
+### Task 5: Final build gate
+
+- [ ] **Step 1: Full build verification**
+
+Run:
+```bash
+cd webapp && pnpm install && pnpm build
+```
+Expected: Clean build with no errors or warnings.
+
+- [ ] **Step 2: Visual verification checklist**
+
+Start dev server (`cd webapp && pnpm dev`) and verify at 390px and 1440px:
+
+1. **Accounts** (`/accounts`) — type badge visible, no clipping at 320px, no Inicio badge
+2. **Plan** (`/plan`) — no top pill bar on mobile, "Más en Plan" list at bottom with 4 items, tapping navigates correctly
+3. **Plan tab** (`/plan?tab=presupuesto`) — bottom list shows 4 other tabs (not presupuesto), top pills visible on desktop
+4. **Settings** (`/settings`) — accordion on mobile with Perfil expanded, cards on desktop unchanged
+5. **Categorizar** (`/categorizar`) — card feed on mobile, desktop layout unchanged, drawer opens on card tap
+
+- [ ] **Step 3: Commit any final tweaks**
+
+If any visual adjustments are needed, commit them:
+```bash
+git add -A
+git commit -m "fix: mobile polish visual adjustments"
+```

--- a/docs/superpowers/plans/2026-04-08-envelope-encryption.md
+++ b/docs/superpowers/plans/2026-04-08-envelope-encryption.md
@@ -1,0 +1,1717 @@
+# Envelope Encryption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Encrypt all PII fields at rest using per-user envelope encryption, transparent to the application via PostgreSQL views and INSTEAD OF triggers.
+
+**Architecture:** Envelope encryption with a master KEK in Supabase Vault encrypting per-user DEKs. Tables with PII are renamed to `_enc`, views with the original names decrypt transparently. INSTEAD OF triggers handle encrypt-on-write. Blind indexes (HMAC) enable exact-match lookups on encrypted fields.
+
+**Tech Stack:** PostgreSQL 17, pgcrypto, Supabase Vault, PL/pgSQL SECURITY DEFINER functions
+
+**Spec:** `docs/superpowers/specs/2026-04-07-envelope-encryption-design.md`
+
+**Planning adjustments from spec:**
+- `email_ingest_addresses.address_key` stays **plaintext** (system-generated lookup key needed for unauthenticated email routing — no PII value)
+- `capture_tokens` gets a `token_hash` column (SHA-256) for unauthenticated Bearer token lookup
+- Total encrypted columns: **26** across 9 tables (spec said 27 before address_key exclusion)
+- Migration uses `ALTER COLUMN ... TYPE BYTEA USING zeta_encrypt_as(col, user_id)` — atomic type change + encryption in one pass
+- `zeta_decrypt` and `zeta_hmac` marked `STABLE` for query optimizer column pruning (unused decrypt calls eliminated)
+- Trigger functions are NOT `SECURITY DEFINER` — RLS enforced naturally through `security_invoker` views
+- ILIKE search on encrypted fields works transparently through views (decrypted before WHERE evaluates) — only `capture_tokens.token` lookup needs app code change (unauthenticated context)
+
+**Task dependency graph:**
+```
+Task 1 → [Tasks 2-10 in parallel] → [Tasks 11-12 in parallel] → Task 13
+```
+
+---
+
+### Task 1: Infrastructure — key hierarchy, functions, signup trigger
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_envelope_encryption_infrastructure.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new envelope_encryption_infrastructure
+```
+
+Write the following SQL content:
+
+```sql
+-- ==================================================
+-- Envelope Encryption Infrastructure
+-- ==================================================
+
+-- Ensure required extensions
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS supabase_vault;
+
+-- 1. Create master key (KEK) in Vault
+SELECT vault.create_secret(
+  encode(gen_random_bytes(32), 'hex'),
+  'zeta_master_key',
+  'Master encryption key for Zeta envelope encryption'
+);
+
+-- 2. Create per-user encryption key table
+CREATE TABLE user_encryption_keys (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  encrypted_dek BYTEA NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE user_encryption_keys ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own_key" ON user_encryption_keys
+  FOR ALL USING ((SELECT auth.uid()) = user_id);
+
+-- 3. zeta_encrypt — encrypt plaintext using calling user's DEK
+CREATE OR REPLACE FUNCTION zeta_encrypt(plaintext TEXT)
+RETURNS BYTEA
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = (SELECT auth.uid());
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', (SELECT auth.uid());
+  END IF;
+
+  RETURN pgp_sym_encrypt(plaintext, user_dek);
+END;
+$$;
+
+-- 4. zeta_decrypt — decrypt ciphertext using calling user's DEK
+CREATE OR REPLACE FUNCTION zeta_decrypt(ciphertext BYTEA)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF ciphertext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = (SELECT auth.uid());
+
+  IF user_dek IS NULL THEN RETURN NULL; END IF;
+
+  RETURN pgp_sym_decrypt(ciphertext, user_dek);
+END;
+$$;
+
+-- 5. zeta_encrypt_as — encrypt using specific user's DEK (migration only)
+CREATE OR REPLACE FUNCTION zeta_encrypt_as(plaintext TEXT, target_user_id UUID)
+RETURNS BYTEA
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = target_user_id;
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', target_user_id;
+  END IF;
+
+  RETURN pgp_sym_encrypt(plaintext, user_dek);
+END;
+$$;
+
+-- 6. zeta_hmac — compute blind index using calling user's DEK
+CREATE OR REPLACE FUNCTION zeta_hmac(plaintext TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = (SELECT auth.uid());
+
+  IF user_dek IS NULL THEN RETURN NULL; END IF;
+
+  RETURN encode(hmac(lower(plaintext), user_dek, 'sha256'), 'hex');
+END;
+$$;
+
+-- 7. zeta_hmac_as — compute HMAC using specific user's DEK (migration only)
+CREATE OR REPLACE FUNCTION zeta_hmac_as(plaintext TEXT, target_user_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = target_user_id;
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', target_user_id;
+  END IF;
+
+  RETURN encode(hmac(lower(plaintext), user_dek, 'sha256'), 'hex');
+END;
+$$;
+
+-- 8. Restrict _as functions to postgres role only
+REVOKE ALL ON FUNCTION zeta_encrypt_as(TEXT, UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION zeta_hmac_as(TEXT, UUID) FROM PUBLIC;
+
+-- 9. Signup trigger — generate DEK for new users
+CREATE OR REPLACE FUNCTION handle_new_user_encryption_key()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  new_dek TEXT;
+BEGIN
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  new_dek := encode(gen_random_bytes(32), 'hex');
+
+  INSERT INTO user_encryption_keys (user_id, encrypted_dek)
+  VALUES (NEW.id, pgp_sym_encrypt(new_dek, master_key));
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created_encryption_key
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_new_user_encryption_key();
+
+-- 10. Generate DEKs for existing users
+INSERT INTO user_encryption_keys (user_id, encrypted_dek)
+SELECT
+  id,
+  pgp_sym_encrypt(
+    encode(gen_random_bytes(32), 'hex'),
+    (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'zeta_master_key')
+  )
+FROM auth.users
+ON CONFLICT DO NOTHING;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+Verify via Supabase SQL Editor:
+```sql
+-- Check master key exists
+SELECT name FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+-- Should return 1 row
+
+-- Check all users have DEKs
+SELECT count(*) FROM user_encryption_keys;
+SELECT count(*) FROM auth.users;
+-- Counts must match
+
+-- Test encrypt/decrypt round-trip (run as authenticated user via RPC or Supabase dashboard)
+SELECT zeta_decrypt(zeta_encrypt('hello world'));
+-- Should return 'hello world'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*envelope_encryption_infrastructure*
+git commit -m "feat: add envelope encryption infrastructure — vault key, DEK table, encrypt/decrypt functions"
+```
+
+---
+
+### Task 2: Encrypt transactions table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_transactions.sql`
+
+Transactions has 40 columns. 5 get encrypted (raw_description, clean_description, merchant_name, notes, capture_input_text). 2 HMAC columns added (merchant_name_hmac, clean_description_hmac).
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_transactions
+```
+
+Write the following SQL:
+
+```sql
+-- ==================================================
+-- Encrypt transactions table (5 encrypted, 2 HMAC)
+-- ==================================================
+
+-- 1. Rename table
+ALTER TABLE transactions RENAME TO transactions_enc;
+
+-- 2. Add HMAC columns and backfill while data is still plaintext
+ALTER TABLE transactions_enc ADD COLUMN merchant_name_hmac TEXT;
+ALTER TABLE transactions_enc ADD COLUMN clean_description_hmac TEXT;
+
+UPDATE transactions_enc SET
+  merchant_name_hmac = zeta_hmac_as(merchant_name, user_id)
+WHERE merchant_name IS NOT NULL;
+
+UPDATE transactions_enc SET
+  clean_description_hmac = zeta_hmac_as(clean_description, user_id)
+WHERE clean_description IS NOT NULL;
+
+-- 3. Encrypt columns — atomic type change + encryption per column
+ALTER TABLE transactions_enc
+  ALTER COLUMN raw_description TYPE BYTEA USING zeta_encrypt_as(raw_description, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN clean_description TYPE BYTEA USING zeta_encrypt_as(clean_description, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN merchant_name TYPE BYTEA USING zeta_encrypt_as(merchant_name, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN notes TYPE BYTEA USING zeta_encrypt_as(notes, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN capture_input_text TYPE BYTEA USING zeta_encrypt_as(capture_input_text, user_id);
+
+-- 4. Create decrypted view
+CREATE VIEW transactions WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, amount_in_base_currency,
+  zeta_decrypt(capture_input_text) AS capture_input_text,
+  capture_method, categorization_confidence, categorization_source,
+  category_id,
+  zeta_decrypt(clean_description) AS clean_description,
+  clean_description_hmac, created_at, currency_code, destinatario_id,
+  direction, exchange_rate, id, idempotency_key, installment_current,
+  installment_group_id, installment_total, is_excluded, is_recurring,
+  is_subscription, merchant_category_code, merchant_logo_url,
+  zeta_decrypt(merchant_name) AS merchant_name,
+  merchant_name_hmac,
+  zeta_decrypt(notes) AS notes,
+  original_amount, posting_date, provider, provider_transaction_id,
+  zeta_decrypt(raw_description) AS raw_description,
+  reconciled_into_transaction_id, reconciliation_score,
+  recurrence_group_id, secondary_category_id, status, tags,
+  transaction_date, updated_at, user_id
+FROM transactions_enc;
+
+-- 5. INSTEAD OF INSERT trigger
+CREATE OR REPLACE FUNCTION transactions_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO transactions_enc (
+    account_id, amount, amount_in_base_currency, capture_input_text,
+    capture_method, categorization_confidence, categorization_source,
+    category_id, clean_description, clean_description_hmac, created_at,
+    currency_code, destinatario_id, direction, exchange_rate, id,
+    idempotency_key, installment_current, installment_group_id,
+    installment_total, is_excluded, is_recurring, is_subscription,
+    merchant_category_code, merchant_logo_url, merchant_name,
+    merchant_name_hmac, notes, original_amount, posting_date, provider,
+    provider_transaction_id, raw_description,
+    reconciled_into_transaction_id, reconciliation_score,
+    recurrence_group_id, secondary_category_id, status, tags,
+    transaction_date, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.amount_in_base_currency,
+    zeta_encrypt(NEW.capture_input_text),
+    NEW.capture_method, NEW.categorization_confidence,
+    NEW.categorization_source, NEW.category_id,
+    zeta_encrypt(NEW.clean_description),
+    zeta_hmac(NEW.clean_description),
+    NEW.created_at, NEW.currency_code, NEW.destinatario_id,
+    NEW.direction, NEW.exchange_rate, NEW.id, NEW.idempotency_key,
+    NEW.installment_current, NEW.installment_group_id,
+    NEW.installment_total, NEW.is_excluded, NEW.is_recurring,
+    NEW.is_subscription, NEW.merchant_category_code,
+    NEW.merchant_logo_url,
+    zeta_encrypt(NEW.merchant_name),
+    zeta_hmac(NEW.merchant_name),
+    zeta_encrypt(NEW.notes),
+    NEW.original_amount, NEW.posting_date, NEW.provider,
+    NEW.provider_transaction_id,
+    zeta_encrypt(NEW.raw_description),
+    NEW.reconciled_into_transaction_id, NEW.reconciliation_score,
+    NEW.recurrence_group_id, NEW.secondary_category_id, NEW.status,
+    NEW.tags, NEW.transaction_date, NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transactions_view_insert_trg
+  INSTEAD OF INSERT ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_insert();
+
+-- 6. INSTEAD OF UPDATE trigger
+CREATE OR REPLACE FUNCTION transactions_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE transactions_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    amount_in_base_currency = NEW.amount_in_base_currency,
+    capture_input_text = zeta_encrypt(NEW.capture_input_text),
+    capture_method = NEW.capture_method,
+    categorization_confidence = NEW.categorization_confidence,
+    categorization_source = NEW.categorization_source,
+    category_id = NEW.category_id,
+    clean_description = zeta_encrypt(NEW.clean_description),
+    clean_description_hmac = zeta_hmac(NEW.clean_description),
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    destinatario_id = NEW.destinatario_id,
+    direction = NEW.direction,
+    exchange_rate = NEW.exchange_rate,
+    idempotency_key = NEW.idempotency_key,
+    installment_current = NEW.installment_current,
+    installment_group_id = NEW.installment_group_id,
+    installment_total = NEW.installment_total,
+    is_excluded = NEW.is_excluded,
+    is_recurring = NEW.is_recurring,
+    is_subscription = NEW.is_subscription,
+    merchant_category_code = NEW.merchant_category_code,
+    merchant_logo_url = NEW.merchant_logo_url,
+    merchant_name = zeta_encrypt(NEW.merchant_name),
+    merchant_name_hmac = zeta_hmac(NEW.merchant_name),
+    notes = zeta_encrypt(NEW.notes),
+    original_amount = NEW.original_amount,
+    posting_date = NEW.posting_date,
+    provider = NEW.provider,
+    provider_transaction_id = NEW.provider_transaction_id,
+    raw_description = zeta_encrypt(NEW.raw_description),
+    reconciled_into_transaction_id = NEW.reconciled_into_transaction_id,
+    reconciliation_score = NEW.reconciliation_score,
+    recurrence_group_id = NEW.recurrence_group_id,
+    secondary_category_id = NEW.secondary_category_id,
+    status = NEW.status,
+    tags = NEW.tags,
+    transaction_date = NEW.transaction_date,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transactions_view_update_trg
+  INSTEAD OF UPDATE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_update();
+
+-- 7. INSTEAD OF DELETE trigger
+CREATE OR REPLACE FUNCTION transactions_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM transactions_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transactions_view_delete_trg
+  INSTEAD OF DELETE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_delete();
+
+-- 8. Grant permissions on view
+GRANT SELECT, INSERT, UPDATE, DELETE ON transactions TO authenticated;
+GRANT ALL ON transactions TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+Verify via Supabase SQL Editor:
+```sql
+-- Raw table shows ciphertext
+SELECT raw_description FROM transactions_enc LIMIT 3;
+
+-- View shows plaintext (run as authenticated user)
+SELECT raw_description, merchant_name FROM transactions LIMIT 3;
+
+-- Row counts match
+SELECT count(*) FROM transactions_enc;
+SELECT count(*) FROM transactions;
+
+-- HMAC populated
+SELECT merchant_name_hmac FROM transactions_enc WHERE merchant_name IS NOT NULL LIMIT 3;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_transactions*
+git commit -m "feat: encrypt transactions table — 5 PII columns + 2 HMAC blind indexes"
+```
+
+---
+
+### Task 3: Encrypt accounts table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_accounts.sql`
+
+Accounts has 34 columns. 6 get encrypted (name, institution_name, mask, debit_card_mask, pdf_password, provider_account_id). 1 HMAC added (mask_hmac).
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_accounts
+```
+
+Write the following SQL:
+
+```sql
+-- ==================================================
+-- Encrypt accounts table (6 encrypted, 1 HMAC)
+-- ==================================================
+
+-- 1. Rename
+ALTER TABLE accounts RENAME TO accounts_enc;
+
+-- 2. Add HMAC and backfill
+ALTER TABLE accounts_enc ADD COLUMN mask_hmac TEXT;
+UPDATE accounts_enc SET mask_hmac = zeta_hmac_as(mask, user_id) WHERE mask IS NOT NULL;
+
+-- 3. Encrypt columns
+ALTER TABLE accounts_enc
+  ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN institution_name TYPE BYTEA USING zeta_encrypt_as(institution_name, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN mask TYPE BYTEA USING zeta_encrypt_as(mask, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN debit_card_mask TYPE BYTEA USING zeta_encrypt_as(debit_card_mask, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN pdf_password TYPE BYTEA USING zeta_encrypt_as(pdf_password, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN provider_account_id TYPE BYTEA USING zeta_encrypt_as(provider_account_id, user_id);
+
+-- 4. Create decrypted view
+CREATE VIEW accounts WITH (security_invoker = true) AS
+SELECT
+  account_type, available_balance, color, connection_status, created_at,
+  credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
+  zeta_decrypt(debit_card_mask) AS debit_card_mask,
+  display_order, expected_return_rate, icon, id, initial_investment,
+  zeta_decrypt(institution_name) AS institution_name,
+  interest_rate, is_active, last_synced_at, loan_amount, loan_end_date,
+  loan_start_date,
+  zeta_decrypt(mask) AS mask,
+  mask_hmac, maturity_date, monthly_payment,
+  zeta_decrypt(name) AS name,
+  payment_day,
+  zeta_decrypt(pdf_password) AS pdf_password,
+  provider,
+  zeta_decrypt(provider_account_id) AS provider_account_id,
+  show_in_dashboard, updated_at, user_id
+FROM accounts_enc;
+
+-- 5. INSTEAD OF INSERT
+CREATE OR REPLACE FUNCTION accounts_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO accounts_enc (
+    account_type, available_balance, color, connection_status, created_at,
+    credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
+    debit_card_mask, display_order, expected_return_rate, icon, id,
+    initial_investment, institution_name, interest_rate, is_active,
+    last_synced_at, loan_amount, loan_end_date, loan_start_date, mask,
+    mask_hmac, maturity_date, monthly_payment, name, payment_day,
+    pdf_password, provider, provider_account_id, show_in_dashboard,
+    updated_at, user_id
+  ) VALUES (
+    NEW.account_type, NEW.available_balance, NEW.color, NEW.connection_status,
+    NEW.created_at, NEW.credit_limit, NEW.currency_balances, NEW.currency_code,
+    NEW.current_balance, NEW.cutoff_day,
+    zeta_encrypt(NEW.debit_card_mask),
+    NEW.display_order, NEW.expected_return_rate, NEW.icon, NEW.id,
+    NEW.initial_investment,
+    zeta_encrypt(NEW.institution_name),
+    NEW.interest_rate, NEW.is_active, NEW.last_synced_at, NEW.loan_amount,
+    NEW.loan_end_date, NEW.loan_start_date,
+    zeta_encrypt(NEW.mask),
+    zeta_hmac(NEW.mask),
+    NEW.maturity_date, NEW.monthly_payment,
+    zeta_encrypt(NEW.name),
+    NEW.payment_day,
+    zeta_encrypt(NEW.pdf_password),
+    NEW.provider,
+    zeta_encrypt(NEW.provider_account_id),
+    NEW.show_in_dashboard, NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_view_insert_trg
+  INSTEAD OF INSERT ON accounts
+  FOR EACH ROW EXECUTE FUNCTION accounts_view_insert();
+
+-- 6. INSTEAD OF UPDATE
+CREATE OR REPLACE FUNCTION accounts_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE accounts_enc SET
+    account_type = NEW.account_type,
+    available_balance = NEW.available_balance,
+    color = NEW.color,
+    connection_status = NEW.connection_status,
+    created_at = NEW.created_at,
+    credit_limit = NEW.credit_limit,
+    currency_balances = NEW.currency_balances,
+    currency_code = NEW.currency_code,
+    current_balance = NEW.current_balance,
+    cutoff_day = NEW.cutoff_day,
+    debit_card_mask = zeta_encrypt(NEW.debit_card_mask),
+    display_order = NEW.display_order,
+    expected_return_rate = NEW.expected_return_rate,
+    icon = NEW.icon,
+    initial_investment = NEW.initial_investment,
+    institution_name = zeta_encrypt(NEW.institution_name),
+    interest_rate = NEW.interest_rate,
+    is_active = NEW.is_active,
+    last_synced_at = NEW.last_synced_at,
+    loan_amount = NEW.loan_amount,
+    loan_end_date = NEW.loan_end_date,
+    loan_start_date = NEW.loan_start_date,
+    mask = zeta_encrypt(NEW.mask),
+    mask_hmac = zeta_hmac(NEW.mask),
+    maturity_date = NEW.maturity_date,
+    monthly_payment = NEW.monthly_payment,
+    name = zeta_encrypt(NEW.name),
+    payment_day = NEW.payment_day,
+    pdf_password = zeta_encrypt(NEW.pdf_password),
+    provider = NEW.provider,
+    provider_account_id = zeta_encrypt(NEW.provider_account_id),
+    show_in_dashboard = NEW.show_in_dashboard,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_view_update_trg
+  INSTEAD OF UPDATE ON accounts
+  FOR EACH ROW EXECUTE FUNCTION accounts_view_update();
+
+-- 7. INSTEAD OF DELETE
+CREATE OR REPLACE FUNCTION accounts_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM accounts_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_view_delete_trg
+  INSTEAD OF DELETE ON accounts
+  FOR EACH ROW EXECUTE FUNCTION accounts_view_delete();
+
+-- 8. Grant
+GRANT SELECT, INSERT, UPDATE, DELETE ON accounts TO authenticated;
+GRANT ALL ON accounts TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+Verify: `SELECT name, mask FROM accounts LIMIT 3;` should show plaintext. `SELECT name FROM accounts_enc LIMIT 3;` should show bytea.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_accounts*
+git commit -m "feat: encrypt accounts table — 6 PII columns + mask HMAC blind index"
+```
+
+---
+
+### Task 4: Encrypt profiles table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_profiles.sql`
+
+Profiles has 16 columns. 2 encrypted (full_name, email). No HMAC. Note: PK is `id` which equals the user's UUID — use `id` instead of `user_id` in `zeta_encrypt_as`.
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_profiles
+```
+
+```sql
+-- ==================================================
+-- Encrypt profiles table (2 encrypted)
+-- ==================================================
+
+ALTER TABLE profiles RENAME TO profiles_enc;
+
+ALTER TABLE profiles_enc
+  ALTER COLUMN full_name TYPE BYTEA USING zeta_encrypt_as(full_name, id);
+ALTER TABLE profiles_enc
+  ALTER COLUMN email TYPE BYTEA USING zeta_encrypt_as(email, id);
+
+CREATE VIEW profiles WITH (security_invoker = true) AS
+SELECT
+  app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+  zeta_decrypt(email) AS email,
+  estimated_monthly_expenses, estimated_monthly_income,
+  zeta_decrypt(full_name) AS full_name,
+  id, locale, monthly_salary, onboarding_completed, preferred_currency,
+  timezone, updated_at
+FROM profiles_enc;
+
+CREATE OR REPLACE FUNCTION profiles_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO profiles_enc (
+    app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+    email, estimated_monthly_expenses, estimated_monthly_income, full_name,
+    id, locale, monthly_salary, onboarding_completed, preferred_currency,
+    timezone, updated_at
+  ) VALUES (
+    NEW.app_purpose, NEW.avatar_url, NEW.budget_mode, NEW.created_at,
+    NEW.dashboard_config,
+    zeta_encrypt(NEW.email),
+    NEW.estimated_monthly_expenses, NEW.estimated_monthly_income,
+    zeta_encrypt(NEW.full_name),
+    NEW.id, NEW.locale, NEW.monthly_salary, NEW.onboarding_completed,
+    NEW.preferred_currency, NEW.timezone, NEW.updated_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_view_insert_trg
+  INSTEAD OF INSERT ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_view_insert();
+
+CREATE OR REPLACE FUNCTION profiles_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE profiles_enc SET
+    app_purpose = NEW.app_purpose,
+    avatar_url = NEW.avatar_url,
+    budget_mode = NEW.budget_mode,
+    created_at = NEW.created_at,
+    dashboard_config = NEW.dashboard_config,
+    email = zeta_encrypt(NEW.email),
+    estimated_monthly_expenses = NEW.estimated_monthly_expenses,
+    estimated_monthly_income = NEW.estimated_monthly_income,
+    full_name = zeta_encrypt(NEW.full_name),
+    locale = NEW.locale,
+    monthly_salary = NEW.monthly_salary,
+    onboarding_completed = NEW.onboarding_completed,
+    preferred_currency = NEW.preferred_currency,
+    timezone = NEW.timezone,
+    updated_at = NEW.updated_at
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_view_update_trg
+  INSTEAD OF UPDATE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_view_update();
+
+CREATE OR REPLACE FUNCTION profiles_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM profiles_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_view_delete_trg
+  INSTEAD OF DELETE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON profiles TO authenticated;
+GRANT ALL ON profiles TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_profiles*
+git commit -m "feat: encrypt profiles table — full_name + email"
+```
+
+---
+
+### Task 5: Encrypt destinatarios table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_destinatarios.sql`
+
+8 columns. 2 encrypted (name, notes). 1 HMAC (name_hmac).
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_destinatarios
+```
+
+```sql
+-- ==================================================
+-- Encrypt destinatarios table (2 encrypted, 1 HMAC)
+-- ==================================================
+
+ALTER TABLE destinatarios RENAME TO destinatarios_enc;
+
+ALTER TABLE destinatarios_enc ADD COLUMN name_hmac TEXT;
+UPDATE destinatarios_enc SET name_hmac = zeta_hmac_as(name, user_id) WHERE name IS NOT NULL;
+
+ALTER TABLE destinatarios_enc
+  ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
+ALTER TABLE destinatarios_enc
+  ALTER COLUMN notes TYPE BYTEA USING zeta_encrypt_as(notes, user_id);
+
+CREATE VIEW destinatarios WITH (security_invoker = true) AS
+SELECT
+  created_at, default_category_id, id, is_active,
+  zeta_decrypt(name) AS name,
+  name_hmac,
+  zeta_decrypt(notes) AS notes,
+  updated_at, user_id
+FROM destinatarios_enc;
+
+CREATE OR REPLACE FUNCTION destinatarios_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO destinatarios_enc (
+    created_at, default_category_id, id, is_active, name, name_hmac,
+    notes, updated_at, user_id
+  ) VALUES (
+    NEW.created_at, NEW.default_category_id, NEW.id, NEW.is_active,
+    zeta_encrypt(NEW.name),
+    zeta_hmac(NEW.name),
+    zeta_encrypt(NEW.notes),
+    NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER destinatarios_view_insert_trg
+  INSTEAD OF INSERT ON destinatarios
+  FOR EACH ROW EXECUTE FUNCTION destinatarios_view_insert();
+
+CREATE OR REPLACE FUNCTION destinatarios_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE destinatarios_enc SET
+    created_at = NEW.created_at,
+    default_category_id = NEW.default_category_id,
+    is_active = NEW.is_active,
+    name = zeta_encrypt(NEW.name),
+    name_hmac = zeta_hmac(NEW.name),
+    notes = zeta_encrypt(NEW.notes),
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER destinatarios_view_update_trg
+  INSTEAD OF UPDATE ON destinatarios
+  FOR EACH ROW EXECUTE FUNCTION destinatarios_view_update();
+
+CREATE OR REPLACE FUNCTION destinatarios_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM destinatarios_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER destinatarios_view_delete_trg
+  INSTEAD OF DELETE ON destinatarios
+  FOR EACH ROW EXECUTE FUNCTION destinatarios_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON destinatarios TO authenticated;
+GRANT ALL ON destinatarios TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_destinatarios*
+git commit -m "feat: encrypt destinatarios table — name + notes + HMAC blind index"
+```
+
+---
+
+### Task 6: Encrypt statement_snapshots table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_statement_snapshots.sql`
+
+29 columns. 2 encrypted (loan_number, source_filename). No HMAC.
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_statement_snapshots
+```
+
+```sql
+-- ==================================================
+-- Encrypt statement_snapshots table (2 encrypted)
+-- ==================================================
+
+ALTER TABLE statement_snapshots RENAME TO statement_snapshots_enc;
+
+ALTER TABLE statement_snapshots_enc
+  ALTER COLUMN loan_number TYPE BYTEA USING zeta_encrypt_as(loan_number, user_id);
+ALTER TABLE statement_snapshots_enc
+  ALTER COLUMN source_filename TYPE BYTEA USING zeta_encrypt_as(source_filename, user_id);
+
+CREATE VIEW statement_snapshots WITH (security_invoker = true) AS
+SELECT
+  account_id, available_credit, created_at, credit_limit, currency_code,
+  final_balance, id, imported_count, initial_amount, installments_in_default,
+  interest_charged, interest_rate, late_interest_rate,
+  zeta_decrypt(loan_number) AS loan_number,
+  minimum_payment, payment_due_date, period_from, period_to, previous_balance,
+  purchases_and_charges, remaining_balance, skipped_count,
+  zeta_decrypt(source_filename) AS source_filename,
+  total_credits, total_debits, total_payment_due, transaction_count,
+  updated_at, user_id
+FROM statement_snapshots_enc;
+
+CREATE OR REPLACE FUNCTION statement_snapshots_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO statement_snapshots_enc (
+    account_id, available_credit, created_at, credit_limit, currency_code,
+    final_balance, id, imported_count, initial_amount, installments_in_default,
+    interest_charged, interest_rate, late_interest_rate, loan_number,
+    minimum_payment, payment_due_date, period_from, period_to, previous_balance,
+    purchases_and_charges, remaining_balance, skipped_count, source_filename,
+    total_credits, total_debits, total_payment_due, transaction_count,
+    updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.available_credit, NEW.created_at, NEW.credit_limit,
+    NEW.currency_code, NEW.final_balance, NEW.id, NEW.imported_count,
+    NEW.initial_amount, NEW.installments_in_default, NEW.interest_charged,
+    NEW.interest_rate, NEW.late_interest_rate,
+    zeta_encrypt(NEW.loan_number),
+    NEW.minimum_payment, NEW.payment_due_date, NEW.period_from, NEW.period_to,
+    NEW.previous_balance, NEW.purchases_and_charges, NEW.remaining_balance,
+    NEW.skipped_count,
+    zeta_encrypt(NEW.source_filename),
+    NEW.total_credits, NEW.total_debits, NEW.total_payment_due,
+    NEW.transaction_count, NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER statement_snapshots_view_insert_trg
+  INSTEAD OF INSERT ON statement_snapshots
+  FOR EACH ROW EXECUTE FUNCTION statement_snapshots_view_insert();
+
+CREATE OR REPLACE FUNCTION statement_snapshots_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE statement_snapshots_enc SET
+    account_id = NEW.account_id,
+    available_credit = NEW.available_credit,
+    created_at = NEW.created_at,
+    credit_limit = NEW.credit_limit,
+    currency_code = NEW.currency_code,
+    final_balance = NEW.final_balance,
+    imported_count = NEW.imported_count,
+    initial_amount = NEW.initial_amount,
+    installments_in_default = NEW.installments_in_default,
+    interest_charged = NEW.interest_charged,
+    interest_rate = NEW.interest_rate,
+    late_interest_rate = NEW.late_interest_rate,
+    loan_number = zeta_encrypt(NEW.loan_number),
+    minimum_payment = NEW.minimum_payment,
+    payment_due_date = NEW.payment_due_date,
+    period_from = NEW.period_from,
+    period_to = NEW.period_to,
+    previous_balance = NEW.previous_balance,
+    purchases_and_charges = NEW.purchases_and_charges,
+    remaining_balance = NEW.remaining_balance,
+    skipped_count = NEW.skipped_count,
+    source_filename = zeta_encrypt(NEW.source_filename),
+    total_credits = NEW.total_credits,
+    total_debits = NEW.total_debits,
+    total_payment_due = NEW.total_payment_due,
+    transaction_count = NEW.transaction_count,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER statement_snapshots_view_update_trg
+  INSTEAD OF UPDATE ON statement_snapshots
+  FOR EACH ROW EXECUTE FUNCTION statement_snapshots_view_update();
+
+CREATE OR REPLACE FUNCTION statement_snapshots_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM statement_snapshots_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER statement_snapshots_view_delete_trg
+  INSTEAD OF DELETE ON statement_snapshots
+  FOR EACH ROW EXECUTE FUNCTION statement_snapshots_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON statement_snapshots TO authenticated;
+GRANT ALL ON statement_snapshots TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_statement_snapshots*
+git commit -m "feat: encrypt statement_snapshots — loan_number + source_filename"
+```
+
+---
+
+### Task 7: Encrypt capture_tokens table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_capture_tokens.sql`
+
+8 columns. 2 encrypted (token, label). 1 hash column added (token_hash — SHA-256, not per-user HMAC, for unauthenticated Bearer token lookup).
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_capture_tokens
+```
+
+```sql
+-- ==================================================
+-- Encrypt capture_tokens table (2 encrypted, 1 hash)
+-- ==================================================
+
+ALTER TABLE capture_tokens RENAME TO capture_tokens_enc;
+
+-- token_hash: SHA-256 of plaintext token for unauthenticated lookup
+-- NOT a per-user HMAC — system-wide hash for API auth flow
+ALTER TABLE capture_tokens_enc ADD COLUMN token_hash TEXT;
+UPDATE capture_tokens_enc SET token_hash = encode(digest(token, 'sha256'), 'hex')
+WHERE token IS NOT NULL;
+
+ALTER TABLE capture_tokens_enc
+  ALTER COLUMN token TYPE BYTEA USING zeta_encrypt_as(token, user_id);
+ALTER TABLE capture_tokens_enc
+  ALTER COLUMN label TYPE BYTEA USING zeta_encrypt_as(label, user_id);
+
+CREATE VIEW capture_tokens WITH (security_invoker = true) AS
+SELECT
+  created_at, default_account_id, id,
+  zeta_decrypt(label) AS label,
+  last_used_at, revoked_at,
+  zeta_decrypt(token) AS token,
+  token_hash, user_id
+FROM capture_tokens_enc;
+
+CREATE OR REPLACE FUNCTION capture_tokens_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO capture_tokens_enc (
+    created_at, default_account_id, id, label, last_used_at, revoked_at,
+    token, token_hash, user_id
+  ) VALUES (
+    NEW.created_at, NEW.default_account_id, NEW.id,
+    zeta_encrypt(NEW.label),
+    NEW.last_used_at, NEW.revoked_at,
+    zeta_encrypt(NEW.token),
+    encode(digest(NEW.token, 'sha256'), 'hex'),
+    NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER capture_tokens_view_insert_trg
+  INSTEAD OF INSERT ON capture_tokens
+  FOR EACH ROW EXECUTE FUNCTION capture_tokens_view_insert();
+
+CREATE OR REPLACE FUNCTION capture_tokens_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE capture_tokens_enc SET
+    created_at = NEW.created_at,
+    default_account_id = NEW.default_account_id,
+    label = zeta_encrypt(NEW.label),
+    last_used_at = NEW.last_used_at,
+    revoked_at = NEW.revoked_at,
+    token = zeta_encrypt(NEW.token),
+    token_hash = encode(digest(NEW.token, 'sha256'), 'hex'),
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER capture_tokens_view_update_trg
+  INSTEAD OF UPDATE ON capture_tokens
+  FOR EACH ROW EXECUTE FUNCTION capture_tokens_view_update();
+
+CREATE OR REPLACE FUNCTION capture_tokens_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM capture_tokens_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER capture_tokens_view_delete_trg
+  INSTEAD OF DELETE ON capture_tokens
+  FOR EACH ROW EXECUTE FUNCTION capture_tokens_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON capture_tokens TO authenticated;
+GRANT ALL ON capture_tokens TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_capture_tokens*
+git commit -m "feat: encrypt capture_tokens — token + label + SHA-256 hash for lookup"
+```
+
+---
+
+### Task 8: Encrypt email_ingest_addresses table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_email_ingest_addresses.sql`
+
+11 columns. 2 encrypted (allowed_sender, gmail_verification_url). `address_key` stays plaintext — it's a system-generated random string needed for unauthenticated email routing.
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_email_ingest_addresses
+```
+
+```sql
+-- ==================================================
+-- Encrypt email_ingest_addresses table (2 encrypted)
+-- address_key stays plaintext (routing lookup key)
+-- ==================================================
+
+ALTER TABLE email_ingest_addresses RENAME TO email_ingest_addresses_enc;
+
+ALTER TABLE email_ingest_addresses_enc
+  ALTER COLUMN allowed_sender TYPE BYTEA USING zeta_encrypt_as(allowed_sender, user_id);
+ALTER TABLE email_ingest_addresses_enc
+  ALTER COLUMN gmail_verification_url TYPE BYTEA USING zeta_encrypt_as(gmail_verification_url, user_id);
+
+CREATE VIEW email_ingest_addresses WITH (security_invoker = true) AS
+SELECT
+  account_id, address_key,
+  zeta_decrypt(allowed_sender) AS allowed_sender,
+  auto_import, created_at, gmail_verification_at,
+  zeta_decrypt(gmail_verification_url) AS gmail_verification_url,
+  id, is_active, pdf_import_enabled, user_id
+FROM email_ingest_addresses_enc;
+
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO email_ingest_addresses_enc (
+    account_id, address_key, allowed_sender, auto_import, created_at,
+    gmail_verification_at, gmail_verification_url, id, is_active,
+    pdf_import_enabled, user_id
+  ) VALUES (
+    NEW.account_id, NEW.address_key,
+    zeta_encrypt(NEW.allowed_sender),
+    NEW.auto_import, NEW.created_at, NEW.gmail_verification_at,
+    zeta_encrypt(NEW.gmail_verification_url),
+    NEW.id, NEW.is_active, NEW.pdf_import_enabled, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_ingest_addresses_view_insert_trg
+  INSTEAD OF INSERT ON email_ingest_addresses
+  FOR EACH ROW EXECUTE FUNCTION email_ingest_addresses_view_insert();
+
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE email_ingest_addresses_enc SET
+    account_id = NEW.account_id,
+    address_key = NEW.address_key,
+    allowed_sender = zeta_encrypt(NEW.allowed_sender),
+    auto_import = NEW.auto_import,
+    created_at = NEW.created_at,
+    gmail_verification_at = NEW.gmail_verification_at,
+    gmail_verification_url = zeta_encrypt(NEW.gmail_verification_url),
+    is_active = NEW.is_active,
+    pdf_import_enabled = NEW.pdf_import_enabled,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_ingest_addresses_view_update_trg
+  INSTEAD OF UPDATE ON email_ingest_addresses
+  FOR EACH ROW EXECUTE FUNCTION email_ingest_addresses_view_update();
+
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM email_ingest_addresses_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_ingest_addresses_view_delete_trg
+  INSTEAD OF DELETE ON email_ingest_addresses
+  FOR EACH ROW EXECUTE FUNCTION email_ingest_addresses_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON email_ingest_addresses TO authenticated;
+GRANT ALL ON email_ingest_addresses TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_email_ingest*
+git commit -m "feat: encrypt email_ingest_addresses — allowed_sender + gmail_verification_url"
+```
+
+---
+
+### Task 9: Encrypt recurring_transaction_templates table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_recurring_templates.sql`
+
+18 columns. 2 encrypted (description, merchant_name). No HMAC.
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_recurring_templates
+```
+
+```sql
+-- ==================================================
+-- Encrypt recurring_transaction_templates (2 encrypted)
+-- ==================================================
+
+ALTER TABLE recurring_transaction_templates RENAME TO recurring_transaction_templates_enc;
+
+ALTER TABLE recurring_transaction_templates_enc
+  ALTER COLUMN description TYPE BYTEA USING zeta_encrypt_as(description, user_id);
+ALTER TABLE recurring_transaction_templates_enc
+  ALTER COLUMN merchant_name TYPE BYTEA USING zeta_encrypt_as(merchant_name, user_id);
+
+CREATE VIEW recurring_transaction_templates WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, category_id, created_at, currency_code,
+  day_of_month, day_of_week,
+  zeta_decrypt(description) AS description,
+  direction, end_date, frequency, id, is_active,
+  zeta_decrypt(merchant_name) AS merchant_name,
+  start_date, transfer_source_account_id, updated_at, user_id
+FROM recurring_transaction_templates_enc;
+
+CREATE OR REPLACE FUNCTION recurring_templates_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO recurring_transaction_templates_enc (
+    account_id, amount, category_id, created_at, currency_code,
+    day_of_month, day_of_week, description, direction, end_date,
+    frequency, id, is_active, merchant_name, start_date,
+    transfer_source_account_id, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.category_id, NEW.created_at,
+    NEW.currency_code, NEW.day_of_month, NEW.day_of_week,
+    zeta_encrypt(NEW.description),
+    NEW.direction, NEW.end_date, NEW.frequency, NEW.id, NEW.is_active,
+    zeta_encrypt(NEW.merchant_name),
+    NEW.start_date, NEW.transfer_source_account_id, NEW.updated_at,
+    NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER recurring_templates_view_insert_trg
+  INSTEAD OF INSERT ON recurring_transaction_templates
+  FOR EACH ROW EXECUTE FUNCTION recurring_templates_view_insert();
+
+CREATE OR REPLACE FUNCTION recurring_templates_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE recurring_transaction_templates_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    category_id = NEW.category_id,
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    day_of_month = NEW.day_of_month,
+    day_of_week = NEW.day_of_week,
+    description = zeta_encrypt(NEW.description),
+    direction = NEW.direction,
+    end_date = NEW.end_date,
+    frequency = NEW.frequency,
+    is_active = NEW.is_active,
+    merchant_name = zeta_encrypt(NEW.merchant_name),
+    start_date = NEW.start_date,
+    transfer_source_account_id = NEW.transfer_source_account_id,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER recurring_templates_view_update_trg
+  INSTEAD OF UPDATE ON recurring_transaction_templates
+  FOR EACH ROW EXECUTE FUNCTION recurring_templates_view_update();
+
+CREATE OR REPLACE FUNCTION recurring_templates_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM recurring_transaction_templates_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER recurring_templates_view_delete_trg
+  INSTEAD OF DELETE ON recurring_transaction_templates
+  FOR EACH ROW EXECUTE FUNCTION recurring_templates_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON recurring_transaction_templates TO authenticated;
+GRANT ALL ON recurring_transaction_templates TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_recurring*
+git commit -m "feat: encrypt recurring_transaction_templates — description + merchant_name"
+```
+
+---
+
+### Task 10: Encrypt wishlist_items table
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encrypt_wishlist_items.sql`
+
+26 columns. 3 encrypted (name, url, why). No HMAC.
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encrypt_wishlist_items
+```
+
+```sql
+-- ==================================================
+-- Encrypt wishlist_items table (3 encrypted)
+-- ==================================================
+
+ALTER TABLE wishlist_items RENAME TO wishlist_items_enc;
+
+ALTER TABLE wishlist_items_enc
+  ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
+ALTER TABLE wishlist_items_enc
+  ALTER COLUMN url TYPE BYTEA USING zeta_encrypt_as(url, user_id);
+ALTER TABLE wishlist_items_enc
+  ALTER COLUMN why TYPE BYTEA USING zeta_encrypt_as(why, user_id);
+
+CREATE VIEW wishlist_items WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, bought_at, category_id, created_at, currency_code,
+  desire_type, enriched, enriched_at, funding_type, id, image_url,
+  installments, last_nudge_dismissed_at, last_score, last_scored_at,
+  last_verdict,
+  zeta_decrypt(name) AS name,
+  ready_at, status, transaction_id, updated_at, urgency,
+  zeta_decrypt(url) AS url,
+  user_id,
+  zeta_decrypt(why) AS why
+FROM wishlist_items_enc;
+
+CREATE OR REPLACE FUNCTION wishlist_items_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO wishlist_items_enc (
+    account_id, amount, bought_at, category_id, created_at, currency_code,
+    desire_type, enriched, enriched_at, funding_type, id, image_url,
+    installments, last_nudge_dismissed_at, last_score, last_scored_at,
+    last_verdict, name, ready_at, status, transaction_id, updated_at,
+    urgency, url, user_id, why
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.bought_at, NEW.category_id,
+    NEW.created_at, NEW.currency_code, NEW.desire_type, NEW.enriched,
+    NEW.enriched_at, NEW.funding_type, NEW.id, NEW.image_url,
+    NEW.installments, NEW.last_nudge_dismissed_at, NEW.last_score,
+    NEW.last_scored_at, NEW.last_verdict,
+    zeta_encrypt(NEW.name),
+    NEW.ready_at, NEW.status, NEW.transaction_id, NEW.updated_at,
+    NEW.urgency,
+    zeta_encrypt(NEW.url),
+    NEW.user_id,
+    zeta_encrypt(NEW.why)
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER wishlist_items_view_insert_trg
+  INSTEAD OF INSERT ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION wishlist_items_view_insert();
+
+CREATE OR REPLACE FUNCTION wishlist_items_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE wishlist_items_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    bought_at = NEW.bought_at,
+    category_id = NEW.category_id,
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    desire_type = NEW.desire_type,
+    enriched = NEW.enriched,
+    enriched_at = NEW.enriched_at,
+    funding_type = NEW.funding_type,
+    image_url = NEW.image_url,
+    installments = NEW.installments,
+    last_nudge_dismissed_at = NEW.last_nudge_dismissed_at,
+    last_score = NEW.last_score,
+    last_scored_at = NEW.last_scored_at,
+    last_verdict = NEW.last_verdict,
+    name = zeta_encrypt(NEW.name),
+    ready_at = NEW.ready_at,
+    status = NEW.status,
+    transaction_id = NEW.transaction_id,
+    updated_at = NEW.updated_at,
+    urgency = NEW.urgency,
+    url = zeta_encrypt(NEW.url),
+    user_id = NEW.user_id,
+    why = zeta_encrypt(NEW.why)
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER wishlist_items_view_update_trg
+  INSTEAD OF UPDATE ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION wishlist_items_view_update();
+
+CREATE OR REPLACE FUNCTION wishlist_items_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM wishlist_items_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER wishlist_items_view_delete_trg
+  INSTEAD OF DELETE ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION wishlist_items_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON wishlist_items TO authenticated;
+GRANT ALL ON wishlist_items TO postgres, service_role;
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encrypt_wishlist*
+git commit -m "feat: encrypt wishlist_items — name + url + why"
+```
+
+---
+
+### Task 11: Index cleanup + HMAC indexes
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_encryption_index_cleanup.sql`
+
+Drop indexes that became useless after encryption (searching on BYTEA ciphertext is meaningless). Add indexes on HMAC/hash columns for efficient lookup.
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+npx supabase migration new encryption_index_cleanup
+```
+
+```sql
+-- ==================================================
+-- Drop useless indexes on encrypted columns
+-- ==================================================
+
+DROP INDEX IF EXISTS idx_destinatarios_user_name;
+DROP INDEX IF EXISTS idx_capture_tokens_token;
+
+-- ==================================================
+-- Add indexes on HMAC/hash columns for lookup
+-- ==================================================
+
+CREATE INDEX idx_transactions_merchant_hmac
+  ON transactions_enc (user_id, merchant_name_hmac);
+
+CREATE INDEX idx_transactions_description_hmac
+  ON transactions_enc (user_id, clean_description_hmac);
+
+CREATE INDEX idx_accounts_mask_hmac
+  ON accounts_enc (user_id, mask_hmac);
+
+CREATE INDEX idx_destinatarios_name_hmac
+  ON destinatarios_enc (user_id, name_hmac);
+
+CREATE UNIQUE INDEX idx_capture_tokens_hash
+  ON capture_tokens_enc (token_hash);
+```
+
+- [ ] **Step 2: Push and verify**
+
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/*encryption_index*
+git commit -m "feat: add HMAC/hash indexes, drop obsolete text indexes on encrypted columns"
+```
+
+---
+
+### Task 12: App code changes — capture token lookup
+
+**Files:**
+- Modify: `webapp/src/app/api/_shared/auth.ts` (capture token lookup)
+
+The transparent view layer handles all other searches (ILIKE on decrypted columns works through views). The **only** app code change needed is the capture token lookup, which runs in an unauthenticated context (Bearer token auth — `auth.uid()` is not set, so the view's `zeta_decrypt` returns NULL).
+
+- [ ] **Step 1: Find the capture token lookup code**
+
+```bash
+cd webapp && grep -n "capture_tokens" src/app/api/_shared/auth.ts
+```
+
+The current code looks like:
+```typescript
+const { data } = await adminClient
+  .from('capture_tokens')
+  .select('*')
+  .eq('token', bearerToken)
+  .is('revoked_at', null)
+  .single();
+```
+
+- [ ] **Step 2: Change to use token_hash on the _enc table**
+
+Replace the lookup to query `capture_tokens_enc` directly (bypasses view, no decryption needed) using `token_hash`:
+
+```typescript
+import { createHash } from 'crypto';
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// In the token lookup:
+const { data } = await adminClient
+  .from('capture_tokens_enc')
+  .select('id, user_id, default_account_id, last_used_at, revoked_at')
+  .eq('token_hash', hashToken(bearerToken))
+  .is('revoked_at', null)
+  .single();
+```
+
+Key changes:
+- Query `capture_tokens_enc` instead of `capture_tokens`
+- Match on `token_hash` instead of `token`
+- Only SELECT plaintext columns (no encrypted columns that would need decryption)
+- Uses Node.js `crypto.createHash` — no new dependencies
+
+- [ ] **Step 3: Verify the build**
+
+```bash
+cd webapp && pnpm build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/app/api/_shared/auth.ts
+git commit -m "fix: use token_hash for capture token lookup (encrypted column not queryable without auth context)"
+```
+
+---
+
+### Task 13: Regenerate types + build verification
+
+**Files:**
+- Modify: `webapp/src/types/database.ts`
+
+- [ ] **Step 1: Push all migrations if not already pushed**
+
+Ensure all migrations from Tasks 1-11 have been pushed:
+```bash
+npx supabase db push
+```
+
+- [ ] **Step 2: Regenerate TypeScript types**
+
+```bash
+npx supabase gen types --lang=typescript --project-id tgkhaxipfgskxydotdtu > webapp/src/types/database.ts
+```
+
+Verify the file starts with `export type Json =` (shell compdef warning can corrupt first line).
+
+Expected changes in the types:
+- Views appear with the same column types as before (TEXT → still `string` through view)
+- New columns: `merchant_name_hmac`, `clean_description_hmac`, `mask_hmac`, `name_hmac`, `token_hash`
+- `_enc` tables appear as new entries with BYTEA columns typed as `string`
+
+- [ ] **Step 3: Install dependencies and build**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta && pnpm install && cd webapp && pnpm build
+```
+
+Build must pass clean. If type errors occur, they'll be from the new HMAC/hash columns appearing in types — existing code won't reference them so this should pass.
+
+- [ ] **Step 4: End-to-end verification via Supabase SQL Editor**
+
+Run as authenticated user:
+```sql
+-- Transactions: plaintext through view
+SELECT id, merchant_name, raw_description, amount FROM transactions LIMIT 5;
+
+-- Transactions: ciphertext in raw table
+SELECT id, merchant_name, raw_description FROM transactions_enc LIMIT 5;
+
+-- Accounts: plaintext through view
+SELECT id, name, mask, institution_name FROM accounts LIMIT 5;
+
+-- Profiles: plaintext through view
+SELECT id, full_name, email FROM profiles LIMIT 1;
+
+-- Insert test: write through view, verify stored encrypted
+INSERT INTO transactions (
+  user_id, account_id, amount, transaction_date, direction,
+  currency_code, idempotency_key, merchant_name, raw_description
+) VALUES (
+  (SELECT auth.uid()), '<valid_account_id>', 100, '2026-04-08', 'OUTFLOW',
+  'COP', 'test_encryption_' || gen_random_uuid(), 'Test Merchant', 'Test Description'
+);
+
+-- Verify the insert stored encrypted data
+SELECT merchant_name FROM transactions_enc
+WHERE idempotency_key LIKE 'test_encryption_%';
+-- Should show BYTEA ciphertext
+
+-- Verify the view returns plaintext
+SELECT merchant_name FROM transactions
+WHERE idempotency_key LIKE 'test_encryption_%';
+-- Should show 'Test Merchant'
+
+-- Clean up test row
+DELETE FROM transactions WHERE idempotency_key LIKE 'test_encryption_%';
+
+-- Verify HMAC blind index works
+SELECT id FROM transactions
+WHERE merchant_name_hmac = zeta_hmac('some known merchant name');
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add webapp/src/types/database.ts
+git commit -m "chore: regenerate types after envelope encryption migration"
+```

--- a/docs/superpowers/plans/2026-04-08-mobile-plan-family.md
+++ b/docs/superpowers/plans/2026-04-08-mobile-plan-family.md
@@ -1,0 +1,891 @@
+# Mobile Plan Family Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create dedicated mobile views for Plan hub, Presupuesto, Recurrentes, and Periodo pages, plus fix mobile issues on Landing, Settings, Accounts, and Transactions.
+
+**Architecture:** Existing `lg:hidden`/`hidden lg:block` split pattern. Mobile Plan hub gets a new cashflow-focused hero (net amount + stacked bar + expandable chart) with drill-down cards. Budget hero moves to Presupuesto sub-page. A reusable `useChartFocusMode` hook locks scroll when charts expand. Sub-pages are tab views within the existing `?tab=` routing.
+
+**Tech Stack:** Next.js 15, React 19, Tailwind v4, Recharts, shadcn/ui
+
+**Spec:** `docs/superpowers/specs/2026-04-08-mobile-plan-family-design.md`
+
+---
+
+## File Structure
+
+### New Files
+- `src/components/mobile/v2/plan/plan-net-hero.tsx` — Net cashflow hero card with stacked bar + expandable chart
+- `src/components/mobile/v2/plan/plan-expandable-chips.tsx` — 2-chip grid (próximo ingreso / próximo pago) with expandable lists
+- `src/components/mobile/v2/plan/plan-drill-cards.tsx` — "IR A" drill-down card list
+- `src/components/mobile/v2/plan/mobile-recurrentes-view.tsx` — Full mobile recurrentes layout (hero + lists)
+- `src/components/mobile/v2/plan/mobile-periodo-view.tsx` — Full mobile periodo layout (chart hero + cards)
+- `src/hooks/use-chart-focus-mode.ts` — Scroll lock + overlay hook for expanded charts
+
+### Modified Files
+- `src/components/mobile/v2/plan/plan-root.tsx` — Replace budget hero with net hero, add chips + drill-cards
+- `src/components/plan/tabs/plan-tab-recurrentes.tsx` — Add `lg:hidden` split for mobile recurrentes view
+- `src/components/plan/tabs/plan-tab-periodo.tsx` — Add `lg:hidden` split for mobile periodo view
+- `src/components/ui/summary-card.tsx:27` — Fix `grid-cols-3` to be responsive
+- `src/components/marketing/landing-page.tsx:580` — Fix hero text overflow
+- `src/app/(dashboard)/plan/page.tsx` — Pass recurring/periodo data to mobile components
+
+### Already Fixed
+- `src/actions/auth.ts` — `translateAuthError()` already added for Spanish error messages
+
+---
+
+### Task 1: `useChartFocusMode` Hook
+
+**Files:**
+- Create: `src/hooks/use-chart-focus-mode.ts`
+
+This hook is used by any component with an expandable chart. It locks body scroll and manages an overlay when active.
+
+- [ ] **Step 1: Create the hook**
+
+```tsx
+// src/hooks/use-chart-focus-mode.ts
+"use client";
+
+import { useEffect, useCallback, useState } from "react";
+
+export function useChartFocusMode(isExpanded: boolean) {
+  const [overlayVisible, setOverlayVisible] = useState(false);
+
+  useEffect(() => {
+    if (isExpanded) {
+      document.body.style.overflow = "hidden";
+      // Small delay so the expand animation starts first
+      const timer = setTimeout(() => setOverlayVisible(true), 50);
+      return () => clearTimeout(timer);
+    } else {
+      document.body.style.overflow = "";
+      setOverlayVisible(false);
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isExpanded]);
+
+  const handleOverlayClick = useCallback((onCollapse: () => void) => {
+    return () => onCollapse();
+  }, []);
+
+  return { overlayVisible, handleOverlayClick };
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && npx tsc --noEmit src/hooks/use-chart-focus-mode.ts 2>&1 | head -5`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/hooks/use-chart-focus-mode.ts
+git commit -m "feat: add useChartFocusMode hook for scroll lock + overlay on chart expand"
+```
+
+---
+
+### Task 2: Plan Net Hero Card
+
+**Files:**
+- Create: `src/components/mobile/v2/plan/plan-net-hero.tsx`
+
+The main hero for the Plan hub. Shows net amount, stacked progress bar (green income → red payments → brass net), and expands to show the full Flujo del Mes chart.
+
+- [ ] **Step 1: Create the net hero component**
+
+```tsx
+// src/components/mobile/v2/plan/plan-net-hero.tsx
+"use client";
+
+import { useState } from "react";
+import { useChartFocusMode } from "@/hooks/use-chart-focus-mode";
+import { PlanFlowChart } from "./plan-flow-chart";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+import type { PlanTimelineData } from "@/actions/plan-timeline";
+
+interface PlanNetHeroProps {
+  ingresos: number;
+  gastos: number;
+  currency: CurrencyCode;
+  daysRemaining: number;
+  timelineData: PlanTimelineData;
+}
+
+export function PlanNetHero({
+  ingresos,
+  gastos,
+  currency,
+  daysRemaining,
+  timelineData,
+}: PlanNetHeroProps) {
+  const [expanded, setExpanded] = useState(false);
+  const neto = ingresos - gastos;
+  const gastosRatio = ingresos > 0 ? Math.min((gastos / ingresos) * 100, 100) : 0;
+  const netoRatio = 100 - gastosRatio;
+
+  const { overlayVisible, handleOverlayClick } = useChartFocusMode(expanded);
+
+  return (
+    <>
+      {/* Overlay */}
+      {overlayVisible && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          onClick={handleOverlayClick(() => setExpanded(false))}
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="relative z-50 w-full rounded-2xl border border-white/8 bg-gradient-to-br from-[#1a2a1a] to-[#1a1a0a] p-4 text-left transition-all"
+      >
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+            Neto del mes
+          </p>
+          <span className="text-[10px] text-muted-foreground">
+            {daysRemaining} días restantes
+          </span>
+        </div>
+
+        <p className="text-3xl font-bold text-z-brass">
+          {neto >= 0 ? "+" : ""}
+          {formatCurrency(neto, currency)}
+        </p>
+
+        {/* Stacked progress bar */}
+        <div className="relative mt-3 h-2.5 overflow-hidden rounded-full bg-z-surface-2">
+          {/* Green: full income width */}
+          <div className="absolute inset-y-0 left-0 w-full rounded-full bg-emerald-500/80" />
+          {/* Red: payments portion from left */}
+          <div
+            className="absolute inset-y-0 left-0 rounded-l-full bg-red-500/80"
+            style={{ width: `${gastosRatio}%` }}
+          />
+          {/* Brass: net remainder on right */}
+          <div
+            className="absolute inset-y-0 right-0 rounded-r-full bg-z-brass/80"
+            style={{ width: `${netoRatio}%` }}
+          />
+        </div>
+
+        {/* Legend */}
+        <div className="mt-2 flex justify-between text-[10px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="inline-block size-1.5 rounded-full bg-emerald-500" />
+            Ingresos {formatCurrency(ingresos, currency)}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block size-1.5 rounded-full bg-red-500" />
+            Gastos {formatCurrency(gastos, currency)}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block size-1.5 rounded-full bg-z-brass" />
+            Neto
+          </span>
+        </div>
+
+        {/* Collapsed: sparkline hint */}
+        {!expanded && (
+          <p className="mt-3 text-center text-[11px] text-z-brass/50">
+            Toca para ver flujo ↓
+          </p>
+        )}
+
+        {/* Expanded: full chart */}
+        {expanded && (
+          <div className="mt-4" onClick={(e) => e.stopPropagation()}>
+            <PlanFlowChart timelineData={timelineData} currency={currency} />
+            <p
+              className="mt-2 text-center text-[11px] text-z-brass cursor-pointer"
+              onClick={() => setExpanded(false)}
+            >
+              Ocultar flujo ↑
+            </p>
+          </div>
+        )}
+      </button>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -10`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
+git commit -m "feat: add PlanNetHero — cashflow hero card with stacked bar and expandable chart"
+```
+
+---
+
+### Task 3: Expandable Chips (Próximo Ingreso / Próximo Pago)
+
+**Files:**
+- Create: `src/components/mobile/v2/plan/plan-expandable-chips.tsx`
+
+Two chips in a 2-column grid. Each shows the next income/payment and expands to a full list on tap.
+
+- [ ] **Step 1: Create the expandable chips component**
+
+```tsx
+// src/components/mobile/v2/plan/plan-expandable-chips.tsx
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import type { CurrencyCode, UpcomingRecurrence } from "@/types/domain";
+
+interface PlanExpandableChipsProps {
+  incomes: UpcomingRecurrence[];
+  payments: UpcomingRecurrence[];
+  currency: CurrencyCode;
+}
+
+type ChipType = "income" | "payment" | null;
+
+export function PlanExpandableChips({
+  incomes,
+  payments,
+  currency,
+}: PlanExpandableChipsProps) {
+  const [expanded, setExpanded] = useState<ChipType>(null);
+
+  const nextIncome = incomes[0] ?? null;
+  const nextPayment = payments[0] ?? null;
+
+  const toggle = (type: ChipType) => {
+    setExpanded((prev) => (prev === type ? null : type));
+  };
+
+  const expandedList = expanded === "income" ? incomes : expanded === "payment" ? payments : [];
+  const expandedLabel = expanded === "income" ? "Ingresos esperados" : "Pagos programados";
+  const expandedColor = expanded === "income" ? "text-emerald-400" : "text-red-400";
+
+  return (
+    <div className="space-y-2">
+      {/* Chips grid */}
+      <div className="grid grid-cols-2 gap-2">
+        {/* Income chip */}
+        <button
+          type="button"
+          onClick={() => toggle("income")}
+          className={cn(
+            "rounded-xl border p-3 text-left transition-all",
+            expanded === "income"
+              ? "border-emerald-500/50 bg-emerald-950/30"
+              : "border-white/6 bg-emerald-950/20",
+            expanded === "payment" && "opacity-50"
+          )}
+        >
+          <p className="text-lg font-bold text-emerald-400">
+            {nextIncome
+              ? formatCurrency(nextIncome.template.amount ?? 0, currency)
+              : "—"}
+          </p>
+          <p className="text-[10px] text-emerald-400/80">Próximo ingreso</p>
+          {nextIncome && (
+            <p className="text-[9px] text-muted-foreground">
+              {nextIncome.template.description} · {formatDate(new Date(nextIncome.next_date), "dd MMM")}
+            </p>
+          )}
+        </button>
+
+        {/* Payment chip */}
+        <button
+          type="button"
+          onClick={() => toggle("payment")}
+          className={cn(
+            "rounded-xl border p-3 text-left transition-all",
+            expanded === "payment"
+              ? "border-red-500/50 bg-red-950/30"
+              : "border-white/6 bg-red-950/20",
+            expanded === "income" && "opacity-50"
+          )}
+        >
+          <p className="text-lg font-bold text-red-400">
+            {nextPayment
+              ? formatCurrency(nextPayment.template.amount ?? 0, currency)
+              : "—"}
+          </p>
+          <p className="text-[10px] text-red-400/80">Próximo pago</p>
+          {nextPayment && (
+            <p className="text-[9px] text-muted-foreground">
+              {nextPayment.template.description} · {formatDate(new Date(nextPayment.next_date), "dd MMM")}
+            </p>
+          )}
+        </button>
+      </div>
+
+      {/* Expanded list */}
+      {expanded && expandedList.length > 0 && (
+        <div className={cn(
+          "rounded-xl border p-3",
+          expanded === "income"
+            ? "border-emerald-500/20 bg-emerald-950/20"
+            : "border-red-500/20 bg-red-950/20"
+        )}>
+          <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", expandedColor)}>
+            {expandedLabel}
+          </p>
+          <div className="divide-y divide-white/5">
+            {expandedList.map((item, i) => (
+              <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-2">
+                <div>
+                  <p className="text-xs font-medium">{item.template.description}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDate(new Date(item.next_date), "dd MMM yyyy")}
+                    {item.template.account && ` · ${item.template.account.name}`}
+                  </p>
+                </div>
+                <p className={cn("text-sm font-semibold", expandedColor)}>
+                  {formatCurrency(item.template.amount ?? 0, currency)}
+                </p>
+              </div>
+            ))}
+          </div>
+          {/* Total */}
+          <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
+            <span className="text-muted-foreground">Total</span>
+            <span className={cn("font-bold", expandedColor)}>
+              {formatCurrency(
+                expandedList.reduce((sum, item) => sum + (item.template.amount ?? 0), 0),
+                currency
+              )}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -10`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+git commit -m "feat: add PlanExpandableChips — income/payment chips with expandable lists"
+```
+
+---
+
+### Task 4: Drill-down Cards
+
+**Files:**
+- Create: `src/components/mobile/v2/plan/plan-drill-cards.tsx`
+
+"IR A" section with cards linking to Presupuesto, Periodo, Recurrentes, Deseos.
+
+- [ ] **Step 1: Create drill-down cards component**
+
+```tsx
+// src/components/mobile/v2/plan/plan-drill-cards.tsx
+import Link from "next/link";
+import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+
+interface DrillCard {
+  title: string;
+  hint: string;
+  hintColor: string;
+  href: string;
+}
+
+interface PlanDrillCardsProps {
+  budget: PlanBudgetSummary;
+  recurring: PlanRecurringSummary;
+  periodoSummary: { hasActive: boolean; percentAssigned: number } | null;
+  wishlistCount: number;
+  currency: CurrencyCode;
+}
+
+export function PlanDrillCards({
+  budget,
+  recurring,
+  periodoSummary,
+  wishlistCount,
+  currency,
+}: PlanDrillCardsProps) {
+  const budgetPct = budget.totalBudgeted > 0
+    ? Math.round((budget.totalSpent / budget.totalBudgeted) * 100)
+    : 0;
+
+  const cards: DrillCard[] = [
+    {
+      title: "Presupuesto",
+      hint: budget.overLimitCount > 0
+        ? `${budgetPct}% · ${budget.overLimitCount} sobre límite`
+        : `${budgetPct}% gastado`,
+      hintColor: budget.overLimitCount > 0 ? "text-red-400" : "text-emerald-400",
+      href: "/plan?tab=presupuesto",
+    },
+    {
+      title: "Periodo",
+      hint: periodoSummary?.hasActive
+        ? `${periodoSummary.percentAssigned}% asignado`
+        : "Sin periodo activo",
+      hintColor: periodoSummary?.hasActive ? "text-emerald-400" : "text-muted-foreground",
+      href: "/plan?tab=periodo",
+    },
+    {
+      title: "Recurrentes",
+      hint: `${formatCurrency(recurring.totalMonthlyExpenses, currency)}/mes`,
+      hintColor: "text-amber-400",
+      href: "/plan?tab=recurrentes",
+    },
+    {
+      title: "Deseos",
+      hint: `${wishlistCount} item${wishlistCount !== 1 ? "s" : ""}`,
+      hintColor: "text-muted-foreground",
+      href: "/plan?tab=deseos",
+    },
+  ];
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        Ir a
+      </p>
+      {cards.map((card) => (
+        <Link
+          key={card.href}
+          href={card.href}
+          className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2/60 px-4 py-3 transition-colors active:bg-z-surface-2"
+        >
+          <div>
+            <p className="text-[13px] font-semibold">{card.title}</p>
+            <p className={`text-[11px] ${card.hintColor}`}>{card.hint}</p>
+          </div>
+          <span className="text-muted-foreground">›</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -10`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+git commit -m "feat: add PlanDrillCards — navigation cards for plan sub-pages"
+```
+
+---
+
+### Task 5: Wire Up New Plan Hub Mobile View
+
+**Files:**
+- Modify: `src/components/mobile/v2/plan/plan-root.tsx`
+- Modify: `src/app/(dashboard)/plan/page.tsx`
+
+Replace the current budget-focused mobile Plan with the new net hero + chips + drill-down layout.
+
+- [ ] **Step 1: Rewrite plan-root.tsx**
+
+Replace the entire contents of `src/components/mobile/v2/plan/plan-root.tsx` with the new layout. The component now uses `PlanNetHero`, `PlanExpandableChips`, and `PlanDrillCards` instead of `PlanHeroWrapper`, `PlanZoneChips`, `PlanFlowChart`, and `PlanDistribution`.
+
+Key changes:
+- Import new components: `PlanNetHero`, `PlanExpandableChips`, `PlanDrillCards`
+- Remove imports: `PlanHeroWrapper`, `PlanZoneChips`, `PlanFlowChart`, `PlanDistribution`
+- Add `periodoSummary` and `wishlistCount` to props
+- Split `recurring.upcoming` into incomes/payments using `template.direction === "INFLOW"` / `"OUTFLOW"`
+- Remove `useExpandableZone` (no longer needed at this level)
+- Keep `MobileHeader` and `MonthSelector`
+
+The new render order:
+1. `MobileHeader` (existing)
+2. `MonthSelector` (existing, single instance)
+3. `PlanNetHero` — net amount, stacked bar, expandable chart
+4. `PlanExpandableChips` — 2 chips with expandable income/payment lists
+5. `PlanDrillCards` — navigation to sub-pages
+6. Scenarios count (existing, optional)
+
+- [ ] **Step 2: Update plan page.tsx to pass new props**
+
+In `src/app/(dashboard)/plan/page.tsx`, update the `PlanRoot` invocation (around line 86) to pass the new props:
+- `periodoSummary` (already computed on line 66-74)
+- `wishlistCount` (from `wishlistSummary`)
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -20`
+Expected: Clean build, no type errors.
+
+- [ ] **Step 4: Manual test on mobile viewport**
+
+Open `http://localhost:3000/plan` at 390×844 and verify:
+- Net hero shows with stacked bar
+- Tapping hero expands chart with scroll lock
+- Tapping chips expands income/payment lists
+- Drill-down cards navigate to correct tabs
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-root.tsx webapp/src/app/\(dashboard\)/plan/page.tsx
+git commit -m "feat: wire up new Plan hub mobile view — net hero + chips + drill cards"
+```
+
+---
+
+### Task 6: Mobile Presupuesto View
+
+**Files:**
+- Modify: `src/components/plan/tabs/plan-tab-presupuesto.tsx`
+
+The presupuesto tab already renders the budget view. We need to add a `lg:hidden` mobile variant that shows the budget hero (moved from Plan) + a vertical category list. The desktop view (`hidden lg:block`) stays unchanged.
+
+- [ ] **Step 1: Read current plan-tab-presupuesto.tsx**
+
+Read the file to understand its current structure, what data it fetches, and how it renders.
+
+- [ ] **Step 2: Add mobile variant**
+
+Wrap existing content in `hidden lg:block`. Add a `lg:hidden` section above with:
+- `MobileHeader variant="sub" title="Presupuesto" backHref="/plan"`
+- Budget hero card (extract from `PlanBudgetHero` or inline): percentage, spent/budget, progress bar, status badge, distribution
+- Category list: vertical list with icon, name, amount/budget, mini progress bar
+- Use the existing `categories` data already available in this component
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+git commit -m "feat: add dedicated mobile Presupuesto view with budget hero"
+```
+
+---
+
+### Task 7: Mobile Recurrentes View
+
+**Files:**
+- Create: `src/components/mobile/v2/plan/mobile-recurrentes-view.tsx`
+- Modify: `src/components/plan/tabs/plan-tab-recurrentes.tsx`
+
+Desktop keeps the calendar. Mobile gets a hero card + chronological list.
+
+- [ ] **Step 1: Create mobile-recurrentes-view.tsx**
+
+```tsx
+// src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+"use client";
+
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { cn } from "@/lib/utils";
+import type { CurrencyCode, UpcomingRecurrence } from "@/types/domain";
+import type { PlanRecurringSummary } from "@/types/plan";
+
+interface MobileRecurrentesViewProps {
+  summary: PlanRecurringSummary;
+  currency: CurrencyCode;
+}
+
+export function MobileRecurrentesView({ summary, currency }: MobileRecurrentesViewProps) {
+  const pending = summary.upcoming.filter((u) => !u.template.is_confirmed);
+  const completed = summary.upcoming.filter((u) => u.template.is_confirmed);
+
+  return (
+    <div className="space-y-4 pb-20">
+      <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
+
+      {/* Hero card */}
+      <div className="rounded-2xl border border-white/8 bg-gradient-to-br from-[#2a1a0a] to-[#1a1a0a] p-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+          Compromiso mensual
+        </p>
+        <p className="mt-1 text-3xl font-bold">
+          {formatCurrency(summary.totalMonthlyExpenses, currency)}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {summary.activeCount} plantillas activas
+        </p>
+
+        <div className="my-3 h-px bg-white/6" />
+
+        <div className="flex justify-between text-center">
+          <div>
+            <p className="text-[10px] text-amber-400">Pendientes</p>
+            <p className="text-lg font-semibold text-amber-400">{summary.dueSoonCount}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-emerald-400">Completados</p>
+            <p className="text-lg font-semibold text-emerald-400">{completed.length}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-[10px] text-muted-foreground">Próximo</p>
+            {pending[0] ? (
+              <p className="text-xs font-semibold">
+                {pending[0].template.description} · {formatDate(new Date(pending[0].next_date), "dd MMM")}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">—</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Upcoming list */}
+      {pending.length > 0 && (
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground mb-2">
+            Próximos
+          </p>
+          <div className="divide-y divide-white/5">
+            {pending.map((item, i) => (
+              <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-3">
+                <div>
+                  <p className="text-xs font-medium">{item.template.description}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDate(new Date(item.next_date), "dd MMM yyyy")}
+                    {item.template.account && ` · ${item.template.account.name}`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-semibold text-red-400">
+                    {formatCurrency(item.template.amount ?? 0, currency)}
+                  </p>
+                  <span className="rounded-md bg-z-brass/10 px-2 py-0.5 text-[10px] text-z-brass">
+                    Confirmar
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Completed list */}
+      {completed.length > 0 && (
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground mb-2">
+            Completados
+          </p>
+          <div className="divide-y divide-white/5 opacity-50">
+            {completed.map((item, i) => (
+              <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-3">
+                <div>
+                  <p className="text-xs">{item.template.description}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDate(new Date(item.next_date), "dd MMM")}
+                  </p>
+                </div>
+                <p className="text-sm text-emerald-400">
+                  ✓ {formatCurrency(item.template.amount ?? 0, currency)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add lg:hidden split to plan-tab-recurrentes.tsx**
+
+Read `src/components/plan/tabs/plan-tab-recurrentes.tsx`, then wrap existing content in `hidden lg:block` and add `lg:hidden` above it rendering `MobileRecurrentesView` with the summary and currency props. The data fetch stays in the parent — both branches use the same data.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+git commit -m "feat: add mobile Recurrentes view — hero card + chronological list (no calendar)"
+```
+
+---
+
+### Task 8: Mobile Periodo View
+
+**Files:**
+- Create: `src/components/mobile/v2/plan/mobile-periodo-view.tsx`
+- Modify: `src/components/plan/tabs/plan-tab-periodo.tsx`
+
+Chart is the hero (always visible). Period summary bar below. Income cards with full "Disponible" labels. Expense list.
+
+- [ ] **Step 1: Create mobile-periodo-view.tsx**
+
+The component receives the period data and timeline data. It renders:
+1. `MobileHeader variant="sub" title="Periodo" backHref="/plan"`
+2. Chart hero — reuse existing `PlanFlowChart` component, always visible (not collapsed). Apply `useChartFocusMode` on touch interaction.
+3. Period summary bar — date range + "100% asignado" badge
+4. Income cards — each with name, amount, date, assignment progress bar, "Disponible: $X" (never truncated)
+5. Expense list — clean rows with "Pendiente" badge
+
+The key difference from desktop: no side-by-side layout, full-width cards, "Disponible" label gets its own line.
+
+- [ ] **Step 2: Add lg:hidden split to plan-tab-periodo.tsx**
+
+Read `src/components/plan/tabs/plan-tab-periodo.tsx`, wrap existing content in `hidden lg:block`, add `lg:hidden` rendering `MobilePeriodoView`.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx webapp/src/components/plan/tabs/plan-tab-periodo.tsx
+git commit -m "feat: add mobile Periodo view — chart hero + income cards + expense list"
+```
+
+---
+
+### Task 9: Landing Page Hero Text Overflow Fix
+
+**Files:**
+- Modify: `src/components/marketing/landing-page.tsx:580`
+
+- [ ] **Step 1: Fix hero headline responsive sizing**
+
+In `src/components/marketing/landing-page.tsx`, line 580, the headline uses `text-5xl sm:text-6xl lg:text-7xl`. On a 390px viewport this overflows because `text-5xl` (3rem/48px) is too large with the current padding.
+
+Change:
+```tsx
+<h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-balance sm:text-6xl lg:text-7xl">
+```
+To:
+```tsx
+<h1 className="max-w-4xl text-3xl font-semibold tracking-tight text-balance sm:text-5xl lg:text-7xl">
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -10`
+
+- [ ] **Step 3: Verify visually at 390px**
+
+Open `http://localhost:3000` at 390×844 and confirm headline no longer clips.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/components/marketing/landing-page.tsx
+git commit -m "fix: reduce landing hero font size on mobile to prevent text overflow"
+```
+
+---
+
+### Task 10: Settings Profile Cards Overflow Fix
+
+**Files:**
+- Modify: `src/components/ui/summary-card.tsx:27`
+
+- [ ] **Step 1: Make SummaryCard grid responsive**
+
+In `src/components/ui/summary-card.tsx`, line 27, change:
+```tsx
+<div className="mt-3 grid grid-cols-3 gap-3">
+```
+To:
+```tsx
+<div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+```
+
+This stacks the 3 metric boxes vertically on mobile (<640px) and keeps the 3-column layout on larger screens.
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -10`
+
+- [ ] **Step 3: Verify visually at 390px**
+
+Open `http://localhost:3000/settings` at 390×844. Profile cards should stack vertically — email and date fully visible.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/components/ui/summary-card.tsx
+git commit -m "fix: stack SummaryCard metrics vertically on mobile to prevent overflow"
+```
+
+---
+
+### Task 11: Bottom Nav Padding + Accounts Tap Targets
+
+**Files:**
+- Modify: `src/app/(dashboard)/transactions/page.tsx` — verify `pb-20` on scrollable container
+- Modify: `src/app/(dashboard)/accounts/page.tsx` — make account cards fully tappable
+
+- [ ] **Step 1: Verify transactions page has bottom padding**
+
+Read `src/app/(dashboard)/transactions/page.tsx` and check the outermost mobile container has `pb-20`. If missing, add it.
+
+- [ ] **Step 2: Make account cards fully tappable**
+
+Read `src/app/(dashboard)/accounts/page.tsx`. Find the account card rendering (likely using `AccountCard` component). If the entire card isn't wrapped in a `Link` to the account detail, wrap it so the whole card is a tap target instead of just the small "Ver detalle" text.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build 2>&1 | tail -10`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/app/\(dashboard\)/transactions/page.tsx webapp/src/app/\(dashboard\)/accounts/page.tsx
+git commit -m "fix: add bottom nav padding on transactions, make account cards fully tappable"
+```
+
+---
+
+### Task 12: Final Build Gate + Verification
+
+- [ ] **Step 1: Full build**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta && pnpm install && pnpm build
+```
+
+Expected: Clean build, zero errors.
+
+- [ ] **Step 2: Visual verification on mobile viewport**
+
+Test all modified pages at 390×844:
+- `/plan` — net hero, chips, drill cards
+- `/plan?tab=presupuesto` — budget hero, category list
+- `/plan?tab=recurrentes` — hero card, upcoming/completed lists
+- `/plan?tab=periodo` — chart hero, income cards, expense list
+- `/` — hero text fits
+- `/settings` — profile cards stack
+- `/accounts` — cards are tappable
+- `/transactions` — no bottom nav overlap
+
+- [ ] **Step 3: Commit any remaining fixes**
+
+```bash
+git add -A && git commit -m "fix: final mobile polish adjustments"
+```

--- a/docs/superpowers/specs/2026-04-07-envelope-encryption-design.md
+++ b/docs/superpowers/specs/2026-04-07-envelope-encryption-design.md
@@ -1,0 +1,396 @@
+# Envelope Encryption for Zeta
+
+**Date:** 2026-04-07 (updated 2026-04-08)  
+**Status:** Approved  
+
+## Context
+
+Zeta stores sensitive personal finance data (transaction descriptions, merchant names, account numbers, PDF passwords, user names) as plaintext in Supabase PostgreSQL. While RLS (53 policies) isolates users from each other, the data is fully readable to anyone with database access — including the developer. Users of a personal finance app need confidence that their financial identity data is cryptographically protected, and that even the app administrator cannot casually browse it.
+
+## Goal
+
+Encrypt all identity/PII fields at rest using per-user encryption keys, while keeping operational fields (amounts, dates, categories) readable for server-side features (budgets, charts, dashboards, auto-categorization). The encryption must be transparent to the application — zero app code changes via PostgreSQL views and triggers.
+
+## Threat Model
+
+| Threat | Protection |
+|--------|-----------|
+| Database dump/breach | All identity fields are ciphertext — useless without keys |
+| Developer browsing data | Raw tables show ciphertext; decryption requires authenticated session |
+| Compromising one user's key | Only that user's data exposed — per-user key isolation |
+| SQL injection reading data | Reads hit encrypted columns; decryption requires valid auth context |
+| Password reset | DEKs are independent of auth password — no data loss |
+
+**Not in scope:** Full zero-knowledge (client-side encryption). The server holds the key hierarchy and could theoretically decrypt via service_role. Mitigation: restrict service_role usage to migrations only, audit access.
+
+## Architecture
+
+### Key Hierarchy (Envelope Encryption)
+
+```
+Supabase Vault (service_role only, not in public schema)
+  └── zeta_master_key (KEK — Key Encryption Key)
+        │
+        ├── encrypts DEK_user_abc
+        ├── encrypts DEK_user_xyz
+        └── ...
+
+user_encryption_keys table (RLS: auth.uid() = user_id)
+  └── user_id UUID PK
+  └── encrypted_dek BYTEA  ← DEK encrypted by KEK via pgp_sym_encrypt
+  └── created_at TIMESTAMPTZ
+```
+
+- **KEK (Key Encryption Key):** Single master key stored in Supabase Vault. Never leaves Vault. Used only to encrypt/decrypt per-user DEKs.
+- **DEK (Data Encryption Key):** One per user. Generated on signup via trigger. Stored encrypted by KEK in `user_encryption_keys`. Used to encrypt/decrypt that user's identity fields.
+
+### Encryption Functions
+
+Five `SECURITY DEFINER` functions (run as the function owner, not the caller — needed to access Vault):
+
+```sql
+-- Encrypts plaintext using the calling user's DEK (for normal app operations)
+zeta_encrypt(plaintext TEXT) → BYTEA
+
+-- Decrypts ciphertext using the calling user's DEK (for normal app operations)
+zeta_decrypt(ciphertext BYTEA) → TEXT
+
+-- Encrypts using a specific user's DEK (for backfill migration only, postgres role only)
+zeta_encrypt_as(plaintext TEXT, target_user_id UUID) → BYTEA
+
+-- Computes HMAC blind index using the calling user's DEK
+zeta_hmac(plaintext TEXT) → TEXT
+-- Returns hex-encoded HMAC-SHA256: encode(hmac(lower(plaintext), dek, 'sha256'), 'hex')
+
+-- Computes HMAC using a specific user's DEK (for backfill migration only, postgres role only)
+zeta_hmac_as(plaintext TEXT, target_user_id UUID) → TEXT
+```
+
+All functions return NULL when given NULL input (NULL-safe).
+
+Internal flow:
+1. Get master key from `vault.decrypted_secrets` (only accessible to function owner)
+2. Get caller's encrypted DEK from `user_encryption_keys` WHERE `user_id = auth.uid()`
+3. Decrypt DEK using master key: `pgp_sym_decrypt(encrypted_dek, master_key)`
+4. Encrypt/decrypt the data using DEK: `pgp_sym_encrypt(plaintext, dek)` / `pgp_sym_decrypt(ciphertext, dek)`
+
+### Transparent View Layer
+
+For each table with encrypted columns:
+
+1. **Rename** table → `<table>_enc` (e.g., `transactions` → `transactions_enc`)
+2. **Create view** with original name (`transactions`) using `security_invoker = true`
+   - View SELECTs all columns, calling `zeta_decrypt()` on encrypted columns
+   - `security_invoker = true` ensures RLS on underlying `_enc` table is checked against the calling user
+3. **Create INSTEAD OF triggers** on the view for INSERT, UPDATE, DELETE
+   - INSERT/UPDATE triggers call `zeta_encrypt()` on identity columns before writing to `_enc` table
+   - DELETE trigger proxies to `_enc` table directly
+
+**Result:** Existing Supabase client queries hit the view and get plaintext — zero app code changes. The real table stores only ciphertext.
+
+## Fields to Encrypt
+
+### Encrypted (identity/PII) — 26 columns across 9 tables
+
+**transactions** (5 columns):
+- `raw_description` — original bank description
+- `clean_description` — cleaned/normalized description
+- `merchant_name` — who was paid
+- `notes` — user's personal notes
+- `capture_input_text` — raw capture input
+
+**accounts** (6 columns):
+- `name` — user's account nickname
+- `institution_name` — bank name
+- `mask` — last 4 digits of account
+- `debit_card_mask` — last 4 digits of debit card
+- `pdf_password` — PDF statement password
+- `provider_account_id` — external account identifier
+
+**profiles** (2 columns):
+- `full_name` — user's name
+- `email` — user's email address
+
+**destinatarios** (2 columns):
+- `name` — payee/merchant name
+- `notes` — notes about payee
+
+**statement_snapshots** (2 columns):
+- `loan_number` — loan identifier
+- `source_filename` — original PDF filename (contains bank/account info)
+
+**capture_tokens** (2 columns):
+- `token` — API bearer token
+- `label` — user-given label for the token
+
+**email_ingest_addresses** (2 columns):
+- `allowed_sender` — email sender filter
+- `gmail_verification_url` — OAuth verification URL
+- ~~`address_key`~~ — stays **plaintext** (system-generated random string needed for unauthenticated email routing lookup)
+
+**recurring_transaction_templates** (2 columns):
+- `description` — recurring transaction description
+- `merchant_name` — recurring payee name
+
+**wishlist_items** (3 columns):
+- `name` — wishlist item name
+- `url` — product URL (reveals purchase intent)
+- `why` — user's personal reasoning for wanting the item
+
+### Plaintext (operational) — kept readable for server-side features
+
+All numeric amounts, dates, category IDs, account types, directions, tags, balances, frequencies, priorities. These power budgets, charts, dashboards, and aggregations.
+
+## Search on Encrypted Fields
+
+Encrypted text columns cannot be searched with `ILIKE` or `%pattern%`. Two mitigation strategies:
+
+### Blind Indexes (exact match)
+
+For fields that need exact-match lookup (merchant matching, destinatario lookup, account mask matching):
+
+- Add `<column>_hmac TEXT` column alongside the encrypted column
+- On write, compute `hmac(lower(plaintext), user_dek, 'sha256')` and store the hex digest
+- On search, compute the same HMAC for the search term and compare
+- HMAC is one-way — cannot reverse to get plaintext
+
+**Tables needing blind indexes:**
+- `transactions.merchant_name_hmac` — for destinatario auto-matching
+- `transactions.clean_description_hmac` — for dedup/idempotency checks
+- `accounts.mask_hmac` — for statement-to-account matching during import
+- `destinatarios.name_hmac` — for destinatario lookup
+
+### Unaffected Search Paths
+
+Most existing search/filter flows use operational (plaintext) fields:
+- Transaction list: filter by date, amount, category, direction, account — all plaintext
+- Budget tracking: aggregates by category + amount — all plaintext
+- Dashboard: sums, averages, counts on amounts/dates — all plaintext
+- Auto-categorization: runs during import wizard (client-side, pre-encryption)
+
+## Migration Strategy
+
+### Phase 1: Infrastructure
+
+```sql
+-- 1. Create master key in Vault
+SELECT vault.create_secret(
+  encode(gen_random_bytes(32), 'hex'),
+  'zeta_master_key',
+  'Master encryption key for Zeta envelope encryption'
+);
+
+-- 2. Create per-user key table
+CREATE TABLE user_encryption_keys (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  encrypted_dek BYTEA NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE user_encryption_keys ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "own_key" ON user_encryption_keys
+  FOR ALL USING ((SELECT auth.uid()) = user_id);
+
+-- 3. Create encrypt/decrypt functions
+-- (SECURITY DEFINER, owned by postgres, callable by authenticated)
+
+-- 4. Create trigger on auth.users for new signups
+-- → generates random DEK, encrypts with KEK, inserts into user_encryption_keys
+```
+
+### Phase 2: Generate DEKs for Existing Users
+
+```sql
+-- For each existing user, generate a random DEK and store encrypted
+INSERT INTO user_encryption_keys (user_id, encrypted_dek)
+SELECT 
+  id,
+  pgp_sym_encrypt(
+    encode(gen_random_bytes(32), 'hex'),
+    (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'zeta_master_key')
+  )
+FROM auth.users
+ON CONFLICT DO NOTHING;
+```
+
+### Phase 3: Per-Table Migration (repeat for each of 9 tables)
+
+Using `transactions` as example:
+
+```sql
+-- 1. Rename table
+ALTER TABLE transactions RENAME TO transactions_enc;
+
+-- 2. Add blind index columns (before encrypting, while data is still plaintext)
+ALTER TABLE transactions_enc ADD COLUMN merchant_name_hmac TEXT;
+ALTER TABLE transactions_enc ADD COLUMN clean_description_hmac TEXT;
+-- Backfill HMACs while plaintext is still accessible:
+UPDATE transactions_enc SET
+  merchant_name_hmac = zeta_hmac_as(merchant_name, user_id),
+  clean_description_hmac = zeta_hmac_as(clean_description, user_id)
+WHERE merchant_name IS NOT NULL OR clean_description IS NOT NULL;
+
+-- 3. Convert columns: change type TEXT → BYTEA and encrypt in one atomic pass
+--    ALTER ... TYPE BYTEA USING zeta_encrypt_as(column, user_id)
+--    This takes an ACCESS EXCLUSIVE lock per ALTER, but with ~10k rows
+--    each completes in seconds. Acceptable for a single-user app.
+ALTER TABLE transactions_enc
+  ALTER COLUMN raw_description TYPE BYTEA USING zeta_encrypt_as(raw_description, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN clean_description TYPE BYTEA USING zeta_encrypt_as(clean_description, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN merchant_name TYPE BYTEA USING zeta_encrypt_as(merchant_name, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN notes TYPE BYTEA USING zeta_encrypt_as(notes, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN capture_input_text TYPE BYTEA USING zeta_encrypt_as(capture_input_text, user_id);
+-- Note: zeta_encrypt_as(plaintext, user_id) is a SECURITY DEFINER variant
+--       that encrypts using a specific user's DEK (not auth.uid()).
+--       Needed for backfill since the migration runs as postgres, not as each user.
+--       Only callable by postgres role — not exposed to authenticated users.
+
+-- 4. Create decrypted view
+CREATE VIEW transactions WITH (security_invoker = true) AS
+SELECT
+  id, user_id, account_id, amount, date, direction, category_id,
+  -- Decrypt identity columns
+  zeta_decrypt(raw_description) AS raw_description,
+  zeta_decrypt(clean_description) AS clean_description,
+  zeta_decrypt(merchant_name) AS merchant_name,
+  zeta_decrypt(notes) AS notes,
+  zeta_decrypt(capture_input_text) AS capture_input_text,
+  -- Pass through blind indexes
+  merchant_name_hmac,
+  clean_description_hmac,
+  -- All other columns passed through as-is
+  ...
+FROM transactions_enc;
+
+-- 5. Create INSTEAD OF triggers for INSERT/UPDATE/DELETE
+CREATE FUNCTION transactions_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO transactions_enc VALUES (
+    NEW.id, NEW.user_id, NEW.account_id, NEW.amount, NEW.date, NEW.direction,
+    zeta_encrypt(NEW.raw_description),
+    zeta_encrypt(NEW.clean_description),
+    zeta_encrypt(NEW.merchant_name),
+    zeta_encrypt(NEW.notes),
+    zeta_encrypt(NEW.capture_input_text),
+    zeta_hmac(NEW.merchant_name),
+    zeta_hmac(NEW.clean_description),
+    ...
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER transactions_view_insert_trigger
+  INSTEAD OF INSERT ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_insert();
+-- (similar for UPDATE, DELETE)
+```
+
+### Phase 4: Verification
+
+```sql
+-- Verify encrypted data is not plaintext
+SELECT raw_description FROM transactions_enc LIMIT 5;
+-- Should show bytea gibberish
+
+-- Verify view decrypts correctly (as authenticated user)
+SELECT raw_description FROM transactions LIMIT 5;
+-- Should show readable text
+
+-- Verify row counts match
+SELECT count(*) FROM transactions_enc;
+SELECT count(*) FROM transactions;
+-- Must be equal
+
+-- Verify blind indexes work
+SELECT * FROM transactions 
+WHERE merchant_name_hmac = zeta_hmac('some merchant');
+```
+
+## App Code Impact
+
+### Zero changes needed for:
+- All `SELECT` queries (read from views transparently)
+- All `INSERT`/`UPDATE` queries (INSTEAD OF triggers handle encryption)
+- Dashboard, budgets, charts (use plaintext operational fields)
+- Authentication flow (unchanged)
+- PDF import flow (unchanged — data flows through views)
+
+### Minor changes needed for:
+- **Destinatario matching** — search queries that use `merchant_name ILIKE '%...'` must switch to blind index exact match or match on plaintext category/amount fields
+- **Account matching during import** — `mask` lookups need to use `mask_hmac` for exact match
+- **Idempotency key computation** — currently uses raw description; needs to use the plaintext value (which it already has during import, before it hits the DB)
+
+### No changes needed for:
+- Auto-categorization (runs client-side during import wizard, before data is written)
+- Budget calculations (use amounts + categories, both plaintext)
+- Chart aggregations (use amounts + dates, both plaintext)
+
+## Performance
+
+- **pgcrypto AES encryption**: ~0.1-1ms per field per row
+- **View overhead**: One decrypt call per encrypted column per row returned
+- **Typical query** (50 transactions): ~5-25ms additional overhead (negligible vs network latency)
+- **Backfill migration** (10k transactions, 5 columns): ~30-60 seconds one-time
+- **Blind index lookup**: O(1) hash comparison — same as regular index
+
+## Key Lifecycle
+
+| Event | Action |
+|-------|--------|
+| User signs up | Trigger generates random DEK → encrypts with KEK → stores in `user_encryption_keys` |
+| User logs in | No key action — DEK retrieved on-demand by decrypt functions |
+| Password reset | No key action — DEK is independent of auth password |
+| Key rotation (admin) | Generate new DEK → re-encrypt all user data → replace old DEK |
+| User deletion | CASCADE deletes DEK → all encrypted data becomes permanently unreadable |
+| Master key rotation | Re-encrypt all DEKs with new KEK (data stays encrypted with same DEKs) |
+
+## Security Boundaries
+
+| Actor | Can see |
+|-------|---------|
+| Authenticated user (via app) | Their own decrypted data (via views + RLS) |
+| Other authenticated user | Nothing — RLS blocks access to other users' rows |
+| Developer (Supabase dashboard) | Ciphertext in raw tables. Cannot decrypt without explicitly invoking service_role + vault |
+| Database backup/dump | Ciphertext only — keys are in Vault, not in tables |
+| Service role (migrations) | Could theoretically decrypt — mitigate by restricting usage to schema-only operations |
+
+## Dependencies
+
+- `pgcrypto` extension — already installed (v1.3)
+- `supabase_vault` extension — already installed (v0.3.1)
+- PostgreSQL 17 `security_invoker` — available on Supabase
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Master key loss | Vault is managed by Supabase infrastructure with backups |
+| Performance regression on large datasets | Blind indexes avoid full-table decryption for lookups; views only decrypt returned rows |
+| Migration failure mid-way | Run per-table in transactions; verify before dropping plaintext |
+| Fuzzy search no longer works on encrypted fields | Users search by date, amount, category (all plaintext); merchant name search uses blind index exact match |
+| INSTEAD OF trigger complexity | Thorough testing of INSERT/UPDATE/DELETE through views before cutover |
+
+## Maintenance Rules
+
+### Column Addition Convention
+
+**When adding a column to any `_enc` table, you MUST also update the corresponding INSTEAD OF INSERT and UPDATE trigger functions on the view.** Otherwise the new column is silently dropped on writes through the view.
+
+Checklist for adding a column to an encrypted table:
+1. `ALTER TABLE <table>_enc ADD COLUMN ...` — add to the real table
+2. If the column is PII: update the view SELECT to include `zeta_decrypt(new_col) AS new_col`
+3. If the column is operational: update the view SELECT to pass through `new_col`
+4. Update the INSTEAD OF INSERT trigger to include `NEW.new_col` (encrypted or plain)
+5. Update the INSTEAD OF UPDATE trigger to include `NEW.new_col` (encrypted or plain)
+6. If PII and needs search: add a `new_col_hmac TEXT` column + update triggers to compute HMAC
+
+## Out of Scope
+
+- Client-side (zero-knowledge) encryption — decided against due to impact on server-side features
+- Encrypting operational fields (amounts, dates, categories) — needed for budgets/charts/aggregations
+- Audit logging for data access — separate concern, can be added later
+- Field-level access control (some users see some fields) — single-user app currently

--- a/docs/superpowers/specs/2026-04-07-mobile-polish-design.md
+++ b/docs/superpowers/specs/2026-04-07-mobile-polish-design.md
@@ -1,0 +1,213 @@
+# Mobile Polish — Design Spec
+
+**Date:** 2026-04-07
+**Scope:** 4 mobile fixes bundled into one implementation pass
+**Approach:** Mobile extraction for Categorizar (new component), inline CSS/responsive fixes for the other 3
+
+---
+
+## 1. Categorizar — Mobile Redesign (P0)
+
+### Problem
+`category-inbox.tsx` (774 lines) is a desktop table with checkboxes, inline suggestion pills, and expandable confirmation panels. Unusable on mobile — no card layout, no touch-optimized interactions.
+
+### Solution
+New `mobile-category-inbox.tsx` component rendered on mobile (`lg:hidden`), existing component kept for desktop (`hidden lg:block`). Both receive the same props from `categorizar/page.tsx`.
+
+### Mobile Layout (top to bottom)
+
+1. **MobileHeader** (sub variant) — "Categorizar" + back button (already exists in page)
+2. **Stats strip** — "24 sin categoría · 8 auto-categorizadas" as tappable filter pills that toggle active tab
+3. **Card feed** — Scrollable list of rich transaction cards, grouped by date with sticky date headers
+4. **Floating bulk bar** — Appears when multi-select active (reuses `bulk-action-bar.tsx` pattern)
+
+### Transaction Card (rich, two-line)
+
+```
+┌─────────────────────────────────────┐
+│ ○  Rappi                    -$45,200│
+│    Bancolombia · 3 abr    💡Delivery│
+└─────────────────────────────────────┘
+```
+
+- **Left:** checkbox + merchant name (line 1), account colored dot + date + suggestion chip (line 2)
+- **Right:** amount, colored by direction (OUTFLOW: red, INFLOW: green)
+- **Merchant name:** 3-field fallback: `merchant_name` → `clean_description` → `raw_description` (same as desktop)
+- **Suggestion chip:** yellow pill with lightbulb icon, shows auto-categorize suggestion when available
+- **Tap card** → opens category action sheet (Drawer)
+- **Long-press** → enters multi-select mode (checkboxes become active)
+
+### Action Sheet (Drawer from bottom)
+
+Opens when user taps a transaction card. Uses shadcn `Drawer` component (vaul).
+
+Contents (top to bottom):
+1. **Transaction summary** — merchant name, account + date, amount
+2. **Category picker grid** — 3-column grid of parent categories (from the same category tree used by desktop `CategoryInbox`). Tap parent → expands to show subcategories inline below the grid. Suggested category pre-highlighted with brass/gold border.
+3. **"Aplicar a N similares" toggle** — shown when merchant group exists (from `extractPattern` utility). Toggle on = batch apply to all matching transactions.
+4. **Destinatario suggestion banner** — shown when destinatario match found. "Vincular con [Destinatario]" with accept/dismiss.
+5. **Confirm button** — brass/gold CTA at bottom. Applies category, closes drawer, shows success toast.
+
+### Bulk Flow
+
+1. Long-press first card → enters selection mode (all checkboxes become visible/tappable)
+2. Tap additional cards to add to selection
+3. Floating action bar appears at bottom: "[N] seleccionadas" + "Categorizar" button
+4. "Categorizar" button opens same Drawer but applies chosen category to all selected transactions
+5. Success toast: "N transacciones categorizadas"
+
+### State Management
+
+- Selection state: local `useState<Set<string>>` for selected transaction IDs
+- Tab state: local `useState<"uncategorized" | "auto">` for active filter
+- No shared hooks with desktop — independent state management
+- Mutations call same server actions as desktop (`categorizeTransaction`, `bulkCategorize`)
+- On success: `revalidateTag("categorize")` handles refresh
+
+### Files
+
+| File | Action |
+|------|--------|
+| `components/categorize/mobile-category-inbox.tsx` | NEW — mobile feed + selection logic |
+| `components/categorize/mobile-category-drawer.tsx` | NEW — action sheet with category picker |
+| `app/(dashboard)/categorizar/page.tsx` | MODIFY — add `lg:hidden` / `hidden lg:block` split |
+
+---
+
+## 2. Accounts — Badge Clipping Fix
+
+### Problem
+`account-card.tsx` header uses `flex justify-between` with type badges and action button on the right. On narrow mobile screens, badges clip outside the card boundary.
+
+### Solution
+- Keep type badge (e.g., "Cheques") top-right next to the action button
+- Remove "Inicio" (`show_in_dashboard`) badge from the card entirely — it's a settings concern, not a display concern
+- Add flex constraints to prevent clipping: `shrink-0` on action button, `min-w-0` on left section, `overflow-hidden` on badge container
+
+### Mobile Layout
+
+```
+┌──────────────────────────────┐
+│ 🏦 Bancolombia  [Cheques] [⚡]│
+│    $2,340,000                │
+└──────────────────────────────┘
+```
+
+- Type badge and action button stay on the same row as the name
+- Name truncates with ellipsis if space is tight
+- No layout change between desktop and mobile — just proper flex constraints
+
+### Files
+
+| File | Action |
+|------|--------|
+| `components/accounts/account-card.tsx` | MODIFY — remove Inicio badge, add flex constraints |
+
+---
+
+## 3. Plan Tab Bar — Bottom List on Mobile
+
+### Problem
+`plan-tab-nav.tsx` renders 5 horizontal pills with `shrink-0 whitespace-nowrap`. On mobile screens, tabs overflow and `scrollbar-none` hides the scroll indicator, so users don't know there are more tabs.
+
+### Solution
+- **Desktop:** keep current horizontal pill bar (`hidden lg:flex`)
+- **Mobile:** hide top pill bar, render a grouped navigation list at the bottom of each tab's content
+
+### Bottom Navigation List
+
+```
+─── Más en Plan ───────────────
+┌─────────────────────────────┐
+│  Presupuesto              → │
+│─────────────────────────────│
+│  Periodo                  → │
+│─────────────────────────────│
+│  Recurrentes              → │
+│─────────────────────────────│
+│  Deseos                   → │
+└─────────────────────────────┘
+```
+
+- Uses `MCardTight` + `MListRow` pattern from mobile/v2
+- Shows all tabs except the currently active one
+- Each row is a `Link` to `/plan?tab=<name>`
+- Section header: "Más en Plan" (eyebrow style)
+- Rendered after tab content, with `lg:hidden`
+
+### Files
+
+| File | Action |
+|------|--------|
+| `components/plan/plan-mobile-nav-list.tsx` | NEW — ~30 lines, receives current tab, renders remaining tabs as list |
+| `components/plan/plan-tab-nav.tsx` | MODIFY — add `hidden lg:flex` to the nav element |
+| `app/(dashboard)/plan/page.tsx` | MODIFY — render `PlanMobileNavList` with `lg:hidden` after tab content |
+
+---
+
+## 4. Settings — Accordion on Mobile
+
+### Problem
+Settings page now has 6+ sections after Etiquetas was embedded (PR #97). On mobile, this creates an excessively long scroll with no way to jump between sections.
+
+### Solution
+- **Desktop:** keep current layout (all sections visible as cards)
+- **Mobile:** wrap sections in a Radix `Accordion` (`type="single"`, one open at a time)
+
+### Mobile Layout
+
+```
+┌─────────────────────────────┐
+│ ▼ Perfil                    │
+│   [expanded form content]   │
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│ ▶ Integraciones             │
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│ ▶ Email                     │
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│ ▶ Etiquetas                 │
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│ ▶ Reportar bug              │
+└─────────────────────────────┘
+```
+
+- First section (Perfil) expanded by default via `defaultValue`
+- Accordion trigger styled to match existing card headers
+- Content inside each item is the existing component, just wrapped
+- Smooth open/close animation from Radix
+- Desktop: sections render as normal cards (no accordion wrapper)
+
+### Implementation
+
+Use responsive rendering: on mobile (`lg:hidden`), render all sections inside `<Accordion type="single" defaultValue="perfil">`. On desktop (`hidden lg:block`), render the same sections without accordion wrapping. Share section content via a helper that returns the inner JSX.
+
+### Files
+
+| File | Action |
+|------|--------|
+| `app/(dashboard)/settings/page.tsx` | MODIFY — add mobile accordion wrapper with `lg:hidden` / `hidden lg:block` split |
+
+---
+
+## Cross-Cutting
+
+### Design Tokens & Patterns
+- All new components use existing mobile/v2 primitives: `MCard`, `MCardTight`, `MListRow`, `MobileHeader`
+- Breakpoint: `lg` (1024px) is the mobile/desktop split — consistent with rest of app
+- Colors: use design tokens from `lib/constants/styles.ts`, no hardcoded colors
+- Drawer: shadcn `Drawer` component (vaul) for action sheets
+
+### Testing
+- Visual verification at 390px (iPhone) and 1440px (desktop) — ensure desktop is unchanged
+- Categorizar: test single categorize, bulk categorize, tab switching, empty state
+- Accounts: verify no badge clipping at 320px minimum width
+- Plan: verify all tabs reachable via bottom list, active tab excluded from list
+- Settings: verify accordion open/close, form submission works within accordion
+
+### Build Gates
+- `pnpm install` (if deps change)
+- `pnpm build` must pass clean

--- a/docs/superpowers/specs/2026-04-08-mobile-plan-family-design.md
+++ b/docs/superpowers/specs/2026-04-08-mobile-plan-family-design.md
@@ -1,0 +1,223 @@
+# Mobile Plan Family Redesign + General Mobile Fixes
+
+**Date:** 2026-04-08
+**Status:** Draft
+**Scope:** Dedicated mobile views for Plan hub, Presupuesto, Recurrentes, Periodo + targeted fixes for Landing, Settings, Accounts, Transactions list
+
+## Context
+
+The Zeta webapp uses a `lg:hidden` / `hidden lg:block` split architecture to serve dedicated mobile views at `<1024px`. Several pages already have polished mobile views (Dashboard, Categorizar, Gestionar, Deudas, Deseos, Transaction detail). Seven pages currently render the desktop layout on mobile, causing overflow, truncation, and cramped interactions.
+
+This spec covers the full redesign of the Plan family (4 pages) and targeted fixes for 4 additional pages.
+
+## Design Principles
+
+- **"Am I on track?" at a glance** — every hero answers this without scrolling
+- **Hybrid: summary card + drill-down** — top-level view shows actionable metrics, tap to go deeper
+- **Chart focus mode** — expanded charts take over touch events
+- **Bottom nav clearance** — all pages get `pb-20` for the fixed MobileTabBar
+
+---
+
+## 1. Plan Hub (`/plan`)
+
+### Current Problems
+- Duplicate month selector (header + section)
+- Budget hero mixed with cashflow — tries to be two things
+- Long scroll with everything inline
+- Content hidden behind bottom nav
+
+### New Mobile Layout
+
+**Structure:** `MobileHeader` → Net Hero Card → 2 Expandable Chips → Drill-down Cards
+
+#### Net Hero Card (tappable → chart)
+- **Title:** "NETO DEL MES"
+- **Main metric:** Net amount (e.g., `+$4.162.587`) in brass/gold
+- **Subtitle:** "22 días restantes"
+- **Stacked progress bar:** Full width = total income (green). Red overlaid from left = total payments. Brass remainder on right = net. Single bar, three segments.
+- **Legend:** Three dot-labeled values: "Ingresos $35.7M" / "Gastos $31.5M" / "Neto"
+- **Tap hint:** "Toca para ver flujo ↓" (muted)
+- **Tap action:** Expands the full Flujo del Mes Recharts chart (bars + net line + ingresos/gastos/neto totals) inline. Enters **chart focus mode**.
+
+#### 2 Expandable Chips (grid, 1fr 1fr)
+- **Próximo ingreso:** Amount in green, source + date below. Tap → expands an inline list of all upcoming incomes with total.
+- **Próximo pago:** Amount in red, source + date below. Tap → expands an inline list of all upcoming payments with total.
+- Active chip gets a highlighted border; sibling dims. List slides in below the chips.
+
+#### Drill-down Cards ("IR A" section)
+Each card shows title + one-line status hint + chevron. Cards:
+- **Presupuesto** — e.g., "914% · 6 sobre límite" (red)
+- **Periodo** — e.g., "100% asignado" (green)
+- **Recurrentes** — e.g., "$2M/mes" (amber)
+- **Deseos** — e.g., "3 items" (muted)
+
+Each navigates to the sub-page via the existing `?tab=` routing.
+
+#### Month Selector
+Single instance in the header row, right-aligned. Compact pill: `‹ Abr ›`.
+
+---
+
+## 2. Chart Focus Mode (cross-cutting)
+
+When any chart expands on mobile (Plan hero, Periodo hero, or any future chart):
+
+1. `document.body.style.overflow = 'hidden'` — locks page scroll
+2. Touch events within the chart area route to Recharts interactions (pan/scrub to see daily detail, pinch to zoom if applicable)
+3. Subtle overlay (semi-transparent dark) dims content below the expanded chart
+4. **Exit:** Tap the hero card header/collapse link, or tap the overlay
+5. On collapse: restore scroll, remove overlay, animate chart closed
+
+Implementation: a `useChartFocusMode(isExpanded: boolean)` hook that handles body scroll lock and overlay. Applied in any component that has an expandable chart.
+
+---
+
+## 3. Presupuesto (`/plan?tab=presupuesto`)
+
+### New Mobile Layout
+
+**Structure:** `← Plan` header → Budget Hero → Category List
+
+#### Budget Hero Card
+- **Title:** "GASTADO ESTE MES"
+- **Main metric:** Percentage (e.g., `914%`) in red when over, green when under
+- **Secondary:** `$29.7M de $3.25M`
+- **Progress bar:** Single bar showing spend vs budget (capped at 100% width, red when over)
+- **Status badge:** "ATENCIÓN" (red) or "En control" (green)
+- **Distribution row:** "Necesario 34% · Deseos 66%"
+
+This is the budget hero that currently lives on the Plan page — it moves here where it belongs.
+
+#### Category List
+Vertical list with each category showing:
+- Icon + name (left)
+- Amount / budget + mini progress bar (right)
+- Warning icon (⚠) for over-budget categories
+- Sorted: over-budget first, then by spend descending
+
+---
+
+## 4. Recurrentes (`/plan?tab=recurrentes`)
+
+### Current Problems
+- Calendar view has cramped payment rows (name + amount + button overlap)
+- Not touch-friendly at 390px
+
+### New Mobile Layout
+
+**Structure:** `← Plan` header → Hero Card → Upcoming List → Completed List
+
+#### Hero Card (informational, no progress bar)
+- **Title:** "COMPROMISO MENSUAL"
+- **Main metric:** Total monthly commitment (e.g., `$2.025.526`)
+- **Subtitle:** "8 plantillas activas"
+- **Divider**
+- **Three-column row:** Pendientes (count, amber) | Completados (count, green) | Próximo (name + date)
+
+No calendar on mobile. The calendar is a desktop-only view. Mobile gets a chronological list.
+
+#### Upcoming List ("PRÓXIMOS")
+Each row: name, date + account, amount (red), "Confirmar" button (brass pill). Sorted by date ascending.
+
+#### Completed List ("COMPLETADOS")
+Dimmed rows with checkmark + amount in green. Collapsed by default if >3 items.
+
+---
+
+## 5. Periodo (`/plan?tab=periodo`)
+
+### Current Problems
+- "Disponible" label truncated to "Dispo..." on income cards
+- No clear hierarchy between income and expense sections
+
+### New Mobile Layout
+
+**Structure:** `← Plan` header → Chart Hero → Period Summary Bar → Income Cards → Expense List
+
+#### Chart Hero
+The Flujo del Mes chart is always visible as the hero — not collapsed. It provides the visual context for "where am I in the month" since Periodo is about allocating income to expenses across the period.
+
+Touch interaction: tapping the chart enters **chart focus mode** for scrubbing daily details.
+
+Below the chart: Ingresos / Gastos / Neto totals in a row.
+
+#### Period Summary Bar
+Compact bar: "01 abr — 30 abr 2026" with "100% asignado" badge. Shows the active period at a glance.
+
+#### Income Cards
+Each income source as a card:
+- Name + amount (right-aligned)
+- Date + account (subtitle)
+- Assignment progress bar (full width)
+- **"Disponible: $X"** — full label, never truncated (the whole reason this page needs a mobile view)
+
+#### Expense List ("GASTOS PENDIENTES")
+Clean list with name, date + account, and "Pendiente" badge. No cards needed — just rows with proper spacing.
+
+---
+
+## 6. Additional Mobile Fixes (brief treatment)
+
+### Landing Page (`/`)
+**Problem:** Hero headline text overflows right edge at 390px. Marquee banner clips.
+**Fix:** Add responsive font sizing to the hero section. The headline currently uses a fixed large `text-5xl` or similar — reduce to `text-3xl` or `text-2xl` on mobile via `text-3xl lg:text-5xl`. Ensure the marquee/banner container has `overflow-hidden` and text wraps properly. Check all sections below the fold for similar overflow (most are fine based on audit).
+
+### Settings (`/settings`)
+**Problem:** Horizontal profile info cards ("PERFIL ACTIVO", "CORREO", "MIEMBRO DESDE") overflow at 390px. Email truncated, date clipped.
+**Fix:** Stack the cards vertically on mobile. Change the grid from `grid-cols-3` to `grid-cols-1 lg:grid-cols-3`. Each card becomes a full-width row showing the label and value. This is a CSS-only fix — no component restructuring needed.
+
+### Accounts (`/accounts`)
+**Problem:** Badge text ("Tarjeta") clips on narrow cards. "Ver detalle >" links are small tap targets.
+**Fix:** Ensure badge text uses `truncate` with `max-w` or wraps to a second line. Increase tap target for "Ver detalle" — make the entire card row tappable (wrap in a link or add `onClick` to the card container) instead of relying on the small text link. Minimum touch target: 44px height.
+
+### Transactions List (`/transactions`)
+**Problem:** Bottom nav overlaps last transaction rows.
+**Fix:** Already has `pb-20` pattern from other pages — verify it's applied to the scrollable container. This is likely a missing padding fix, not a redesign. The list layout itself works fine on mobile.
+
+---
+
+## 7. Auth Error i18n (already fixed)
+
+Login error "Invalid login credentials" was in English. Added `translateAuthError()` map in `actions/auth.ts` to translate common Supabase auth errors to Spanish. Applied to all `signIn`, `signUp`, `resetPasswordRequest`, and `updatePassword` actions.
+
+---
+
+## Data Requirements
+
+### Plan Hub Hero
+- **Net amount:** `ingresos - gastos` for the current month (from existing `getMonthlyCashflowCached()`)
+- **Próximo ingreso:** Next upcoming income from `recurring_transactions` where type is income-like and `next_occurrence_date > today`, ordered by date. Falls back to periodo income assignments if no recurring match.
+- **Próximo pago:** Same logic but for outflow/payment recurring entries.
+- **Upcoming income/payment lists:** All recurring entries for the current month, separated by direction. Data comes from the same server action that feeds the Recurrentes page.
+- **Stacked bar proportions:** `gastos / ingresos` ratio
+
+### Recurrentes Hero
+- **Monthly commitment:** Sum of all active recurring `amount` values
+- **Pending/completed counts:** Count of recurring entries for current month by confirmed status
+
+### Periodo Chart Hero
+- Reuses the existing Flujo del Mes chart component and data — no new data fetching needed
+
+---
+
+## Component Architecture
+
+### New Components
+- `MobilePlanHub` — the Plan hub mobile view (lg:hidden wrapper)
+- `MobilePlanHero` — net hero card with stacked bar, expandable chart
+- `MobileExpandableChips` — 2-chip grid with expand/collapse income/payment lists
+- `MobilePlanDrillCards` — drill-down card list
+- `MobilePresupuestoView` — budget hero + category list
+- `MobileRecurrentesView` — hero card + upcoming/completed lists
+- `MobilePeriodoView` — chart hero + period bar + income cards + expense list
+- `useChartFocusMode` — hook for scroll lock + overlay when chart is expanded
+
+### Existing Components Reused
+- `MobileHeader` — sticky header with back arrow
+- `MobileTabBar` — bottom navigation (unchanged)
+- Flujo del Mes chart (Recharts) — reused as-is, just placed in new containers
+- Budget category rows — extracted from current desktop presupuesto view
+
+### Pattern
+All new mobile components follow the established `lg:hidden` / `hidden lg:block` pattern. The desktop views remain completely unchanged. Each page's `page.tsx` renders both branches.

--- a/scripts/patch-encryption-types.js
+++ b/scripts/patch-encryption-types.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = process.argv[2];
+let content = fs.readFileSync(path, 'utf8');
+
+// Tables that were converted to views
+const encTables = [
+  'accounts', 'capture_tokens', 'destinatarios', 'email_ingest_addresses',
+  'profiles', 'recurring_transaction_templates', 'statement_snapshots',
+  'transactions', 'wishlist_items'
+];
+
+// For each _enc table, duplicate its entry as the original name in Tables
+for (const name of encTables) {
+  const encName = name + '_enc';
+  
+  // Find the _enc entry in Tables section - capture from "      <encName>: {" to the closing "      }"
+  const encPattern = new RegExp(`(      ${encName}: \\{[\\s\\S]*?\\n      \\})`, 'm');
+  const match = content.match(encPattern);
+  if (!match) {
+    console.error(`WARNING: Could not find ${encName} in Tables`);
+    continue;
+  }
+  
+  // Create a copy with the original name
+  let copy = match[1].replace(new RegExp(encName, 'g'), name);
+  
+  // Fix referencedRelation values that point to _enc tables
+  for (const t of encTables) {
+    copy = copy.replace(new RegExp(`referencedRelation: "${t}_enc"`, 'g'), `referencedRelation: "${t}"`);
+  }
+  
+  // Fix foreignKeyName values
+  copy = copy.replace(/_enc_/g, '_');
+  
+  // Insert the copy after the _enc entry
+  content = content.replace(match[1], match[1] + '\n' + copy);
+}
+
+// Remove view entries from Views section (replace with empty)
+// Find Views section
+const viewsStart = content.indexOf('    Views: {');
+const viewsEnd = content.indexOf('\n    }', viewsStart + 10);
+if (viewsStart !== -1 && viewsEnd !== -1) {
+  content = content.substring(0, viewsStart) + '    Views: {\n      [_ in never]: never' + content.substring(viewsEnd);
+}
+
+fs.writeFileSync(path, content);
+console.log('Types patched successfully');

--- a/services/pdf_parser/main.py
+++ b/services/pdf_parser/main.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from models import ParsedStatement
 from parsers import detect_and_parse
+from parsers.image_detection import detect_and_parse_image
 from parsers.opendataloader_fallback import (
     get_opendataloaders_binary,
     is_opendataloader_fallback_enabled,
@@ -203,6 +204,78 @@ async def parse_pdf(file: UploadFile, password: str | None = Form(None)):
             os.remove(tmp_path)
         except OSError as exc:
             logger.warning("Failed to delete temp file %s: %s", tmp_path, exc)
+
+
+MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MB
+ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
+
+
+@app.post("/parse-image", response_model=ParseResponse, dependencies=[Depends(_verify_key)])
+async def parse_image(
+    file: UploadFile,
+    screenshot_date: str | None = Form(None),
+):
+    """Parse a bank app screenshot into transactions."""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No se proporcionó un archivo")
+
+    ext = os.path.splitext(file.filename.lower())[1]
+    if ext not in ALLOWED_IMAGE_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail="Formato no soportado. Se aceptan PNG, JPG o WEBP.",
+        )
+
+    content = await file.read()
+
+    if len(content) > MAX_IMAGE_BYTES:
+        raise HTTPException(status_code=413, detail="La imagen excede el tamaño máximo de 20MB")
+
+    with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+    os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+
+    logger.info(
+        "Image parse request: filename=%s size_bytes=%s screenshot_date=%s",
+        file.filename,
+        len(content),
+        screenshot_date,
+    )
+
+    from datetime import date as date_type
+
+    sd = None
+    if screenshot_date:
+        try:
+            sd = date_type.fromisoformat(screenshot_date)
+        except ValueError:
+            pass
+
+    try:
+        statements = detect_and_parse_image(tmp_path, screenshot_date=sd)
+        logger.info("Image parse succeeded: filename=%s statements=%s", file.filename, len(statements))
+        return ParseResponse(statements=statements)
+    except ValueError as e:
+        logger.warning("Image parse rejected: filename=%s: %s", file.filename, e)
+        raise HTTPException(
+            status_code=422,
+            detail={"message": str(e), "type": "unsupported_format"},
+        )
+    except Exception:
+        logger.exception("Unexpected image parser failure: filename=%s", file.filename)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "message": "Error interno procesando la imagen.",
+                "type": "internal_error",
+            },
+        )
+    finally:
+        try:
+            os.remove(tmp_path)
+        except OSError as exc:
+            logger.warning("Failed to delete temp image %s: %s", tmp_path, exc)
 
 
 @app.post("/save-unrecognized", dependencies=[Depends(_verify_key)])

--- a/services/pdf_parser/parsers/bancolombia_app_screenshot.py
+++ b/services/pdf_parser/parsers/bancolombia_app_screenshot.py
@@ -1,0 +1,122 @@
+"""Bancolombia mobile app screenshot parser.
+
+Parses screenshots from the Bancolombia app's transaction list view.
+Expected OCR format (repeating):
+
+    DD MMM YYYY
+    DESCRIPTION
+    COP -$ XX.XXX,XX
+
+Number format: Colombian (dot = thousands, comma = decimals) e.g. 30.000,00
+Direction: negative amounts (-$) are OUTFLOW, positive (+$ or bare $) are INFLOW.
+
+OCR quirks handled:
+- "cor" instead of "COP" (common OCR misread)
+- Space instead of comma in decimals: "43.627 81" → 43627.81
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+
+from models import (
+    ParsedStatement,
+    ParsedTransaction,
+    StatementType,
+    TransactionDirection,
+)
+from parsers.image_utils import MONTH_MAP, parse_colombian_number
+
+logger = logging.getLogger("pdf_parser.bancolombia_app")
+
+# Date line: "06 ABR 2026" or "6 ABR 2026"
+DATE_RE = re.compile(
+    r"^(\d{1,2})\s+(ene|feb|mar|abr|may|jun|jul|ago|sep|oct|nov|dic)\s+(\d{4})$",
+    re.IGNORECASE,
+)
+
+# Amount line: "COP -$ 30.000,00" — OCR may produce "cor" instead of "cop",
+# and space instead of comma for decimals
+AMOUNT_RE = re.compile(
+    r"^co[pr]\s*([+-])?\s*\$\s*([\d., ]+)$",
+    re.IGNORECASE,
+)
+
+# UI noise to skip when collecting description lines
+SKIP_PATTERNS = [
+    "cuenta de ahorro", "detalles", "movimientos", "transferir plata",
+    "ir a día", "ira día", "más", "bancolombia",
+]
+
+
+def parse_bancolombia_app(
+    ocr_text: str,
+    screenshot_date: date | None = None,
+) -> ParsedStatement:
+    """Parse Bancolombia app OCR text into a ParsedStatement."""
+    lines = [line.strip() for line in ocr_text.splitlines() if line.strip()]
+
+    transactions: list[ParsedTransaction] = []
+    current_date: date | None = None
+    description_lines: list[str] = []
+
+    for line in lines:
+        date_match = DATE_RE.match(line)
+        if date_match:
+            day = int(date_match.group(1))
+            month = MONTH_MAP[date_match.group(2).lower()]
+            year = int(date_match.group(3))
+            current_date = date(year, month, day)
+            description_lines = []
+            continue
+
+        amount_match = AMOUNT_RE.match(line)
+        if amount_match and current_date is not None:
+            sign = amount_match.group(1) or "+"
+            raw = amount_match.group(2).strip()
+            try:
+                amount = parse_colombian_number(raw)
+            except ValueError:
+                logger.warning("Could not parse Bancolombia amount: %s", line)
+                continue
+
+            direction = (
+                TransactionDirection.OUTFLOW if sign == "-"
+                else TransactionDirection.INFLOW
+            )
+            description = " ".join(description_lines).strip() or "Sin descripción"
+
+            transactions.append(ParsedTransaction(
+                date=current_date,
+                description=description,
+                amount=amount,
+                direction=direction,
+                currency="COP",
+            ))
+            current_date = None
+            description_lines = []
+            continue
+
+        if current_date is not None:
+            lower = line.lower()
+            if not any(p in lower for p in SKIP_PATTERNS):
+                description_lines.append(line)
+
+    logger.info("Bancolombia app parsed: transactions=%s", len(transactions))
+
+    if not transactions:
+        raise ValueError(
+            "No se encontraron transacciones en la captura de pantalla de Bancolombia."
+        )
+
+    dates = [t.date for t in transactions]
+    return ParsedStatement(
+        bank="bancolombia",
+        statement_type=StatementType.SAVINGS,
+        period_from=min(dates),
+        period_to=max(dates),
+        currency="COP",
+        transactions=transactions,
+    )

--- a/services/pdf_parser/parsers/image_detection.py
+++ b/services/pdf_parser/parsers/image_detection.py
@@ -19,8 +19,8 @@ from parsers.nu_credit_card_app_screenshot import parse_nu_credit_card_app
 
 logger = logging.getLogger("pdf_parser.image_detector")
 
-# Type alias for parser functions
-type ImageParser = type[None]  # just for documentation
+# Type alias for parser functions (plain assignment for Python 3.11 compat)
+ImageParser = None  # documentation-only marker
 
 IMAGE_DETECTORS: list[dict] = [
     {

--- a/services/pdf_parser/parsers/image_detection.py
+++ b/services/pdf_parser/parsers/image_detection.py
@@ -1,0 +1,126 @@
+"""Multi-bank image detection and routing for app screenshots.
+
+Similar to the PDF detector system: OCR the image once, score bank-specific
+signals against the text, and route to the winning parser.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+
+from models import ParsedStatement
+from parsers.image_utils import ocr_image
+from parsers.bancolombia_app_screenshot import parse_bancolombia_app
+from parsers.nequi_app_screenshot import parse_nequi_app
+from parsers.nu_savings_app_screenshot import parse_nu_savings_app
+from parsers.nu_credit_card_app_screenshot import parse_nu_credit_card_app
+
+logger = logging.getLogger("pdf_parser.image_detector")
+
+# Type alias for parser functions
+type ImageParser = type[None]  # just for documentation
+
+IMAGE_DETECTORS: list[dict] = [
+    {
+        "name": "bancolombia_app",
+        "signals": [
+            (5, lambda t: "COP" in t and bool(re.search(r"COP\s*[+-]?\s*\$", t))),
+            (3, lambda t: "CUENTA DE AHORRO" in t),
+            (3, lambda t: "BANCOLOMBIA" in t),
+            (4, lambda t: "TRANSFERIR PLATA" in t),
+            (4, lambda t: bool(re.search(r"\d{1,2}\s+(ENE|FEB|MAR|ABR|MAY|JUN|JUL|AGO|SEP|OCT|NOV|DIC)\s+\d{4}", t))),
+        ],
+        "parse": lambda text, sd: parse_bancolombia_app(text, sd),
+    },
+    {
+        "name": "nequi_app",
+        "signals": [
+            (5, lambda t: "NEQUI" in t or "NEQUI.COM.CO" in t),
+            (5, lambda t: bool(re.search(r"\d+\s+DE\s+\w+\s+DE\s+\d{4}", t))),
+            (3, lambda t: "MÁS MOVIMIENTOS" in t or "MAS MOVIMIENTOS" in t),
+            (3, lambda t: "RETIRO EN" in t or "RECARGA EN" in t or "PAGO DE" in t),
+        ],
+        "parse": lambda text, sd: parse_nequi_app(text, sd),
+    },
+    {
+        "name": "nu_savings_app",
+        "signals": [
+            (4, lambda t: "BUSCAR MOVIMIENTO" in t),
+            (4, lambda t: "ENVIASTE A" in t or "RECIBISTE DE" in t),
+            (3, lambda t: "CAJITA" in t or "RETIRASTE DINERO" in t),
+            (4, lambda t: bool(re.search(r"\d{1,2}\s+(ENE|FEB|MAR|ABR|MAY|JUN|JUL|AGO|SEP|OCT|NOV|DIC)\s*-\s*\d{1,2}:\d{2}", t))),
+            (3, lambda t: bool(re.search(r"[+-]\$\s*[\d.,]+", t))),
+        ],
+        "parse": lambda text, sd: parse_nu_savings_app(text, sd),
+    },
+    {
+        "name": "nu_credit_card_app",
+        "signals": [
+            (5, lambda t: "GRACIAS POR TU PAGO" in t),
+            (5, lambda t: bool(re.search(r"PAGASTE\s+\$", t))),
+            (4, lambda t: bool(re.search(r"A\s+\d+\s+MESES", t))),
+            (3, lambda t: bool(re.search(r"COMISIÓN POR", t)) or bool(re.search(r"COMISION POR", t))),
+        ],
+        "parse": lambda text, sd: parse_nu_credit_card_app(text, sd),
+    },
+]
+
+MIN_CONFIDENCE = 6
+
+
+def detect_and_parse_image(
+    image_path: str,
+    screenshot_date: date | None = None,
+) -> list[ParsedStatement]:
+    """OCR an image, detect the bank app, and parse transactions.
+
+    Returns a list of ParsedStatement (single item) for consistency
+    with the PDF parser return type.
+    """
+    ocr_text = ocr_image(image_path)
+    text_upper = ocr_text.upper()
+
+    logger.info("Image OCR sample (first 300 chars): %s", text_upper[:300])
+
+    # Score every detector
+    scored: list[tuple[int, dict]] = []
+    for detector in IMAGE_DETECTORS:
+        score = sum(w for w, fn in detector["signals"] if fn(text_upper))
+        if score > 0:
+            scored.append((score, detector))
+
+    if not scored:
+        logger.warning("No image detector match found")
+        raise ValueError(
+            "No se pudo detectar el banco de esta captura de pantalla. "
+            "Bancos soportados: Bancolombia, Nequi, Nu (cuenta y tarjeta de crédito)."
+        )
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    best_score, best_detector = scored[0]
+    top_candidates = [f"{d['name']}:{s}" for s, d in scored[:3]]
+    logger.info("Image detector scores (top): %s", ", ".join(top_candidates))
+
+    if best_score < MIN_CONFIDENCE:
+        logger.warning(
+            "Image detector confidence too low: detector=%s score=%s min=%s",
+            best_detector["name"],
+            best_score,
+            MIN_CONFIDENCE,
+        )
+        raise ValueError(
+            f"No se pudo detectar el banco con suficiente confianza "
+            f"(mejor candidato: {best_detector['name']}, puntaje: {best_score}/{MIN_CONFIDENCE}). "
+            f"Bancos soportados: Bancolombia, Nequi, Nu (cuenta y tarjeta de crédito)."
+        )
+
+    logger.info(
+        "Selected image detector: %s (score=%s)",
+        best_detector["name"],
+        best_score,
+    )
+
+    statement = best_detector["parse"](ocr_text, screenshot_date)
+    return [statement]

--- a/services/pdf_parser/parsers/image_utils.py
+++ b/services/pdf_parser/parsers/image_utils.py
@@ -1,0 +1,87 @@
+"""Shared utilities for app screenshot parsers."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, timedelta
+
+from PIL import Image
+import pytesseract
+
+logger = logging.getLogger("pdf_parser.image_utils")
+
+# Spanish month abbreviations → month number
+MONTH_MAP: dict[str, int] = {
+    "ene": 1, "feb": 2, "mar": 3, "abr": 4,
+    "may": 5, "jun": 6, "jul": 7, "ago": 8,
+    "sep": 9, "oct": 10, "nov": 11, "dic": 12,
+    # Full names (OCR sometimes outputs these)
+    "enero": 1, "febrero": 2, "marzo": 3, "abril": 4,
+    "mayo": 5, "junio": 6, "julio": 7, "agosto": 8,
+    "septiembre": 9, "octubre": 10, "noviembre": 11, "diciembre": 12,
+}
+
+# Spanish day names → weekday number (Monday=0)
+DAY_NAME_MAP: dict[str, int] = {
+    "lunes": 0, "martes": 1, "miércoles": 2, "miercoles": 2,
+    "jueves": 3, "viernes": 4, "sábado": 5, "sabado": 5,
+    "domingo": 6,
+}
+
+# OCR often reads app icons as short chars at the start of lines
+ICON_ARTIFACT_RE = re.compile(r"^[A-Za-z0-9@#<>(){}[\]*=+\-_|!?]{1,3}[\s)]+")
+
+
+def parse_colombian_number(s: str) -> float:
+    """Parse Colombian-formatted number: 30.000,00 → 30000.00
+
+    Also handles OCR artifacts:
+    - Space instead of comma for decimals: "43.627 81" → 43627.81
+    - Missing comma: "43.62781" (concatenated)
+    """
+    # Handle space-separated decimals: "43.627 81" → "43.627,81"
+    s = re.sub(r"(\d)\s+(\d{2})$", r"\1,\2", s.strip())
+    cleaned = s.replace(".", "").replace(",", ".")
+    return float(cleaned)
+
+
+def strip_icon_artifacts(line: str) -> str:
+    """Remove OCR artifacts from app icons at the start of a line.
+
+    Examples: "E Enviaste a" → "Enviaste a", "0) Recarga" → "Recarga",
+    "a Claude.Ai" → "Claude.Ai", "uy  Novaventa" → "Novaventa"
+    """
+    return ICON_ARTIFACT_RE.sub("", line).strip()
+
+
+def ocr_image(image_path: str) -> str:
+    """OCR a screenshot image and return the extracted text."""
+    img = Image.open(image_path)
+    text = pytesseract.image_to_string(img, lang="spa", config="--psm 4")
+    logger.info("OCR completed: image=%s chars=%s", image_path, len(text))
+    return text
+
+
+def resolve_relative_date(label: str, reference_date: date) -> date | None:
+    """Resolve relative day labels ('Ayer', 'Hoy', 'Domingo') to a date.
+
+    For day names, returns the most recent past occurrence relative to
+    reference_date (or reference_date itself if it falls on that day).
+    """
+    lower = label.lower().strip()
+
+    if lower == "hoy":
+        return reference_date
+    if lower == "ayer":
+        return reference_date - timedelta(days=1)
+
+    weekday = DAY_NAME_MAP.get(lower)
+    if weekday is not None:
+        ref_weekday = reference_date.weekday()
+        days_back = (ref_weekday - weekday) % 7
+        if days_back == 0:
+            days_back = 7  # "Domingo" on a Sunday means last Sunday
+        return reference_date - timedelta(days=days_back)
+
+    return None

--- a/services/pdf_parser/parsers/nequi_app_screenshot.py
+++ b/services/pdf_parser/parsers/nequi_app_screenshot.py
@@ -1,0 +1,143 @@
+"""Nequi mobile app screenshot parser.
+
+Expected OCR format:
+
+    D De Mes De YYYY           ← grouped date header
+    [icon] Description -$XX.XXX,XX   ← description + amount on same line
+    Subtitle                   ← optional subtitle below
+
+OCR quirks handled:
+- App icons OCR'd as "Q", "0)", "O", etc. at start of lines
+- Description and amount often on the same line
+- Sometimes amount is on a separate line with just icon artifact + amount
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+
+from models import (
+    ParsedStatement,
+    ParsedTransaction,
+    StatementType,
+    TransactionDirection,
+)
+from parsers.image_utils import MONTH_MAP, parse_colombian_number, strip_icon_artifacts
+
+logger = logging.getLogger("pdf_parser.nequi_app")
+
+# Date header: "9 De Marzo De 2026" or "9 de marzo de 2026"
+DATE_HEADER_RE = re.compile(
+    r"^(\d{1,2})\s+[Dd]e\s+(\w+)\s+[Dd]e\s+(\d{4})$",
+)
+
+# Amount pattern anywhere in a line: "-$20.000,00" or "$20.000,00" or "-$ 20.000,00"
+# OCR sometimes reads "$" as "s", so we also match "s 20.000,00" at end of line
+AMOUNT_INLINE_RE = re.compile(
+    r"([+-])?\s*[\$s]\s*([\d.,]+)",
+)
+
+# UI noise to skip
+SKIP_PATTERNS = [
+    "movimientos", "busca", "hoy", "más movimientos", "mas movimientos",
+    "nequi.com.co", "para ver más", "para ver mas", "inicio", "servicios",
+]
+
+
+def parse_nequi_app(
+    ocr_text: str,
+    screenshot_date: date | None = None,
+) -> ParsedStatement:
+    """Parse Nequi app OCR text into a ParsedStatement.
+
+    Nequi groups transactions under date headers. Due to OCR quirks with
+    app icons, we look for amount patterns ($) on each line and extract
+    the description from the text before the amount.
+    """
+    lines = [line.strip() for line in ocr_text.splitlines() if line.strip()]
+
+    transactions: list[ParsedTransaction] = []
+    current_date: date | None = None
+    last_description: str | None = None
+
+    for line in lines:
+        lower = line.lower()
+
+        # Skip UI noise
+        if any(p in lower for p in SKIP_PATTERNS):
+            continue
+
+        # Date header
+        date_match = DATE_HEADER_RE.match(line)
+        if date_match:
+            day = int(date_match.group(1))
+            month_name = date_match.group(2).lower()
+            year = int(date_match.group(3))
+            month = MONTH_MAP.get(month_name)
+            if month:
+                current_date = date(year, month, day)
+                last_description = None
+            continue
+
+        if current_date is None:
+            continue
+
+        # Look for amount pattern in the line
+        amount_match = AMOUNT_INLINE_RE.search(line)
+        if amount_match:
+            sign = amount_match.group(1) or "+"
+            try:
+                amount = parse_colombian_number(amount_match.group(2))
+            except ValueError:
+                logger.warning("Could not parse Nequi amount: %s", line)
+                continue
+
+            direction = (
+                TransactionDirection.OUTFLOW if sign == "-"
+                else TransactionDirection.INFLOW
+            )
+
+            # Extract description from text before the amount
+            before_amount = line[:amount_match.start()].strip()
+            description = strip_icon_artifacts(before_amount)
+
+            # If description is empty/short, use the previous non-amount line
+            if len(description) < 3 and last_description:
+                description = last_description
+
+            if not description:
+                description = "Sin descripción"
+
+            transactions.append(ParsedTransaction(
+                date=current_date,
+                description=description,
+                amount=amount,
+                direction=direction,
+                currency="COP",
+            ))
+            last_description = None
+            continue
+
+        # Non-amount, non-date line: potential description for next amount
+        cleaned = strip_icon_artifacts(line)
+        if cleaned and len(cleaned) > 2:
+            last_description = cleaned
+
+    logger.info("Nequi app parsed: transactions=%s", len(transactions))
+
+    if not transactions:
+        raise ValueError(
+            "No se encontraron transacciones en la captura de pantalla de Nequi."
+        )
+
+    dates = [t.date for t in transactions]
+    return ParsedStatement(
+        bank="nequi",
+        statement_type=StatementType.SAVINGS,
+        period_from=min(dates),
+        period_to=max(dates),
+        currency="COP",
+        transactions=transactions,
+    )

--- a/services/pdf_parser/parsers/nu_credit_card_app_screenshot.py
+++ b/services/pdf_parser/parsers/nu_credit_card_app_screenshot.py
@@ -1,0 +1,191 @@
+"""Nu credit card app screenshot parser.
+
+Expected OCR format:
+
+    Day label (Ayer / Domingo / Hoy)   ← relative date header
+    [icon] Description...    $XX.XXX,XX  ← amount (no sign)
+    HH:MM             a XX meses       ← time + optional installments
+
+    ¡Gracias por tu pago!              ← payment line (INFLOW)
+    Pagaste $X.XXX.XXX,XX
+
+Number format: Colombian (dot = thousands, comma = decimals)
+Direction: "Gracias por tu pago" / "Pagaste" = INFLOW, everything else = OUTFLOW.
+
+OCR quirks handled:
+- Icons OCR'd as "E", "a", "uy", "*=" at line starts
+- "a24 meses" (no space between "a" and number)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+
+from models import (
+    ParsedStatement,
+    ParsedTransaction,
+    StatementType,
+    TransactionDirection,
+)
+from parsers.image_utils import (
+    DAY_NAME_MAP,
+    parse_colombian_number,
+    resolve_relative_date,
+    strip_icon_artifacts,
+)
+
+logger = logging.getLogger("pdf_parser.nu_cc_app")
+
+# Description + amount: "Comisión por... $1.686,54"
+DESC_AMOUNT_RE = re.compile(
+    r"^(.+?)\s+\$\s*([\d.,]+)$",
+)
+
+# Payment amount: "Pagaste $3.816.555,03"
+PAYMENT_RE = re.compile(
+    r"^[Pp]agaste\s+\$\s*([\d.,]+)$",
+)
+
+# Installment: "a 24 meses" or "a24 meses" (OCR may drop space)
+INSTALLMENT_RE = re.compile(
+    r"\ba\s*(\d+)\s+meses?\b",
+    re.IGNORECASE,
+)
+
+# Time line: "14:07" or "01:04"
+TIME_RE = re.compile(r"^\d{1,2}:\d{2}$")
+
+# Time + installment: "14:07 a 24 meses" or "14:07 a24 meses"
+TIME_INSTALLMENT_RE = re.compile(
+    r"^(\d{1,2}:\d{2})\s+a\s*(\d+)\s+meses?$",
+    re.IGNORECASE,
+)
+
+# Relative day labels
+RELATIVE_LABELS = {"hoy", "ayer"} | set(DAY_NAME_MAP.keys())
+
+# UI noise
+SKIP_PATTERNS = [
+    "buscar", "nu colombia",
+]
+
+
+def _is_day_label(line: str) -> bool:
+    """Check if a line is a relative day label (Ayer, Domingo, etc.)."""
+    return line.lower().strip() in RELATIVE_LABELS
+
+
+def parse_nu_credit_card_app(
+    ocr_text: str,
+    screenshot_date: date | None = None,
+) -> ParsedStatement:
+    """Parse Nu credit card app OCR text into a ParsedStatement.
+
+    Uses screenshot_date (defaults to today) to resolve relative day labels.
+    """
+    ref_date = screenshot_date or date.today()
+    lines = [line.strip() for line in ocr_text.splitlines() if line.strip()]
+
+    transactions: list[ParsedTransaction] = []
+    current_date: date = ref_date
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        lower = line.lower()
+
+        # Skip UI noise
+        if any(p in lower for p in SKIP_PATTERNS):
+            i += 1
+            continue
+
+        # Day label header
+        cleaned_line = strip_icon_artifacts(line)
+        if _is_day_label(cleaned_line):
+            resolved = resolve_relative_date(cleaned_line, ref_date)
+            if resolved:
+                current_date = resolved
+            i += 1
+            continue
+
+        # Payment line: "¡Gracias por tu pago!"
+        if "gracias por tu pago" in lower:
+            # Next line should be "Pagaste $X.XXX.XXX,XX"
+            if i + 1 < len(lines):
+                payment_match = PAYMENT_RE.match(strip_icon_artifacts(lines[i + 1]))
+                if payment_match:
+                    try:
+                        amount = parse_colombian_number(payment_match.group(1))
+                        transactions.append(ParsedTransaction(
+                            date=current_date,
+                            description="Pago tarjeta de crédito",
+                            amount=amount,
+                            direction=TransactionDirection.INFLOW,
+                            currency="COP",
+                        ))
+                    except ValueError:
+                        logger.warning("Could not parse payment: %s", lines[i + 1])
+                    i += 2
+                    continue
+            i += 1
+            continue
+
+        # Regular transaction: "[icon] Description... $XX.XXX,XX"
+        desc_match = DESC_AMOUNT_RE.match(cleaned_line)
+        if desc_match:
+            description = strip_icon_artifacts(desc_match.group(1).strip())
+            try:
+                amount = parse_colombian_number(desc_match.group(2))
+            except ValueError:
+                logger.warning("Could not parse Nu CC amount: %s", line)
+                i += 1
+                continue
+
+            installment_total: int | None = None
+
+            # Peek at next line for time + installments
+            if i + 1 < len(lines):
+                next_line = strip_icon_artifacts(lines[i + 1])
+                ti_match = TIME_INSTALLMENT_RE.match(next_line)
+                if ti_match:
+                    installment_total = int(ti_match.group(2))
+                    i += 1
+                elif TIME_RE.match(next_line):
+                    # Check if installment info is on a separate line after time
+                    if i + 2 < len(lines):
+                        inst_match = INSTALLMENT_RE.match(strip_icon_artifacts(lines[i + 2]))
+                        if inst_match:
+                            installment_total = int(inst_match.group(1))
+                            i += 1
+                    i += 1
+
+            transactions.append(ParsedTransaction(
+                date=current_date,
+                description=description or "Sin descripción",
+                amount=amount,
+                direction=TransactionDirection.OUTFLOW,
+                currency="COP",
+                installment_total=installment_total,
+                installment_current=1 if installment_total else None,
+            ))
+
+        i += 1
+
+    logger.info("Nu CC app parsed: transactions=%s", len(transactions))
+
+    if not transactions:
+        raise ValueError(
+            "No se encontraron transacciones en la captura de pantalla de Nu tarjeta de crédito."
+        )
+
+    dates = [t.date for t in transactions]
+    return ParsedStatement(
+        bank="nu",
+        statement_type=StatementType.CREDIT_CARD,
+        period_from=min(dates),
+        period_to=max(dates),
+        currency="COP",
+        transactions=transactions,
+    )

--- a/services/pdf_parser/parsers/nu_savings_app_screenshot.py
+++ b/services/pdf_parser/parsers/nu_savings_app_screenshot.py
@@ -1,0 +1,161 @@
+"""Nu (Cuenta Nu) savings app screenshot parser.
+
+Expected OCR format (each transaction spans 2+ lines):
+
+    [icon] Description text...    -$XX.XXX,XX or +$XX.XXX,XX
+    [continuation lines...]
+    DD mes - HH:MM [+ ...] or DD mes - HH:...
+
+Number format: Colombian (dot = thousands, comma = decimals)
+Direction: -$ = OUTFLOW, +$ = INFLOW
+
+OCR quirks handled:
+- Icons OCR'd as single chars ("E", "3", "a") at line starts
+- "•" OCR'd as "+" in date lines: "20 oct - 15:51 + B..."
+- Description may span multiple lines before the date line
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+
+from models import (
+    ParsedStatement,
+    ParsedTransaction,
+    StatementType,
+    TransactionDirection,
+)
+from parsers.image_utils import MONTH_MAP, parse_colombian_number, strip_icon_artifacts
+
+logger = logging.getLogger("pdf_parser.nu_savings_app")
+
+# Line with description and amount: "Enviaste a -$23.000,00"
+# Amount is at the end with +/- sign
+DESC_AMOUNT_RE = re.compile(
+    r"^(.+?)\s+([+-])\s*\$\s*([\d.,]+)$",
+)
+
+# Date line: "20 oct - 15:51" or "12 may - 09:..." or "07 oct - 18:55 + ..."
+# OCR renders "•" as "+" and may truncate with "..."
+DATE_LINE_RE = re.compile(
+    r"^(\d{1,2})\s+(ene|feb|mar|abr|may|jun|jul|ago|sep|oct|nov|dic)\b",
+    re.IGNORECASE,
+)
+
+# UI noise
+SKIP_PATTERNS = [
+    "movimientos", "buscar movimiento", "buscar",
+]
+
+
+def parse_nu_savings_app(
+    ocr_text: str,
+    screenshot_date: date | None = None,
+) -> ParsedStatement:
+    """Parse Nu savings app OCR text into a ParsedStatement.
+
+    Each transaction consists of:
+    1. A line with description + signed amount (may have icon artifact prefix)
+    2. Optional continuation lines (name wrapping)
+    3. A date line (DD mes - HH:MM)
+    """
+    lines = [line.strip() for line in ocr_text.splitlines() if line.strip()]
+    ref_date = screenshot_date or date.today()
+
+    transactions: list[ParsedTransaction] = []
+    # Pending transaction data (waiting for date line)
+    pending_desc: str | None = None
+    pending_amount: float | None = None
+    pending_direction: TransactionDirection | None = None
+
+    for line in lines:
+        lower = line.lower()
+
+        # Skip UI noise
+        if any(p in lower for p in SKIP_PATTERNS):
+            continue
+
+        # Check for description + amount line
+        cleaned = strip_icon_artifacts(line)
+        desc_match = DESC_AMOUNT_RE.match(cleaned)
+        if desc_match:
+            # If we had a pending transaction without a date, emit with fallback date
+            if pending_desc is not None and pending_amount is not None:
+                transactions.append(ParsedTransaction(
+                    date=ref_date,
+                    description=pending_desc,
+                    amount=pending_amount,
+                    direction=pending_direction or TransactionDirection.OUTFLOW,
+                    currency="COP",
+                ))
+
+            pending_desc = desc_match.group(1).strip()
+            sign = desc_match.group(2)
+            try:
+                pending_amount = parse_colombian_number(desc_match.group(3))
+            except ValueError:
+                logger.warning("Could not parse Nu amount: %s", line)
+                pending_desc = None
+                pending_amount = None
+                continue
+
+            pending_direction = (
+                TransactionDirection.OUTFLOW if sign == "-"
+                else TransactionDirection.INFLOW
+            )
+            continue
+
+        # Check for date line (completes a pending transaction)
+        date_match = DATE_LINE_RE.match(line)
+        if date_match and pending_desc is not None:
+            day = int(date_match.group(1))
+            month = MONTH_MAP.get(date_match.group(2).lower(), 1)
+            # Infer year
+            year = ref_date.year
+            if month > ref_date.month:
+                year -= 1
+            try:
+                tx_date = date(year, month, day)
+            except ValueError:
+                tx_date = ref_date
+
+            transactions.append(ParsedTransaction(
+                date=tx_date,
+                description=pending_desc,
+                amount=pending_amount or 0,
+                direction=pending_direction or TransactionDirection.OUTFLOW,
+                currency="COP",
+            ))
+            pending_desc = None
+            pending_amount = None
+            pending_direction = None
+            continue
+
+    # Emit last pending transaction if any
+    if pending_desc is not None and pending_amount is not None:
+        transactions.append(ParsedTransaction(
+            date=ref_date,
+            description=pending_desc,
+            amount=pending_amount,
+            direction=pending_direction or TransactionDirection.OUTFLOW,
+            currency="COP",
+        ))
+
+    logger.info("Nu savings app parsed: transactions=%s", len(transactions))
+
+    if not transactions:
+        raise ValueError(
+            "No se encontraron transacciones en la captura de pantalla de Nu."
+        )
+
+    dates = [t.date for t in transactions]
+    return ParsedStatement(
+        bank="nu",
+        statement_type=StatementType.SAVINGS,
+        period_from=min(dates),
+        period_to=max(dates),
+        currency="COP",
+        transactions=transactions,
+    )

--- a/supabase/migrations/20260408142903_envelope_encryption_infrastructure.sql
+++ b/supabase/migrations/20260408142903_envelope_encryption_infrastructure.sql
@@ -1,0 +1,205 @@
+-- ==================================================
+-- Envelope Encryption Infrastructure
+-- ==================================================
+
+-- Ensure required extensions
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS supabase_vault;
+
+-- 1. Create master key (KEK) in Vault
+SELECT vault.create_secret(
+  encode(gen_random_bytes(32), 'hex'),
+  'zeta_master_key',
+  'Master encryption key for Zeta envelope encryption'
+);
+
+-- 2. Create per-user encryption key table
+CREATE TABLE user_encryption_keys (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  encrypted_dek BYTEA NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE user_encryption_keys ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own_key" ON user_encryption_keys
+  FOR ALL USING ((SELECT auth.uid()) = user_id);
+
+-- 3. zeta_encrypt — encrypt plaintext using calling user's DEK
+CREATE OR REPLACE FUNCTION zeta_encrypt(plaintext TEXT)
+RETURNS BYTEA
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = (SELECT auth.uid());
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', (SELECT auth.uid());
+  END IF;
+
+  RETURN pgp_sym_encrypt(plaintext, user_dek);
+END;
+$$;
+
+-- 4. zeta_decrypt — decrypt ciphertext using calling user's DEK
+CREATE OR REPLACE FUNCTION zeta_decrypt(ciphertext BYTEA)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF ciphertext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = (SELECT auth.uid());
+
+  IF user_dek IS NULL THEN RETURN NULL; END IF;
+
+  RETURN pgp_sym_decrypt(ciphertext, user_dek);
+END;
+$$;
+
+-- 5. zeta_encrypt_as — encrypt using specific user's DEK (migration only)
+CREATE OR REPLACE FUNCTION zeta_encrypt_as(plaintext TEXT, target_user_id UUID)
+RETURNS BYTEA
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = target_user_id;
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', target_user_id;
+  END IF;
+
+  RETURN pgp_sym_encrypt(plaintext, user_dek);
+END;
+$$;
+
+-- 6. zeta_hmac — compute blind index using calling user's DEK
+CREATE OR REPLACE FUNCTION zeta_hmac(plaintext TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = (SELECT auth.uid());
+
+  IF user_dek IS NULL THEN RETURN NULL; END IF;
+
+  RETURN encode(hmac(lower(plaintext), user_dek, 'sha256'), 'hex');
+END;
+$$;
+
+-- 7. zeta_hmac_as — compute HMAC using specific user's DEK (migration only)
+CREATE OR REPLACE FUNCTION zeta_hmac_as(plaintext TEXT, target_user_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  user_dek TEXT;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = target_user_id;
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', target_user_id;
+  END IF;
+
+  RETURN encode(hmac(lower(plaintext), user_dek, 'sha256'), 'hex');
+END;
+$$;
+
+-- 8. Restrict _as functions to postgres role only
+REVOKE ALL ON FUNCTION zeta_encrypt_as(TEXT, UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION zeta_hmac_as(TEXT, UUID) FROM PUBLIC;
+
+-- 9. Signup trigger — generate DEK for new users
+CREATE OR REPLACE FUNCTION handle_new_user_encryption_key()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  master_key TEXT;
+  new_dek TEXT;
+BEGIN
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  new_dek := encode(gen_random_bytes(32), 'hex');
+
+  INSERT INTO user_encryption_keys (user_id, encrypted_dek)
+  VALUES (NEW.id, pgp_sym_encrypt(new_dek, master_key));
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created_encryption_key
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_new_user_encryption_key();
+
+-- 10. Generate DEKs for existing users
+INSERT INTO user_encryption_keys (user_id, encrypted_dek)
+SELECT
+  id,
+  pgp_sym_encrypt(
+    encode(gen_random_bytes(32), 'hex'),
+    (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'zeta_master_key')
+  )
+FROM auth.users
+ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20260408142903_envelope_encryption_infrastructure.sql
+++ b/supabase/migrations/20260408142903_envelope_encryption_infrastructure.sql
@@ -6,6 +6,9 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS supabase_vault;
 
+-- Supabase installs pgcrypto in the extensions schema
+SET search_path = public, extensions;
+
 -- 1. Create master key (KEK) in Vault
 SELECT vault.create_secret(
   encode(gen_random_bytes(32), 'hex'),
@@ -31,7 +34,7 @@ RETURNS BYTEA
 LANGUAGE plpgsql
 VOLATILE
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
   master_key TEXT;
@@ -59,7 +62,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
   master_key TEXT;
@@ -85,7 +88,7 @@ RETURNS BYTEA
 LANGUAGE plpgsql
 VOLATILE
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
   master_key TEXT;
@@ -113,7 +116,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
   master_key TEXT;
@@ -139,7 +142,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
   master_key TEXT;
@@ -170,7 +173,7 @@ CREATE OR REPLACE FUNCTION handle_new_user_encryption_key()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
   master_key TEXT;

--- a/supabase/migrations/20260408143001_encrypt_transactions.sql
+++ b/supabase/migrations/20260408143001_encrypt_transactions.sql
@@ -1,0 +1,169 @@
+-- ==================================================
+-- Encrypt transactions table (5 encrypted, 2 HMAC)
+-- ==================================================
+
+-- 1. Rename table
+ALTER TABLE transactions RENAME TO transactions_enc;
+
+-- 2. Add HMAC columns and backfill while data is still plaintext
+ALTER TABLE transactions_enc ADD COLUMN merchant_name_hmac TEXT;
+ALTER TABLE transactions_enc ADD COLUMN clean_description_hmac TEXT;
+
+UPDATE transactions_enc SET
+  merchant_name_hmac = zeta_hmac_as(merchant_name, user_id)
+WHERE merchant_name IS NOT NULL;
+
+UPDATE transactions_enc SET
+  clean_description_hmac = zeta_hmac_as(clean_description, user_id)
+WHERE clean_description IS NOT NULL;
+
+-- 3. Encrypt columns — atomic type change + encryption per column
+ALTER TABLE transactions_enc
+  ALTER COLUMN raw_description TYPE BYTEA USING zeta_encrypt_as(raw_description, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN clean_description TYPE BYTEA USING zeta_encrypt_as(clean_description, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN merchant_name TYPE BYTEA USING zeta_encrypt_as(merchant_name, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN notes TYPE BYTEA USING zeta_encrypt_as(notes, user_id);
+ALTER TABLE transactions_enc
+  ALTER COLUMN capture_input_text TYPE BYTEA USING zeta_encrypt_as(capture_input_text, user_id);
+
+-- 4. Create decrypted view
+CREATE VIEW transactions WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, amount_in_base_currency,
+  zeta_decrypt(capture_input_text) AS capture_input_text,
+  capture_method, categorization_confidence, categorization_source,
+  category_id,
+  zeta_decrypt(clean_description) AS clean_description,
+  clean_description_hmac, created_at, currency_code, destinatario_id,
+  direction, exchange_rate, id, idempotency_key, installment_current,
+  installment_group_id, installment_total, is_excluded, is_recurring,
+  is_subscription, merchant_category_code, merchant_logo_url,
+  zeta_decrypt(merchant_name) AS merchant_name,
+  merchant_name_hmac,
+  zeta_decrypt(notes) AS notes,
+  original_amount, posting_date, provider, provider_transaction_id,
+  zeta_decrypt(raw_description) AS raw_description,
+  reconciled_into_transaction_id, reconciliation_score,
+  recurrence_group_id, secondary_category_id, status, tags,
+  transaction_date, updated_at, user_id
+FROM transactions_enc;
+
+-- 5. INSTEAD OF INSERT trigger
+CREATE OR REPLACE FUNCTION transactions_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO transactions_enc (
+    account_id, amount, amount_in_base_currency, capture_input_text,
+    capture_method, categorization_confidence, categorization_source,
+    category_id, clean_description, clean_description_hmac, created_at,
+    currency_code, destinatario_id, direction, exchange_rate, id,
+    idempotency_key, installment_current, installment_group_id,
+    installment_total, is_excluded, is_recurring, is_subscription,
+    merchant_category_code, merchant_logo_url, merchant_name,
+    merchant_name_hmac, notes, original_amount, posting_date, provider,
+    provider_transaction_id, raw_description,
+    reconciled_into_transaction_id, reconciliation_score,
+    recurrence_group_id, secondary_category_id, status, tags,
+    transaction_date, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.amount_in_base_currency,
+    zeta_encrypt(NEW.capture_input_text),
+    NEW.capture_method, NEW.categorization_confidence,
+    NEW.categorization_source, NEW.category_id,
+    zeta_encrypt(NEW.clean_description),
+    zeta_hmac(NEW.clean_description),
+    NEW.created_at, NEW.currency_code, NEW.destinatario_id,
+    NEW.direction, NEW.exchange_rate, NEW.id, NEW.idempotency_key,
+    NEW.installment_current, NEW.installment_group_id,
+    NEW.installment_total, NEW.is_excluded, NEW.is_recurring,
+    NEW.is_subscription, NEW.merchant_category_code,
+    NEW.merchant_logo_url,
+    zeta_encrypt(NEW.merchant_name),
+    zeta_hmac(NEW.merchant_name),
+    zeta_encrypt(NEW.notes),
+    NEW.original_amount, NEW.posting_date, NEW.provider,
+    NEW.provider_transaction_id,
+    zeta_encrypt(NEW.raw_description),
+    NEW.reconciled_into_transaction_id, NEW.reconciliation_score,
+    NEW.recurrence_group_id, NEW.secondary_category_id, NEW.status,
+    NEW.tags, NEW.transaction_date, NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transactions_view_insert_trg
+  INSTEAD OF INSERT ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_insert();
+
+-- 6. INSTEAD OF UPDATE trigger
+CREATE OR REPLACE FUNCTION transactions_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE transactions_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    amount_in_base_currency = NEW.amount_in_base_currency,
+    capture_input_text = zeta_encrypt(NEW.capture_input_text),
+    capture_method = NEW.capture_method,
+    categorization_confidence = NEW.categorization_confidence,
+    categorization_source = NEW.categorization_source,
+    category_id = NEW.category_id,
+    clean_description = zeta_encrypt(NEW.clean_description),
+    clean_description_hmac = zeta_hmac(NEW.clean_description),
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    destinatario_id = NEW.destinatario_id,
+    direction = NEW.direction,
+    exchange_rate = NEW.exchange_rate,
+    idempotency_key = NEW.idempotency_key,
+    installment_current = NEW.installment_current,
+    installment_group_id = NEW.installment_group_id,
+    installment_total = NEW.installment_total,
+    is_excluded = NEW.is_excluded,
+    is_recurring = NEW.is_recurring,
+    is_subscription = NEW.is_subscription,
+    merchant_category_code = NEW.merchant_category_code,
+    merchant_logo_url = NEW.merchant_logo_url,
+    merchant_name = zeta_encrypt(NEW.merchant_name),
+    merchant_name_hmac = zeta_hmac(NEW.merchant_name),
+    notes = zeta_encrypt(NEW.notes),
+    original_amount = NEW.original_amount,
+    posting_date = NEW.posting_date,
+    provider = NEW.provider,
+    provider_transaction_id = NEW.provider_transaction_id,
+    raw_description = zeta_encrypt(NEW.raw_description),
+    reconciled_into_transaction_id = NEW.reconciled_into_transaction_id,
+    reconciliation_score = NEW.reconciliation_score,
+    recurrence_group_id = NEW.recurrence_group_id,
+    secondary_category_id = NEW.secondary_category_id,
+    status = NEW.status,
+    tags = NEW.tags,
+    transaction_date = NEW.transaction_date,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transactions_view_update_trg
+  INSTEAD OF UPDATE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_update();
+
+-- 7. INSTEAD OF DELETE trigger
+CREATE OR REPLACE FUNCTION transactions_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM transactions_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transactions_view_delete_trg
+  INSTEAD OF DELETE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_view_delete();
+
+-- 8. Grant permissions on view
+GRANT SELECT, INSERT, UPDATE, DELETE ON transactions TO authenticated;
+GRANT ALL ON transactions TO postgres, service_role;

--- a/supabase/migrations/20260408143001_encrypt_transactions.sql
+++ b/supabase/migrations/20260408143001_encrypt_transactions.sql
@@ -17,7 +17,11 @@ UPDATE transactions_enc SET
   clean_description_hmac = zeta_hmac_as(clean_description, user_id)
 WHERE clean_description IS NOT NULL;
 
--- 3. Encrypt columns — atomic type change + encryption per column
+-- 3. Drop GIN text search index that references encrypted columns
+--    (COALESCE on clean_description/merchant_name is incompatible with BYTEA)
+DROP INDEX IF EXISTS idx_transactions_description_search;
+
+-- 4. Encrypt columns — atomic type change + encryption per column
 ALTER TABLE transactions_enc
   ALTER COLUMN raw_description TYPE BYTEA USING zeta_encrypt_as(raw_description, user_id);
 ALTER TABLE transactions_enc

--- a/supabase/migrations/20260408143002_encrypt_accounts.sql
+++ b/supabase/migrations/20260408143002_encrypt_accounts.sql
@@ -5,11 +5,17 @@
 -- 1. Rename
 ALTER TABLE accounts RENAME TO accounts_enc;
 
--- 2. Add HMAC and backfill
-ALTER TABLE accounts_enc ADD COLUMN mask_hmac TEXT;
-UPDATE accounts_enc SET mask_hmac = zeta_hmac_as(mask, user_id) WHERE mask IS NOT NULL;
+-- 2. Drop indexes that reference encrypted columns (incompatible with BYTEA)
+DROP INDEX IF EXISTS accounts_provider_unique;
+DROP INDEX IF EXISTS idx_accounts_user_debit_card_mask;
 
--- 3. Encrypt columns
+-- 3. Add HMAC columns and backfill
+ALTER TABLE accounts_enc ADD COLUMN mask_hmac TEXT;
+ALTER TABLE accounts_enc ADD COLUMN provider_account_id_hmac TEXT;
+UPDATE accounts_enc SET mask_hmac = zeta_hmac_as(mask, user_id) WHERE mask IS NOT NULL;
+UPDATE accounts_enc SET provider_account_id_hmac = zeta_hmac_as(provider_account_id, user_id) WHERE provider_account_id IS NOT NULL;
+
+-- 4. Encrypt columns
 ALTER TABLE accounts_enc
   ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
 ALTER TABLE accounts_enc
@@ -40,7 +46,7 @@ SELECT
   zeta_decrypt(pdf_password) AS pdf_password,
   provider,
   zeta_decrypt(provider_account_id) AS provider_account_id,
-  show_in_dashboard, updated_at, user_id
+  provider_account_id_hmac, show_in_dashboard, updated_at, user_id
 FROM accounts_enc;
 
 -- 5. INSTEAD OF INSERT
@@ -53,8 +59,8 @@ BEGIN
     initial_investment, institution_name, interest_rate, is_active,
     last_synced_at, loan_amount, loan_end_date, loan_start_date, mask,
     mask_hmac, maturity_date, monthly_payment, name, payment_day,
-    pdf_password, provider, provider_account_id, show_in_dashboard,
-    updated_at, user_id
+    pdf_password, provider, provider_account_id, provider_account_id_hmac,
+    show_in_dashboard, updated_at, user_id
   ) VALUES (
     NEW.account_type, NEW.available_balance, NEW.color, NEW.connection_status,
     NEW.created_at, NEW.credit_limit, NEW.currency_balances, NEW.currency_code,
@@ -73,6 +79,7 @@ BEGIN
     zeta_encrypt(NEW.pdf_password),
     NEW.provider,
     zeta_encrypt(NEW.provider_account_id),
+    zeta_hmac(NEW.provider_account_id),
     NEW.show_in_dashboard, NEW.updated_at, NEW.user_id
   );
   RETURN NEW;
@@ -118,6 +125,7 @@ BEGIN
     pdf_password = zeta_encrypt(NEW.pdf_password),
     provider = NEW.provider,
     provider_account_id = zeta_encrypt(NEW.provider_account_id),
+    provider_account_id_hmac = zeta_hmac(NEW.provider_account_id),
     show_in_dashboard = NEW.show_in_dashboard,
     updated_at = NEW.updated_at,
     user_id = NEW.user_id
@@ -142,6 +150,11 @@ CREATE TRIGGER accounts_view_delete_trg
   INSTEAD OF DELETE ON accounts
   FOR EACH ROW EXECUTE FUNCTION accounts_view_delete();
 
--- 8. Grant
+-- 8. Recreate unique constraint using HMAC (original used plaintext provider_account_id)
+CREATE UNIQUE INDEX accounts_provider_unique
+  ON accounts_enc (user_id, provider, provider_account_id_hmac)
+  WHERE provider_account_id_hmac IS NOT NULL;
+
+-- 9. Grant
 GRANT SELECT, INSERT, UPDATE, DELETE ON accounts TO authenticated;
 GRANT ALL ON accounts TO postgres, service_role;

--- a/supabase/migrations/20260408143002_encrypt_accounts.sql
+++ b/supabase/migrations/20260408143002_encrypt_accounts.sql
@@ -5,7 +5,8 @@
 -- 1. Rename
 ALTER TABLE accounts RENAME TO accounts_enc;
 
--- 2. Drop indexes that reference encrypted columns (incompatible with BYTEA)
+-- 2. Drop indexes and constraints that reference encrypted columns (incompatible with BYTEA)
+ALTER TABLE accounts_enc DROP CONSTRAINT IF EXISTS accounts_name_length;
 DROP INDEX IF EXISTS accounts_provider_unique;
 DROP INDEX IF EXISTS idx_accounts_user_debit_card_mask;
 

--- a/supabase/migrations/20260408143002_encrypt_accounts.sql
+++ b/supabase/migrations/20260408143002_encrypt_accounts.sql
@@ -1,0 +1,147 @@
+-- ==================================================
+-- Encrypt accounts table (6 encrypted, 1 HMAC)
+-- ==================================================
+
+-- 1. Rename
+ALTER TABLE accounts RENAME TO accounts_enc;
+
+-- 2. Add HMAC and backfill
+ALTER TABLE accounts_enc ADD COLUMN mask_hmac TEXT;
+UPDATE accounts_enc SET mask_hmac = zeta_hmac_as(mask, user_id) WHERE mask IS NOT NULL;
+
+-- 3. Encrypt columns
+ALTER TABLE accounts_enc
+  ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN institution_name TYPE BYTEA USING zeta_encrypt_as(institution_name, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN mask TYPE BYTEA USING zeta_encrypt_as(mask, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN debit_card_mask TYPE BYTEA USING zeta_encrypt_as(debit_card_mask, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN pdf_password TYPE BYTEA USING zeta_encrypt_as(pdf_password, user_id);
+ALTER TABLE accounts_enc
+  ALTER COLUMN provider_account_id TYPE BYTEA USING zeta_encrypt_as(provider_account_id, user_id);
+
+-- 4. Create decrypted view
+CREATE VIEW accounts WITH (security_invoker = true) AS
+SELECT
+  account_type, available_balance, color, connection_status, created_at,
+  credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
+  zeta_decrypt(debit_card_mask) AS debit_card_mask,
+  display_order, expected_return_rate, icon, id, initial_investment,
+  zeta_decrypt(institution_name) AS institution_name,
+  interest_rate, is_active, last_synced_at, loan_amount, loan_end_date,
+  loan_start_date,
+  zeta_decrypt(mask) AS mask,
+  mask_hmac, maturity_date, monthly_payment,
+  zeta_decrypt(name) AS name,
+  payment_day,
+  zeta_decrypt(pdf_password) AS pdf_password,
+  provider,
+  zeta_decrypt(provider_account_id) AS provider_account_id,
+  show_in_dashboard, updated_at, user_id
+FROM accounts_enc;
+
+-- 5. INSTEAD OF INSERT
+CREATE OR REPLACE FUNCTION accounts_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO accounts_enc (
+    account_type, available_balance, color, connection_status, created_at,
+    credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
+    debit_card_mask, display_order, expected_return_rate, icon, id,
+    initial_investment, institution_name, interest_rate, is_active,
+    last_synced_at, loan_amount, loan_end_date, loan_start_date, mask,
+    mask_hmac, maturity_date, monthly_payment, name, payment_day,
+    pdf_password, provider, provider_account_id, show_in_dashboard,
+    updated_at, user_id
+  ) VALUES (
+    NEW.account_type, NEW.available_balance, NEW.color, NEW.connection_status,
+    NEW.created_at, NEW.credit_limit, NEW.currency_balances, NEW.currency_code,
+    NEW.current_balance, NEW.cutoff_day,
+    zeta_encrypt(NEW.debit_card_mask),
+    NEW.display_order, NEW.expected_return_rate, NEW.icon, NEW.id,
+    NEW.initial_investment,
+    zeta_encrypt(NEW.institution_name),
+    NEW.interest_rate, NEW.is_active, NEW.last_synced_at, NEW.loan_amount,
+    NEW.loan_end_date, NEW.loan_start_date,
+    zeta_encrypt(NEW.mask),
+    zeta_hmac(NEW.mask),
+    NEW.maturity_date, NEW.monthly_payment,
+    zeta_encrypt(NEW.name),
+    NEW.payment_day,
+    zeta_encrypt(NEW.pdf_password),
+    NEW.provider,
+    zeta_encrypt(NEW.provider_account_id),
+    NEW.show_in_dashboard, NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_view_insert_trg
+  INSTEAD OF INSERT ON accounts
+  FOR EACH ROW EXECUTE FUNCTION accounts_view_insert();
+
+-- 6. INSTEAD OF UPDATE
+CREATE OR REPLACE FUNCTION accounts_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE accounts_enc SET
+    account_type = NEW.account_type,
+    available_balance = NEW.available_balance,
+    color = NEW.color,
+    connection_status = NEW.connection_status,
+    created_at = NEW.created_at,
+    credit_limit = NEW.credit_limit,
+    currency_balances = NEW.currency_balances,
+    currency_code = NEW.currency_code,
+    current_balance = NEW.current_balance,
+    cutoff_day = NEW.cutoff_day,
+    debit_card_mask = zeta_encrypt(NEW.debit_card_mask),
+    display_order = NEW.display_order,
+    expected_return_rate = NEW.expected_return_rate,
+    icon = NEW.icon,
+    initial_investment = NEW.initial_investment,
+    institution_name = zeta_encrypt(NEW.institution_name),
+    interest_rate = NEW.interest_rate,
+    is_active = NEW.is_active,
+    last_synced_at = NEW.last_synced_at,
+    loan_amount = NEW.loan_amount,
+    loan_end_date = NEW.loan_end_date,
+    loan_start_date = NEW.loan_start_date,
+    mask = zeta_encrypt(NEW.mask),
+    mask_hmac = zeta_hmac(NEW.mask),
+    maturity_date = NEW.maturity_date,
+    monthly_payment = NEW.monthly_payment,
+    name = zeta_encrypt(NEW.name),
+    payment_day = NEW.payment_day,
+    pdf_password = zeta_encrypt(NEW.pdf_password),
+    provider = NEW.provider,
+    provider_account_id = zeta_encrypt(NEW.provider_account_id),
+    show_in_dashboard = NEW.show_in_dashboard,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_view_update_trg
+  INSTEAD OF UPDATE ON accounts
+  FOR EACH ROW EXECUTE FUNCTION accounts_view_update();
+
+-- 7. INSTEAD OF DELETE
+CREATE OR REPLACE FUNCTION accounts_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM accounts_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_view_delete_trg
+  INSTEAD OF DELETE ON accounts
+  FOR EACH ROW EXECUTE FUNCTION accounts_view_delete();
+
+-- 8. Grant
+GRANT SELECT, INSERT, UPDATE, DELETE ON accounts TO authenticated;
+GRANT ALL ON accounts TO postgres, service_role;

--- a/supabase/migrations/20260408143003_encrypt_profiles.sql
+++ b/supabase/migrations/20260408143003_encrypt_profiles.sql
@@ -1,0 +1,85 @@
+-- ==================================================
+-- Encrypt profiles table (2 encrypted)
+-- ==================================================
+
+ALTER TABLE profiles RENAME TO profiles_enc;
+
+ALTER TABLE profiles_enc
+  ALTER COLUMN full_name TYPE BYTEA USING zeta_encrypt_as(full_name, id);
+ALTER TABLE profiles_enc
+  ALTER COLUMN email TYPE BYTEA USING zeta_encrypt_as(email, id);
+
+CREATE VIEW profiles WITH (security_invoker = true) AS
+SELECT
+  app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+  zeta_decrypt(email) AS email,
+  estimated_monthly_expenses, estimated_monthly_income,
+  zeta_decrypt(full_name) AS full_name,
+  id, locale, monthly_salary, onboarding_completed, preferred_currency,
+  timezone, updated_at
+FROM profiles_enc;
+
+CREATE OR REPLACE FUNCTION profiles_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO profiles_enc (
+    app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+    email, estimated_monthly_expenses, estimated_monthly_income, full_name,
+    id, locale, monthly_salary, onboarding_completed, preferred_currency,
+    timezone, updated_at
+  ) VALUES (
+    NEW.app_purpose, NEW.avatar_url, NEW.budget_mode, NEW.created_at,
+    NEW.dashboard_config,
+    zeta_encrypt(NEW.email),
+    NEW.estimated_monthly_expenses, NEW.estimated_monthly_income,
+    zeta_encrypt(NEW.full_name),
+    NEW.id, NEW.locale, NEW.monthly_salary, NEW.onboarding_completed,
+    NEW.preferred_currency, NEW.timezone, NEW.updated_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_view_insert_trg
+  INSTEAD OF INSERT ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_view_insert();
+
+CREATE OR REPLACE FUNCTION profiles_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE profiles_enc SET
+    app_purpose = NEW.app_purpose,
+    avatar_url = NEW.avatar_url,
+    budget_mode = NEW.budget_mode,
+    created_at = NEW.created_at,
+    dashboard_config = NEW.dashboard_config,
+    email = zeta_encrypt(NEW.email),
+    estimated_monthly_expenses = NEW.estimated_monthly_expenses,
+    estimated_monthly_income = NEW.estimated_monthly_income,
+    full_name = zeta_encrypt(NEW.full_name),
+    locale = NEW.locale,
+    monthly_salary = NEW.monthly_salary,
+    onboarding_completed = NEW.onboarding_completed,
+    preferred_currency = NEW.preferred_currency,
+    timezone = NEW.timezone,
+    updated_at = NEW.updated_at
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_view_update_trg
+  INSTEAD OF UPDATE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_view_update();
+
+CREATE OR REPLACE FUNCTION profiles_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM profiles_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_view_delete_trg
+  INSTEAD OF DELETE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON profiles TO authenticated;
+GRANT ALL ON profiles TO postgres, service_role;

--- a/supabase/migrations/20260408143004_encrypt_destinatarios.sql
+++ b/supabase/migrations/20260408143004_encrypt_destinatarios.sql
@@ -4,6 +4,9 @@
 
 ALTER TABLE destinatarios RENAME TO destinatarios_enc;
 
+-- Drop index that uses lower(name) — incompatible with BYTEA
+DROP INDEX IF EXISTS idx_destinatarios_user_name;
+
 ALTER TABLE destinatarios_enc ADD COLUMN name_hmac TEXT;
 UPDATE destinatarios_enc SET name_hmac = zeta_hmac_as(name, user_id) WHERE name IS NOT NULL;
 

--- a/supabase/migrations/20260408143004_encrypt_destinatarios.sql
+++ b/supabase/migrations/20260408143004_encrypt_destinatarios.sql
@@ -1,0 +1,76 @@
+-- ==================================================
+-- Encrypt destinatarios table (2 encrypted, 1 HMAC)
+-- ==================================================
+
+ALTER TABLE destinatarios RENAME TO destinatarios_enc;
+
+ALTER TABLE destinatarios_enc ADD COLUMN name_hmac TEXT;
+UPDATE destinatarios_enc SET name_hmac = zeta_hmac_as(name, user_id) WHERE name IS NOT NULL;
+
+ALTER TABLE destinatarios_enc
+  ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
+ALTER TABLE destinatarios_enc
+  ALTER COLUMN notes TYPE BYTEA USING zeta_encrypt_as(notes, user_id);
+
+CREATE VIEW destinatarios WITH (security_invoker = true) AS
+SELECT
+  created_at, default_category_id, id, is_active,
+  zeta_decrypt(name) AS name,
+  name_hmac,
+  zeta_decrypt(notes) AS notes,
+  updated_at, user_id
+FROM destinatarios_enc;
+
+CREATE OR REPLACE FUNCTION destinatarios_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO destinatarios_enc (
+    created_at, default_category_id, id, is_active, name, name_hmac,
+    notes, updated_at, user_id
+  ) VALUES (
+    NEW.created_at, NEW.default_category_id, NEW.id, NEW.is_active,
+    zeta_encrypt(NEW.name),
+    zeta_hmac(NEW.name),
+    zeta_encrypt(NEW.notes),
+    NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER destinatarios_view_insert_trg
+  INSTEAD OF INSERT ON destinatarios
+  FOR EACH ROW EXECUTE FUNCTION destinatarios_view_insert();
+
+CREATE OR REPLACE FUNCTION destinatarios_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE destinatarios_enc SET
+    created_at = NEW.created_at,
+    default_category_id = NEW.default_category_id,
+    is_active = NEW.is_active,
+    name = zeta_encrypt(NEW.name),
+    name_hmac = zeta_hmac(NEW.name),
+    notes = zeta_encrypt(NEW.notes),
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER destinatarios_view_update_trg
+  INSTEAD OF UPDATE ON destinatarios
+  FOR EACH ROW EXECUTE FUNCTION destinatarios_view_update();
+
+CREATE OR REPLACE FUNCTION destinatarios_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM destinatarios_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER destinatarios_view_delete_trg
+  INSTEAD OF DELETE ON destinatarios
+  FOR EACH ROW EXECUTE FUNCTION destinatarios_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON destinatarios TO authenticated;
+GRANT ALL ON destinatarios TO postgres, service_role;

--- a/supabase/migrations/20260408143005_encrypt_statement_snapshots.sql
+++ b/supabase/migrations/20260408143005_encrypt_statement_snapshots.sql
@@ -1,0 +1,108 @@
+-- ==================================================
+-- Encrypt statement_snapshots table (2 encrypted)
+-- ==================================================
+
+ALTER TABLE statement_snapshots RENAME TO statement_snapshots_enc;
+
+ALTER TABLE statement_snapshots_enc
+  ALTER COLUMN loan_number TYPE BYTEA USING zeta_encrypt_as(loan_number, user_id);
+ALTER TABLE statement_snapshots_enc
+  ALTER COLUMN source_filename TYPE BYTEA USING zeta_encrypt_as(source_filename, user_id);
+
+CREATE VIEW statement_snapshots WITH (security_invoker = true) AS
+SELECT
+  account_id, available_credit, created_at, credit_limit, currency_code,
+  final_balance, id, imported_count, initial_amount, installments_in_default,
+  interest_charged, interest_rate, late_interest_rate,
+  zeta_decrypt(loan_number) AS loan_number,
+  minimum_payment, payment_due_date, period_from, period_to, previous_balance,
+  purchases_and_charges, remaining_balance, skipped_count,
+  zeta_decrypt(source_filename) AS source_filename,
+  total_credits, total_debits, total_payment_due, transaction_count,
+  updated_at, user_id
+FROM statement_snapshots_enc;
+
+CREATE OR REPLACE FUNCTION statement_snapshots_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO statement_snapshots_enc (
+    account_id, available_credit, created_at, credit_limit, currency_code,
+    final_balance, id, imported_count, initial_amount, installments_in_default,
+    interest_charged, interest_rate, late_interest_rate, loan_number,
+    minimum_payment, payment_due_date, period_from, period_to, previous_balance,
+    purchases_and_charges, remaining_balance, skipped_count, source_filename,
+    total_credits, total_debits, total_payment_due, transaction_count,
+    updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.available_credit, NEW.created_at, NEW.credit_limit,
+    NEW.currency_code, NEW.final_balance, NEW.id, NEW.imported_count,
+    NEW.initial_amount, NEW.installments_in_default, NEW.interest_charged,
+    NEW.interest_rate, NEW.late_interest_rate,
+    zeta_encrypt(NEW.loan_number),
+    NEW.minimum_payment, NEW.payment_due_date, NEW.period_from, NEW.period_to,
+    NEW.previous_balance, NEW.purchases_and_charges, NEW.remaining_balance,
+    NEW.skipped_count,
+    zeta_encrypt(NEW.source_filename),
+    NEW.total_credits, NEW.total_debits, NEW.total_payment_due,
+    NEW.transaction_count, NEW.updated_at, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER statement_snapshots_view_insert_trg
+  INSTEAD OF INSERT ON statement_snapshots
+  FOR EACH ROW EXECUTE FUNCTION statement_snapshots_view_insert();
+
+CREATE OR REPLACE FUNCTION statement_snapshots_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE statement_snapshots_enc SET
+    account_id = NEW.account_id,
+    available_credit = NEW.available_credit,
+    created_at = NEW.created_at,
+    credit_limit = NEW.credit_limit,
+    currency_code = NEW.currency_code,
+    final_balance = NEW.final_balance,
+    imported_count = NEW.imported_count,
+    initial_amount = NEW.initial_amount,
+    installments_in_default = NEW.installments_in_default,
+    interest_charged = NEW.interest_charged,
+    interest_rate = NEW.interest_rate,
+    late_interest_rate = NEW.late_interest_rate,
+    loan_number = zeta_encrypt(NEW.loan_number),
+    minimum_payment = NEW.minimum_payment,
+    payment_due_date = NEW.payment_due_date,
+    period_from = NEW.period_from,
+    period_to = NEW.period_to,
+    previous_balance = NEW.previous_balance,
+    purchases_and_charges = NEW.purchases_and_charges,
+    remaining_balance = NEW.remaining_balance,
+    skipped_count = NEW.skipped_count,
+    source_filename = zeta_encrypt(NEW.source_filename),
+    total_credits = NEW.total_credits,
+    total_debits = NEW.total_debits,
+    total_payment_due = NEW.total_payment_due,
+    transaction_count = NEW.transaction_count,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER statement_snapshots_view_update_trg
+  INSTEAD OF UPDATE ON statement_snapshots
+  FOR EACH ROW EXECUTE FUNCTION statement_snapshots_view_update();
+
+CREATE OR REPLACE FUNCTION statement_snapshots_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM statement_snapshots_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER statement_snapshots_view_delete_trg
+  INSTEAD OF DELETE ON statement_snapshots
+  FOR EACH ROW EXECUTE FUNCTION statement_snapshots_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON statement_snapshots TO authenticated;
+GRANT ALL ON statement_snapshots TO postgres, service_role;

--- a/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
+++ b/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
@@ -9,6 +9,7 @@ ALTER TABLE capture_tokens RENAME TO capture_tokens_enc;
 ALTER TABLE capture_tokens_enc ADD COLUMN token_hash TEXT;
 UPDATE capture_tokens_enc SET token_hash = encode(digest(token, 'sha256'), 'hex')
 WHERE token IS NOT NULL;
+ALTER TABLE capture_tokens_enc ALTER COLUMN token_hash SET NOT NULL;
 
 ALTER TABLE capture_tokens_enc
   ALTER COLUMN token TYPE BYTEA USING zeta_encrypt_as(token, user_id);

--- a/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
+++ b/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
@@ -6,7 +6,8 @@ SET search_path = public, extensions;
 
 ALTER TABLE capture_tokens RENAME TO capture_tokens_enc;
 
--- Drop CHECK constraint referencing encrypted column (char_length incompatible with BYTEA)
+-- Drop index and CHECK constraint referencing encrypted columns
+DROP INDEX IF EXISTS idx_capture_tokens_token;
 ALTER TABLE capture_tokens_enc DROP CONSTRAINT IF EXISTS capture_tokens_token_length;
 
 -- token_hash: SHA-256 of plaintext token for unauthenticated lookup

--- a/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
+++ b/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
@@ -1,0 +1,80 @@
+-- ==================================================
+-- Encrypt capture_tokens table (2 encrypted, 1 hash)
+-- ==================================================
+
+ALTER TABLE capture_tokens RENAME TO capture_tokens_enc;
+
+-- token_hash: SHA-256 of plaintext token for unauthenticated lookup
+-- NOT a per-user HMAC — system-wide hash for API auth flow
+ALTER TABLE capture_tokens_enc ADD COLUMN token_hash TEXT;
+UPDATE capture_tokens_enc SET token_hash = encode(digest(token, 'sha256'), 'hex')
+WHERE token IS NOT NULL;
+
+ALTER TABLE capture_tokens_enc
+  ALTER COLUMN token TYPE BYTEA USING zeta_encrypt_as(token, user_id);
+ALTER TABLE capture_tokens_enc
+  ALTER COLUMN label TYPE BYTEA USING zeta_encrypt_as(label, user_id);
+
+CREATE VIEW capture_tokens WITH (security_invoker = true) AS
+SELECT
+  created_at, default_account_id, id,
+  zeta_decrypt(label) AS label,
+  last_used_at, revoked_at,
+  zeta_decrypt(token) AS token,
+  token_hash, user_id
+FROM capture_tokens_enc;
+
+CREATE OR REPLACE FUNCTION capture_tokens_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO capture_tokens_enc (
+    created_at, default_account_id, id, label, last_used_at, revoked_at,
+    token, token_hash, user_id
+  ) VALUES (
+    NEW.created_at, NEW.default_account_id, NEW.id,
+    zeta_encrypt(NEW.label),
+    NEW.last_used_at, NEW.revoked_at,
+    zeta_encrypt(NEW.token),
+    encode(digest(NEW.token, 'sha256'), 'hex'),
+    NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER capture_tokens_view_insert_trg
+  INSTEAD OF INSERT ON capture_tokens
+  FOR EACH ROW EXECUTE FUNCTION capture_tokens_view_insert();
+
+CREATE OR REPLACE FUNCTION capture_tokens_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE capture_tokens_enc SET
+    created_at = NEW.created_at,
+    default_account_id = NEW.default_account_id,
+    label = zeta_encrypt(NEW.label),
+    last_used_at = NEW.last_used_at,
+    revoked_at = NEW.revoked_at,
+    token = zeta_encrypt(NEW.token),
+    token_hash = encode(digest(NEW.token, 'sha256'), 'hex'),
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER capture_tokens_view_update_trg
+  INSTEAD OF UPDATE ON capture_tokens
+  FOR EACH ROW EXECUTE FUNCTION capture_tokens_view_update();
+
+CREATE OR REPLACE FUNCTION capture_tokens_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM capture_tokens_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER capture_tokens_view_delete_trg
+  INSTEAD OF DELETE ON capture_tokens
+  FOR EACH ROW EXECUTE FUNCTION capture_tokens_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON capture_tokens TO authenticated;
+GRANT ALL ON capture_tokens TO postgres, service_role;

--- a/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
+++ b/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
@@ -19,6 +19,7 @@ ALTER TABLE capture_tokens_enc ALTER COLUMN token_hash SET NOT NULL;
 
 ALTER TABLE capture_tokens_enc
   ALTER COLUMN token TYPE BYTEA USING zeta_encrypt_as(token, user_id);
+ALTER TABLE capture_tokens_enc ALTER COLUMN label DROP DEFAULT;
 ALTER TABLE capture_tokens_enc
   ALTER COLUMN label TYPE BYTEA USING zeta_encrypt_as(label, user_id);
 

--- a/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
+++ b/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
@@ -2,6 +2,8 @@
 -- Encrypt capture_tokens table (2 encrypted, 1 hash)
 -- ==================================================
 
+SET search_path = public, extensions;
+
 ALTER TABLE capture_tokens RENAME TO capture_tokens_enc;
 
 -- token_hash: SHA-256 of plaintext token for unauthenticated lookup

--- a/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
+++ b/supabase/migrations/20260408143006_encrypt_capture_tokens.sql
@@ -6,6 +6,9 @@ SET search_path = public, extensions;
 
 ALTER TABLE capture_tokens RENAME TO capture_tokens_enc;
 
+-- Drop CHECK constraint referencing encrypted column (char_length incompatible with BYTEA)
+ALTER TABLE capture_tokens_enc DROP CONSTRAINT IF EXISTS capture_tokens_token_length;
+
 -- token_hash: SHA-256 of plaintext token for unauthenticated lookup
 -- NOT a per-user HMAC — system-wide hash for API auth flow
 ALTER TABLE capture_tokens_enc ADD COLUMN token_hash TEXT;

--- a/supabase/migrations/20260408143007_encrypt_email_ingest_addresses.sql
+++ b/supabase/migrations/20260408143007_encrypt_email_ingest_addresses.sql
@@ -1,0 +1,77 @@
+-- ==================================================
+-- Encrypt email_ingest_addresses table (2 encrypted)
+-- address_key stays plaintext (routing lookup key)
+-- ==================================================
+
+ALTER TABLE email_ingest_addresses RENAME TO email_ingest_addresses_enc;
+
+ALTER TABLE email_ingest_addresses_enc
+  ALTER COLUMN allowed_sender TYPE BYTEA USING zeta_encrypt_as(allowed_sender, user_id);
+ALTER TABLE email_ingest_addresses_enc
+  ALTER COLUMN gmail_verification_url TYPE BYTEA USING zeta_encrypt_as(gmail_verification_url, user_id);
+
+CREATE VIEW email_ingest_addresses WITH (security_invoker = true) AS
+SELECT
+  account_id, address_key,
+  zeta_decrypt(allowed_sender) AS allowed_sender,
+  auto_import, created_at, gmail_verification_at,
+  zeta_decrypt(gmail_verification_url) AS gmail_verification_url,
+  id, is_active, pdf_import_enabled, user_id
+FROM email_ingest_addresses_enc;
+
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO email_ingest_addresses_enc (
+    account_id, address_key, allowed_sender, auto_import, created_at,
+    gmail_verification_at, gmail_verification_url, id, is_active,
+    pdf_import_enabled, user_id
+  ) VALUES (
+    NEW.account_id, NEW.address_key,
+    zeta_encrypt(NEW.allowed_sender),
+    NEW.auto_import, NEW.created_at, NEW.gmail_verification_at,
+    zeta_encrypt(NEW.gmail_verification_url),
+    NEW.id, NEW.is_active, NEW.pdf_import_enabled, NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_ingest_addresses_view_insert_trg
+  INSTEAD OF INSERT ON email_ingest_addresses
+  FOR EACH ROW EXECUTE FUNCTION email_ingest_addresses_view_insert();
+
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE email_ingest_addresses_enc SET
+    account_id = NEW.account_id,
+    address_key = NEW.address_key,
+    allowed_sender = zeta_encrypt(NEW.allowed_sender),
+    auto_import = NEW.auto_import,
+    created_at = NEW.created_at,
+    gmail_verification_at = NEW.gmail_verification_at,
+    gmail_verification_url = zeta_encrypt(NEW.gmail_verification_url),
+    is_active = NEW.is_active,
+    pdf_import_enabled = NEW.pdf_import_enabled,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_ingest_addresses_view_update_trg
+  INSTEAD OF UPDATE ON email_ingest_addresses
+  FOR EACH ROW EXECUTE FUNCTION email_ingest_addresses_view_update();
+
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM email_ingest_addresses_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_ingest_addresses_view_delete_trg
+  INSTEAD OF DELETE ON email_ingest_addresses
+  FOR EACH ROW EXECUTE FUNCTION email_ingest_addresses_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON email_ingest_addresses TO authenticated;
+GRANT ALL ON email_ingest_addresses TO postgres, service_role;

--- a/supabase/migrations/20260408143008_encrypt_recurring_templates.sql
+++ b/supabase/migrations/20260408143008_encrypt_recurring_templates.sql
@@ -1,0 +1,87 @@
+-- ==================================================
+-- Encrypt recurring_transaction_templates (2 encrypted)
+-- ==================================================
+
+ALTER TABLE recurring_transaction_templates RENAME TO recurring_transaction_templates_enc;
+
+ALTER TABLE recurring_transaction_templates_enc
+  ALTER COLUMN description TYPE BYTEA USING zeta_encrypt_as(description, user_id);
+ALTER TABLE recurring_transaction_templates_enc
+  ALTER COLUMN merchant_name TYPE BYTEA USING zeta_encrypt_as(merchant_name, user_id);
+
+CREATE VIEW recurring_transaction_templates WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, category_id, created_at, currency_code,
+  day_of_month, day_of_week,
+  zeta_decrypt(description) AS description,
+  direction, end_date, frequency, id, is_active,
+  zeta_decrypt(merchant_name) AS merchant_name,
+  start_date, transfer_source_account_id, updated_at, user_id
+FROM recurring_transaction_templates_enc;
+
+CREATE OR REPLACE FUNCTION recurring_templates_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO recurring_transaction_templates_enc (
+    account_id, amount, category_id, created_at, currency_code,
+    day_of_month, day_of_week, description, direction, end_date,
+    frequency, id, is_active, merchant_name, start_date,
+    transfer_source_account_id, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.category_id, NEW.created_at,
+    NEW.currency_code, NEW.day_of_month, NEW.day_of_week,
+    zeta_encrypt(NEW.description),
+    NEW.direction, NEW.end_date, NEW.frequency, NEW.id, NEW.is_active,
+    zeta_encrypt(NEW.merchant_name),
+    NEW.start_date, NEW.transfer_source_account_id, NEW.updated_at,
+    NEW.user_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER recurring_templates_view_insert_trg
+  INSTEAD OF INSERT ON recurring_transaction_templates
+  FOR EACH ROW EXECUTE FUNCTION recurring_templates_view_insert();
+
+CREATE OR REPLACE FUNCTION recurring_templates_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE recurring_transaction_templates_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    category_id = NEW.category_id,
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    day_of_month = NEW.day_of_month,
+    day_of_week = NEW.day_of_week,
+    description = zeta_encrypt(NEW.description),
+    direction = NEW.direction,
+    end_date = NEW.end_date,
+    frequency = NEW.frequency,
+    is_active = NEW.is_active,
+    merchant_name = zeta_encrypt(NEW.merchant_name),
+    start_date = NEW.start_date,
+    transfer_source_account_id = NEW.transfer_source_account_id,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER recurring_templates_view_update_trg
+  INSTEAD OF UPDATE ON recurring_transaction_templates
+  FOR EACH ROW EXECUTE FUNCTION recurring_templates_view_update();
+
+CREATE OR REPLACE FUNCTION recurring_templates_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM recurring_transaction_templates_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER recurring_templates_view_delete_trg
+  INSTEAD OF DELETE ON recurring_transaction_templates
+  FOR EACH ROW EXECUTE FUNCTION recurring_templates_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON recurring_transaction_templates TO authenticated;
+GRANT ALL ON recurring_transaction_templates TO postgres, service_role;

--- a/supabase/migrations/20260408143009_encrypt_wishlist_items.sql
+++ b/supabase/migrations/20260408143009_encrypt_wishlist_items.sql
@@ -1,0 +1,105 @@
+-- ==================================================
+-- Encrypt wishlist_items table (3 encrypted)
+-- ==================================================
+
+ALTER TABLE wishlist_items RENAME TO wishlist_items_enc;
+
+ALTER TABLE wishlist_items_enc
+  ALTER COLUMN name TYPE BYTEA USING zeta_encrypt_as(name, user_id);
+ALTER TABLE wishlist_items_enc
+  ALTER COLUMN url TYPE BYTEA USING zeta_encrypt_as(url, user_id);
+ALTER TABLE wishlist_items_enc
+  ALTER COLUMN why TYPE BYTEA USING zeta_encrypt_as(why, user_id);
+
+CREATE VIEW wishlist_items WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, bought_at, category_id, created_at, currency_code,
+  desire_type, enriched, enriched_at, funding_type, id, image_url,
+  installments, last_nudge_dismissed_at, last_score, last_scored_at,
+  last_verdict,
+  zeta_decrypt(name) AS name,
+  ready_at, status, transaction_id, updated_at, urgency,
+  zeta_decrypt(url) AS url,
+  user_id,
+  zeta_decrypt(why) AS why
+FROM wishlist_items_enc;
+
+CREATE OR REPLACE FUNCTION wishlist_items_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO wishlist_items_enc (
+    account_id, amount, bought_at, category_id, created_at, currency_code,
+    desire_type, enriched, enriched_at, funding_type, id, image_url,
+    installments, last_nudge_dismissed_at, last_score, last_scored_at,
+    last_verdict, name, ready_at, status, transaction_id, updated_at,
+    urgency, url, user_id, why
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.bought_at, NEW.category_id,
+    NEW.created_at, NEW.currency_code, NEW.desire_type, NEW.enriched,
+    NEW.enriched_at, NEW.funding_type, NEW.id, NEW.image_url,
+    NEW.installments, NEW.last_nudge_dismissed_at, NEW.last_score,
+    NEW.last_scored_at, NEW.last_verdict,
+    zeta_encrypt(NEW.name),
+    NEW.ready_at, NEW.status, NEW.transaction_id, NEW.updated_at,
+    NEW.urgency,
+    zeta_encrypt(NEW.url),
+    NEW.user_id,
+    zeta_encrypt(NEW.why)
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER wishlist_items_view_insert_trg
+  INSTEAD OF INSERT ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION wishlist_items_view_insert();
+
+CREATE OR REPLACE FUNCTION wishlist_items_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE wishlist_items_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    bought_at = NEW.bought_at,
+    category_id = NEW.category_id,
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    desire_type = NEW.desire_type,
+    enriched = NEW.enriched,
+    enriched_at = NEW.enriched_at,
+    funding_type = NEW.funding_type,
+    image_url = NEW.image_url,
+    installments = NEW.installments,
+    last_nudge_dismissed_at = NEW.last_nudge_dismissed_at,
+    last_score = NEW.last_score,
+    last_scored_at = NEW.last_scored_at,
+    last_verdict = NEW.last_verdict,
+    name = zeta_encrypt(NEW.name),
+    ready_at = NEW.ready_at,
+    status = NEW.status,
+    transaction_id = NEW.transaction_id,
+    updated_at = NEW.updated_at,
+    urgency = NEW.urgency,
+    url = zeta_encrypt(NEW.url),
+    user_id = NEW.user_id,
+    why = zeta_encrypt(NEW.why)
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER wishlist_items_view_update_trg
+  INSTEAD OF UPDATE ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION wishlist_items_view_update();
+
+CREATE OR REPLACE FUNCTION wishlist_items_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM wishlist_items_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER wishlist_items_view_delete_trg
+  INSTEAD OF DELETE ON wishlist_items
+  FOR EACH ROW EXECUTE FUNCTION wishlist_items_view_delete();
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON wishlist_items TO authenticated;
+GRANT ALL ON wishlist_items TO postgres, service_role;

--- a/supabase/migrations/20260408143010_encryption_index_cleanup.sql
+++ b/supabase/migrations/20260408143010_encryption_index_cleanup.sql
@@ -1,12 +1,6 @@
 -- ==================================================
--- Drop useless indexes on encrypted columns
--- ==================================================
-
-DROP INDEX IF EXISTS idx_destinatarios_user_name;
-DROP INDEX IF EXISTS idx_capture_tokens_token;
-
--- ==================================================
 -- Add indexes on HMAC/hash columns for lookup
+-- (blocking indexes already dropped in per-table migrations)
 -- ==================================================
 
 CREATE INDEX idx_transactions_merchant_hmac

--- a/supabase/migrations/20260408143010_encryption_index_cleanup.sql
+++ b/supabase/migrations/20260408143010_encryption_index_cleanup.sql
@@ -1,0 +1,25 @@
+-- ==================================================
+-- Drop useless indexes on encrypted columns
+-- ==================================================
+
+DROP INDEX IF EXISTS idx_destinatarios_user_name;
+DROP INDEX IF EXISTS idx_capture_tokens_token;
+
+-- ==================================================
+-- Add indexes on HMAC/hash columns for lookup
+-- ==================================================
+
+CREATE INDEX idx_transactions_merchant_hmac
+  ON transactions_enc (user_id, merchant_name_hmac);
+
+CREATE INDEX idx_transactions_description_hmac
+  ON transactions_enc (user_id, clean_description_hmac);
+
+CREATE INDEX idx_accounts_mask_hmac
+  ON accounts_enc (user_id, mask_hmac);
+
+CREATE INDEX idx_destinatarios_name_hmac
+  ON destinatarios_enc (user_id, name_hmac);
+
+CREATE UNIQUE INDEX idx_capture_tokens_hash
+  ON capture_tokens_enc (token_hash);

--- a/supabase/migrations/20260408143011_optimize_zeta_decrypt_dek_cache.sql
+++ b/supabase/migrations/20260408143011_optimize_zeta_decrypt_dek_cache.sql
@@ -1,0 +1,133 @@
+-- ==================================================
+-- Optimize zeta_decrypt: cache DEK per transaction
+-- ==================================================
+-- Before: each zeta_decrypt() call queries vault.decrypted_secrets + user_encryption_keys
+-- After: first call caches the decrypted DEK in a transaction-local session variable;
+--        subsequent calls within the same statement/transaction skip both lookups.
+--
+-- Impact: a query returning 10 accounts × 6 encrypted cols goes from
+--         60 vault lookups → 1 vault lookup + 59 session var reads.
+
+-- 1. Optimized zeta_decrypt — cache DEK in session variable
+CREATE OR REPLACE FUNCTION zeta_decrypt(ciphertext BYTEA)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  user_dek TEXT;
+  master_key TEXT;
+  current_uid UUID;
+BEGIN
+  IF ciphertext IS NULL THEN RETURN NULL; END IF;
+
+  current_uid := (SELECT auth.uid());
+
+  -- Try cached DEK first (transaction-local)
+  user_dek := current_setting('zeta.cached_dek', true);
+
+  -- Validate cache belongs to current user
+  IF user_dek IS NOT NULL AND current_setting('zeta.cached_uid', true) = current_uid::text THEN
+    RETURN pgp_sym_decrypt(ciphertext, user_dek);
+  END IF;
+
+  -- Cache miss: fetch master key + decrypt DEK
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = current_uid;
+
+  IF user_dek IS NULL THEN RETURN NULL; END IF;
+
+  -- Cache for remainder of this transaction
+  PERFORM set_config('zeta.cached_dek', user_dek, true);
+  PERFORM set_config('zeta.cached_uid', current_uid::text, true);
+
+  RETURN pgp_sym_decrypt(ciphertext, user_dek);
+END;
+$$;
+
+-- 2. Optimized zeta_encrypt — same caching pattern
+CREATE OR REPLACE FUNCTION zeta_encrypt(plaintext TEXT)
+RETURNS BYTEA
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  user_dek TEXT;
+  master_key TEXT;
+  current_uid UUID;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  current_uid := (SELECT auth.uid());
+
+  -- Try cached DEK first
+  user_dek := current_setting('zeta.cached_dek', true);
+
+  IF user_dek IS NOT NULL AND current_setting('zeta.cached_uid', true) = current_uid::text THEN
+    RETURN pgp_sym_encrypt(plaintext, user_dek);
+  END IF;
+
+  -- Cache miss
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = current_uid;
+
+  IF user_dek IS NULL THEN
+    RAISE EXCEPTION 'No encryption key found for user %', current_uid;
+  END IF;
+
+  PERFORM set_config('zeta.cached_dek', user_dek, true);
+  PERFORM set_config('zeta.cached_uid', current_uid::text, true);
+
+  RETURN pgp_sym_encrypt(plaintext, user_dek);
+END;
+$$;
+
+-- 3. Optimized zeta_hmac — same caching pattern
+CREATE OR REPLACE FUNCTION zeta_hmac(plaintext TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  user_dek TEXT;
+  master_key TEXT;
+  current_uid UUID;
+BEGIN
+  IF plaintext IS NULL THEN RETURN NULL; END IF;
+
+  current_uid := (SELECT auth.uid());
+
+  -- Try cached DEK first
+  user_dek := current_setting('zeta.cached_dek', true);
+
+  IF user_dek IS NOT NULL AND current_setting('zeta.cached_uid', true) = current_uid::text THEN
+    RETURN encode(hmac(lower(plaintext), user_dek, 'sha256'), 'hex');
+  END IF;
+
+  -- Cache miss
+  SELECT decrypted_secret INTO master_key
+  FROM vault.decrypted_secrets WHERE name = 'zeta_master_key';
+
+  SELECT pgp_sym_decrypt(encrypted_dek, master_key) INTO user_dek
+  FROM user_encryption_keys WHERE user_id = current_uid;
+
+  IF user_dek IS NULL THEN RETURN NULL; END IF;
+
+  PERFORM set_config('zeta.cached_dek', user_dek, true);
+  PERFORM set_config('zeta.cached_uid', current_uid::text, true);
+
+  RETURN encode(hmac(lower(plaintext), user_dek, 'sha256'), 'hex');
+END;
+$$;

--- a/supabase/migrations/20260408143012_fix_insert_trigger_defaults.sql
+++ b/supabase/migrations/20260408143012_fix_insert_trigger_defaults.sql
@@ -1,0 +1,259 @@
+-- ===========================================================================
+-- Fix: INSERT triggers forward NULLs for defaulted columns (id, created_at,
+-- updated_at).
+--
+-- Problem: All 9 encrypted-table INSTEAD OF INSERT triggers pass NEW.id,
+-- NEW.created_at, NEW.updated_at directly. When an INSERT omits these
+-- columns (relying on table defaults), they arrive as NULL in the NEW
+-- record, violating NOT NULL constraints on the _enc table.
+--
+-- Fix: Wrap each defaulted column with COALESCE so the trigger generates
+-- the same default the table would have used:
+--   NEW.id         -> COALESCE(NEW.id, gen_random_uuid())
+--   NEW.created_at -> COALESCE(NEW.created_at, now())
+--   NEW.updated_at -> COALESCE(NEW.updated_at, now())
+--
+-- Exception: profiles_enc.id references auth.users — it must always be
+-- provided, so no COALESCE is added for that column.
+--
+-- Each function also adds RETURNING * INTO NEW so generated defaults
+-- propagate back to the caller.
+-- ===========================================================================
+
+-- 1. transactions_view_insert
+CREATE OR REPLACE FUNCTION transactions_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO transactions_enc (
+    account_id, amount, amount_in_base_currency, capture_input_text,
+    capture_method, categorization_confidence, categorization_source,
+    category_id, clean_description, clean_description_hmac, created_at,
+    currency_code, destinatario_id, direction, exchange_rate, id,
+    idempotency_key, installment_current, installment_group_id,
+    installment_total, is_excluded, is_recurring, is_subscription,
+    merchant_category_code, merchant_logo_url, merchant_name,
+    merchant_name_hmac, notes, original_amount, posting_date, provider,
+    provider_transaction_id, raw_description,
+    reconciled_into_transaction_id, reconciliation_score,
+    recurrence_group_id, secondary_category_id, status, tags,
+    transaction_date, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.amount_in_base_currency,
+    zeta_encrypt(NEW.capture_input_text),
+    NEW.capture_method, NEW.categorization_confidence,
+    NEW.categorization_source, NEW.category_id,
+    zeta_encrypt(NEW.clean_description),
+    zeta_hmac(NEW.clean_description),
+    COALESCE(NEW.created_at, now()), NEW.currency_code, NEW.destinatario_id,
+    NEW.direction, NEW.exchange_rate, COALESCE(NEW.id, gen_random_uuid()), NEW.idempotency_key,
+    NEW.installment_current, NEW.installment_group_id,
+    NEW.installment_total, NEW.is_excluded, NEW.is_recurring,
+    NEW.is_subscription, NEW.merchant_category_code,
+    NEW.merchant_logo_url,
+    zeta_encrypt(NEW.merchant_name),
+    zeta_hmac(NEW.merchant_name),
+    zeta_encrypt(NEW.notes),
+    NEW.original_amount, NEW.posting_date, NEW.provider,
+    NEW.provider_transaction_id,
+    zeta_encrypt(NEW.raw_description),
+    NEW.reconciled_into_transaction_id, NEW.reconciliation_score,
+    NEW.recurrence_group_id, NEW.secondary_category_id, NEW.status,
+    NEW.tags, NEW.transaction_date, COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. accounts_view_insert
+CREATE OR REPLACE FUNCTION accounts_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO accounts_enc (
+    account_type, available_balance, color, connection_status, created_at,
+    credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
+    debit_card_mask, display_order, expected_return_rate, icon, id,
+    initial_investment, institution_name, interest_rate, is_active,
+    last_synced_at, loan_amount, loan_end_date, loan_start_date, mask,
+    mask_hmac, maturity_date, monthly_payment, name, payment_day,
+    pdf_password, provider, provider_account_id, provider_account_id_hmac,
+    show_in_dashboard, updated_at, user_id
+  ) VALUES (
+    NEW.account_type, NEW.available_balance, NEW.color, NEW.connection_status,
+    COALESCE(NEW.created_at, now()), NEW.credit_limit, NEW.currency_balances, NEW.currency_code,
+    NEW.current_balance, NEW.cutoff_day,
+    zeta_encrypt(NEW.debit_card_mask),
+    NEW.display_order, NEW.expected_return_rate, NEW.icon, COALESCE(NEW.id, gen_random_uuid()),
+    NEW.initial_investment,
+    zeta_encrypt(NEW.institution_name),
+    NEW.interest_rate, NEW.is_active, NEW.last_synced_at, NEW.loan_amount,
+    NEW.loan_end_date, NEW.loan_start_date,
+    zeta_encrypt(NEW.mask),
+    zeta_hmac(NEW.mask),
+    NEW.maturity_date, NEW.monthly_payment,
+    zeta_encrypt(NEW.name),
+    NEW.payment_day,
+    zeta_encrypt(NEW.pdf_password),
+    NEW.provider,
+    zeta_encrypt(NEW.provider_account_id),
+    zeta_hmac(NEW.provider_account_id),
+    NEW.show_in_dashboard, COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. profiles_view_insert (id is NOT defaulted — references auth.users)
+CREATE OR REPLACE FUNCTION profiles_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO profiles_enc (
+    app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+    email, estimated_monthly_expenses, estimated_monthly_income, full_name,
+    id, locale, monthly_salary, onboarding_completed, preferred_currency,
+    timezone, updated_at
+  ) VALUES (
+    NEW.app_purpose, NEW.avatar_url, NEW.budget_mode, COALESCE(NEW.created_at, now()),
+    NEW.dashboard_config,
+    zeta_encrypt(NEW.email),
+    NEW.estimated_monthly_expenses, NEW.estimated_monthly_income,
+    zeta_encrypt(NEW.full_name),
+    NEW.id, NEW.locale, NEW.monthly_salary, NEW.onboarding_completed,
+    NEW.preferred_currency, NEW.timezone, COALESCE(NEW.updated_at, now())
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. destinatarios_view_insert
+CREATE OR REPLACE FUNCTION destinatarios_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO destinatarios_enc (
+    created_at, default_category_id, id, is_active, name, name_hmac,
+    notes, updated_at, user_id
+  ) VALUES (
+    COALESCE(NEW.created_at, now()), NEW.default_category_id, COALESCE(NEW.id, gen_random_uuid()), NEW.is_active,
+    zeta_encrypt(NEW.name),
+    zeta_hmac(NEW.name),
+    zeta_encrypt(NEW.notes),
+    COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 5. statement_snapshots_view_insert
+CREATE OR REPLACE FUNCTION statement_snapshots_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO statement_snapshots_enc (
+    account_id, available_credit, created_at, credit_limit, currency_code,
+    final_balance, id, imported_count, initial_amount, installments_in_default,
+    interest_charged, interest_rate, late_interest_rate, loan_number,
+    minimum_payment, payment_due_date, period_from, period_to, previous_balance,
+    purchases_and_charges, remaining_balance, skipped_count, source_filename,
+    total_credits, total_debits, total_payment_due, transaction_count,
+    updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.available_credit, COALESCE(NEW.created_at, now()), NEW.credit_limit,
+    NEW.currency_code, NEW.final_balance, COALESCE(NEW.id, gen_random_uuid()), NEW.imported_count,
+    NEW.initial_amount, NEW.installments_in_default, NEW.interest_charged,
+    NEW.interest_rate, NEW.late_interest_rate,
+    zeta_encrypt(NEW.loan_number),
+    NEW.minimum_payment, NEW.payment_due_date, NEW.period_from, NEW.period_to,
+    NEW.previous_balance, NEW.purchases_and_charges, NEW.remaining_balance,
+    NEW.skipped_count,
+    zeta_encrypt(NEW.source_filename),
+    NEW.total_credits, NEW.total_debits, NEW.total_payment_due,
+    NEW.transaction_count, COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 6. capture_tokens_view_insert (no updated_at column)
+CREATE OR REPLACE FUNCTION capture_tokens_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO capture_tokens_enc (
+    created_at, default_account_id, id, label, last_used_at, revoked_at,
+    token, token_hash, user_id
+  ) VALUES (
+    COALESCE(NEW.created_at, now()), NEW.default_account_id, COALESCE(NEW.id, gen_random_uuid()),
+    zeta_encrypt(NEW.label),
+    NEW.last_used_at, NEW.revoked_at,
+    zeta_encrypt(NEW.token),
+    encode(digest(NEW.token, 'sha256'), 'hex'),
+    NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 7. email_ingest_addresses_view_insert (no updated_at column)
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO email_ingest_addresses_enc (
+    account_id, address_key, allowed_sender, auto_import, created_at,
+    gmail_verification_at, gmail_verification_url, id, is_active,
+    pdf_import_enabled, user_id
+  ) VALUES (
+    NEW.account_id, NEW.address_key,
+    zeta_encrypt(NEW.allowed_sender),
+    NEW.auto_import, COALESCE(NEW.created_at, now()), NEW.gmail_verification_at,
+    zeta_encrypt(NEW.gmail_verification_url),
+    COALESCE(NEW.id, gen_random_uuid()), NEW.is_active, NEW.pdf_import_enabled, NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 8. recurring_templates_view_insert (table: recurring_transaction_templates_enc)
+CREATE OR REPLACE FUNCTION recurring_templates_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO recurring_transaction_templates_enc (
+    account_id, amount, category_id, created_at, currency_code,
+    day_of_month, day_of_week, description, direction, end_date,
+    frequency, id, is_active, merchant_name, start_date,
+    transfer_source_account_id, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.category_id, COALESCE(NEW.created_at, now()),
+    NEW.currency_code, NEW.day_of_month, NEW.day_of_week,
+    zeta_encrypt(NEW.description),
+    NEW.direction, NEW.end_date, NEW.frequency, COALESCE(NEW.id, gen_random_uuid()), NEW.is_active,
+    zeta_encrypt(NEW.merchant_name),
+    NEW.start_date, NEW.transfer_source_account_id, COALESCE(NEW.updated_at, now()),
+    NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 9. wishlist_items_view_insert
+CREATE OR REPLACE FUNCTION wishlist_items_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO wishlist_items_enc (
+    account_id, amount, bought_at, category_id, created_at, currency_code,
+    desire_type, enriched, enriched_at, funding_type, id, image_url,
+    installments, last_nudge_dismissed_at, last_score, last_scored_at,
+    last_verdict, name, ready_at, status, transaction_id, updated_at,
+    urgency, url, user_id, why
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.bought_at, NEW.category_id,
+    COALESCE(NEW.created_at, now()), NEW.currency_code, NEW.desire_type, NEW.enriched,
+    NEW.enriched_at, NEW.funding_type, COALESCE(NEW.id, gen_random_uuid()), NEW.image_url,
+    NEW.installments, NEW.last_nudge_dismissed_at, NEW.last_score,
+    NEW.last_scored_at, NEW.last_verdict,
+    zeta_encrypt(NEW.name),
+    NEW.ready_at, NEW.status, NEW.transaction_id, COALESCE(NEW.updated_at, now()),
+    NEW.urgency,
+    zeta_encrypt(NEW.url),
+    NEW.user_id,
+    zeta_encrypt(NEW.why)
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20260408143013_fix_all_insert_trigger_defaults.sql
+++ b/supabase/migrations/20260408143013_fix_all_insert_trigger_defaults.sql
@@ -1,18 +1,29 @@
 -- ===========================================================================
--- Fix: INSERT triggers must COALESCE ALL columns that have NOT NULL + DEFAULT
--- constraints on the _enc tables.
+-- Fix: INSERT triggers assign defaults to NEW before INSERT, no RETURNING
 --
--- Problem: The previous migration (20260408143012) only added COALESCE for
--- id, created_at, updated_at. But many more columns have NOT NULL + DEFAULT
--- constraints (exchange_rate, status, is_excluded, provider, etc.) and pass
--- NULL when the INSERT omits them, violating NOT NULL constraints.
+-- Previous approach used COALESCE inline + RETURNING * INTO NEW, but
+-- RETURNING * from _enc tables has BYTEA columns that don't match the
+-- view's TEXT structure → "returned row structure does not match"
 --
--- Fix: Add COALESCE for every NOT NULL + DEFAULT column in each _enc table.
+-- Correct approach: assign COALESCE'd defaults to NEW fields first,
+-- then INSERT using NEW.* (already defaulted), RETURN NEW as-is.
 -- ===========================================================================
 
--- 1. transactions_view_insert
+-- 1. transactions
 CREATE OR REPLACE FUNCTION transactions_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.exchange_rate := COALESCE(NEW.exchange_rate, 1.000000);
+  NEW.status := COALESCE(NEW.status, 'POSTED'::transaction_status);
+  NEW.categorization_source := COALESCE(NEW.categorization_source, 'USER_CREATED'::categorization_source);
+  NEW.is_subscription := COALESCE(NEW.is_subscription, false);
+  NEW.is_recurring := COALESCE(NEW.is_recurring, false);
+  NEW.provider := COALESCE(NEW.provider, 'MANUAL'::data_provider);
+  NEW.is_excluded := COALESCE(NEW.is_excluded, false);
+  NEW.capture_method := COALESCE(NEW.capture_method, 'MANUAL_FORM'::transaction_capture_method);
+
   INSERT INTO transactions_enc (
     account_id, amount, amount_in_base_currency, capture_input_text,
     capture_method, categorization_confidence, categorization_source,
@@ -29,257 +40,231 @@ BEGIN
   ) VALUES (
     NEW.account_id, NEW.amount, NEW.amount_in_base_currency,
     zeta_encrypt(NEW.capture_input_text),
-    COALESCE(NEW.capture_method, 'MANUAL_FORM'::transaction_capture_method),
-    NEW.categorization_confidence,
-    COALESCE(NEW.categorization_source, 'USER_CREATED'::categorization_source),
-    NEW.category_id,
+    NEW.capture_method, NEW.categorization_confidence,
+    NEW.categorization_source, NEW.category_id,
     zeta_encrypt(NEW.clean_description),
     zeta_hmac(NEW.clean_description),
-    COALESCE(NEW.created_at, now()), NEW.currency_code, NEW.destinatario_id,
-    NEW.direction,
-    COALESCE(NEW.exchange_rate, 1.000000),
-    COALESCE(NEW.id, gen_random_uuid()), NEW.idempotency_key,
+    NEW.created_at, NEW.currency_code, NEW.destinatario_id,
+    NEW.direction, NEW.exchange_rate, NEW.id, NEW.idempotency_key,
     NEW.installment_current, NEW.installment_group_id,
-    NEW.installment_total,
-    COALESCE(NEW.is_excluded, false),
-    COALESCE(NEW.is_recurring, false),
-    COALESCE(NEW.is_subscription, false),
-    NEW.merchant_category_code,
+    NEW.installment_total, NEW.is_excluded, NEW.is_recurring,
+    NEW.is_subscription, NEW.merchant_category_code,
     NEW.merchant_logo_url,
     zeta_encrypt(NEW.merchant_name),
     zeta_hmac(NEW.merchant_name),
     zeta_encrypt(NEW.notes),
-    NEW.original_amount, NEW.posting_date,
-    COALESCE(NEW.provider, 'MANUAL'::data_provider),
+    NEW.original_amount, NEW.posting_date, NEW.provider,
     NEW.provider_transaction_id,
     zeta_encrypt(NEW.raw_description),
     NEW.reconciled_into_transaction_id, NEW.reconciliation_score,
-    NEW.recurrence_group_id, NEW.secondary_category_id,
-    COALESCE(NEW.status, 'POSTED'::transaction_status),
-    NEW.tags, NEW.transaction_date, COALESCE(NEW.updated_at, now()), NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    NEW.recurrence_group_id, NEW.secondary_category_id, NEW.status,
+    NEW.tags, NEW.transaction_date, NEW.updated_at, NEW.user_id
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 2. accounts_view_insert
+-- 2. accounts
 CREATE OR REPLACE FUNCTION accounts_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.current_balance := COALESCE(NEW.current_balance, 0);
+  NEW.currency_code := COALESCE(NEW.currency_code, 'COP'::currency_code);
+  NEW.provider := COALESCE(NEW.provider, 'MANUAL'::data_provider);
+  NEW.connection_status := COALESCE(NEW.connection_status, 'CONNECTED'::connection_status);
+  NEW.is_active := COALESCE(NEW.is_active, true);
+  NEW.display_order := COALESCE(NEW.display_order, 0);
+  NEW.show_in_dashboard := COALESCE(NEW.show_in_dashboard, true);
+
   INSERT INTO accounts_enc (
-    account_type, available_balance, color, connection_status, created_at,
-    credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
-    debit_card_mask, display_order, expected_return_rate, icon, id,
-    initial_investment, institution_name, interest_rate, is_active,
-    last_synced_at, loan_amount, loan_end_date, loan_start_date, mask,
-    mask_hmac, maturity_date, monthly_payment, name, payment_day,
-    pdf_password, provider, provider_account_id, provider_account_id_hmac,
-    show_in_dashboard, updated_at, user_id
+    account_type, color, connection_status, created_at, credit_limit,
+    currency_balances, currency_code, current_balance, debit_card_mask,
+    display_order, expected_return_rate, icon, id, institution_name,
+    interest_rate, is_active, mask, monthly_payment, name, pdf_password,
+    provider, provider_account_id, provider_account_id_hmac,
+    show_in_dashboard, updated_at, user_id, mask_hmac
   ) VALUES (
-    NEW.account_type, NEW.available_balance, NEW.color,
-    COALESCE(NEW.connection_status, 'CONNECTED'::connection_status),
-    COALESCE(NEW.created_at, now()), NEW.credit_limit, NEW.currency_balances,
-    COALESCE(NEW.currency_code, 'COP'::currency_code),
-    COALESCE(NEW.current_balance, 0),
-    NEW.cutoff_day,
-    zeta_encrypt(NEW.debit_card_mask),
-    COALESCE(NEW.display_order, 0),
-    NEW.expected_return_rate, NEW.icon, COALESCE(NEW.id, gen_random_uuid()),
-    NEW.initial_investment,
-    zeta_encrypt(NEW.institution_name),
-    NEW.interest_rate,
-    COALESCE(NEW.is_active, true),
-    NEW.last_synced_at, NEW.loan_amount,
-    NEW.loan_end_date, NEW.loan_start_date,
-    zeta_encrypt(NEW.mask),
-    zeta_hmac(NEW.mask),
-    NEW.maturity_date, NEW.monthly_payment,
-    zeta_encrypt(NEW.name),
-    NEW.payment_day,
-    zeta_encrypt(NEW.pdf_password),
-    COALESCE(NEW.provider, 'MANUAL'::data_provider),
+    NEW.account_type, NEW.color, NEW.connection_status, NEW.created_at,
+    NEW.credit_limit, NEW.currency_balances, NEW.currency_code,
+    NEW.current_balance, zeta_encrypt(NEW.debit_card_mask),
+    NEW.display_order, NEW.expected_return_rate, NEW.icon, NEW.id,
+    zeta_encrypt(NEW.institution_name), NEW.interest_rate, NEW.is_active,
+    zeta_encrypt(NEW.mask), NEW.monthly_payment, zeta_encrypt(NEW.name),
+    zeta_encrypt(NEW.pdf_password), NEW.provider,
     zeta_encrypt(NEW.provider_account_id),
-    zeta_hmac(NEW.provider_account_id),
-    COALESCE(NEW.show_in_dashboard, true),
-    COALESCE(NEW.updated_at, now()), NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    zeta_hmac(NEW.provider_account_id), NEW.show_in_dashboard,
+    NEW.updated_at, NEW.user_id, zeta_hmac(NEW.mask)
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 3. profiles_view_insert (id is NOT defaulted — references auth.users)
+-- 3. profiles (id is auth.users FK — never defaulted)
 CREATE OR REPLACE FUNCTION profiles_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.preferred_currency := COALESCE(NEW.preferred_currency, 'COP'::currency_code);
+  NEW.locale := COALESCE(NEW.locale, 'es-CO'::text);
+  NEW.timezone := COALESCE(NEW.timezone, 'America/Bogota'::text);
+  NEW.onboarding_completed := COALESCE(NEW.onboarding_completed, false);
+
   INSERT INTO profiles_enc (
-    app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
-    email, estimated_monthly_expenses, estimated_monthly_income, full_name,
-    id, locale, monthly_salary, onboarding_completed, preferred_currency,
-    timezone, updated_at
+    id, full_name, email, preferred_currency, locale, timezone,
+    onboarding_completed, created_at, updated_at, dashboard_config,
+    monthly_salary, estimated_monthly_income, salary_currency
   ) VALUES (
-    NEW.app_purpose, NEW.avatar_url, NEW.budget_mode, COALESCE(NEW.created_at, now()),
-    NEW.dashboard_config,
-    zeta_encrypt(NEW.email),
-    NEW.estimated_monthly_expenses, NEW.estimated_monthly_income,
-    zeta_encrypt(NEW.full_name),
-    NEW.id,
-    COALESCE(NEW.locale, 'es-CO'::text),
-    NEW.monthly_salary,
-    COALESCE(NEW.onboarding_completed, false),
-    COALESCE(NEW.preferred_currency, 'COP'::currency_code),
-    COALESCE(NEW.timezone, 'America/Bogota'::text),
-    COALESCE(NEW.updated_at, now())
-  )
-  RETURNING * INTO NEW;
+    NEW.id, zeta_encrypt(NEW.full_name), zeta_encrypt(NEW.email),
+    NEW.preferred_currency, NEW.locale, NEW.timezone,
+    NEW.onboarding_completed, NEW.created_at, NEW.updated_at,
+    NEW.dashboard_config, NEW.monthly_salary,
+    NEW.estimated_monthly_income, NEW.salary_currency
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 4. destinatarios_view_insert
+-- 4. destinatarios
 CREATE OR REPLACE FUNCTION destinatarios_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.is_active := COALESCE(NEW.is_active, true);
+
   INSERT INTO destinatarios_enc (
-    created_at, default_category_id, id, is_active, name, name_hmac,
-    notes, updated_at, user_id
+    id, user_id, name, name_hmac, notes, default_category_id,
+    is_active, created_at, updated_at
   ) VALUES (
-    COALESCE(NEW.created_at, now()), NEW.default_category_id, COALESCE(NEW.id, gen_random_uuid()),
-    COALESCE(NEW.is_active, true),
-    zeta_encrypt(NEW.name),
-    zeta_hmac(NEW.name),
-    zeta_encrypt(NEW.notes),
-    COALESCE(NEW.updated_at, now()), NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    NEW.id, NEW.user_id, zeta_encrypt(NEW.name), zeta_hmac(NEW.name),
+    zeta_encrypt(NEW.notes), NEW.default_category_id, NEW.is_active,
+    NEW.created_at, NEW.updated_at
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 5. statement_snapshots_view_insert
+-- 5. statement_snapshots
 CREATE OR REPLACE FUNCTION statement_snapshots_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.transaction_count := COALESCE(NEW.transaction_count, 0);
+  NEW.imported_count := COALESCE(NEW.imported_count, 0);
+  NEW.skipped_count := COALESCE(NEW.skipped_count, 0);
+  NEW.currency_code := COALESCE(NEW.currency_code, 'COP'::text);
+
   INSERT INTO statement_snapshots_enc (
-    account_id, available_credit, created_at, credit_limit, currency_code,
-    final_balance, id, imported_count, initial_amount, installments_in_default,
-    interest_charged, interest_rate, late_interest_rate, loan_number,
-    minimum_payment, payment_due_date, period_from, period_to, previous_balance,
-    purchases_and_charges, remaining_balance, skipped_count, source_filename,
-    total_credits, total_debits, total_payment_due, transaction_count,
-    updated_at, user_id
+    id, user_id, account_id, period_from, period_to,
+    opening_balance, closing_balance, total_debits, total_credits,
+    minimum_payment, remaining_balance, initial_amount,
+    transaction_count, imported_count, skipped_count,
+    loan_number, source_filename, currency_code,
+    created_at, updated_at
   ) VALUES (
-    NEW.account_id, NEW.available_credit, COALESCE(NEW.created_at, now()), NEW.credit_limit,
-    COALESCE(NEW.currency_code, 'COP'::text),
-    NEW.final_balance, COALESCE(NEW.id, gen_random_uuid()),
-    COALESCE(NEW.imported_count, 0),
-    NEW.initial_amount, NEW.installments_in_default, NEW.interest_charged,
-    NEW.interest_rate, NEW.late_interest_rate,
-    zeta_encrypt(NEW.loan_number),
-    NEW.minimum_payment, NEW.payment_due_date, NEW.period_from, NEW.period_to,
-    NEW.previous_balance, NEW.purchases_and_charges, NEW.remaining_balance,
-    COALESCE(NEW.skipped_count, 0),
-    zeta_encrypt(NEW.source_filename),
-    NEW.total_credits, NEW.total_debits, NEW.total_payment_due,
-    COALESCE(NEW.transaction_count, 0),
-    COALESCE(NEW.updated_at, now()), NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    NEW.id, NEW.user_id, NEW.account_id, NEW.period_from, NEW.period_to,
+    NEW.opening_balance, NEW.closing_balance, NEW.total_debits,
+    NEW.total_credits, NEW.minimum_payment, NEW.remaining_balance,
+    NEW.initial_amount, NEW.transaction_count, NEW.imported_count,
+    NEW.skipped_count, zeta_encrypt(NEW.loan_number),
+    zeta_encrypt(NEW.source_filename), NEW.currency_code,
+    NEW.created_at, NEW.updated_at
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 6. capture_tokens_view_insert (no updated_at column)
+-- 6. capture_tokens
 CREATE OR REPLACE FUNCTION capture_tokens_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+
   INSERT INTO capture_tokens_enc (
-    created_at, default_account_id, id, label, last_used_at, revoked_at,
-    token, token_hash, user_id
+    id, user_id, token, token_hash, label, default_account_id, created_at
   ) VALUES (
-    COALESCE(NEW.created_at, now()), NEW.default_account_id, COALESCE(NEW.id, gen_random_uuid()),
-    zeta_encrypt(NEW.label),
-    NEW.last_used_at, NEW.revoked_at,
-    zeta_encrypt(NEW.token),
+    NEW.id, NEW.user_id, zeta_encrypt(NEW.token),
     encode(digest(NEW.token, 'sha256'), 'hex'),
-    NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    zeta_encrypt(NEW.label), NEW.default_account_id, NEW.created_at
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 7. email_ingest_addresses_view_insert (no updated_at column)
+-- 7. email_ingest_addresses
 CREATE OR REPLACE FUNCTION email_ingest_addresses_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.auto_import := COALESCE(NEW.auto_import, false);
+  NEW.is_active := COALESCE(NEW.is_active, true);
+  NEW.pdf_import_enabled := COALESCE(NEW.pdf_import_enabled, false);
+
   INSERT INTO email_ingest_addresses_enc (
-    account_id, address_key, allowed_sender, auto_import, created_at,
-    gmail_verification_at, gmail_verification_url, id, is_active,
-    pdf_import_enabled, user_id
+    id, user_id, address_key, allowed_sender, default_account_id,
+    auto_import, is_active, gmail_verification_url, created_at,
+    pdf_import_enabled
   ) VALUES (
-    NEW.account_id, NEW.address_key,
-    zeta_encrypt(NEW.allowed_sender),
-    COALESCE(NEW.auto_import, false),
-    COALESCE(NEW.created_at, now()), NEW.gmail_verification_at,
-    zeta_encrypt(NEW.gmail_verification_url),
-    COALESCE(NEW.id, gen_random_uuid()),
-    COALESCE(NEW.is_active, true),
-    COALESCE(NEW.pdf_import_enabled, false),
-    NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    NEW.id, NEW.user_id, NEW.address_key,
+    zeta_encrypt(NEW.allowed_sender), NEW.default_account_id,
+    NEW.auto_import, NEW.is_active,
+    zeta_encrypt(NEW.gmail_verification_url), NEW.created_at,
+    NEW.pdf_import_enabled
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 8. recurring_templates_view_insert (table: recurring_transaction_templates_enc)
+-- 8. recurring_transaction_templates
 CREATE OR REPLACE FUNCTION recurring_templates_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.currency_code := COALESCE(NEW.currency_code, 'COP'::currency_code);
+  NEW.is_active := COALESCE(NEW.is_active, true);
+
   INSERT INTO recurring_transaction_templates_enc (
-    account_id, amount, category_id, created_at, currency_code,
-    day_of_month, day_of_week, description, direction, end_date,
-    frequency, id, is_active, merchant_name, start_date,
-    transfer_source_account_id, updated_at, user_id
+    id, user_id, account_id, amount, currency_code, direction,
+    frequency, day_of_month, day_of_week, merchant_name, description,
+    category_id, is_active, start_date, end_date, last_occurrence_date,
+    next_occurrence_date, created_at, updated_at,
+    transfer_source_account_id
   ) VALUES (
-    NEW.account_id, NEW.amount, NEW.category_id, COALESCE(NEW.created_at, now()),
-    COALESCE(NEW.currency_code, 'COP'::currency_code),
-    NEW.day_of_month, NEW.day_of_week,
-    zeta_encrypt(NEW.description),
-    NEW.direction, NEW.end_date, NEW.frequency, COALESCE(NEW.id, gen_random_uuid()),
-    COALESCE(NEW.is_active, true),
-    zeta_encrypt(NEW.merchant_name),
-    NEW.start_date, NEW.transfer_source_account_id, COALESCE(NEW.updated_at, now()),
-    NEW.user_id
-  )
-  RETURNING * INTO NEW;
+    NEW.id, NEW.user_id, NEW.account_id, NEW.amount, NEW.currency_code,
+    NEW.direction, NEW.frequency, NEW.day_of_month, NEW.day_of_week,
+    zeta_encrypt(NEW.merchant_name), zeta_encrypt(NEW.description),
+    NEW.category_id, NEW.is_active, NEW.start_date, NEW.end_date,
+    NEW.last_occurrence_date, NEW.next_occurrence_date,
+    NEW.created_at, NEW.updated_at, NEW.transfer_source_account_id
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 9. wishlist_items_view_insert
+-- 9. wishlist_items
 CREATE OR REPLACE FUNCTION wishlist_items_view_insert() RETURNS TRIGGER AS $$
 BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.currency_code := COALESCE(NEW.currency_code, 'COP'::text);
+  NEW.status := COALESCE(NEW.status, 'wishlist'::text);
+  NEW.enriched := COALESCE(NEW.enriched, false);
+
   INSERT INTO wishlist_items_enc (
-    account_id, amount, bought_at, category_id, created_at, currency_code,
-    desire_type, enriched, enriched_at, funding_type, id, image_url,
-    installments, last_nudge_dismissed_at, last_score, last_scored_at,
-    last_verdict, name, ready_at, status, transaction_id, updated_at,
-    urgency, url, user_id, why
+    id, user_id, name, url, price, currency_code, why,
+    status, enriched, enrichment_data, score_data,
+    created_at, updated_at
   ) VALUES (
-    NEW.account_id, NEW.amount, NEW.bought_at, NEW.category_id,
-    COALESCE(NEW.created_at, now()),
-    COALESCE(NEW.currency_code, 'COP'::text),
-    NEW.desire_type,
-    COALESCE(NEW.enriched, false),
-    NEW.enriched_at, NEW.funding_type, COALESCE(NEW.id, gen_random_uuid()), NEW.image_url,
-    NEW.installments, NEW.last_nudge_dismissed_at, NEW.last_score,
-    NEW.last_scored_at, NEW.last_verdict,
-    zeta_encrypt(NEW.name),
-    NEW.ready_at,
-    COALESCE(NEW.status, 'wishlist'::text),
-    NEW.transaction_id, COALESCE(NEW.updated_at, now()),
-    NEW.urgency,
-    zeta_encrypt(NEW.url),
-    NEW.user_id,
-    zeta_encrypt(NEW.why)
-  )
-  RETURNING * INTO NEW;
+    NEW.id, NEW.user_id, zeta_encrypt(NEW.name), zeta_encrypt(NEW.url),
+    NEW.price, NEW.currency_code, zeta_encrypt(NEW.why),
+    NEW.status, NEW.enriched, NEW.enrichment_data, NEW.score_data,
+    NEW.created_at, NEW.updated_at
+  );
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/supabase/migrations/20260408143013_fix_all_insert_trigger_defaults.sql
+++ b/supabase/migrations/20260408143013_fix_all_insert_trigger_defaults.sql
@@ -1,0 +1,285 @@
+-- ===========================================================================
+-- Fix: INSERT triggers must COALESCE ALL columns that have NOT NULL + DEFAULT
+-- constraints on the _enc tables.
+--
+-- Problem: The previous migration (20260408143012) only added COALESCE for
+-- id, created_at, updated_at. But many more columns have NOT NULL + DEFAULT
+-- constraints (exchange_rate, status, is_excluded, provider, etc.) and pass
+-- NULL when the INSERT omits them, violating NOT NULL constraints.
+--
+-- Fix: Add COALESCE for every NOT NULL + DEFAULT column in each _enc table.
+-- ===========================================================================
+
+-- 1. transactions_view_insert
+CREATE OR REPLACE FUNCTION transactions_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO transactions_enc (
+    account_id, amount, amount_in_base_currency, capture_input_text,
+    capture_method, categorization_confidence, categorization_source,
+    category_id, clean_description, clean_description_hmac, created_at,
+    currency_code, destinatario_id, direction, exchange_rate, id,
+    idempotency_key, installment_current, installment_group_id,
+    installment_total, is_excluded, is_recurring, is_subscription,
+    merchant_category_code, merchant_logo_url, merchant_name,
+    merchant_name_hmac, notes, original_amount, posting_date, provider,
+    provider_transaction_id, raw_description,
+    reconciled_into_transaction_id, reconciliation_score,
+    recurrence_group_id, secondary_category_id, status, tags,
+    transaction_date, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.amount_in_base_currency,
+    zeta_encrypt(NEW.capture_input_text),
+    COALESCE(NEW.capture_method, 'MANUAL_FORM'::transaction_capture_method),
+    NEW.categorization_confidence,
+    COALESCE(NEW.categorization_source, 'USER_CREATED'::categorization_source),
+    NEW.category_id,
+    zeta_encrypt(NEW.clean_description),
+    zeta_hmac(NEW.clean_description),
+    COALESCE(NEW.created_at, now()), NEW.currency_code, NEW.destinatario_id,
+    NEW.direction,
+    COALESCE(NEW.exchange_rate, 1.000000),
+    COALESCE(NEW.id, gen_random_uuid()), NEW.idempotency_key,
+    NEW.installment_current, NEW.installment_group_id,
+    NEW.installment_total,
+    COALESCE(NEW.is_excluded, false),
+    COALESCE(NEW.is_recurring, false),
+    COALESCE(NEW.is_subscription, false),
+    NEW.merchant_category_code,
+    NEW.merchant_logo_url,
+    zeta_encrypt(NEW.merchant_name),
+    zeta_hmac(NEW.merchant_name),
+    zeta_encrypt(NEW.notes),
+    NEW.original_amount, NEW.posting_date,
+    COALESCE(NEW.provider, 'MANUAL'::data_provider),
+    NEW.provider_transaction_id,
+    zeta_encrypt(NEW.raw_description),
+    NEW.reconciled_into_transaction_id, NEW.reconciliation_score,
+    NEW.recurrence_group_id, NEW.secondary_category_id,
+    COALESCE(NEW.status, 'POSTED'::transaction_status),
+    NEW.tags, NEW.transaction_date, COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. accounts_view_insert
+CREATE OR REPLACE FUNCTION accounts_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO accounts_enc (
+    account_type, available_balance, color, connection_status, created_at,
+    credit_limit, currency_balances, currency_code, current_balance, cutoff_day,
+    debit_card_mask, display_order, expected_return_rate, icon, id,
+    initial_investment, institution_name, interest_rate, is_active,
+    last_synced_at, loan_amount, loan_end_date, loan_start_date, mask,
+    mask_hmac, maturity_date, monthly_payment, name, payment_day,
+    pdf_password, provider, provider_account_id, provider_account_id_hmac,
+    show_in_dashboard, updated_at, user_id
+  ) VALUES (
+    NEW.account_type, NEW.available_balance, NEW.color,
+    COALESCE(NEW.connection_status, 'CONNECTED'::connection_status),
+    COALESCE(NEW.created_at, now()), NEW.credit_limit, NEW.currency_balances,
+    COALESCE(NEW.currency_code, 'COP'::currency_code),
+    COALESCE(NEW.current_balance, 0),
+    NEW.cutoff_day,
+    zeta_encrypt(NEW.debit_card_mask),
+    COALESCE(NEW.display_order, 0),
+    NEW.expected_return_rate, NEW.icon, COALESCE(NEW.id, gen_random_uuid()),
+    NEW.initial_investment,
+    zeta_encrypt(NEW.institution_name),
+    NEW.interest_rate,
+    COALESCE(NEW.is_active, true),
+    NEW.last_synced_at, NEW.loan_amount,
+    NEW.loan_end_date, NEW.loan_start_date,
+    zeta_encrypt(NEW.mask),
+    zeta_hmac(NEW.mask),
+    NEW.maturity_date, NEW.monthly_payment,
+    zeta_encrypt(NEW.name),
+    NEW.payment_day,
+    zeta_encrypt(NEW.pdf_password),
+    COALESCE(NEW.provider, 'MANUAL'::data_provider),
+    zeta_encrypt(NEW.provider_account_id),
+    zeta_hmac(NEW.provider_account_id),
+    COALESCE(NEW.show_in_dashboard, true),
+    COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. profiles_view_insert (id is NOT defaulted — references auth.users)
+CREATE OR REPLACE FUNCTION profiles_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO profiles_enc (
+    app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+    email, estimated_monthly_expenses, estimated_monthly_income, full_name,
+    id, locale, monthly_salary, onboarding_completed, preferred_currency,
+    timezone, updated_at
+  ) VALUES (
+    NEW.app_purpose, NEW.avatar_url, NEW.budget_mode, COALESCE(NEW.created_at, now()),
+    NEW.dashboard_config,
+    zeta_encrypt(NEW.email),
+    NEW.estimated_monthly_expenses, NEW.estimated_monthly_income,
+    zeta_encrypt(NEW.full_name),
+    NEW.id,
+    COALESCE(NEW.locale, 'es-CO'::text),
+    NEW.monthly_salary,
+    COALESCE(NEW.onboarding_completed, false),
+    COALESCE(NEW.preferred_currency, 'COP'::currency_code),
+    COALESCE(NEW.timezone, 'America/Bogota'::text),
+    COALESCE(NEW.updated_at, now())
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. destinatarios_view_insert
+CREATE OR REPLACE FUNCTION destinatarios_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO destinatarios_enc (
+    created_at, default_category_id, id, is_active, name, name_hmac,
+    notes, updated_at, user_id
+  ) VALUES (
+    COALESCE(NEW.created_at, now()), NEW.default_category_id, COALESCE(NEW.id, gen_random_uuid()),
+    COALESCE(NEW.is_active, true),
+    zeta_encrypt(NEW.name),
+    zeta_hmac(NEW.name),
+    zeta_encrypt(NEW.notes),
+    COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 5. statement_snapshots_view_insert
+CREATE OR REPLACE FUNCTION statement_snapshots_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO statement_snapshots_enc (
+    account_id, available_credit, created_at, credit_limit, currency_code,
+    final_balance, id, imported_count, initial_amount, installments_in_default,
+    interest_charged, interest_rate, late_interest_rate, loan_number,
+    minimum_payment, payment_due_date, period_from, period_to, previous_balance,
+    purchases_and_charges, remaining_balance, skipped_count, source_filename,
+    total_credits, total_debits, total_payment_due, transaction_count,
+    updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.available_credit, COALESCE(NEW.created_at, now()), NEW.credit_limit,
+    COALESCE(NEW.currency_code, 'COP'::text),
+    NEW.final_balance, COALESCE(NEW.id, gen_random_uuid()),
+    COALESCE(NEW.imported_count, 0),
+    NEW.initial_amount, NEW.installments_in_default, NEW.interest_charged,
+    NEW.interest_rate, NEW.late_interest_rate,
+    zeta_encrypt(NEW.loan_number),
+    NEW.minimum_payment, NEW.payment_due_date, NEW.period_from, NEW.period_to,
+    NEW.previous_balance, NEW.purchases_and_charges, NEW.remaining_balance,
+    COALESCE(NEW.skipped_count, 0),
+    zeta_encrypt(NEW.source_filename),
+    NEW.total_credits, NEW.total_debits, NEW.total_payment_due,
+    COALESCE(NEW.transaction_count, 0),
+    COALESCE(NEW.updated_at, now()), NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 6. capture_tokens_view_insert (no updated_at column)
+CREATE OR REPLACE FUNCTION capture_tokens_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO capture_tokens_enc (
+    created_at, default_account_id, id, label, last_used_at, revoked_at,
+    token, token_hash, user_id
+  ) VALUES (
+    COALESCE(NEW.created_at, now()), NEW.default_account_id, COALESCE(NEW.id, gen_random_uuid()),
+    zeta_encrypt(NEW.label),
+    NEW.last_used_at, NEW.revoked_at,
+    zeta_encrypt(NEW.token),
+    encode(digest(NEW.token, 'sha256'), 'hex'),
+    NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 7. email_ingest_addresses_view_insert (no updated_at column)
+CREATE OR REPLACE FUNCTION email_ingest_addresses_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO email_ingest_addresses_enc (
+    account_id, address_key, allowed_sender, auto_import, created_at,
+    gmail_verification_at, gmail_verification_url, id, is_active,
+    pdf_import_enabled, user_id
+  ) VALUES (
+    NEW.account_id, NEW.address_key,
+    zeta_encrypt(NEW.allowed_sender),
+    COALESCE(NEW.auto_import, false),
+    COALESCE(NEW.created_at, now()), NEW.gmail_verification_at,
+    zeta_encrypt(NEW.gmail_verification_url),
+    COALESCE(NEW.id, gen_random_uuid()),
+    COALESCE(NEW.is_active, true),
+    COALESCE(NEW.pdf_import_enabled, false),
+    NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 8. recurring_templates_view_insert (table: recurring_transaction_templates_enc)
+CREATE OR REPLACE FUNCTION recurring_templates_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO recurring_transaction_templates_enc (
+    account_id, amount, category_id, created_at, currency_code,
+    day_of_month, day_of_week, description, direction, end_date,
+    frequency, id, is_active, merchant_name, start_date,
+    transfer_source_account_id, updated_at, user_id
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.category_id, COALESCE(NEW.created_at, now()),
+    COALESCE(NEW.currency_code, 'COP'::currency_code),
+    NEW.day_of_month, NEW.day_of_week,
+    zeta_encrypt(NEW.description),
+    NEW.direction, NEW.end_date, NEW.frequency, COALESCE(NEW.id, gen_random_uuid()),
+    COALESCE(NEW.is_active, true),
+    zeta_encrypt(NEW.merchant_name),
+    NEW.start_date, NEW.transfer_source_account_id, COALESCE(NEW.updated_at, now()),
+    NEW.user_id
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 9. wishlist_items_view_insert
+CREATE OR REPLACE FUNCTION wishlist_items_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO wishlist_items_enc (
+    account_id, amount, bought_at, category_id, created_at, currency_code,
+    desire_type, enriched, enriched_at, funding_type, id, image_url,
+    installments, last_nudge_dismissed_at, last_score, last_scored_at,
+    last_verdict, name, ready_at, status, transaction_id, updated_at,
+    urgency, url, user_id, why
+  ) VALUES (
+    NEW.account_id, NEW.amount, NEW.bought_at, NEW.category_id,
+    COALESCE(NEW.created_at, now()),
+    COALESCE(NEW.currency_code, 'COP'::text),
+    NEW.desire_type,
+    COALESCE(NEW.enriched, false),
+    NEW.enriched_at, NEW.funding_type, COALESCE(NEW.id, gen_random_uuid()), NEW.image_url,
+    NEW.installments, NEW.last_nudge_dismissed_at, NEW.last_score,
+    NEW.last_scored_at, NEW.last_verdict,
+    zeta_encrypt(NEW.name),
+    NEW.ready_at,
+    COALESCE(NEW.status, 'wishlist'::text),
+    NEW.transaction_id, COALESCE(NEW.updated_at, now()),
+    NEW.urgency,
+    zeta_encrypt(NEW.url),
+    NEW.user_id,
+    zeta_encrypt(NEW.why)
+  )
+  RETURNING * INTO NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/webapp/src/actions/accounts.ts
+++ b/webapp/src/actions/accounts.ts
@@ -2,7 +2,7 @@
 
 import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { accountSchema } from "@/lib/validators/account";
 import { computeIdempotencyKey } from "@zeta/shared";
 import { getDirectionForBalanceDelta } from "@/lib/utils/account-balance";
@@ -15,18 +15,22 @@ import type { Database } from "@/types/database";
 import type { ActionResult } from "@/types/actions";
 import type { Account, AccountRow, CurrencyCode, TransactionDirection } from "@/types/domain";
 
-// ─── Cached inner functions ───────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function stripSensitive({ pdf_password: _, ...rest }: AccountRow): Account {
   return rest;
 }
 
-async function getAccountsCached(userId: string): Promise<Account[]> {
+// ─── Cached inner functions ───────────────────────────────────────────────────
+// Uses createCachedClient(accessToken) so "use cache" works WITH encryption.
+// The admin client has no JWT → zeta_decrypt returns NULL for encrypted columns.
+
+async function getAccountsCached(userId: string, accessToken: string): Promise<Account[]> {
   "use cache";
   cacheTag("accounts");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("accounts")
     .select("*")
@@ -38,12 +42,12 @@ async function getAccountsCached(userId: string): Promise<Account[]> {
   return (data ?? []).map(stripSensitive);
 }
 
-async function getAccountCached(userId: string, id: string): Promise<Account> {
+async function getAccountCached(userId: string, id: string, accessToken: string): Promise<Account> {
   "use cache";
   cacheTag("accounts");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("accounts")
     .select("*")
@@ -58,10 +62,10 @@ async function getAccountCached(userId: string, id: string): Promise<Account> {
 // ─── Public wrappers ──────────────────────────────────────────────────────────
 
 export async function getAccounts(): Promise<ActionResult<Account[]>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getAccountsCached(user.id);
+    const data = await getAccountsCached(user.id, accessToken);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading accounts:", error);
@@ -70,10 +74,10 @@ export async function getAccounts(): Promise<ActionResult<Account[]>> {
 }
 
 export async function getAccount(id: string): Promise<ActionResult<Account>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getAccountCached(user.id, id);
+    const data = await getAccountCached(user.id, id, accessToken);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading account:", error);

--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -4,7 +4,7 @@ import "server-only";
 import { cacheTag, cacheLife } from "next/cache";
 import { addDays } from "date-fns";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { toISODateString } from "@/lib/utils/date";
 import { getOccurrencesBetween } from "@zeta/shared";
 import type { RecurrenceFrequency } from "@zeta/shared";
@@ -55,13 +55,14 @@ const EMPTY: AttentionItems = {
 // ─── Cached inner function ───────────────────────────────────────────────────
 
 async function getAttentionItemsCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<AttentionItems> {
   "use cache";
   cacheTag("attention");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const today = new Date();
   const todayStr = toISODateString(today);
   const in7Days = addDays(today, 7);
@@ -161,11 +162,11 @@ async function getAttentionItemsCached(
 // ─── Public wrapper ──────────────────────────────────────────────────────────
 
 export async function getAttentionItems(): Promise<AttentionItems> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return EMPTY;
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return EMPTY;
 
   try {
-    return await getAttentionItemsCached(user.id);
+    return await getAttentionItemsCached(user.id, accessToken);
   } catch (err) {
     console.error("Error fetching attention items:", err);
     return EMPTY;

--- a/webapp/src/actions/auth.ts
+++ b/webapp/src/actions/auth.ts
@@ -10,6 +10,19 @@ export type AuthActionResult = {
   success?: boolean;
 };
 
+const AUTH_ERROR_MAP: Record<string, string> = {
+  "Invalid login credentials": "Credenciales incorrectas",
+  "Email not confirmed": "Correo no confirmado",
+  "User already registered": "Este correo ya está registrado",
+  "Password should be at least 6 characters": "La contraseña debe tener al menos 6 caracteres",
+  "Email rate limit exceeded": "Demasiados intentos. Intenta más tarde",
+  "For security purposes, you can only request this once every 60 seconds": "Por seguridad, solo puedes solicitar esto una vez cada 60 segundos",
+};
+
+function translateAuthError(message: string): string {
+  return AUTH_ERROR_MAP[message] ?? message;
+}
+
 export async function signIn(
   _prevState: AuthActionResult,
   formData: FormData
@@ -44,7 +57,7 @@ export async function signIn(
       error_code: "login_failed",
       metadata: { email: parsed.data.email },
     });
-    return { error: error.message };
+    return { error: translateAuthError(error.message) };
   }
 
   await trackProductEvent({
@@ -100,7 +113,7 @@ export async function signUp(
       error_code: "signup_failed",
       metadata: { email: parsed.data.email },
     });
-    return { error: error.message };
+    return { error: translateAuthError(error.message) };
   }
 
   if (data.user?.id) {
@@ -140,7 +153,7 @@ export async function resetPasswordRequest(
   });
 
   if (error) {
-    return { error: error.message };
+    return { error: translateAuthError(error.message) };
   }
 
   return { success: true };
@@ -165,7 +178,7 @@ export async function updatePassword(
   });
 
   if (error) {
-    return { error: error.message };
+    return { error: translateAuthError(error.message) };
   }
 
   redirect("/dashboard");

--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -2,7 +2,7 @@
 
 import { revalidateTag, cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import {
   planningPeriodSchema,
   planningEntrySchema,
@@ -34,13 +34,14 @@ const TAG = "cashflow-planner";
 // ─── Cached queries ──────────────────────────────────────────────────────────
 
 async function getPlanningPeriodsCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<PlanningPeriod[]> {
   "use cache";
   cacheTag(TAG);
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("planning_periods")
     .select("*")
@@ -54,10 +55,10 @@ async function getPlanningPeriodsCached(
 export async function getPlanningPeriods(): Promise<
   ActionResult<PlanningPeriod[]>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
 
-  const periods = await getPlanningPeriodsCached(user.id);
+  const periods = await getPlanningPeriodsCached(user.id, accessToken);
   return { success: true, data: periods };
 }
 
@@ -65,9 +66,10 @@ export async function getPlanningPeriods(): Promise<
 
 async function hydratePeriodData(
   userId: string,
-  period: PlanningPeriod
+  period: PlanningPeriod,
+  accessToken: string
 ): Promise<PeriodPlanData> {
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const periodCurrency = period.currency_code;
 
   const [{ data: rawEntries }, { data: rawAssignments }] = await Promise.all([
@@ -206,10 +208,10 @@ async function hydratePeriodData(
 export async function getActivePeriod(): Promise<
   ActionResult<PeriodPlanData | null>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data: period } = await supabase
     .from("planning_periods")
     .select("*")
@@ -223,7 +225,8 @@ export async function getActivePeriod(): Promise<
 
   const planData = await hydratePeriodData(
     user.id,
-    period as PlanningPeriod
+    period as PlanningPeriod,
+    accessToken
   );
   return { success: true, data: planData };
 }
@@ -231,10 +234,10 @@ export async function getActivePeriod(): Promise<
 export async function getPeriodPlanData(
   periodId: string
 ): Promise<ActionResult<PeriodPlanData>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data: period, error } = await supabase
     .from("planning_periods")
     .select("*")
@@ -247,7 +250,8 @@ export async function getPeriodPlanData(
 
   const planData = await hydratePeriodData(
     user.id,
-    period as PlanningPeriod
+    period as PlanningPeriod,
+    accessToken
   );
   return { success: true, data: planData };
 }

--- a/webapp/src/actions/categorize.ts
+++ b/webapp/src/actions/categorize.ts
@@ -2,9 +2,9 @@
 
 import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { extractPattern, matchDestinatario, prepareDestinatarioRules } from "@zeta/shared";
-import { getDestinatarioRulesCached } from "./destinatarios";
+import { fetchDestinatarioRules } from "./destinatarios";
 import type { ActionResult } from "@/types/actions";
 import type { TransactionWithRelations } from "@/types/domain";
 import type { UserRule } from "@zeta/shared";
@@ -12,13 +12,14 @@ import type { UserRule } from "@zeta/shared";
 // ─── Cached inner functions ───────────────────────────────────────────────────
 
 async function getUncategorizedTransactionsCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<TransactionWithRelations[]> {
   "use cache";
   cacheTag("categorize");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { data, error } = await supabase
     .from("transactions")
@@ -35,12 +36,12 @@ async function getUncategorizedTransactionsCached(
   return (data ?? []) as TransactionWithRelations[];
 }
 
-async function getUncategorizedCountCached(userId: string): Promise<number> {
+async function getUncategorizedCountCached(userId: string, accessToken: string): Promise<number> {
   "use cache";
   cacheTag("categorize");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { count, error } = await supabase
     .from("transactions")
@@ -53,12 +54,12 @@ async function getUncategorizedCountCached(userId: string): Promise<number> {
   return count ?? 0;
 }
 
-async function getUserCategoryRulesCached(userId: string): Promise<UserRule[]> {
+async function getUserCategoryRulesCached(userId: string, accessToken: string): Promise<UserRule[]> {
   "use cache";
   cacheTag("categorize");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { data, error } = await supabase
     .from("category_rules")
@@ -71,13 +72,14 @@ async function getUserCategoryRulesCached(userId: string): Promise<UserRule[]> {
 }
 
 async function getUnreviewedAutoCategorizedCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<TransactionWithRelations[]> {
   "use cache";
   cacheTag("categorize");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { data, error } = await supabase
     .from("transactions")
@@ -96,12 +98,12 @@ async function getUnreviewedAutoCategorizedCached(
   return (data ?? []) as TransactionWithRelations[];
 }
 
-async function getUnreviewedAutoCountCached(userId: string): Promise<number> {
+async function getUnreviewedAutoCountCached(userId: string, accessToken: string): Promise<number> {
   "use cache";
   cacheTag("categorize");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { count, error } = await supabase
     .from("transactions")
@@ -123,10 +125,10 @@ async function getUnreviewedAutoCountCached(userId: string): Promise<number> {
 export async function getUncategorizedTransactions(): Promise<
   TransactionWithRelations[]
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return [];
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
   try {
-    return await getUncategorizedTransactionsCached(user.id);
+    return await getUncategorizedTransactionsCached(user.id, accessToken);
   } catch (err) {
     console.error("Error fetching uncategorized transactions:", err);
     return [];
@@ -137,10 +139,10 @@ export async function getUncategorizedTransactions(): Promise<
  * Count uncategorized, non-excluded transactions (for sidebar badge).
  */
 export async function getUncategorizedCount(): Promise<number> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return 0;
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return 0;
   try {
-    return await getUncategorizedCountCached(user.id);
+    return await getUncategorizedCountCached(user.id, accessToken);
   } catch (err) {
     if (err && typeof err === "object" && "message" in err) {
       console.warn("Error counting uncategorized:", (err as { message: string }).message);
@@ -153,10 +155,10 @@ export async function getUncategorizedCount(): Promise<number> {
  * Fetch user's category rules for auto-categorization.
  */
 export async function getUserCategoryRules(): Promise<UserRule[]> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return [];
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
   try {
-    return await getUserCategoryRulesCached(user.id);
+    return await getUserCategoryRulesCached(user.id, accessToken);
   } catch (err) {
     console.error("Error fetching category rules:", err);
     return [];
@@ -170,10 +172,10 @@ export async function getUserCategoryRules(): Promise<UserRule[]> {
 export async function getUnreviewedAutoTransactions(): Promise<
   TransactionWithRelations[]
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return [];
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
   try {
-    return await getUnreviewedAutoCategorizedCached(user.id);
+    return await getUnreviewedAutoCategorizedCached(user.id, accessToken);
   } catch (err) {
     console.error("Error fetching unreviewed auto-categorized:", err);
     return [];
@@ -184,10 +186,10 @@ export async function getUnreviewedAutoTransactions(): Promise<
  * Count auto-categorized transactions not yet reviewed (for badge).
  */
 export async function getUnreviewedAutoCount(): Promise<number> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return 0;
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return 0;
   try {
-    return await getUnreviewedAutoCountCached(user.id);
+    return await getUnreviewedAutoCountCached(user.id, accessToken);
   } catch (err) {
     console.error("Error fetching unreviewed auto count:", err);
     return 0;
@@ -522,12 +524,12 @@ export async function assignDestinatario(
 export async function getDestinatarioSuggestionsForInbox(): Promise<
   Record<string, { destinatario_id: string; destinatario_name: string; category_id: string | null }>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return {};
+  const { supabase, user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return {};
 
   const [transactions, rules] = await Promise.all([
-    getUncategorizedTransactionsCached(user.id),
-    getDestinatarioRulesCached(user.id),
+    getUncategorizedTransactionsCached(user.id, accessToken),
+    fetchDestinatarioRules(supabase, user.id),
   ]);
 
   if (rules.length === 0 || transactions.length === 0) return {};

--- a/webapp/src/actions/categorize.ts
+++ b/webapp/src/actions/categorize.ts
@@ -24,7 +24,7 @@ async function getUncategorizedTransactionsCached(
   const { data, error } = await supabase
     .from("transactions")
     .select(
-      "*, account:accounts(id, name, icon, color), category:categories!category_id(id, name, name_es, icon, color)"
+      "*, account:accounts!transactions_account_id_fkey(id, name, icon, color), category:categories!transactions_category_id_fkey(id, name, name_es, icon, color)"
     )
     .eq("user_id", userId)
     .is("category_id", null)
@@ -84,7 +84,7 @@ async function getUnreviewedAutoCategorizedCached(
   const { data, error } = await supabase
     .from("transactions")
     .select(
-      "*, account:accounts(id, name, icon, color), category:categories!category_id(id, name, name_es, icon, color)"
+      "*, account:accounts!transactions_account_id_fkey(id, name, icon, color), category:categories!transactions_category_id_fkey(id, name, name_es, icon, color)"
     )
     .eq("user_id", userId)
     .not("category_id", "is", null)

--- a/webapp/src/actions/debt-countdown.ts
+++ b/webapp/src/actions/debt-countdown.ts
@@ -2,7 +2,7 @@
 
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { formatMonthParam } from "@/lib/utils/date";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -26,13 +26,14 @@ export interface DebtCountdownData {
 
 async function getDebtFreeCountdownCached(
   userId: string,
-  currency: CurrencyCode
+  currency: CurrencyCode,
+  accessToken: string
 ): Promise<DebtCountdownData | null> {
   "use cache";
   cacheTag("debt", "snapshots");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   // Fetch debt accounts + latest snapshots in parallel
   // Snapshots not filtered by account_id (unknown until accounts query resolves) — acceptable trade-off for parallelism
@@ -133,11 +134,11 @@ export async function getDebtFreeCountdown(
   currency?: CurrencyCode
 ): Promise<DebtCountdownData | null> {
   const baseCurrency = currency ?? "COP";
-  const { user } = await getAuthenticatedClient();
-  if (!user) return null;
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return null;
 
   try {
-    return await getDebtFreeCountdownCached(user.id, baseCurrency);
+    return await getDebtFreeCountdownCached(user.id, baseCurrency, accessToken);
   } catch (error) {
     console.error("Error computing debt countdown:", error);
     return null;

--- a/webapp/src/actions/debt.ts
+++ b/webapp/src/actions/debt.ts
@@ -2,7 +2,7 @@
 
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import {
   extractDebtAccounts,
   calcUtilization,
@@ -28,13 +28,14 @@ const EMPTY_DEBT_OVERVIEW: DebtOverview = {
 
 async function getDebtOverviewCached(
   userId: string,
-  currency: CurrencyCode
+  currency: CurrencyCode,
+  accessToken: string
 ): Promise<DebtOverview> {
   "use cache";
   cacheTag("debt");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const baseCurrency = currency;
 
   const { data: accounts, error } = await supabase
@@ -113,8 +114,8 @@ async function getDebtOverviewCached(
 
 export async function getDebtOverview(currency?: CurrencyCode): Promise<DebtOverview> {
   const baseCurrency = currency ?? "COP";
-  const { user } = await getAuthenticatedClient();
+  const { user, accessToken } = await getAuthenticatedClient();
 
-  if (!user) return EMPTY_DEBT_OVERVIEW;
-  return getDebtOverviewCached(user.id, baseCurrency);
+  if (!user || !accessToken) return EMPTY_DEBT_OVERVIEW;
+  return getDebtOverviewCached(user.id, baseCurrency, accessToken);
 }

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -142,10 +142,11 @@ export async function fetchDestinatarioRules(
  */
 export async function matchTransactionToDestinatario(
   userId: string,
-  text: string
+  text: string,
+  supabaseClient?: import("@supabase/supabase-js").SupabaseClient<import("@/types/database").Database>,
 ): Promise<{ destinatario_id: string; category_id: string | null } | null> {
-  const { supabase } = await getAuthenticatedClient();
-  const rules = await fetchDestinatarioRules(supabase, userId);
+  const client = supabaseClient ?? (await getAuthenticatedClient()).supabase;
+  const rules = await fetchDestinatarioRules(client, userId);
   if (rules.length === 0) return null;
 
   const prepared = prepareDestinatarioRules(rules);

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -2,7 +2,7 @@
 
 import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import {
   destinatarioSchema,
   destinatarioRuleSchema,
@@ -99,74 +99,15 @@ export async function testDestinatarioPattern(
   };
 }
 
-// ─── Cached inner functions ───────────────────────────────────────────────────
+// ─── Reads ───────────────────────────────────────────────────────────────────
+// NOTE: These use the authenticated client (not admin) because the destinatarios
+// and transactions views decrypt PII via zeta_decrypt(auth.uid()). The admin
+// client has no JWT so encrypted columns would return NULL.
 
-async function getDestinatariosCached(
-  userId: string
-): Promise<DestinatarioWithCounts[]> {
-  "use cache";
-  cacheTag("destinatarios");
-  cacheLife("zeta");
-
-  const supabase = createAdminClient();
-
-  const { data: destinatarios, error } = await supabase
-    .from("destinatarios")
-    .select("*, destinatario_rules(count), transactions(count)")
-    .eq("user_id", userId)
-    .order("name", { ascending: true });
-
-  if (error) throw error;
-
-  return (destinatarios ?? []).map((d) => {
-    const { destinatario_rules, transactions, ...rest } = d;
-    return {
-      ...rest,
-      rule_count: (destinatario_rules as unknown as { count: number }[])?.[0]
-        ?.count ?? 0,
-      transaction_count: (transactions as unknown as { count: number }[])?.[0]
-        ?.count ?? 0,
-    };
-  });
-}
-
-async function getDestinatarioCached(
-  userId: string,
-  id: string
-): Promise<DestinatarioWithRules> {
-  "use cache";
-  cacheTag("destinatarios");
-  cacheLife("zeta");
-
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("destinatarios")
-    .select("*, destinatario_rules(*)")
-    .eq("user_id", userId)
-    .eq("id", id)
-    .single();
-
-  if (error) throw error;
-  if (!data) throw new Error("Destinatario no encontrado");
-
-  const { destinatario_rules, ...rest } = data;
-
-  return {
-    ...rest,
-    rules: destinatario_rules ?? [],
-  };
-}
-
-export async function getDestinatarioRulesCached(
+export async function fetchDestinatarioRules(
+  supabase: import("@supabase/supabase-js").SupabaseClient<import("@/types/database").Database>,
   userId: string
 ): Promise<DestinatarioRule[]> {
-  "use cache";
-  cacheTag("destinatarios");
-  cacheLife("zeta");
-
-  const supabase = createAdminClient();
-
   const { data, error } = await supabase
     .from("destinatario_rules")
     .select(
@@ -177,7 +118,6 @@ export async function getDestinatarioRulesCached(
 
   if (error) throw error;
 
-  // Shape into DestinatarioRule[], filtering to only active destinatarios
   const rules: DestinatarioRule[] = [];
   for (const row of data ?? []) {
     const dest = row.destinatarios;
@@ -204,7 +144,8 @@ export async function matchTransactionToDestinatario(
   userId: string,
   text: string
 ): Promise<{ destinatario_id: string; category_id: string | null } | null> {
-  const rules = await getDestinatarioRulesCached(userId);
+  const { supabase } = await getAuthenticatedClient();
+  const rules = await fetchDestinatarioRules(supabase, userId);
   if (rules.length === 0) return null;
 
   const prepared = prepareDestinatarioRules(rules);
@@ -217,123 +158,43 @@ export async function matchTransactionToDestinatario(
   };
 }
 
-async function getUnmatchedDescriptionsCached(
-  userId: string
-): Promise<string[]> {
-  "use cache";
-  cacheTag("destinatarios");
-  cacheLife("zeta");
-
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("transactions")
-    .select("raw_description")
-    .eq("user_id", userId)
-    .is("destinatario_id", null)
-    .not("raw_description", "is", null)
-    .order("transaction_date", { ascending: false })
-    .limit(500);
-
-  if (error) throw error;
-
-  // Extract distinct raw_description values
-  const seen = new Set<string>();
-  const descriptions: string[] = [];
-  for (const row of data ?? []) {
-    if (row.raw_description && !seen.has(row.raw_description)) {
-      seen.add(row.raw_description);
-      descriptions.push(row.raw_description);
-    }
-  }
-
-  return descriptions;
-}
-
-async function getDestinatarioSuggestionsCached(
-  userId: string
-): Promise<DestinatarioSuggestionResult[]> {
-  "use cache";
-  cacheTag("destinatarios");
-  cacheLife("zeta");
-
-  const supabase = createAdminClient();
-
-  // Fetch unmatched transactions with raw descriptions
-  const { data, error } = await supabase
-    .from("transactions")
-    .select("transaction_date, raw_description, amount")
-    .eq("user_id", userId)
-    .is("destinatario_id", null)
-    .not("raw_description", "is", null)
-    .order("transaction_date", { ascending: false })
-    .limit(1000);
-
-  if (error) throw error;
-
-  // Group by cleaned description
-  const groups = new Map<
-    string,
-    {
-      count: number;
-      dates: string[];
-      samples: { date: string; rawDescription: string; amount: number }[];
-    }
-  >();
-
-  for (const row of data ?? []) {
-    if (!row.raw_description) continue;
-    const cleaned = cleanDescription(row.raw_description);
-    if (cleaned.length === 0) continue;
-
-    if (!groups.has(cleaned)) {
-      groups.set(cleaned, { count: 0, dates: [], samples: [] });
-    }
-    const group = groups.get(cleaned)!;
-    group.count++;
-    group.dates.push(row.transaction_date);
-    if (group.samples.length < 5) {
-      group.samples.push({
-        date: row.transaction_date,
-        rawDescription: row.raw_description,
-        amount: row.amount,
-      });
-    }
-  }
-
-  // Filter to groups with 3+ occurrences, sort by count desc, limit to 20
-  const suggestions: DestinatarioSuggestionResult[] = [];
-  for (const [pattern, group] of groups) {
-    if (group.count < 3) continue;
-    const sortedDates = group.dates.sort();
-    suggestions.push({
-      cleanedPattern: pattern,
-      count: group.count,
-      dateRange: {
-        from: sortedDates[0],
-        to: sortedDates[sortedDates.length - 1],
-      },
-      sampleTransactions: group.samples,
-    });
-  }
-
-  suggestions.sort((a, b) => b.count - a.count);
-
-  // Group related patterns by common prefix (e.g., "NEQUI PAGO" variants)
-  const grouped = groupSuggestionsByPrefix(suggestions);
-
-  return grouped.slice(0, 20);
-}
-
 // ─── getDestinatarios ─────────────────────────────────────────────────────────
+
+async function getDestinatariosCached(
+  userId: string,
+  accessToken: string
+): Promise<DestinatarioWithCounts[]> {
+  "use cache";
+  cacheTag("destinatarios");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data: destinatarios, error } = await supabase
+    .from("destinatarios")
+    .select("*, destinatario_rules(count), transactions(count)")
+    .eq("user_id", userId)
+    .order("name", { ascending: true });
+
+  if (error) throw error;
+  return (destinatarios ?? []).map((d) => {
+    const { destinatario_rules, transactions, ...rest } = d;
+    return {
+      ...rest,
+      rule_count: (destinatario_rules as unknown as { count: number }[])?.[0]
+        ?.count ?? 0,
+      transaction_count: (transactions as unknown as { count: number }[])?.[0]
+        ?.count ?? 0,
+    };
+  });
+}
 
 export async function getDestinatarios(): Promise<
   ActionResult<DestinatarioWithCounts[]>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getDestinatariosCached(user.id);
+    const data = await getDestinatariosCached(user.id, accessToken);
     return { success: true, data };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Error al cargar los destinatarios";
@@ -389,13 +250,36 @@ export async function getDestinatariosWithSpend(): Promise<
 
 // ─── getDestinatario ──────────────────────────────────────────────────────────
 
+async function getDestinatarioCached(
+  userId: string,
+  id: string,
+  accessToken: string
+): Promise<DestinatarioWithRules> {
+  "use cache";
+  cacheTag("destinatarios");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data, error } = await supabase
+    .from("destinatarios")
+    .select("*, destinatario_rules(*)")
+    .eq("user_id", userId)
+    .eq("id", id)
+    .single();
+
+  if (error) throw error;
+  if (!data) throw new Error("Destinatario no encontrado");
+  const { destinatario_rules, ...rest } = data;
+  return { ...rest, rules: destinatario_rules ?? [] };
+}
+
 export async function getDestinatario(
   id: string
 ): Promise<ActionResult<DestinatarioWithRules>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getDestinatarioCached(user.id, id);
+    const data = await getDestinatarioCached(user.id, id, accessToken);
     return { success: true, data };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Destinatario no encontrado";
@@ -408,10 +292,10 @@ export async function getDestinatario(
 export async function getDestinatarioRules(): Promise<
   ActionResult<DestinatarioRule[]>
 > {
-  const { user } = await getAuthenticatedClient();
+  const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
   try {
-    const data = await getDestinatarioRulesCached(user.id);
+    const data = await fetchDestinatarioRules(supabase, user.id);
     return { success: true, data };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Error al cargar las reglas";
@@ -786,15 +670,30 @@ export async function removeDestinatarioRule(
 export async function getUnmatchedDescriptions(): Promise<
   ActionResult<string[]>
 > {
-  const { user } = await getAuthenticatedClient();
+  const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
-  try {
-    const data = await getUnmatchedDescriptionsCached(user.id);
-    return { success: true, data };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Error al cargar las descripciones";
-    return { success: false, error: message };
+
+  const { data, error } = await supabase
+    .from("transactions")
+    .select("raw_description")
+    .eq("user_id", user.id)
+    .is("destinatario_id", null)
+    .not("raw_description", "is", null)
+    .order("transaction_date", { ascending: false })
+    .limit(500);
+
+  if (error) return { success: false, error: error.message };
+
+  const seen = new Set<string>();
+  const descriptions: string[] = [];
+  for (const row of data ?? []) {
+    if (row.raw_description && !seen.has(row.raw_description)) {
+      seen.add(row.raw_description);
+      descriptions.push(row.raw_description);
+    }
   }
+
+  return { success: true, data: descriptions };
 }
 
 // ─── getDestinatarioSuggestions ──────────────────────────────────────────────
@@ -847,15 +746,67 @@ function groupSuggestionsByPrefix(
 export async function getDestinatarioSuggestions(): Promise<
   ActionResult<DestinatarioSuggestionResult[]>
 > {
-  const { user } = await getAuthenticatedClient();
+  const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
-  try {
-    const data = await getDestinatarioSuggestionsCached(user.id);
-    return { success: true, data };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Error al cargar las sugerencias";
-    return { success: false, error: message };
+
+  const { data, error } = await supabase
+    .from("transactions")
+    .select("transaction_date, raw_description, amount")
+    .eq("user_id", user.id)
+    .is("destinatario_id", null)
+    .not("raw_description", "is", null)
+    .order("transaction_date", { ascending: false })
+    .limit(1000);
+
+  if (error) return { success: false, error: error.message };
+
+  const groups = new Map<
+    string,
+    {
+      count: number;
+      dates: string[];
+      samples: { date: string; rawDescription: string; amount: number }[];
+    }
+  >();
+
+  for (const row of data ?? []) {
+    if (!row.raw_description) continue;
+    const cleaned = cleanDescription(row.raw_description);
+    if (cleaned.length === 0) continue;
+
+    if (!groups.has(cleaned)) {
+      groups.set(cleaned, { count: 0, dates: [], samples: [] });
+    }
+    const group = groups.get(cleaned)!;
+    group.count++;
+    group.dates.push(row.transaction_date);
+    if (group.samples.length < 5) {
+      group.samples.push({
+        date: row.transaction_date,
+        rawDescription: row.raw_description,
+        amount: row.amount,
+      });
+    }
   }
+
+  const suggestions: DestinatarioSuggestionResult[] = [];
+  for (const [pattern, group] of groups) {
+    if (group.count < 3) continue;
+    const sortedDates = group.dates.sort();
+    suggestions.push({
+      cleanedPattern: pattern,
+      count: group.count,
+      dateRange: {
+        from: sortedDates[0],
+        to: sortedDates[sortedDates.length - 1],
+      },
+      sampleTransactions: group.samples,
+    });
+  }
+
+  suggestions.sort((a, b) => b.count - a.count);
+  const grouped = groupSuggestionsByPrefix(suggestions);
+  return { success: true, data: grouped.slice(0, 20) };
 }
 
 // ─── getDestinatarioTransactions ──────────────────────────────────────────────

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -172,7 +172,7 @@ async function getDestinatariosCached(
   const supabase = createCachedClient(accessToken);
   const { data: destinatarios, error } = await supabase
     .from("destinatarios")
-    .select("*, destinatario_rules(count), transactions(count)")
+    .select("*, destinatario_rules!destinatario_rules_destinatario_id_fkey(count), transactions!transactions_destinatario_id_fkey(count)")
     .eq("user_id", userId)
     .order("name", { ascending: true });
 
@@ -263,7 +263,7 @@ async function getDestinatarioCached(
   const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("destinatarios")
-    .select("*, destinatario_rules(*)")
+    .select("*, destinatario_rules!destinatario_rules_destinatario_id_fkey(*)")
     .eq("user_id", userId)
     .eq("id", id)
     .single();
@@ -668,22 +668,25 @@ export async function removeDestinatarioRule(
 
 // ─── getUnmatchedDescriptions ─────────────────────────────────────────────────
 
-export async function getUnmatchedDescriptions(): Promise<
-  ActionResult<string[]>
-> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+async function getUnmatchedDescriptionsCached(
+  userId: string,
+  accessToken: string,
+): Promise<string[]> {
+  "use cache";
+  cacheTag("destinatarios");
+  cacheLife("zeta");
 
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("transactions")
     .select("raw_description")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .is("destinatario_id", null)
     .not("raw_description", "is", null)
     .order("transaction_date", { ascending: false })
     .limit(500);
 
-  if (error) return { success: false, error: error.message };
+  if (error) throw error;
 
   const seen = new Set<string>();
   const descriptions: string[] = [];
@@ -693,8 +696,21 @@ export async function getUnmatchedDescriptions(): Promise<
       descriptions.push(row.raw_description);
     }
   }
+  return descriptions;
+}
 
-  return { success: true, data: descriptions };
+export async function getUnmatchedDescriptions(): Promise<
+  ActionResult<string[]>
+> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const data = await getUnmatchedDescriptionsCached(user.id, accessToken);
+    return { success: true, data };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Error al cargar las descripciones";
+    return { success: false, error: message };
+  }
 }
 
 // ─── getDestinatarioSuggestions ──────────────────────────────────────────────
@@ -744,22 +760,25 @@ function groupSuggestionsByPrefix(
   return groups;
 }
 
-export async function getDestinatarioSuggestions(): Promise<
-  ActionResult<DestinatarioSuggestionResult[]>
-> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+async function getDestinatarioSuggestionsCached(
+  userId: string,
+  accessToken: string,
+): Promise<DestinatarioSuggestionResult[]> {
+  "use cache";
+  cacheTag("destinatarios");
+  cacheLife("zeta");
 
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("transactions")
     .select("transaction_date, raw_description, amount")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .is("destinatario_id", null)
     .not("raw_description", "is", null)
     .order("transaction_date", { ascending: false })
     .limit(1000);
 
-  if (error) return { success: false, error: error.message };
+  if (error) throw error;
 
   const groups = new Map<
     string,
@@ -806,8 +825,21 @@ export async function getDestinatarioSuggestions(): Promise<
   }
 
   suggestions.sort((a, b) => b.count - a.count);
-  const grouped = groupSuggestionsByPrefix(suggestions);
-  return { success: true, data: grouped.slice(0, 20) };
+  return groupSuggestionsByPrefix(suggestions).slice(0, 20);
+}
+
+export async function getDestinatarioSuggestions(): Promise<
+  ActionResult<DestinatarioSuggestionResult[]>
+> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const data = await getDestinatarioSuggestionsCached(user.id, accessToken);
+    return { success: true, data };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Error al cargar las sugerencias";
+    return { success: false, error: message };
+  }
 }
 
 // ─── getDestinatarioTransactions ──────────────────────────────────────────────

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -91,7 +91,7 @@ async function persistParsedEmail(params: {
     const matchedAccount = candidateAccounts?.find((a) => a.id === suggestedAccountId);
     const currencyCode = matchedAccount?.currency_code ?? parsed.currency;
     const matchText = parsed.merchant ?? parsed.destination ?? parsed.raw_line ?? "";
-    const destMatch = await matchTransactionToDestinatario(userId, matchText);
+    const destMatch = await matchTransactionToDestinatario(userId, matchText, supabase);
 
     let categoryId: string | null = null;
     let destinatarioId: string | null = null;

--- a/webapp/src/actions/income.ts
+++ b/webapp/src/actions/income.ts
@@ -3,7 +3,7 @@
 import { subMonths } from "date-fns";
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { toISODateString } from "@/lib/utils/date";
 import type { CurrencyCode } from "@zeta/shared";
 
@@ -26,14 +26,15 @@ export interface IncomeEstimate {
 async function getEstimatedIncomeCached(
   userId: string,
   currency: CurrencyCode,
-  month: string | undefined
+  month: string | undefined,
+  accessToken: string
 ): Promise<IncomeEstimate | null> {
   "use cache";
   cacheTag("debt");
   cacheTag("profile");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const baseCurrency = currency;
 
   // Fetch profile salary and liquid accounts in parallel
@@ -143,7 +144,7 @@ export async function getEstimatedIncome(
   currency?: CurrencyCode,
   month?: string // "YYYY-MM" — if provided, return income for that specific month
 ): Promise<IncomeEstimate | null> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return null;
-  return getEstimatedIncomeCached(user.id, currency ?? "COP", month);
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return null;
+  return getEstimatedIncomeCached(user.id, currency ?? "COP", month, accessToken);
 }

--- a/webapp/src/actions/payment-reminders.ts
+++ b/webapp/src/actions/payment-reminders.ts
@@ -2,7 +2,7 @@
 
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { toISODateString } from "@/lib/utils/date";
 
 export interface UpcomingPayment {
@@ -19,14 +19,15 @@ export interface UpcomingPayment {
 // ─── Cached inner function ────────────────────────────────────────────────────
 
 async function getUpcomingPaymentsCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<UpcomingPayment[]> {
   "use cache";
   cacheTag("snapshots");
   cacheLife("zeta");
 
   const today = toISODateString(new Date());
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   // We want to fetch the LATEST snapshot for each account
   // But doing a group-by or distinct-on is tricky in Supabase clients without a view
@@ -86,11 +87,11 @@ async function getUpcomingPaymentsCached(
 // ─── Public wrapper ───────────────────────────────────────────────────────────
 
 export async function getUpcomingPayments(): Promise<UpcomingPayment[]> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return [];
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
 
   try {
-    return await getUpcomingPaymentsCached(user.id);
+    return await getUpcomingPaymentsCached(user.id, accessToken);
   } catch (error) {
     console.error("Error loading upcoming payments:", error);
     return [];

--- a/webapp/src/actions/profile.ts
+++ b/webapp/src/actions/profile.ts
@@ -2,19 +2,19 @@
 
 import { revalidateTag, cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import type { ActionResult } from "@/types/actions";
 import type { CurrencyCode, Profile } from "@/types/domain";
 import { z } from "zod";
 
 // ─── Cached inner functions ───────────────────────────────────────────────────
 
-async function getPreferredCurrencyCached(userId: string): Promise<CurrencyCode> {
+async function getPreferredCurrencyCached(userId: string, accessToken: string): Promise<CurrencyCode> {
   "use cache";
   cacheTag("profile");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data: profile } = await supabase
     .from("profiles")
     .select("preferred_currency")
@@ -24,12 +24,12 @@ async function getPreferredCurrencyCached(userId: string): Promise<CurrencyCode>
   return (profile?.preferred_currency ?? "COP") as CurrencyCode;
 }
 
-async function getProfileCached(userId: string): Promise<Profile> {
+async function getProfileCached(userId: string, accessToken: string): Promise<Profile> {
   "use cache";
   cacheTag("profile");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("profiles")
     .select("*")
@@ -46,9 +46,9 @@ async function getProfileCached(userId: string): Promise<Profile> {
  * Get the user's effective preferred currency, with fallback.
  */
 export async function getPreferredCurrency(): Promise<CurrencyCode> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return "COP" as CurrencyCode;
-  return getPreferredCurrencyCached(user.id);
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return "COP" as CurrencyCode;
+  return getPreferredCurrencyCached(user.id, accessToken);
 }
 
 const profileSchema = z.object({
@@ -63,10 +63,10 @@ const profileSchema = z.object({
 });
 
 export async function getProfile(): Promise<ActionResult<Profile>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getProfileCached(user.id);
+    const data = await getProfileCached(user.id, accessToken);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading profile:", error);

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -3,7 +3,7 @@
 import { revalidateTag, cacheTag, cacheLife } from "next/cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { recurringTemplateSchema } from "@/lib/validators/recurring-template";
 import { computeIdempotencyKey } from "@/lib/utils/idempotency";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
@@ -50,13 +50,14 @@ async function computeRecurringGroupUuid(templateId: string, occurrenceDate: str
 // ─── Cached inner functions ───────────────────────────────────────────────────
 
 async function getRecurringTemplatesCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<RecurringTemplateWithRelations[]> {
   "use cache";
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("recurring_transaction_templates")
     .select(TEMPLATE_SELECT)
@@ -70,13 +71,14 @@ async function getRecurringTemplatesCached(
 
 async function getRecurringTemplateCached(
   userId: string,
-  id: string
+  id: string,
+  accessToken: string
 ): Promise<RecurringTemplateWithRelations> {
   "use cache";
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("recurring_transaction_templates")
     .select(TEMPLATE_SELECT)
@@ -90,13 +92,14 @@ async function getRecurringTemplateCached(
 
 async function getUpcomingRecurrencesCached(
   userId: string,
-  days: number
+  days: number,
+  accessToken: string
 ): Promise<UpcomingRecurrence[]> {
   "use cache";
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data: templates } = await supabase
     .from("recurring_transaction_templates")
     .select(TEMPLATE_SELECT)
@@ -129,7 +132,7 @@ async function getUpcomingRecurrencesCached(
   return upcoming;
 }
 
-async function getRecurringSummaryCached(userId: string): Promise<{
+async function getRecurringSummaryCached(userId: string, accessToken: string): Promise<{
   totalMonthlyExpenses: number;
   totalMonthlyIncome: number;
   activeCount: number;
@@ -138,7 +141,7 @@ async function getRecurringSummaryCached(userId: string): Promise<{
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data: templates } = await supabase
     .from("recurring_transaction_templates")
     .select("amount, direction, frequency, accounts!recurring_transaction_templates_account_id_fkey(account_type)")
@@ -174,10 +177,10 @@ async function getRecurringSummaryCached(userId: string): Promise<{
 export async function getRecurringTemplates(): Promise<
   ActionResult<RecurringTemplateWithRelations[]>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getRecurringTemplatesCached(user.id);
+    const data = await getRecurringTemplatesCached(user.id, accessToken);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading recurring templates:", error);
@@ -188,10 +191,10 @@ export async function getRecurringTemplates(): Promise<
 export async function getRecurringTemplate(
   id: string
 ): Promise<ActionResult<RecurringTemplateWithRelations>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getRecurringTemplateCached(user.id, id);
+    const data = await getRecurringTemplateCached(user.id, id, accessToken);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading recurring template:", error);
@@ -889,9 +892,9 @@ export async function getPaidOccurrenceKeys(
 export async function getUpcomingRecurrences(
   days: number = 30
 ): Promise<UpcomingRecurrence[]> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return [];
-  return getUpcomingRecurrencesCached(user.id, days);
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
+  return getUpcomingRecurrencesCached(user.id, days, accessToken);
 }
 
 /**
@@ -902,9 +905,9 @@ export async function getRecurringSummary(): Promise<{
   totalMonthlyIncome: number;
   activeCount: number;
 }> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
-  return getRecurringSummaryCached(user.id);
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
+  return getRecurringSummaryCached(user.id, accessToken);
 }
 
 function toMonthlyAmount(

--- a/webapp/src/actions/scenarios.ts
+++ b/webapp/src/actions/scenarios.ts
@@ -2,19 +2,19 @@
 
 import { revalidateTag, cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { saveScenarioSchema, type SaveScenarioInput } from "@/lib/validators/scenario";
 import type { ActionResult } from "@/types/actions";
 import type { Database } from "@/types/database";
 
 type DebtScenario = Database["public"]["Tables"]["debt_scenarios"]["Row"];
 
-async function getScenariosCached(userId: string): Promise<DebtScenario[]> {
+async function getScenariosCached(userId: string, accessToken: string): Promise<DebtScenario[]> {
   "use cache";
   cacheTag("debt");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("debt_scenarios")
     .select("*")
@@ -27,11 +27,11 @@ async function getScenariosCached(userId: string): Promise<DebtScenario[]> {
 }
 
 export async function getScenarios(): Promise<DebtScenario[]> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return [];
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
 
   try {
-    return await getScenariosCached(user.id);
+    return await getScenariosCached(user.id, accessToken);
   } catch (error) {
     console.error("Failed to fetch scenarios:", error);
     return [];

--- a/webapp/src/actions/statement-snapshots.ts
+++ b/webapp/src/actions/statement-snapshots.ts
@@ -2,7 +2,7 @@
 
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import type { ActionResult } from "@/types/actions";
 import type { Tables } from "@/types/database";
 
@@ -11,13 +11,14 @@ export type StatementSnapshot = Tables<"statement_snapshots">;
 // ─── Cached inner functions ───────────────────────────────────────────────────
 
 async function getLatestSnapshotDatesCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<Record<string, string>> {
   "use cache";
   cacheTag("snapshots");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { data, error } = await supabase
     .from("statement_snapshots")
@@ -40,13 +41,14 @@ async function getLatestSnapshotDatesCached(
 
 async function getStatementSnapshotsCached(
   userId: string,
-  accountId: string
+  accountId: string,
+  accessToken: string
 ): Promise<StatementSnapshot[]> {
   "use cache";
   cacheTag("snapshots");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { data, error } = await supabase
     .from("statement_snapshots")
@@ -68,10 +70,10 @@ async function getStatementSnapshotsCached(
 export async function getLatestSnapshotDates(): Promise<
   Record<string, string>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return {};
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return {};
   try {
-    return await getLatestSnapshotDatesCached(user.id);
+    return await getLatestSnapshotDatesCached(user.id, accessToken);
   } catch (error) {
     console.error("Error loading snapshot dates:", error);
     return {};
@@ -81,10 +83,10 @@ export async function getLatestSnapshotDates(): Promise<
 export async function getStatementSnapshots(
   accountId: string
 ): Promise<ActionResult<StatementSnapshot[]>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getStatementSnapshotsCached(user.id, accountId);
+    const data = await getStatementSnapshotsCached(user.id, accountId, accessToken);
     return { success: true, data };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Error al cargar los extractos";

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { autoCategorize, computeIdempotencyKey } from "@zeta/shared";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createDestinatario, matchTransactionToDestinatario } from "@/actions/destinatarios";
@@ -165,6 +166,7 @@ async function adjustBalancesForTransactionChanges(params: {
 }
 
 function revalidateFinancialViews() {
+  revalidateTag("transactions", "zeta");
   revalidateTag("accounts", "zeta");
   revalidateTag("dashboard:accounts", "zeta");
   revalidateTag("dashboard:charts", "zeta");
@@ -422,35 +424,40 @@ async function persistTransaction(
   return { success: true, data };
 }
 
-export async function getTransactions(
-  filters: Record<string, string | undefined>
+// ─── Cached transaction listing ──────────────────────────────────────────────
+
+async function getTransactionsCached(
+  userId: string,
+  accessToken: string,
+  page: number,
+  pageSize: number,
+  dateFrom: string | undefined,
+  dateTo: string | undefined,
+  accountId: string | undefined,
+  categoryId: string | undefined,
+  direction: string | undefined,
+  search: string | undefined,
+  amountMin: number | undefined,
+  amountMax: number | undefined,
+  source: string | undefined,
+  showExcluded: boolean,
+  tagId: string | undefined,
 ): Promise<PaginatedResult<TransactionWithAccount>> {
-  const { supabase, user } = await getAuthenticatedClient();
+  "use cache";
+  cacheTag("transactions");
+  cacheLife("zeta");
 
-  if (!user) return { data: [], count: 0, page: 1, pageSize: 20, totalPages: 0 };
-
-  const parsed = transactionFiltersSchema.safeParse(filters);
-  const params = parsed.success
-    ? parsed.data
-    : { page: 1, pageSize: 20, showExcluded: false as const };
-
-  const { page, pageSize } = params;
+  const supabase = createCachedClient(accessToken);
   const from = (page - 1) * pageSize;
   const to = from + pageSize - 1;
 
-  if (params.month && !params.dateFrom && !params.dateTo) {
-    const target = parseMonth(params.month);
-    params.dateFrom = monthStartStr(target);
-    params.dateTo = monthEndStr(target);
-  }
-
   // Tag filter: pre-fetch matching transaction IDs
   let taggedTransactionIds: string[] | null = null;
-  if (params.tagId) {
+  if (tagId) {
     const { data: taggedIds } = await supabase
       .from("transaction_tags")
       .select("transaction_id")
-      .eq("tag_id", params.tagId);
+      .eq("tag_id", tagId);
 
     if (taggedIds && taggedIds.length > 0) {
       taggedTransactionIds = taggedIds.map((r) => r.transaction_id);
@@ -459,41 +466,36 @@ export async function getTransactions(
     }
   }
 
-  const buildQuery = () => {
-    let query = supabase
-      .from("transactions")
-      .select("*, account:accounts(id, name, icon, color)", { count: "exact" })
-      .eq("user_id", user.id)
-      .order("transaction_date", { ascending: false })
-      .order("created_at", { ascending: false })
-      .range(from, to);
+  let query = supabase
+    .from("transactions")
+    .select("*, account:accounts!transactions_account_id_fkey(id, name, icon, color), category:categories!transactions_category_id_fkey(id, name, name_es, icon, color), destinatario:destinatarios!transactions_destinatario_id_fkey(id, name)", { count: "exact" })
+    .eq("user_id", userId)
+    .order("transaction_date", { ascending: false })
+    .order("created_at", { ascending: false })
+    .range(from, to);
 
-    if (params.accountId) query = query.eq("account_id", params.accountId);
-    if (params.categoryId) query = query.eq("category_id", params.categoryId);
-    if (params.direction) query = query.eq("direction", params.direction);
-    if (params.dateFrom) query = query.gte("transaction_date", params.dateFrom);
-    if (params.dateTo) query = query.lte("transaction_date", params.dateTo);
-    if (params.search) {
-      // Escape PostgREST filter special characters to prevent filter injection
-      const sanitized = params.search
-        .slice(0, 200)
-        .replace(/[\\%_]/g, (c) => `\\${c}`)
-        .replace(/[.,()]/g, "");
-      query = query.or(
-        `merchant_name.ilike.%${sanitized}%,raw_description.ilike.%${sanitized}%,clean_description.ilike.%${sanitized}%`
-      );
-    }
-    if (params.amountMin !== undefined) query = query.gte("amount", params.amountMin);
-    if (params.amountMax !== undefined) query = query.lte("amount", params.amountMax);
-    if (params.source) query = query.eq("capture_method", params.source);
-    if (!params.showExcluded) query = query.eq("is_excluded", false);
-    if (taggedTransactionIds) query = query.in("id", taggedTransactionIds);
+  if (accountId) query = query.eq("account_id", accountId);
+  if (categoryId) query = query.eq("category_id", categoryId);
+  if (direction) query = query.eq("direction", direction as "INFLOW" | "OUTFLOW");
+  if (dateFrom) query = query.gte("transaction_date", dateFrom);
+  if (dateTo) query = query.lte("transaction_date", dateTo);
+  if (search) {
+    const sanitized = search
+      .slice(0, 200)
+      .replace(/[\\%_]/g, (c) => `\\${c}`)
+      .replace(/[.,()]/g, "");
+    query = query.or(
+      `merchant_name.ilike.%${sanitized}%,raw_description.ilike.%${sanitized}%,clean_description.ilike.%${sanitized}%`
+    );
+  }
+  if (amountMin !== undefined) query = query.gte("amount", amountMin);
+  if (amountMax !== undefined) query = query.lte("amount", amountMax);
+  if (source) query = query.eq("capture_method", source as Database["public"]["Enums"]["transaction_capture_method"]);
+  if (!showExcluded) query = query.eq("is_excluded", false);
+  if (taggedTransactionIds) query = query.in("id", taggedTransactionIds);
 
-    return query;
-  };
-
-  const { data, error, count } = await buildQuery().is("reconciled_into_transaction_id", null);
-  if (error) return { data: [], count: 0, page, pageSize, totalPages: 0 };
+  const { data, error, count } = await query.is("reconciled_into_transaction_id", null);
+  if (error) throw error;
 
   return {
     data: (data ?? []) as unknown as TransactionWithAccount[],
@@ -504,21 +506,71 @@ export async function getTransactions(
   };
 }
 
-export async function getTransaction(id: string): Promise<ActionResult<Transaction>> {
-  const { supabase, user } = await getAuthenticatedClient();
+export async function getTransactions(
+  filters: Record<string, string | undefined>
+): Promise<PaginatedResult<TransactionWithAccount>> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { data: [], count: 0, page: 1, pageSize: 20, totalPages: 0 };
 
-  if (!user) return { success: false, error: "No autenticado" };
+  const parsed = transactionFiltersSchema.safeParse(filters);
+  const params = parsed.success
+    ? parsed.data
+    : { page: 1, pageSize: 20, showExcluded: false as const };
 
+  if (params.month && !params.dateFrom && !params.dateTo) {
+    const target = parseMonth(params.month);
+    params.dateFrom = monthStartStr(target);
+    params.dateTo = monthEndStr(target);
+  }
+
+  try {
+    return await getTransactionsCached(
+      user.id, accessToken,
+      params.page, params.pageSize,
+      params.dateFrom, params.dateTo,
+      params.accountId, params.categoryId,
+      params.direction, params.search,
+      params.amountMin, params.amountMax,
+      params.source, params.showExcluded ?? false,
+      params.tagId,
+    );
+  } catch {
+    return { data: [], count: 0, page: params.page, pageSize: params.pageSize, totalPages: 0 };
+  }
+}
+
+async function getTransactionCached(
+  userId: string,
+  id: string,
+  accessToken: string,
+): Promise<Transaction> {
+  "use cache";
+  cacheTag("transactions");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("transactions")
     .select("*")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .eq("id", id)
     .is("reconciled_into_transaction_id", null)
     .single();
 
-  if (error) return { success: false, error: error.message };
-  return { success: true, data };
+  if (error) throw error;
+  return data;
+}
+
+export async function getTransaction(id: string): Promise<ActionResult<Transaction>> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const data = await getTransactionCached(user.id, id, accessToken);
+    return { success: true, data };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Error al cargar la transacción";
+    return { success: false, error: message };
+  }
 }
 
 export async function createTransaction(

--- a/webapp/src/app/(dashboard)/categorizar/page.tsx
+++ b/webapp/src/app/(dashboard)/categorizar/page.tsx
@@ -22,6 +22,11 @@ const CategoryInbox = dynamic(
   { loading: () => <div className="h-64 rounded-xl bg-muted animate-pulse" /> }
 );
 
+const MobileCategoryInbox = dynamic(
+  () => import("@/components/categorize/mobile-category-inbox").then((m) => ({ default: m.MobileCategoryInbox })),
+  { loading: () => <div className="h-64 rounded-xl bg-muted animate-pulse lg:hidden" /> }
+);
+
 export default async function CategorizarPage() {
   await connection();
   const [transactions, unreviewedAutoTransactions, categoriesResult, userRules, tagGroupsResult, destinatarioSuggestions] = await Promise.all([
@@ -191,14 +196,26 @@ export default async function CategorizarPage() {
         </div>
       </div>
 
-      <CategoryInbox
+      {/* Mobile */}
+      <MobileCategoryInbox
         initialTransactions={transactions}
         autoCategorizedTransactions={unreviewedAutoTransactions}
         categories={categories}
         userRules={userRules}
-        tagGroups={tagGroups}
         destinatarioSuggestions={destinatarioSuggestions}
       />
+
+      {/* Desktop */}
+      <div className="hidden lg:block">
+        <CategoryInbox
+          initialTransactions={transactions}
+          autoCategorizedTransactions={unreviewedAutoTransactions}
+          categories={categories}
+          userRules={userRules}
+          tagGroups={tagGroups}
+          destinatarioSuggestions={destinatarioSuggestions}
+        />
+      </div>
     </div>
   );
 }

--- a/webapp/src/app/(dashboard)/categorizar/page.tsx
+++ b/webapp/src/app/(dashboard)/categorizar/page.tsx
@@ -197,13 +197,15 @@ export default async function CategorizarPage() {
       </div>
 
       {/* Mobile */}
-      <MobileCategoryInbox
-        initialTransactions={transactions}
-        autoCategorizedTransactions={unreviewedAutoTransactions}
-        categories={categories}
-        userRules={userRules}
-        destinatarioSuggestions={destinatarioSuggestions}
-      />
+      <div className="lg:hidden">
+        <MobileCategoryInbox
+          initialTransactions={transactions}
+          autoCategorizedTransactions={unreviewedAutoTransactions}
+          categories={categories}
+          userRules={userRules}
+          destinatarioSuggestions={destinatarioSuggestions}
+        />
+      </div>
 
       {/* Desktop */}
       <div className="hidden lg:block">

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -17,6 +17,7 @@ import { PlanTabRecurrentes } from "@/components/plan/tabs/plan-tab-recurrentes"
 import { PlanTabDeseos } from "@/components/plan/tabs/plan-tab-deseos";
 import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { PlanRoot } from "@/components/mobile/v2/plan/plan-root";
+import { PlanMobileNavList } from "@/components/plan/plan-mobile-nav-list";
 import { getCategoriesWithBudgetData } from "@/actions/categories";
 import { getPreferredCurrency } from "@/actions/profile";
 import { getActivePeriod } from "@/actions/cashflow-planner";
@@ -171,7 +172,7 @@ export default async function PlanPage({
               </Suspense>
             )}
           </div>
-          <PlanTabNav activeTab={activeTab} />
+          {/* NOTE: PlanTabNav removed from here — hidden on mobile, replaced by bottom nav list */}
         </div>
 
         {/* Mobile tab content */}
@@ -183,6 +184,9 @@ export default async function PlanPage({
             </Suspense>
           </div>
         )}
+
+        {/* Bottom navigation to other Plan tabs */}
+        <PlanMobileNavList activeTab={activeTab} />
       </div>
 
       {/* ── Desktop ── */}

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -17,8 +17,6 @@ import { PlanTabRecurrentes } from "@/components/plan/tabs/plan-tab-recurrentes"
 import { PlanTabDeseos } from "@/components/plan/tabs/plan-tab-deseos";
 import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { PlanRoot } from "@/components/mobile/v2/plan/plan-root";
-import { PlanMobileNavList } from "@/components/plan/plan-mobile-nav-list";
-import { getCategoriesWithBudgetData } from "@/actions/categories";
 import { getPreferredCurrency } from "@/actions/profile";
 import { getActivePeriod } from "@/actions/cashflow-planner";
 import { getPlanTimelineData } from "@/actions/plan-timeline";
@@ -53,14 +51,13 @@ export default async function PlanPage({
   const isResumen = activeTab === "resumen";
 
   // Only fetch heavy plan data for resumen tab
-  const [planData, rhythmResult, categoryBudgetResult, timelineData] = isResumen
+  const [planData, rhythmResult, timelineData] = isResumen
     ? await Promise.all([
         getPlanPageData(month, currency),
         getCategoriesByRhythm(month, currency),
-        getCategoriesWithBudgetData(month, currency),
         getPlanTimelineData(month, currency),
       ])
-    : [null, null, null, null];
+    : [null, null, null];
 
   const activePeriod = activePeriodResult.success ? activePeriodResult.data : null;
   const periodoSummary = activePeriod
@@ -76,8 +73,6 @@ export default async function PlanPage({
   // ── Mobile: show PlanRoot for resumen, tab content for others ──
   const mobileContent = (() => {
     if (isResumen && planData) {
-      const allocationData = planData.budget.allocation;
-      const categoryBudgetData = categoryBudgetResult?.success ? categoryBudgetResult.data : [];
       const now = new Date();
       const planDayOfMonth = now.getDate();
       const planDaysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
@@ -85,13 +80,13 @@ export default async function PlanPage({
       return (
         <PlanRoot
           planData={planData}
-          allocationData={allocationData}
           timelineData={timelineData!}
           currency={planData.currency}
           monthLabel={monthLabel}
           dayOfMonth={planDayOfMonth}
           daysInMonth={planDaysInMonth}
-          categories={categoryBudgetData}
+          periodoSummary={periodoSummary}
+          wishlistCount={wishlistSummary?.totalCount ?? 0}
         />
       );
     }
@@ -101,7 +96,6 @@ export default async function PlanPage({
   // ── Desktop: resumen tab shows the full plan layout ──
   const desktopResumenContent = (() => {
     if (!isResumen || !planData) return null;
-    const allocationData = planData.budget.allocation;
     const rhythmData = rhythmResult?.success ? rhythmResult.data : [];
 
     return (
@@ -159,23 +153,7 @@ export default async function PlanPage({
     <div className={PAGE_STACK_CLASS}>
       {/* ── Mobile ── */}
       <div className="lg:hidden">
-        {/* Tab navigation — always visible on mobile */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">Plan</p>
-              <h1 className="text-xl font-semibold">{activeTab === "resumen" ? "Tu plan" : ""}</h1>
-            </div>
-            {isResumen && (
-              <Suspense fallback={<span className="text-xs capitalize text-muted-foreground">{monthLabel}</span>}>
-                <MonthSelector />
-              </Suspense>
-            )}
-          </div>
-          {/* NOTE: PlanTabNav removed from here — hidden on mobile, replaced by bottom nav list */}
-        </div>
-
-        {/* Mobile tab content */}
+        {/* Mobile tab content — PlanRoot handles its own header + month selector */}
         {mobileContent}
         {tabContent && (
           <div className="mt-4">
@@ -184,9 +162,6 @@ export default async function PlanPage({
             </Suspense>
           </div>
         )}
-
-        {/* Bottom navigation to other Plan tabs */}
-        <PlanMobileNavList activeTab={activeTab} />
       </div>
 
       {/* ── Desktop ── */}

--- a/webapp/src/app/(dashboard)/settings/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from "next/server";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Activity, ArrowRight, Bug, Tag, UserRound } from "lucide-react";
+import { Activity, ArrowRight, Bug, Mail, Tag, UserRound } from "lucide-react";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
@@ -18,6 +18,7 @@ import { EmailIngestCard } from "@/components/settings/email-ingest-card";
 import { UnrecognizedEmailsCard } from "@/components/settings/unrecognized-emails-card";
 import { BuildInfo } from "@/components/settings/build-info";
 import { ReviewModeToggle } from "@/components/settings/review-mode-toggle";
+import { SettingsMobileAccordion } from "@/components/settings/settings-mobile-accordion";
 import { getCaptureTokens } from "@/actions/capture-tokens";
 import { getEmailIngestAddress, getUnrecognizedEmails } from "@/actions/email-ingest";
 import { getTagGroups } from "@/actions/tags";
@@ -55,6 +56,53 @@ export default async function SettingsPage() {
   const unrecognizedEmails = unrecognizedResult.success ? unrecognizedResult.data : [];
   const memberSince = new Date(profile.created_at).toLocaleDateString("es-CO");
 
+  const accordionSections = [
+    {
+      id: "perfil",
+      title: "Perfil",
+      icon: <UserRound className="size-4 text-z-brass" />,
+      children: <ProfileForm profile={profile} />,
+    },
+    {
+      id: "integraciones",
+      title: "Integraciones",
+      icon: <Activity className="size-4 text-z-brass" />,
+      children: (
+        <IntegrationsCard accounts={(accounts ?? []) as Account[]} tokens={tokens} />
+      ),
+    },
+    {
+      id: "email",
+      title: "Email",
+      icon: <Mail className="size-4 text-z-brass" />,
+      children: (
+        <div className="space-y-4">
+          <EmailIngestCard
+            accounts={(accounts ?? []) as Account[]}
+            initialAddress={emailIngestAddress}
+          />
+          <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
+        </div>
+      ),
+    },
+    {
+      id: "etiquetas",
+      title: "Etiquetas",
+      icon: <Tag className="size-4 text-z-brass" />,
+      children: tagGroupsResult.success ? (
+        <TagManager tagGroups={tagGroupsResult.data} />
+      ) : (
+        <p className="text-sm text-destructive">{tagGroupsResult.error}</p>
+      ),
+    },
+    {
+      id: "bug",
+      title: "Reportar bug",
+      icon: <Bug className="size-4 text-z-brass" />,
+      children: <BugReportForm />,
+    },
+  ];
+
   return (
     <div className="max-w-4xl space-y-6 lg:space-y-8">
       <MobileHeader variant="sub" title="Ajustes" backHref="/gestionar" />
@@ -84,83 +132,92 @@ export default async function SettingsPage() {
         <AttentionCard signals={[]} />
       </div>
 
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-              <UserRound className="size-4 text-z-brass" />
+      {/* Mobile: accordion */}
+      <div className="lg:hidden">
+        <SettingsMobileAccordion sections={accordionSections} />
+      </div>
+
+      {/* Desktop: flat card list */}
+      <div className="hidden lg:block space-y-6">
+        <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+                <UserRound className="size-4 text-z-brass" />
+              </div>
+              <CardTitle>Perfil</CardTitle>
             </div>
-            <CardTitle>Perfil</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <ProfileForm profile={profile} />
-        </CardContent>
-      </Card>
+          </CardHeader>
+          <CardContent>
+            <ProfileForm profile={profile} />
+          </CardContent>
+        </Card>
 
-      <IntegrationsCard accounts={(accounts ?? []) as Account[]} tokens={tokens} />
+        <IntegrationsCard accounts={(accounts ?? []) as Account[]} tokens={tokens} />
 
-      <EmailIngestCard
-        accounts={(accounts ?? []) as Account[]}
-        initialAddress={emailIngestAddress}
-      />
+        <EmailIngestCard
+          accounts={(accounts ?? []) as Account[]}
+          initialAddress={emailIngestAddress}
+        />
 
-      <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
+        <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
 
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-              <Activity className="size-4 text-z-brass" />
+        <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+                <Tag className="size-4 text-z-brass" />
+              </div>
+              <CardTitle>Etiquetas</CardTitle>
             </div>
-            <CardTitle>Actividad de uso</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <Button asChild className={cn(BRASS_BUTTON_CLASS, "w-full")}>
-            <Link href="/settings/analytics">
-              Abrir actividad de uso
-              <ArrowRight className="size-4" />
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
+            <p className="text-sm text-muted-foreground">
+              Organiza etiquetas en grupos para anotar transacciones, destinatarios y categorías.
+            </p>
+          </CardHeader>
+          <CardContent>
+            {tagGroupsResult.success ? (
+              <TagManager tagGroups={tagGroupsResult.data} />
+            ) : (
+              <p className="text-sm text-destructive">{tagGroupsResult.error}</p>
+            )}
+          </CardContent>
+        </Card>
 
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-              <Tag className="size-4 text-z-brass" />
+        <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+                <Bug className="size-4 text-z-brass" />
+              </div>
+              <CardTitle>Reportar bug</CardTitle>
             </div>
-            <CardTitle>Etiquetas</CardTitle>
-          </div>
-          <p className="text-sm text-muted-foreground">
-            Organiza etiquetas en grupos para anotar transacciones, destinatarios y categorías.
-          </p>
-        </CardHeader>
-        <CardContent>
-          {tagGroupsResult.success ? (
-            <TagManager tagGroups={tagGroupsResult.data} />
-          ) : (
-            <p className="text-sm text-destructive">{tagGroupsResult.error}</p>
-          )}
-        </CardContent>
-      </Card>
+          </CardHeader>
+          <CardContent>
+            <BugReportForm />
+          </CardContent>
+        </Card>
 
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-              <Bug className="size-4 text-z-brass" />
+        <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+                <Activity className="size-4 text-z-brass" />
+              </div>
+              <CardTitle>Actividad de uso</CardTitle>
             </div>
-            <CardTitle>Reportar bug</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <BugReportForm />
-        </CardContent>
-      </Card>
+          </CardHeader>
+          <CardContent>
+            <Button asChild className={cn(BRASS_BUTTON_CLASS, "w-full")}>
+              <Link href="/settings/analytics">
+                Abrir actividad de uso
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
 
+      {/* Shared bottom items — always visible */}
       <BuildInfo />
 
       <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">

--- a/webapp/src/app/(dashboard)/transactions/[id]/loading.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TransactionDetailLoading() {
+  return (
+    <div className="max-w-4xl space-y-6 lg:space-y-8">
+      {/* Mobile header */}
+      <div className="flex items-center gap-3 lg:hidden">
+        <Skeleton className="h-8 w-8 rounded-lg" />
+        <Skeleton className="h-5 w-24" />
+      </div>
+
+      {/* Hero */}
+      <div className="space-y-4 rounded-2xl border border-white/6 bg-z-surface-2/70 p-6">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-6 w-40 rounded-full" />
+          <Skeleton className="h-6 w-16 rounded-full" />
+          <Skeleton className="h-6 w-20 rounded-full" />
+        </div>
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-48" />
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+        </div>
+      </div>
+
+      {/* Content grid */}
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <Skeleton className="h-48 rounded-xl" />
+        <div className="space-y-6">
+          <Skeleton className="h-40 rounded-xl" />
+          <Skeleton className="h-40 rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { connection } from "next/server";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -18,6 +19,106 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { PageHero } from "@/components/ui/page-hero";
 import { StatCard } from "@/components/ui/stat-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Transaction } from "@/types/domain";
+
+// ─── Deferred: edit button (needs accounts + categories) ─────────────────────
+
+async function TransactionEditAction({ transaction }: { transaction: Transaction }) {
+  const [accountsResult, categoriesResult] = await Promise.all([
+    getAccounts(),
+    getCategories(),
+  ]);
+
+  return (
+    <TransactionFormDialog
+      transaction={transaction}
+      accounts={accountsResult.success ? accountsResult.data : []}
+      categories={categoriesResult.success ? categoriesResult.data : []}
+    />
+  );
+}
+
+// ─── Deferred: sidebar (needs destinatarios, categories, tags) ───────────────
+
+async function TransactionSidebar({ transaction }: { transaction: Transaction }) {
+  const [destinatariosResult, categoriesResult, tagGroupsResult, transactionTags] = await Promise.all([
+    getDestinatarios(),
+    getCategories(),
+    getTagGroups(),
+    getTagsForEntity("transaction", transaction.id),
+  ]);
+
+  const destinatarios = destinatariosResult.success ? destinatariosResult.data : [];
+  const categories = categoriesResult.success ? categoriesResult.data : [];
+  const tagGroups = tagGroupsResult.success ? tagGroupsResult.data : [];
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+              <ReceiptText className="size-4 text-z-brass" />
+            </div>
+            <div className="space-y-1">
+              <CardTitle>Destinatario</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Ajusta la asociación comercial para mejorar contexto y futuras reglas.
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <DestinatarioPicker
+            transactionId={transaction.id}
+            currentDestinatarioId={transaction.destinatario_id}
+            destinatarios={destinatarios}
+            rawDescription={transaction.raw_description}
+            categories={categories}
+          />
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+              <Tags className="size-4 text-z-brass" />
+            </div>
+            <div className="space-y-1">
+              <CardTitle>Etiquetas</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Agrega contexto libre: viajes, personas, proyectos.
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <TagPicker
+            entityType="transaction"
+            entityId={transaction.id}
+            currentTags={transactionTags}
+            allTagGroups={tagGroups}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Skeletons ───────────────────────────────────────────────────────────────
+
+function SidebarSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-40 rounded-xl" />
+    </div>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
 
 export default async function TransactionDetailPage({
   params,
@@ -26,25 +127,12 @@ export default async function TransactionDetailPage({
 }) {
   await connection();
   const { id } = await params;
-  const [txResult, accountsResult, categoriesResult, destinatariosResult, tagGroupsResult, transactionTags] =
-    await Promise.all([
-      getTransaction(id),
-      getAccounts(),
-      getCategories(),
-      getDestinatarios(),
-      getTagGroups(),
-      getTagsForEntity("transaction", id),
-    ]);
 
+  // Only fetch the transaction — everything else streams in via Suspense
+  const txResult = await getTransaction(id);
   if (!txResult.success) notFound();
 
   const tx = txResult.data;
-  const accounts = accountsResult.success ? accountsResult.data : [];
-  const categories = categoriesResult.success ? categoriesResult.data : [];
-  const destinatarios = destinatariosResult.success
-    ? destinatariosResult.data
-    : [];
-  const tagGroups = tagGroupsResult.success ? tagGroupsResult.data : [];
   const isInflow = tx.direction === "INFLOW";
   const txStatus =
     tx.status === "POSTED"
@@ -76,11 +164,9 @@ export default async function TransactionDetailPage({
         description={`${formatDate(tx.transaction_date, "dd MMMM yyyy")} \u00b7 ${tx.provider}`}
         actions={
           <>
-            <TransactionFormDialog
-              transaction={tx}
-              accounts={accounts}
-              categories={categories}
-            />
+            <Suspense fallback={<Skeleton className="h-9 w-20 rounded-md" />}>
+              <TransactionEditAction transaction={tx} />
+            </Suspense>
             <DeleteTransactionButton transactionId={tx.id} />
           </>
         }
@@ -160,56 +246,9 @@ export default async function TransactionDetailPage({
           </CardContent>
         </Card>
 
-        <div className="space-y-6">
-          <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-                  <ReceiptText className="size-4 text-z-brass" />
-                </div>
-                <div className="space-y-1">
-                  <CardTitle>Destinatario</CardTitle>
-                  <p className="text-sm text-muted-foreground">
-                    Ajusta la asociación comercial para mejorar contexto y futuras reglas.
-                  </p>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <DestinatarioPicker
-                transactionId={tx.id}
-                currentDestinatarioId={tx.destinatario_id}
-                destinatarios={destinatarios}
-                rawDescription={tx.raw_description}
-                categories={categories}
-              />
-            </CardContent>
-          </Card>
-
-          <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-                  <Tags className="size-4 text-z-brass" />
-                </div>
-                <div className="space-y-1">
-                  <CardTitle>Etiquetas</CardTitle>
-                  <p className="text-sm text-muted-foreground">
-                    Agrega contexto libre: viajes, personas, proyectos.
-                  </p>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <TagPicker
-                entityType="transaction"
-                entityId={tx.id}
-                currentTags={transactionTags}
-                allTagGroups={tagGroups}
-              />
-            </CardContent>
-          </Card>
-        </div>
+        <Suspense fallback={<SidebarSkeleton />}>
+          <TransactionSidebar transaction={tx} />
+        </Suspense>
       </div>
     </div>
   );

--- a/webapp/src/app/(dashboard)/transactions/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/page.tsx
@@ -92,7 +92,7 @@ export default async function TransactionsPage({
 
   return (
     <div className={PAGE_STACK_CLASS}>
-      <div className="lg:hidden">
+      <div className="pb-20 lg:hidden lg:pb-0">
         <MovimientosRoot
           transactions={transactionsResult.data}
           outflowCategories={outflowCategories}

--- a/webapp/src/app/api/_shared/capture-auth.ts
+++ b/webapp/src/app/api/_shared/capture-auth.ts
@@ -1,5 +1,10 @@
 import type { NextRequest } from "next/server";
+import { createHash } from "crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
 
 export type CaptureAuth = {
   userId: string;
@@ -22,18 +27,20 @@ export async function authenticateCaptureToken(
 
   const admin = createAdminClient();
 
+  // Query _enc table directly — this runs in unauthenticated context (Bearer auth),
+  // so the view's zeta_decrypt can't resolve auth.uid(). Use token_hash for lookup.
   const { data, error } = await admin
-    .from("capture_tokens")
+    .from("capture_tokens_enc" as "capture_tokens")
     .select("id, user_id, default_account_id")
-    .eq("token", token)
+    .eq("token_hash", hashToken(token))
     .is("revoked_at", null)
     .single();
 
   if (error || !data) return null;
 
-  // Fire-and-forget: update last_used_at
+  // Fire-and-forget: update last_used_at (use view — auth context not needed for admin client update)
   void admin
-    .from("capture_tokens")
+    .from("capture_tokens_enc" as "capture_tokens")
     .update({ last_used_at: new Date().toISOString() })
     .eq("id", data.id);
 

--- a/webapp/src/app/api/capture/route.ts
+++ b/webapp/src/app/api/capture/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<CaptureRe
 
   // Destinatario match → auto-categorize fallback
   const matchText = merchant_name ?? capture_input_text ?? "";
-  const destMatch = await matchTransactionToDestinatario(auth.userId, matchText);
+  const destMatch = await matchTransactionToDestinatario(auth.userId, matchText, admin);
 
   let categoryId = body.category_id ?? null;
   let destinatarioId: string | null = null;

--- a/webapp/src/app/api/parse-image/route.ts
+++ b/webapp/src/app/api/parse-image/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRequestUser } from "@/app/api/_shared/auth";
+
+const PARSER_URL = process.env.PDF_PARSER_URL || "http://localhost:8000";
+const PARSER_API_KEY = process.env.PDF_PARSER_API_KEY ?? "";
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
+const FETCH_TIMEOUT_MS = 60_000; // 60 seconds
+const ALLOWED_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+
+export async function POST(request: NextRequest) {
+  const user = await getRequestUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file") as File | null;
+
+  if (!file || !file.name) {
+    return NextResponse.json(
+      { error: "No se proporcionó un archivo" },
+      { status: 400 }
+    );
+  }
+
+  const ext = file.name.toLowerCase().slice(file.name.lastIndexOf("."));
+  if (!ALLOWED_EXTENSIONS.has(ext)) {
+    return NextResponse.json(
+      { error: "Formato no soportado. Se aceptan PNG, JPG o WEBP." },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: "La imagen excede el tamaño máximo de 20MB" },
+      { status: 400 }
+    );
+  }
+
+  if (!PARSER_API_KEY) {
+    return NextResponse.json(
+      { error: "El servicio de procesamiento no está disponible. Intenta más tarde." },
+      { status: 503 }
+    );
+  }
+
+  const proxyForm = new FormData();
+  const fileBuffer = await file.arrayBuffer();
+  proxyForm.append("file", new Blob([fileBuffer], { type: file.type }), file.name);
+
+  const screenshotDate = formData.get("screenshot_date") as string | null;
+  if (screenshotDate) {
+    proxyForm.append("screenshot_date", screenshotDate);
+  }
+
+  try {
+    const response = await fetch(`${PARSER_URL}/parse-image`, {
+      method: "POST",
+      headers: { "X-Parser-Key": PARSER_API_KEY },
+      body: proxyForm,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const body = await response
+        .json()
+        .catch(() => ({ detail: "Error del parser" }));
+      const detail = body.detail;
+
+      if (detail && typeof detail === "object" && detail.type) {
+        return NextResponse.json(
+          { error: detail.message || "Error procesando la imagen", errorType: detail.type },
+          { status: response.status }
+        );
+      }
+      return NextResponse.json(
+        { error: (typeof detail === "string" ? detail : null) || "Error procesando la imagen" },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json(
+      { error: "No se pudo conectar con el servicio de procesamiento. Asegúrate de que esté ejecutándose." },
+      { status: 503 }
+    );
+  }
+}

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -599,7 +599,7 @@ export async function POST(request: NextRequest) {
     const matchedAccount = candidateAccounts?.find((a) => a.id === suggestedAccountId);
     const currencyCode = matchedAccount?.currency_code ?? parsed.currency;
     const matchText = parsed.merchant ?? parsed.destination ?? parsed.raw_line ?? "";
-    const destMatch = await matchTransactionToDestinatario(userId, matchText);
+    const destMatch = await matchTransactionToDestinatario(userId, matchText, admin);
 
     let categoryId: string | null = null;
     let destinatarioId: string | null = null;

--- a/webapp/src/components/accounts/account-card.tsx
+++ b/webapp/src/components/accounts/account-card.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { QuickPaymentDialog } from "@/components/accounts/quick-payment-dialog";
 import { formatCurrency } from "@/lib/utils/currency";
 import { cn } from "@/lib/utils";
@@ -82,17 +81,10 @@ export function AccountCard({ account, allAccounts }: AccountCardProps) {
                 ) : null}
               </div>
             </div>
-            <div className="flex items-center gap-2">
-              <div className="flex flex-wrap justify-end gap-2">
-                <Badge variant="secondary" className="border-white/6 bg-black/15 text-[11px] text-z-white">
-                  {ACCOUNT_TYPE_SHORT_LABELS[account.account_type]}
-                </Badge>
-                {account.show_in_dashboard ? (
-                  <Badge className="border-z-brass/30 bg-z-brass/10 text-[11px] font-medium text-z-brass hover:bg-z-brass/10">
-                    Inicio
-                  </Badge>
-                ) : null}
-              </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Badge variant="secondary" className="border-white/6 bg-black/15 text-[11px] text-z-white">
+                {ACCOUNT_TYPE_SHORT_LABELS[account.account_type]}
+              </Badge>
               {allAccounts && allAccounts.length > 0 && (
                 <div
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}

--- a/webapp/src/components/categorize/mobile-category-drawer.tsx
+++ b/webapp/src/components/categorize/mobile-category-drawer.tsx
@@ -48,12 +48,12 @@ export function MobileCategoryDrawer({
   const [applySimilar, setApplySimilar] = useState(false);
   const [expandedParent, setExpandedParent] = useState<string | null>(null);
 
-  // Reset state when transaction changes
+  // Reset state when transaction changes — pre-select suggestion if available
   useEffect(() => {
-    setSelectedCategoryId(null);
+    setSelectedCategoryId(suggestion?.category_id ?? null);
     setApplySimilar(false);
     setExpandedParent(null);
-  }, [transaction?.id]);
+  }, [transaction?.id, suggestion?.category_id]);
 
   if (!transaction) return null;
 

--- a/webapp/src/components/categorize/mobile-category-drawer.tsx
+++ b/webapp/src/components/categorize/mobile-category-drawer.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Check, ChevronRight, User } from "lucide-react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+import type { TransactionWithRelations, CategoryWithChildren } from "@/types/domain";
+import type { CategorizationResult } from "@zeta/shared";
+
+interface MobileCategoryDrawerProps {
+  transaction: TransactionWithRelations | null;
+  suggestion: CategorizationResult | null;
+  categories: CategoryWithChildren[];
+  similarCount: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (categoryId: string, applySimilar: boolean) => void;
+  isPending: boolean;
+  destinatarioSuggestion?: {
+    destinatario_id: string;
+    destinatario_name: string;
+    category_id: string | null;
+  } | null;
+}
+
+export function MobileCategoryDrawer({
+  transaction,
+  suggestion,
+  categories,
+  similarCount,
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+  destinatarioSuggestion,
+}: MobileCategoryDrawerProps) {
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
+  const [applySimilar, setApplySimilar] = useState(false);
+  const [expandedParent, setExpandedParent] = useState<string | null>(null);
+
+  // Reset state when transaction changes
+  useEffect(() => {
+    setSelectedCategoryId(null);
+    setApplySimilar(false);
+    setExpandedParent(null);
+  }, [transaction?.id]);
+
+  if (!transaction) return null;
+
+  const isOutflow = transaction.direction === "OUTFLOW";
+  const amountColor = isOutflow ? "text-z-debt" : "text-z-sage-light";
+
+  // Flat list of parent categories (no parent_id or top-level)
+  const parentCategories = categories.filter((c) => !c.parent_id);
+
+  const handleCategoryTap = (cat: CategoryWithChildren) => {
+    if (cat.children && cat.children.length > 0) {
+      // Toggle expand
+      setExpandedParent(expandedParent === cat.id ? null : cat.id);
+    } else {
+      // Leaf — select it
+      setSelectedCategoryId(cat.id);
+      setExpandedParent(null);
+    }
+  };
+
+  const handleSubcategoryTap = (catId: string) => {
+    setSelectedCategoryId(catId);
+    setExpandedParent(null);
+  };
+
+  const handleConfirm = () => {
+    if (!selectedCategoryId) return;
+    onConfirm(selectedCategoryId, applySimilar);
+  };
+
+  // Find expanded parent's children
+  const expandedChildren = expandedParent
+    ? parentCategories.find((c) => c.id === expandedParent)?.children ?? []
+    : [];
+
+  // Resolve selected name for display
+  const findCategoryName = (id: string): string => {
+    for (const parent of parentCategories) {
+      if (parent.id === id) return parent.name_es ?? parent.name;
+      for (const child of parent.children) {
+        if (child.id === id) return child.name_es ?? child.name;
+      }
+    }
+    return id;
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[92dvh] overflow-hidden flex flex-col">
+        {/* Transaction summary */}
+        <DrawerHeader className="pb-3 border-b border-white/6">
+          <DrawerTitle className="sr-only">Categorizar movimiento</DrawerTitle>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-semibold text-base leading-tight">
+                {transaction.merchant_name ?? transaction.clean_description ?? transaction.raw_description ?? "Sin descripción"}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {transaction.account.name} · {formatDate(transaction.transaction_date)}
+              </p>
+            </div>
+            <p className={cn("text-base font-semibold shrink-0 tabular-nums", amountColor)}>
+              {isOutflow ? "−" : "+"}{formatCurrency(transaction.amount, transaction.currency_code ?? "COP")}
+            </p>
+          </div>
+        </DrawerHeader>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+          {/* Destinatario suggestion banner */}
+          {destinatarioSuggestion && (
+            <div className="rounded-xl border border-z-brass/20 bg-z-brass/8 px-3 py-2 flex items-center gap-2">
+              <User className="size-4 text-z-brass shrink-0" />
+              <p className="text-xs text-z-brass leading-snug">
+                Posible destinatario: <span className="font-semibold">{destinatarioSuggestion.destinatario_name}</span>
+              </p>
+            </div>
+          )}
+
+          {/* Category grid */}
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground mb-2">
+              Categoría
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {parentCategories.map((cat) => {
+                const isSuggested = suggestion?.category_id === cat.id ||
+                  cat.children.some((c) => c.id === suggestion?.category_id);
+                const isSelected = selectedCategoryId === cat.id ||
+                  cat.children.some((c) => c.id === selectedCategoryId);
+                const isExpanded = expandedParent === cat.id;
+                const hasChildren = cat.children.length > 0;
+
+                return (
+                  <button
+                    key={cat.id}
+                    onClick={() => handleCategoryTap(cat)}
+                    className={cn(
+                      "relative rounded-xl border px-2 py-2.5 text-left transition-colors",
+                      isSelected
+                        ? "border-z-brass/50 bg-z-brass/12 text-z-brass"
+                        : isSuggested
+                          ? "border-z-brass/30 bg-z-brass/6 text-foreground"
+                          : "border-white/6 bg-black/10 text-foreground",
+                      isExpanded && "border-z-sage-dark/30 bg-z-sage-dark/8"
+                    )}
+                  >
+                    <span className="text-base leading-none mb-1 block">{cat.icon}</span>
+                    <span className="text-[11px] font-medium leading-tight line-clamp-2">
+                      {cat.name_es ?? cat.name}
+                    </span>
+                    {hasChildren && (
+                      <ChevronRight
+                        className={cn(
+                          "absolute top-2 right-1.5 size-3 text-muted-foreground/50 transition-transform",
+                          isExpanded && "rotate-90"
+                        )}
+                      />
+                    )}
+                    {isSuggested && !isSelected && (
+                      <span className="absolute -top-1 -right-1 size-2 rounded-full bg-z-brass" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Subcategory expansion */}
+            {expandedParent && expandedChildren.length > 0 && (
+              <div className="mt-2 rounded-xl border border-white/6 bg-black/5 p-2">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground mb-2 px-1">
+                  {findCategoryName(expandedParent)} — subcategorías
+                </p>
+                <div className="grid grid-cols-2 gap-1.5">
+                  {expandedChildren.map((sub) => {
+                    const isSubSuggested = suggestion?.category_id === sub.id;
+                    const isSubSelected = selectedCategoryId === sub.id;
+
+                    return (
+                      <button
+                        key={sub.id}
+                        onClick={() => handleSubcategoryTap(sub.id)}
+                        className={cn(
+                          "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                          isSubSelected
+                            ? "border-z-brass/50 bg-z-brass/12 text-z-brass font-medium"
+                            : isSubSuggested
+                              ? "border-z-brass/30 bg-z-brass/6 text-foreground"
+                              : "border-white/6 bg-black/10 text-foreground"
+                        )}
+                      >
+                        <span className="text-sm mr-1">{sub.icon}</span>
+                        <span className="text-[11px]">{sub.name_es ?? sub.name}</span>
+                        {isSubSuggested && (
+                          <span className="ml-1 text-[9px] font-semibold text-z-brass uppercase tracking-wide">
+                            Sugerida
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Suggestion chip if category not yet visible in grid */}
+          {suggestion && !selectedCategoryId && (
+            <div className="rounded-xl border border-z-brass/20 bg-z-brass/8 px-3 py-2 flex items-center gap-2">
+              <span className="text-xs text-z-brass">
+                Sugerencia: <span className="font-semibold">{findCategoryName(suggestion.category_id)}</span>
+              </span>
+              <button
+                onClick={() => setSelectedCategoryId(suggestion.category_id)}
+                className="ml-auto text-[11px] font-semibold text-z-brass underline-offset-2 hover:underline"
+              >
+                Usar
+              </button>
+            </div>
+          )}
+
+          {/* Apply to similar toggle */}
+          {similarCount > 0 && (
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-white/6 bg-black/10 px-3 py-2.5">
+              <div className="min-w-0">
+                <p className="text-sm font-medium leading-tight">
+                  Aplicar a {similarCount} similares
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Misma categoría para transacciones del mismo comercio
+                </p>
+              </div>
+              <Switch
+                checked={applySimilar}
+                onCheckedChange={setApplySimilar}
+                size="sm"
+                aria-label="Aplicar a transacciones similares"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer CTA */}
+        <div className="shrink-0 border-t border-white/6 p-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          <Button
+            className={cn("w-full", BRASS_BUTTON_CLASS)}
+            disabled={!selectedCategoryId || isPending}
+            onClick={handleConfirm}
+          >
+            {selectedCategoryId ? (
+              <>
+                <Check className="size-4 mr-1.5" />
+                Confirmar — {findCategoryName(selectedCategoryId)}
+              </>
+            ) : (
+              "Selecciona una categoría"
+            )}
+          </Button>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/webapp/src/components/categorize/mobile-category-inbox.tsx
+++ b/webapp/src/components/categorize/mobile-category-inbox.tsx
@@ -167,12 +167,24 @@ export function MobileCategoryInbox({
     if (!drawerTx) return;
     startTransition(async () => {
       if (activeTab === "auto-review") {
-        const result = await confirmAutoCategory(drawerTx.id);
-        if (result.success) {
-          setAutoTransactions((prev) => prev.filter((t) => t.id !== drawerTx.id));
-          toast.success("Auto-categorización confirmada");
+        // If user picked a different category than the auto-assigned one, override it
+        const autoCategory = drawerTx.category_id;
+        if (autoCategory && categoryId !== autoCategory) {
+          const result = await categorizeTransaction(drawerTx.id, categoryId);
+          if (result.success) {
+            setAutoTransactions((prev) => prev.filter((t) => t.id !== drawerTx.id));
+            toast.success("Categoría corregida");
+          } else {
+            toast.error(result.error ?? "Error al categorizar");
+          }
         } else {
-          toast.error(result.error ?? "Error al confirmar");
+          const result = await confirmAutoCategory(drawerTx.id);
+          if (result.success) {
+            setAutoTransactions((prev) => prev.filter((t) => t.id !== drawerTx.id));
+            toast.success("Auto-categorización confirmada");
+          } else {
+            toast.error(result.error ?? "Error al confirmar");
+          }
         }
       } else {
         const idsToUpdate = [drawerTx.id];
@@ -248,7 +260,7 @@ export function MobileCategoryInbox({
   };
 
   return (
-    <div className="lg:hidden space-y-4">
+    <div className="space-y-4">
       {/* Tab pills */}
       <div className="flex items-center gap-2">
         <button

--- a/webapp/src/components/categorize/mobile-category-inbox.tsx
+++ b/webapp/src/components/categorize/mobile-category-inbox.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useState, useMemo, useTransition } from "react";
+import { Inbox, CheckCheck } from "lucide-react";
+import { autoCategorize, extractPattern } from "@zeta/shared";
+import {
+  categorizeTransaction,
+  bulkCategorize,
+  confirmAutoCategory,
+  bulkConfirmAutoCategory,
+} from "@/actions/categorize";
+import { BulkActionBar } from "./bulk-action-bar";
+import { MobileCategoryDrawer } from "./mobile-category-drawer";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { MOBILE_EYEBROW_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import type { TransactionWithRelations, CategoryWithChildren } from "@/types/domain";
+import type { UserRule, CategorizationResult } from "@zeta/shared";
+
+type ActiveTab = "uncategorized" | "auto-review";
+
+interface MobileCategoryInboxProps {
+  initialTransactions: TransactionWithRelations[];
+  autoCategorizedTransactions?: TransactionWithRelations[];
+  categories: CategoryWithChildren[];
+  userRules: UserRule[];
+  destinatarioSuggestions?: Record<
+    string,
+    {
+      destinatario_id: string;
+      destinatario_name: string;
+      category_id: string | null;
+    }
+  >;
+}
+
+function groupByDate(
+  items: TransactionWithRelations[]
+): { date: string; transactions: TransactionWithRelations[] }[] {
+  const sorted = [...items].sort((a, b) =>
+    b.transaction_date.localeCompare(a.transaction_date)
+  );
+  const map = new Map<string, TransactionWithRelations[]>();
+  for (const tx of sorted) {
+    const group = map.get(tx.transaction_date) ?? [];
+    group.push(tx);
+    map.set(tx.transaction_date, group);
+  }
+  return Array.from(map.entries()).map(([date, transactions]) => ({
+    date,
+    transactions,
+  }));
+}
+
+export function MobileCategoryInbox({
+  initialTransactions,
+  autoCategorizedTransactions = [],
+  categories,
+  userRules,
+  destinatarioSuggestions = {},
+}: MobileCategoryInboxProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>("uncategorized");
+  const [transactions, setTransactions] = useState(initialTransactions);
+  const [autoTransactions, setAutoTransactions] = useState(
+    autoCategorizedTransactions
+  );
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectMode, setSelectMode] = useState(false);
+  const [drawerTx, setDrawerTx] =
+    useState<TransactionWithRelations | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  // Compute suggestions via autoCategorize
+  const suggestions = useMemo(() => {
+    const map = new Map<string, CategorizationResult>();
+    for (const tx of transactions) {
+      if (
+        tx.categorization_source === "USER_OVERRIDE" ||
+        tx.categorization_source === "USER_CREATED"
+      )
+        continue;
+      const desc =
+        tx.merchant_name ?? tx.clean_description ?? tx.raw_description ?? "";
+      const result = autoCategorize(desc, userRules);
+      if (result) map.set(tx.id, result);
+    }
+    return map;
+  }, [transactions, userRules]);
+
+  // Count similar transactions using extractPattern
+  const similarCounts = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const tx of transactions) {
+      const pattern = extractPattern(
+        tx.merchant_name,
+        tx.clean_description,
+        tx.raw_description
+      );
+      if (!pattern) continue;
+      if (!map.has(pattern)) map.set(pattern, []);
+      map.get(pattern)!.push(tx.id);
+    }
+    // Return txId → count of others with same pattern
+    const result = new Map<string, number>();
+    for (const ids of map.values()) {
+      if (ids.length < 2) continue;
+      for (const id of ids) {
+        result.set(id, ids.length - 1);
+      }
+    }
+    return result;
+  }, [transactions]);
+
+  const activeList = activeTab === "uncategorized" ? transactions : autoTransactions;
+  const grouped = useMemo(() => groupByDate(activeList), [activeList]);
+
+  // --- Handlers ---
+
+  const openDrawer = (tx: TransactionWithRelations) => {
+    setDrawerTx(tx);
+    setDrawerOpen(true);
+  };
+
+  const handleCardTap = (tx: TransactionWithRelations) => {
+    if (selectMode) {
+      toggleSelect(tx.id);
+    } else {
+      openDrawer(tx);
+    }
+  };
+
+  const handleCardLongPress = (tx: TransactionWithRelations) => {
+    if (!selectMode) {
+      setSelectMode(true);
+      setSelected(new Set([tx.id]));
+    }
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+        if (next.size === 0) setSelectMode(false);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const clearSelection = () => {
+    setSelected(new Set());
+    setSelectMode(false);
+  };
+
+  const handleTabChange = (tab: ActiveTab) => {
+    setActiveTab(tab);
+    clearSelection();
+  };
+
+  // Single transaction categorize (from drawer)
+  const handleDrawerConfirm = (categoryId: string, applySimilar: boolean) => {
+    if (!drawerTx) return;
+    startTransition(async () => {
+      if (activeTab === "auto-review") {
+        const result = await confirmAutoCategory(drawerTx.id);
+        if (result.success) {
+          setAutoTransactions((prev) => prev.filter((t) => t.id !== drawerTx.id));
+          toast.success("Auto-categorización confirmada");
+        } else {
+          toast.error(result.error ?? "Error al confirmar");
+        }
+      } else {
+        const idsToUpdate = [drawerTx.id];
+        if (applySimilar) {
+          const pattern = extractPattern(
+            drawerTx.merchant_name,
+            drawerTx.clean_description,
+            drawerTx.raw_description
+          );
+          if (pattern) {
+            for (const tx of transactions) {
+              if (tx.id === drawerTx.id) continue;
+              const p = extractPattern(tx.merchant_name, tx.clean_description, tx.raw_description);
+              if (p === pattern) idsToUpdate.push(tx.id);
+            }
+          }
+        }
+
+        if (idsToUpdate.length === 1) {
+          const result = await categorizeTransaction(drawerTx.id, categoryId);
+          if (result.success) {
+            setTransactions((prev) => prev.filter((t) => t.id !== drawerTx.id));
+            toast.success("Categoría asignada");
+          } else {
+            toast.error(result.error ?? "Error al categorizar");
+          }
+        } else {
+          const items = idsToUpdate.map((id) => ({ txId: id, categoryId }));
+          const result = await bulkCategorize(items);
+          if (result.success) {
+            setTransactions((prev) =>
+              prev.filter((t) => !idsToUpdate.includes(t.id))
+            );
+            toast.success(
+              `${result.data.categorized} movimientos categorizados`
+            );
+          } else {
+            toast.error(result.error ?? "Error al categorizar");
+          }
+        }
+      }
+      setDrawerOpen(false);
+    });
+  };
+
+  // Bulk assign from BulkActionBar
+  const handleBulkAssign = (categoryId: string) => {
+    if (selected.size === 0) return;
+    const ids = Array.from(selected);
+    startTransition(async () => {
+      if (activeTab === "auto-review") {
+        const result = await bulkConfirmAutoCategory(ids);
+        if (result.success) {
+          setAutoTransactions((prev) =>
+            prev.filter((t) => !ids.includes(t.id))
+          );
+          toast.success(`${result.data.confirmed} confirmadas`);
+        } else {
+          toast.error(result.error ?? "Error al confirmar");
+        }
+      } else {
+        const items = ids.map((id) => ({ txId: id, categoryId }));
+        const result = await bulkCategorize(items);
+        if (result.success) {
+          setTransactions((prev) => prev.filter((t) => !ids.includes(t.id)));
+          toast.success(`${result.data.categorized} movimientos categorizados`);
+        } else {
+          toast.error(result.error ?? "Error al categorizar");
+        }
+      }
+      clearSelection();
+    });
+  };
+
+  return (
+    <div className="lg:hidden space-y-4">
+      {/* Tab pills */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => handleTabChange("uncategorized")}
+          className={cn(
+            "rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors",
+            activeTab === "uncategorized"
+              ? "bg-z-brass text-z-ink"
+              : "border border-white/10 bg-black/10 text-muted-foreground"
+          )}
+        >
+          {transactions.length} sin categoría
+        </button>
+        <button
+          onClick={() => handleTabChange("auto-review")}
+          className={cn(
+            "rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors",
+            activeTab === "auto-review"
+              ? "bg-z-brass text-z-ink"
+              : "border border-white/10 bg-black/10 text-muted-foreground"
+          )}
+        >
+          {autoTransactions.length} auto-categorizadas
+        </button>
+      </div>
+
+      {/* Feed */}
+      {grouped.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+          <div className="rounded-full border border-white/8 bg-black/10 p-4">
+            {activeTab === "uncategorized" ? (
+              <CheckCheck className="size-8 text-z-sage-dark" />
+            ) : (
+              <Inbox className="size-8 text-z-sage-dark" />
+            )}
+          </div>
+          <div>
+            <p className="font-semibold text-base">Bandeja limpia</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              {activeTab === "uncategorized"
+                ? "No hay movimientos pendientes de categorizar"
+                : "No hay auto-categorizaciones pendientes de revisión"}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {grouped.map(({ date, transactions: dayTxs }) => (
+            <div key={date}>
+              {/* Sticky date header */}
+              <div className="sticky top-0 z-10 -mx-1 px-1 pb-1 pt-0.5 backdrop-blur-sm">
+                <p className={cn(MOBILE_EYEBROW_CLASS, "py-1")}>
+                  {formatDate(date)}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                {dayTxs.map((tx) => {
+                  const isOutflow = tx.direction === "OUTFLOW";
+                  const amountColor = isOutflow
+                    ? "text-z-debt"
+                    : "text-z-sage-light";
+                  const isSelected = selected.has(tx.id);
+                  const txSuggestion =
+                    activeTab === "uncategorized"
+                      ? (suggestions.get(tx.id) ?? null)
+                      : null;
+                  const hasSuggestion = !!txSuggestion;
+
+                  return (
+                    <div
+                      key={tx.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => handleCardTap(tx)}
+                      onContextMenu={(e) => {
+                        e.preventDefault();
+                        handleCardLongPress(tx);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ")
+                          handleCardTap(tx);
+                      }}
+                      className={cn(
+                        "relative flex items-center gap-3 rounded-xl border px-3 py-3 transition-colors cursor-pointer select-none",
+                        isSelected
+                          ? "border-z-brass/30 bg-z-brass/10"
+                          : "border-white/6 bg-z-surface-2/70"
+                      )}
+                    >
+                      {/* Select checkbox indicator */}
+                      {selectMode && (
+                        <div
+                          className={cn(
+                            "shrink-0 size-5 rounded-full border-2 flex items-center justify-center",
+                            isSelected
+                              ? "border-z-brass bg-z-brass"
+                              : "border-white/20 bg-transparent"
+                          )}
+                        >
+                          {isSelected && (
+                            <CheckCheck className="size-3 text-z-ink" />
+                          )}
+                        </div>
+                      )}
+
+                      {/* Account color dot */}
+                      <div
+                        className="shrink-0 size-2 rounded-full mt-0.5"
+                        style={{ backgroundColor: tx.account?.color ?? "var(--z-sage-dark)" }}
+                      />
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        {/* Line 1: merchant + amount */}
+                        <div className="flex items-start justify-between gap-2">
+                          <p className="text-sm font-medium leading-tight truncate">
+                            {tx.merchant_name ??
+                              tx.clean_description ??
+                              tx.raw_description ??
+                              "Sin descripción"}
+                          </p>
+                          <p
+                            className={cn(
+                              "text-sm font-semibold tabular-nums shrink-0",
+                              amountColor
+                            )}
+                          >
+                            {isOutflow ? "−" : "+"}
+                            {formatCurrency(tx.amount, tx.currency_code)}
+                          </p>
+                        </div>
+
+                        {/* Line 2: account + date + suggestion chip */}
+                        <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+                          <span className="text-xs text-muted-foreground truncate">
+                            {tx.account.name}
+                          </span>
+                          <span className="text-xs text-muted-foreground/50">
+                            ·
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {formatDate(tx.transaction_date)}
+                          </span>
+                          {hasSuggestion && (
+                            <span className="rounded-full bg-z-brass/10 px-1.5 py-0.5 text-[10px] font-semibold text-z-brass leading-none">
+                              Sugerida
+                            </span>
+                          )}
+                          {activeTab === "auto-review" && tx.category && (
+                            <span className="rounded-full bg-z-sage-dark/10 px-1.5 py-0.5 text-[10px] font-semibold text-z-sage-dark leading-none">
+                              {tx.category.name_es ?? tx.category.name}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Bulk action bar */}
+      {selectMode && selected.size > 0 && (
+        <BulkActionBar
+          selectedCount={selected.size}
+          categories={categories}
+          onAssign={handleBulkAssign}
+          onClearSelection={clearSelection}
+          isPending={isPending}
+        />
+      )}
+
+      {/* Drawer for single categorization */}
+      <MobileCategoryDrawer
+        transaction={drawerTx}
+        suggestion={
+          drawerTx
+            ? (suggestions.get(drawerTx.id) ?? null)
+            : null
+        }
+        categories={categories}
+        similarCount={drawerTx ? (similarCounts.get(drawerTx.id) ?? 0) : 0}
+        open={drawerOpen}
+        onOpenChange={(v) => {
+          setDrawerOpen(v);
+          if (!v) setDrawerTx(null);
+        }}
+        onConfirm={handleDrawerConfirm}
+        isPending={isPending}
+        destinatarioSuggestion={
+          drawerTx ? destinatarioSuggestions[drawerTx.id] : null
+        }
+      />
+    </div>
+  );
+}

--- a/webapp/src/components/layout/quick-view-menu.tsx
+++ b/webapp/src/components/layout/quick-view-menu.tsx
@@ -48,7 +48,7 @@ export function QuickViewMenu({ profile, attentionSnapshot }: QuickViewMenuProps
   const [data, setData] = useState<QuickViewData | null>(null);
   const [loading, startTransition] = useTransition();
 
-  const initials = (profile.full_name ?? profile.email)
+  const initials = (profile.full_name ?? profile.email ?? "?")
     .split(" ")
     .map((n) => n[0])
     .join("")

--- a/webapp/src/components/marketing/landing-page.tsx
+++ b/webapp/src/components/marketing/landing-page.tsx
@@ -577,7 +577,7 @@ export function MarketingLandingPage() {
               </Badge>
 
               <div className="space-y-6">
-                <h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-balance sm:text-6xl lg:text-7xl">
+                <h1 className="max-w-4xl text-3xl font-semibold tracking-tight text-balance sm:text-5xl lg:text-7xl">
                   Tu dinero deja de sentirse confuso y empieza a contar una historia clara.
                 </h1>
                 <p className="max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
-import { ArrowUpRight, ArrowDownLeft, ArrowRight, QrCode, CreditCard, Banknote, Building, Wallet, ArrowUpRight as TransferIcon, Mail } from "lucide-react";
+import { ArrowUpRight, ArrowDownLeft, ArrowRight, QrCode, CreditCard, Banknote, Building, Wallet, ArrowUpRight as TransferIcon, Mail, Hash, UserRound, Pencil } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -17,7 +17,6 @@ import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { categorizeTransaction, uncategorizeTransaction } from "@/actions/categorize";
-import { toggleExcludeTransaction } from "@/actions/transactions";
 import {
   approveEmailTransaction,
   dismissEmailTransaction,
@@ -303,17 +302,6 @@ function CategorizarDetail({
     });
   }
 
-  function handleExclude(txId: string) {
-    startTransition(async () => {
-      const result = await toggleExcludeTransaction(txId, true);
-      if (result.success) {
-        toast.success("Excluida del presupuesto");
-      } else {
-        toast.error(result.error ?? "Error");
-      }
-    });
-  }
-
   if (totalCount === 0) {
     return (
       <div className="space-y-2">
@@ -358,36 +346,45 @@ function CategorizarDetail({
                 <p className="shrink-0 text-xs font-semibold tabular-nums">
                   {formatCurrency(tx.amount, currency)}
                 </p>
-                <div onClick={(e) => e.stopPropagation()}>
+                <span
+                  className={cn(
+                    "text-muted-foreground/50 text-xs transition-transform shrink-0",
+                    isExpanded && "rotate-90"
+                  )}
+                >
+                  ›
+                </span>
+              </div>
+              {isExpanded && (
+                <div className="flex items-center gap-1.5 pb-2 pl-7" onClick={(e) => e.stopPropagation()}>
                   <CategoryZonePicker
                     categories={categories}
                     value={null}
                     onValueChange={(catId) => handleCategorize(tx, catId)}
                     direction="OUTFLOW"
+                    placeholder="Categoría"
                     variant="drawer"
-                    triggerClassName="text-[10px] h-auto py-1 px-2.5"
+                    triggerClassName="text-[10px] h-auto py-1 px-2.5 rounded-lg border border-white/10 bg-white/[0.03] text-z-brass hover:bg-white/[0.06]"
                   />
-                </div>
-              </div>
-              {isExpanded && (
-                <div className="flex flex-wrap items-center gap-1.5 pb-2 pl-7">
                   <Link
                     href={`/transactions/${tx.id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-white/[0.06]"
+                    className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] p-1.5 text-muted-foreground transition-colors hover:bg-white/[0.06]"
                   >
-                    Asignar destinatario
+                    <UserRound className="size-3" />
                   </Link>
                   <Link
                     href={`/transactions/${tx.id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-white/[0.06]"
+                    className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] p-1.5 text-muted-foreground transition-colors hover:bg-white/[0.06]"
                   >
-                    Etiquetar
+                    <Hash className="size-3" />
                   </Link>
-                  <ActionPill onClick={() => handleExclude(tx.id)} variant="danger">
-                    Excluir
-                  </ActionPill>
+                  <div className="flex-1" />
+                  <Link
+                    href={`/transactions/${tx.id}`}
+                    className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] p-1.5 text-muted-foreground transition-colors hover:bg-white/[0.06]"
+                  >
+                    <Pencil className="size-3" />
+                  </Link>
                 </div>
               )}
             </div>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { Hash, UserRound, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { MOBILE_ACTION_BUTTON_CLASS } from "@/lib/constants/styles";
+import { formatDate } from "@/lib/utils/date";
 import type { TransactionWithAccount } from "@/types/domain";
 
 interface MovimientosTransactionRowProps {
@@ -20,7 +21,10 @@ export function MovimientosTransactionRow({
     tx.merchant_name ||
     tx.clean_description ||
     tx.raw_description ||
-    "Sin descripcion";
+    "Sin descripción";
+
+  const categoryName = tx.category?.name_es ?? tx.category?.name ?? null;
+  const destinatarioName = tx.destinatario?.name ?? null;
 
   return (
     <div
@@ -29,16 +33,16 @@ export function MovimientosTransactionRow({
         expanded && "border-l-2 border-z-brass pl-2"
       )}
     >
-      {/* Collapsed row — always visible */}
+      {/* Collapsed row */}
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
         className={cn(
-          "flex w-full items-center justify-between px-2 py-2 text-left transition-colors hover:bg-white/5",
+          "flex w-full items-center justify-between gap-2 px-2 py-2.5 text-left transition-colors hover:bg-white/5",
           tx.is_excluded && "opacity-40"
         )}
       >
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium">{description}</p>
           <p className="text-[11px] text-muted-foreground flex items-center gap-1">
             <span
@@ -46,12 +50,14 @@ export function MovimientosTransactionRow({
               style={{ backgroundColor: tx.account.color ?? undefined }}
             />
             <span className="truncate">{tx.account.name}</span>
+            <span className="text-white/15">·</span>
+            <span>{formatDate(tx.transaction_date, "dd MMM")}</span>
           </p>
         </div>
-        <span className="flex shrink-0 items-center gap-1.5 ml-2">
+        <div className="flex shrink-0 items-center gap-1.5">
           <span
             className={cn(
-              "text-sm font-medium",
+              "text-sm font-medium tabular-nums",
               tx.direction === "INFLOW" && "text-z-income",
               tx.is_excluded && "line-through"
             )}
@@ -67,33 +73,51 @@ export function MovimientosTransactionRow({
           >
             ›
           </span>
-        </span>
+        </div>
       </button>
 
-      {/* Expanded: action pills */}
+      {/* Expanded: metadata chips + icon actions */}
       {expanded && (
-        <div className="flex gap-2 px-2 pb-2 pt-1">
-          <Link
-            href="/categorizar"
-            className={cn(
-              MOBILE_ACTION_BUTTON_CLASS,
-              "rounded-full px-3 py-1"
-            )}
-          >
-            Categorizar
-          </Link>
+        <div className="flex items-center gap-1.5 px-2 pb-2.5 pt-0.5">
+          {categoryName && (
+            <span className="rounded-lg bg-z-brass/10 px-2.5 py-1 text-[10px] font-semibold text-z-brass">
+              {categoryName}
+            </span>
+          )}
+          {!categoryName && (
+            <Link
+              href="/categorizar"
+              className="rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-1 text-[10px] text-z-brass transition-colors hover:bg-white/[0.06]"
+            >
+              Categoría
+            </Link>
+          )}
+          {destinatarioName && (
+            <span className="rounded-lg bg-white/5 px-2.5 py-1 text-[10px] font-medium text-muted-foreground">
+              {destinatarioName}
+            </span>
+          )}
+          {!destinatarioName && (
+            <Link
+              href={`/transactions/${tx.id}`}
+              className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] p-1.5 text-muted-foreground transition-colors hover:bg-white/[0.06]"
+            >
+              <UserRound className="size-3" />
+            </Link>
+          )}
           <Link
             href={`/transactions/${tx.id}`}
-            className="rounded-full border border-white/8 bg-transparent px-3 py-1 text-[10px] font-semibold text-muted-foreground"
+            className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] p-1.5 text-muted-foreground transition-colors hover:bg-white/[0.06]"
           >
-            Editar
+            <Hash className="size-3" />
           </Link>
-          <button
-            type="button"
-            className="rounded-full border border-white/8 bg-transparent px-3 py-1 text-[10px] font-semibold text-muted-foreground"
+          <div className="flex-1" />
+          <Link
+            href={`/transactions/${tx.id}`}
+            className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] p-1.5 text-muted-foreground transition-colors hover:bg-white/[0.06]"
           >
-            Excluir
-          </button>
+            <Pencil className="size-3" />
+          </Link>
         </div>
       )}
     </div>

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+import { PlanFlowChart } from "./plan-flow-chart";
+import type { PlanTimelineData } from "@/actions/plan-timeline";
+import type { PeriodPlanData, IncomeEnvelope, PlanningEntryWithRelations } from "@/types/cashflow-planner";
+import type { CurrencyCode } from "@/types/domain";
+
+interface MobilePeriodoViewProps {
+  planData: PeriodPlanData;
+  timelineData: PlanTimelineData;
+  currency: CurrencyCode;
+  isExpired: boolean;
+}
+
+export function MobilePeriodoView({
+  planData,
+  timelineData,
+  currency,
+  isExpired,
+}: MobilePeriodoViewProps) {
+  const {
+    period,
+    income_envelopes,
+    expense_entries,
+    total_expenses,
+    total_assigned,
+  } = planData;
+
+  const percentAssigned =
+    total_expenses > 0 ? Math.round((total_assigned / total_expenses) * 100) : 0;
+
+  return (
+    <div className={cn("space-y-4", isExpired && "opacity-60")}>
+      {/* Chart hero — always visible */}
+      <PlanFlowChart timelineData={timelineData} currency={currency} />
+
+      {/* Period summary bar */}
+      <div
+        className={cn(
+          PANEL_INSET_CLASS,
+          "flex items-center justify-between px-4 py-2.5"
+        )}
+      >
+        <p className="text-xs text-muted-foreground">
+          {formatDate(period.start_date, "dd MMM")} —{" "}
+          {formatDate(period.end_date, "dd MMM yyyy")}
+        </p>
+        <span
+          className={cn(
+            "rounded-md px-2 py-0.5 text-[10px] font-semibold",
+            percentAssigned >= 100
+              ? "bg-z-income/10 text-z-income"
+              : "bg-z-brass/10 text-z-brass"
+          )}
+        >
+          {percentAssigned}% asignado
+        </span>
+      </div>
+
+      {/* Income envelopes */}
+      {income_envelopes.length > 0 && (
+        <div>
+          <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark mb-2">
+            Ingresos
+          </p>
+          <div className="space-y-2">
+            {income_envelopes.map((envelope) => (
+              <IncomeCard
+                key={envelope.entry.id}
+                envelope={envelope}
+                currency={currency}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Expenses */}
+      {expense_entries.length > 0 && (
+        <div>
+          <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark mb-2">
+            Gastos
+          </p>
+          <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
+            {expense_entries.map((entry) => (
+              <ExpenseRow key={entry.id} entry={entry} currency={currency} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ────── Income card ────── */
+
+function IncomeCard({
+  envelope,
+  currency,
+}: {
+  envelope: IncomeEnvelope;
+  currency: CurrencyCode;
+}) {
+  const { entry, total_amount, assigned_amount, remaining_amount } = envelope;
+  const pct =
+    total_amount > 0 ? Math.min(100, (assigned_amount / total_amount) * 100) : 0;
+
+  return (
+    <div className={cn(PANEL_INSET_CLASS, "p-3.5 space-y-2")}>
+      {/* Name + amount */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold truncate">{entry.label}</p>
+          <p className="text-[10px] text-muted-foreground">
+            {formatDate(entry.expected_date, "dd MMM yyyy")}
+            {entry.account && ` · ${entry.account.name}`}
+          </p>
+        </div>
+        <p className="text-sm font-semibold tabular-nums text-z-income shrink-0">
+          {formatCurrency(total_amount, currency)}
+        </p>
+      </div>
+
+      {/* Assignment progress bar */}
+      <div className="h-1.5 w-full rounded-full bg-white/6 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-z-income transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      {/* Disponible line — never truncated */}
+      <p className="text-xs text-muted-foreground">
+        Disponible:{" "}
+        <span
+          className={cn(
+            "font-semibold",
+            remaining_amount > 0 ? "text-z-brass" : "text-z-income"
+          )}
+        >
+          {formatCurrency(remaining_amount, currency)}
+        </span>
+      </p>
+    </div>
+  );
+}
+
+/* ────── Expense row ────── */
+
+function ExpenseRow({
+  entry,
+  currency,
+}: {
+  entry: PlanningEntryWithRelations;
+  currency: CurrencyCode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 px-3.5 py-3">
+      <div className="min-w-0">
+        <p className="text-xs font-medium truncate">{entry.label}</p>
+        <p className="text-[10px] text-muted-foreground">
+          {formatDate(entry.expected_date, "dd MMM yyyy")}
+          {entry.account && ` · ${entry.account.name}`}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <p className="text-sm font-semibold tabular-nums text-z-debt">
+          {formatCurrency(entry.converted_amount, currency)}
+        </p>
+        <span className="rounded-md bg-amber-400/10 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+          Pendiente
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { HERO_CARD_GRADIENT_CLASS } from "@/lib/constants/styles";
+import type { CurrencyCode, UpcomingRecurrence } from "@/types/domain";
+import type { PlanRecurringSummary } from "@/types/plan";
+
+interface MobileRecurrentesViewProps {
+  summary: PlanRecurringSummary;
+  currency: CurrencyCode;
+}
+
+export function MobileRecurrentesView({ summary, currency }: MobileRecurrentesViewProps) {
+  // All upcoming items are pending — "confirmed" state is tracked client-side
+  // in the desktop checklist and not available in the server summary
+  const pending: UpcomingRecurrence[] = summary.upcoming;
+
+  return (
+    <div className="space-y-4 pb-20">
+      {/* Hero card */}
+      <div className={`rounded-2xl border border-white/6 ${HERO_CARD_GRADIENT_CLASS} p-4`}>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+          Compromiso mensual
+        </p>
+        <p className="mt-1 text-3xl font-bold">
+          {formatCurrency(summary.totalMonthlyExpenses, currency)}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {summary.activeCount} plantillas activas
+        </p>
+
+        <div className="my-3 h-px bg-white/6" />
+
+        <div className="flex justify-between text-center">
+          <div>
+            <p className="text-[10px] text-amber-400">Pendientes</p>
+            <p className="text-lg font-semibold text-amber-400">{summary.dueSoonCount}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-emerald-400">Ingresos/mes</p>
+            <p className="text-lg font-semibold text-emerald-400">
+              {formatCurrency(summary.totalMonthlyIncome, currency)}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[10px] text-muted-foreground">Proximo</p>
+            {pending[0] ? (
+              <p className="text-xs font-semibold">
+                {pending[0].template.description} · {formatDate(new Date(pending[0].next_date), "dd MMM")}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">—</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Upcoming list */}
+      {pending.length > 0 && (
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground mb-2">
+            Proximos
+          </p>
+          <div className="divide-y divide-white/5">
+            {pending.map((item, i) => (
+              <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-3">
+                <div>
+                  <p className="text-xs font-medium">{item.template.description}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDate(new Date(item.next_date), "dd MMM yyyy")}
+                    {item.template.account && ` · ${item.template.account.name}`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-semibold text-red-400">
+                    {formatCurrency(item.template.amount ?? 0, currency)}
+                  </p>
+                  <span className="rounded-md bg-z-brass/10 px-2 py-0.5 text-[10px] text-z-brass">
+                    Confirmar
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+
+interface DrillCard {
+  title: string;
+  hint: string;
+  hintColor: string;
+  href: string;
+}
+
+interface PlanDrillCardsProps {
+  budget: PlanBudgetSummary;
+  recurring: PlanRecurringSummary;
+  periodoSummary: { hasActive: boolean; percentAssigned: number } | null;
+  wishlistCount: number;
+  currency: CurrencyCode;
+}
+
+export function PlanDrillCards({
+  budget,
+  recurring,
+  periodoSummary,
+  wishlistCount,
+  currency,
+}: PlanDrillCardsProps) {
+  const budgetPct = budget.totalBudgeted > 0
+    ? Math.round((budget.totalSpent / budget.totalBudgeted) * 100)
+    : 0;
+
+  const cards: DrillCard[] = [
+    {
+      title: "Presupuesto",
+      hint: budget.overLimitCount > 0
+        ? `${budgetPct}% · ${budget.overLimitCount} sobre límite`
+        : `${budgetPct}% gastado`,
+      hintColor: budget.overLimitCount > 0 ? "text-red-400" : "text-emerald-400",
+      href: "/plan?tab=presupuesto",
+    },
+    {
+      title: "Periodo",
+      hint: periodoSummary?.hasActive
+        ? `${periodoSummary.percentAssigned}% asignado`
+        : "Sin periodo activo",
+      hintColor: periodoSummary?.hasActive ? "text-emerald-400" : "text-muted-foreground",
+      href: "/plan?tab=periodo",
+    },
+    {
+      title: "Recurrentes",
+      hint: `${formatCurrency(recurring.totalMonthlyExpenses, currency)}/mes`,
+      hintColor: "text-amber-400",
+      href: "/plan?tab=recurrentes",
+    },
+    {
+      title: "Deseos",
+      hint: `${wishlistCount} item${wishlistCount !== 1 ? "s" : ""}`,
+      hintColor: "text-muted-foreground",
+      href: "/plan?tab=deseos",
+    },
+  ];
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        Ir a
+      </p>
+      {cards.map((card) => (
+        <Link
+          key={card.href}
+          href={card.href}
+          className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2/60 px-4 py-3 transition-colors active:bg-z-surface-2"
+        >
+          <div>
+            <p className="text-[13px] font-semibold">{card.title}</p>
+            <p className={`text-[11px] ${card.hintColor}`}>{card.hint}</p>
+          </div>
+          <span className="text-muted-foreground">›</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import type { CurrencyCode, UpcomingRecurrence } from "@/types/domain";
+
+interface PlanExpandableChipsProps {
+  incomes: UpcomingRecurrence[];
+  payments: UpcomingRecurrence[];
+  currency: CurrencyCode;
+}
+
+type ChipType = "income" | "payment" | null;
+
+export function PlanExpandableChips({
+  incomes,
+  payments,
+  currency,
+}: PlanExpandableChipsProps) {
+  const [expanded, setExpanded] = useState<ChipType>(null);
+
+  const nextIncome = incomes[0] ?? null;
+  const nextPayment = payments[0] ?? null;
+
+  const toggle = (type: ChipType) => {
+    setExpanded((prev) => (prev === type ? null : type));
+  };
+
+  const expandedList = expanded === "income" ? incomes : expanded === "payment" ? payments : [];
+  const expandedLabel = expanded === "income" ? "Ingresos esperados" : "Pagos programados";
+  const expandedColor = expanded === "income" ? "text-emerald-400" : "text-red-400";
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={() => toggle("income")}
+          className={cn(
+            "rounded-xl border p-3 text-left transition-all",
+            expanded === "income"
+              ? "border-emerald-500/50 bg-emerald-950/30"
+              : "border-white/6 bg-emerald-950/20",
+            expanded === "payment" && "opacity-50"
+          )}
+        >
+          <p className="text-lg font-bold text-emerald-400">
+            {nextIncome
+              ? formatCurrency(nextIncome.template.amount ?? 0, currency)
+              : "—"}
+          </p>
+          <p className="text-[10px] text-emerald-400/80">Próximo ingreso</p>
+          {nextIncome && (
+            <p className="text-[9px] text-muted-foreground">
+              {nextIncome.template.description} · {formatDate(new Date(nextIncome.next_date), "dd MMM")}
+            </p>
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => toggle("payment")}
+          className={cn(
+            "rounded-xl border p-3 text-left transition-all",
+            expanded === "payment"
+              ? "border-red-500/50 bg-red-950/30"
+              : "border-white/6 bg-red-950/20",
+            expanded === "income" && "opacity-50"
+          )}
+        >
+          <p className="text-lg font-bold text-red-400">
+            {nextPayment
+              ? formatCurrency(nextPayment.template.amount ?? 0, currency)
+              : "—"}
+          </p>
+          <p className="text-[10px] text-red-400/80">Próximo pago</p>
+          {nextPayment && (
+            <p className="text-[9px] text-muted-foreground">
+              {nextPayment.template.description} · {formatDate(new Date(nextPayment.next_date), "dd MMM")}
+            </p>
+          )}
+        </button>
+      </div>
+
+      {expanded && expandedList.length > 0 && (
+        <div className={cn(
+          "rounded-xl border p-3",
+          expanded === "income"
+            ? "border-emerald-500/20 bg-emerald-950/20"
+            : "border-red-500/20 bg-red-950/20"
+        )}>
+          <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", expandedColor)}>
+            {expandedLabel}
+          </p>
+          <div className="divide-y divide-white/5">
+            {expandedList.map((item, i) => (
+              <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-2">
+                <div>
+                  <p className="text-xs font-medium">{item.template.description}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDate(new Date(item.next_date), "dd MMM yyyy")}
+                    {item.template.account && ` · ${item.template.account.name}`}
+                  </p>
+                </div>
+                <p className={cn("text-sm font-semibold", expandedColor)}>
+                  {formatCurrency(item.template.amount ?? 0, currency)}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
+            <span className="text-muted-foreground">Total</span>
+            <span className={cn("font-bold", expandedColor)}>
+              {formatCurrency(
+                expandedList.reduce((sum, item) => sum + (item.template.amount ?? 0), 0),
+                currency
+              )}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { useChartFocusMode } from "@/hooks/use-chart-focus-mode";
+import { PlanFlowChart } from "./plan-flow-chart";
+import { formatCurrency } from "@/lib/utils/currency";
+import { HERO_CARD_GRADIENT_CLASS } from "@/lib/constants/styles";
+import type { CurrencyCode } from "@/types/domain";
+import type { PlanTimelineData } from "@/actions/plan-timeline";
+
+interface PlanNetHeroProps {
+  ingresos: number;
+  gastos: number;
+  currency: CurrencyCode;
+  daysRemaining: number;
+  timelineData: PlanTimelineData;
+}
+
+export function PlanNetHero({
+  ingresos,
+  gastos,
+  currency,
+  daysRemaining,
+  timelineData,
+}: PlanNetHeroProps) {
+  const [expanded, setExpanded] = useState(false);
+  const neto = ingresos - gastos;
+  const gastosRatio = ingresos > 0 ? Math.min((gastos / ingresos) * 100, 100) : 0;
+  const netoRatio = 100 - gastosRatio;
+
+  const { overlayVisible, handleOverlayClick } = useChartFocusMode(expanded);
+
+  return (
+    <>
+      {overlayVisible && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          onClick={handleOverlayClick(() => setExpanded(false))}
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className={`relative z-50 w-full rounded-2xl border border-white/6 ${HERO_CARD_GRADIENT_CLASS} p-4 text-left transition-all`}
+      >
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+            Neto del mes
+          </p>
+          <span className="text-[10px] text-muted-foreground">
+            {daysRemaining} días restantes
+          </span>
+        </div>
+
+        <p className="text-3xl font-bold text-z-brass">
+          {neto >= 0 ? "+" : ""}
+          {formatCurrency(neto, currency)}
+        </p>
+
+        {/* Stacked progress bar */}
+        <div className="relative mt-3 h-2.5 overflow-hidden rounded-full bg-z-surface-2">
+          <div className="absolute inset-y-0 left-0 w-full rounded-full bg-emerald-500/80" />
+          <div
+            className="absolute inset-y-0 left-0 rounded-l-full bg-red-500/80"
+            style={{ width: `${gastosRatio}%` }}
+          />
+          <div
+            className="absolute inset-y-0 right-0 rounded-r-full bg-z-brass/80"
+            style={{ width: `${netoRatio}%` }}
+          />
+        </div>
+
+        {/* Legend */}
+        <div className="mt-2 flex justify-between text-[10px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="inline-block size-1.5 rounded-full bg-emerald-500" />
+            Ingresos {formatCurrency(ingresos, currency)}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block size-1.5 rounded-full bg-red-500" />
+            Gastos {formatCurrency(gastos, currency)}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block size-1.5 rounded-full bg-z-brass" />
+            Neto
+          </span>
+        </div>
+
+        {!expanded && (
+          <p className="mt-3 text-center text-[11px] text-z-brass/50">
+            Toca para ver flujo ↓
+          </p>
+        )}
+
+        {expanded && (
+          <div className="mt-4" onClick={(e) => e.stopPropagation()}>
+            <PlanFlowChart timelineData={timelineData} currency={currency} />
+            <p
+              className="mt-2 text-center text-[11px] text-z-brass cursor-pointer"
+              onClick={() => setExpanded(false)}
+            >
+              Ocultar flujo ↑
+            </p>
+          </div>
+        )}
+      </button>
+    </>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -1,43 +1,46 @@
 "use client";
 
-import { Suspense } from "react";
-import { useExpandableZone } from "@/components/mobile/v2/use-expandable-zone";
+import { Suspense, useMemo } from "react";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
-import { PlanHeroWrapper } from "./plan-hero-wrapper";
-import { PlanZoneChips } from "./plan-zone-chips";
-import { PlanFlowChart } from "./plan-flow-chart";
-import { PlanDistribution } from "./plan-distribution";
+import { PlanNetHero } from "./plan-net-hero";
+import { PlanExpandableChips } from "./plan-expandable-chips";
+import { PlanDrillCards } from "./plan-drill-cards";
 import { MonthSelector } from "@/components/month-selector";
 import type { PlanPageData } from "@/types/plan";
-import type { AllocationData } from "@/actions/allocation";
 import type { PlanTimelineData } from "@/actions/plan-timeline";
-import type { CurrencyCode, CategoryBudgetData } from "@/types/domain";
+import type { CurrencyCode } from "@/types/domain";
 
 interface PlanRootProps {
   planData: PlanPageData;
-  allocationData: AllocationData | null;
   timelineData: PlanTimelineData;
   currency: CurrencyCode;
   monthLabel: string;
   dayOfMonth: number;
   daysInMonth: number;
-  categories: CategoryBudgetData[];
+  periodoSummary: { hasActive: boolean; percentAssigned: number } | null;
+  wishlistCount: number;
 }
 
 export function PlanRoot({
   planData,
-  allocationData,
   timelineData,
   currency,
   monthLabel,
   dayOfMonth,
   daysInMonth,
-  categories,
+  periodoSummary,
+  wishlistCount,
 }: PlanRootProps) {
-  const { activeZone, toggle } = useExpandableZone<string>();
+  const { incomes, payments } = useMemo(() => {
+    const upcoming = planData.recurring.upcoming;
+    return {
+      incomes: upcoming.filter((u) => u.template.direction === "INFLOW"),
+      payments: upcoming.filter((u) => u.template.direction === "OUTFLOW"),
+    };
+  }, [planData.recurring.upcoming]);
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 pb-20">
       <MobileHeader
         variant="main"
         title="Plan"
@@ -51,34 +54,30 @@ export function PlanRoot({
         </Suspense>
       </div>
 
-      {/* Budget hero — expandable per-category (client boundary isolated) */}
-      <PlanHeroWrapper
-        totalSpent={planData.budget.totalSpent}
-        totalBudgeted={planData.budget.totalBudgeted}
-        pressure={planData.heroSummary.pressure}
-        dayOfMonth={dayOfMonth}
-        daysInMonth={daysInMonth}
+      {/* Net hero — ingresos vs gastos with expandable chart */}
+      <PlanNetHero
+        ingresos={planData.recurring.totalMonthlyIncome}
+        gastos={planData.recurring.totalMonthlyExpenses}
         currency={currency}
-        categories={categories}
+        daysRemaining={daysInMonth - dayOfMonth}
+        timelineData={timelineData}
       />
 
-      {/* Expandable zone chips — presupuesto, obligaciones */}
-      <PlanZoneChips
+      {/* Expandable chips — próximo ingreso / próximo pago */}
+      <PlanExpandableChips
+        incomes={incomes}
+        payments={payments}
+        currency={currency}
+      />
+
+      {/* Drill cards — navigate to Presupuesto, Periodo, Recurrentes, Deseos */}
+      <PlanDrillCards
         budget={planData.budget}
         recurring={planData.recurring}
-        currency={currency}
-        activeZone={activeZone}
-        onToggle={toggle}
-      />
-
-      {/* Flow chart — timeline with real+projected data */}
-      <PlanFlowChart
-        timelineData={timelineData}
+        periodoSummary={periodoSummary}
+        wishlistCount={wishlistCount}
         currency={currency}
       />
-
-      {/* Distribution — budget-type aware */}
-      <PlanDistribution allocation={allocationData} />
 
       {/* Scenarios — only when stable */}
       {planData.scenarios.count > 0 && (

--- a/webapp/src/components/plan/plan-mobile-nav-list.tsx
+++ b/webapp/src/components/plan/plan-mobile-nav-list.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { MCardTight, MListRow } from "@/components/mobile/v2/mobile-card";
+import { MOBILE_EYEBROW_CLASS } from "@/lib/constants/styles";
+import type { PlanTab } from "@/components/plan/plan-tab-nav";
+
+const PLAN_TABS: { key: PlanTab; label: string }[] = [
+  { key: "resumen", label: "Resumen" },
+  { key: "presupuesto", label: "Presupuesto" },
+  { key: "periodo", label: "Periodo" },
+  { key: "recurrentes", label: "Recurrentes" },
+  { key: "deseos", label: "Deseos" },
+];
+
+export function PlanMobileNavList({ activeTab }: { activeTab: PlanTab }) {
+  const otherTabs = PLAN_TABS.filter((t) => t.key !== activeTab);
+
+  return (
+    <div className="mt-6 space-y-2 lg:hidden">
+      <p className={MOBILE_EYEBROW_CLASS}>Más en Plan</p>
+      <MCardTight>
+        {otherTabs.map((tab) => (
+          <Link key={tab.key} href={tab.key === "resumen" ? "/plan" : `/plan?tab=${tab.key}`}>
+            <MListRow>
+              <span className="text-sm font-medium">{tab.label}</span>
+              <ChevronRight className="size-4 text-muted-foreground" />
+            </MListRow>
+          </Link>
+        ))}
+      </MCardTight>
+    </div>
+  );
+}

--- a/webapp/src/components/plan/plan-tab-nav.tsx
+++ b/webapp/src/components/plan/plan-tab-nav.tsx
@@ -16,7 +16,7 @@ export type PlanTab = (typeof PLAN_TABS)[number]["key"];
 
 export function PlanTabNav({ activeTab }: { activeTab: PlanTab }) {
   return (
-    <nav className="flex gap-1 overflow-x-auto scrollbar-none rounded-xl border border-white/6 bg-black/10 p-1">
+    <nav className="hidden gap-1 overflow-x-auto scrollbar-none rounded-xl border border-white/6 bg-black/10 p-1 lg:flex">
       {PLAN_TABS.map((tab) => (
         <Link
           key={tab.key}

--- a/webapp/src/components/plan/tabs/plan-tab-deseos.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-deseos.tsx
@@ -7,6 +7,7 @@ import {
 import { getAccounts } from "@/actions/accounts";
 import { getPreferredCurrency } from "@/actions/profile";
 import { DeseosList } from "@/components/deseos/deseos-list";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 
 export async function PlanTabDeseos() {
   const [items, nudges, insights, pendingReflections, accountsResult, currency] =
@@ -23,10 +24,14 @@ export async function PlanTabDeseos() {
 
   return (
     <div className="space-y-6">
+      {/* Mobile back button */}
+      <div className="lg:hidden">
+        <MobileHeader variant="sub" title="Deseos" backHref="/plan" />
+      </div>
+
       <div>
         <h2 className="text-2xl font-semibold hidden lg:block">Deseos</h2>
-        <h2 className="text-lg font-semibold lg:hidden">Deseos</h2>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm text-muted-foreground hidden lg:block">
           Lo que quieres comprar, evaluado contra tu realidad financiera
         </p>
       </div>

--- a/webapp/src/components/plan/tabs/plan-tab-periodo.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-periodo.tsx
@@ -2,18 +2,21 @@ import { getActivePeriod } from "@/actions/cashflow-planner";
 import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getPreferredCurrency } from "@/actions/profile";
+import { getPlanTimelineData } from "@/actions/plan-timeline";
 import { PeriodHeader } from "@/components/cashflow-planner/period-header";
 import { EnvelopeBoard } from "@/components/cashflow-planner/envelope-board";
 import { PeriodSetupDialog } from "@/components/cashflow-planner/period-setup-dialog";
+import { MobilePeriodoView } from "@/components/mobile/v2/plan/mobile-periodo-view";
 import { CalendarPlus } from "lucide-react";
 
 export async function PlanTabPeriodo() {
-  const [periodResult, accountsResult, categoriesResult, currency] =
+  const [periodResult, accountsResult, categoriesResult, currency, timelineData] =
     await Promise.all([
       getActivePeriod(),
       getAccounts(),
       getCategories("OUTFLOW"),
       getPreferredCurrency(),
+      getPlanTimelineData(),
     ]);
 
   const planData = periodResult.success ? periodResult.data : null;
@@ -39,86 +42,103 @@ export async function PlanTabPeriodo() {
   }
 
   return (
-    <div className="space-y-6">
-      {/* Desktop header */}
-      <div className="hidden lg:flex items-center justify-between gap-4">
-        <div className="space-y-1">
-          <h2 className="text-2xl font-semibold">Planear tu dinero</h2>
-          <p className="text-sm text-muted-foreground">
-            Asigna cada gasto a un ingreso para saber de dónde sale cada peso
-          </p>
-        </div>
-        {planData && !isExpired && (
-          <PeriodSetupDialog currency={currency} />
-        )}
-      </div>
-
-      {/* Mobile header */}
-      <div className="lg:hidden flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold">Planear periodo</h2>
-          <p className="text-xs text-muted-foreground">
-            Asigna cada gasto a un ingreso
-          </p>
-        </div>
-        {planData && !isExpired && (
-          <PeriodSetupDialog currency={currency} />
-        )}
-      </div>
-
-      {/* Expired period banner */}
-      {planData && isExpired && (
-        <div className="rounded-xl border border-amber-400/20 bg-amber-400/5 p-3 sm:p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <div>
-            <p className="text-sm font-medium text-amber-400">
-              Tu periodo terminó
-            </p>
-            <p className="text-xs text-muted-foreground">
-              Crea uno nuevo para seguir planeando tu dinero
-            </p>
-          </div>
-          <PeriodSetupDialog
+    <>
+      {/* ── Mobile view ── */}
+      {planData && !isExpired && (
+        <div className="lg:hidden pb-20">
+          <MobilePeriodoView
+            planData={planData}
+            timelineData={timelineData}
             currency={currency}
-            suggestedStartDate={suggestedStart}
-            trigger={
-              <button className="flex items-center justify-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-sm font-medium text-amber-400 transition-colors hover:bg-amber-400/20 w-full sm:w-auto">
-                <CalendarPlus className="h-4 w-4" />
-                Nuevo periodo
-              </button>
-            }
+            isExpired={isExpired}
           />
         </div>
       )}
 
-      {/* No active period */}
-      {!planData && (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-white/10 py-16 px-8 text-center space-y-4">
-          <div className="rounded-full bg-card p-4">
-            <CalendarPlus className="h-8 w-8 text-muted-foreground" />
+      {/* ── Desktop view (+ mobile fallbacks for empty/expired states) ── */}
+      <div className={planData && !isExpired ? "hidden lg:block" : undefined}>
+        <div className="space-y-6">
+          {/* Desktop header */}
+          <div className="hidden lg:flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="text-2xl font-semibold">Planear tu dinero</h2>
+              <p className="text-sm text-muted-foreground">
+                Asigna cada gasto a un ingreso para saber de dónde sale cada peso
+              </p>
+            </div>
+            {planData && !isExpired && (
+              <PeriodSetupDialog currency={currency} />
+            )}
           </div>
-          <div className="space-y-2">
-            <h2 className="text-lg font-semibold">No tienes un periodo activo</h2>
-            <p className="text-sm text-muted-foreground max-w-sm">
-              Crea un periodo para planear tus ingresos y gastos, y asignar cada
-              compromiso a un ingreso específico.
-            </p>
-          </div>
-          <PeriodSetupDialog currency={currency} />
-        </div>
-      )}
 
-      {planData && (
-        <div className={isExpired ? "opacity-60" : undefined}>
-          <PeriodHeader data={planData} isExpired={isExpired} />
-          {!isExpired && (
-            <EnvelopeBoard
-              data={planData}
-              accounts={accounts}
-              categories={categories}
-            />
+          {/* Mobile header */}
+          <div className="lg:hidden flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Planear periodo</h2>
+              <p className="text-xs text-muted-foreground">
+                Asigna cada gasto a un ingreso
+              </p>
+            </div>
+            {planData && !isExpired && (
+              <PeriodSetupDialog currency={currency} />
+            )}
+          </div>
+
+          {/* Expired period banner */}
+          {planData && isExpired && (
+            <div className="rounded-xl border border-amber-400/20 bg-amber-400/5 p-3 sm:p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-amber-400">
+                  Tu periodo terminó
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Crea uno nuevo para seguir planeando tu dinero
+                </p>
+              </div>
+              <PeriodSetupDialog
+                currency={currency}
+                suggestedStartDate={suggestedStart}
+                trigger={
+                  <button className="flex items-center justify-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-sm font-medium text-amber-400 transition-colors hover:bg-amber-400/20 w-full sm:w-auto">
+                    <CalendarPlus className="h-4 w-4" />
+                    Nuevo periodo
+                  </button>
+                }
+              />
+            </div>
+          )}
+
+          {/* No active period */}
+          {!planData && (
+            <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-white/10 py-16 px-8 text-center space-y-4">
+              <div className="rounded-full bg-card p-4">
+                <CalendarPlus className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-lg font-semibold">No tienes un periodo activo</h2>
+                <p className="text-sm text-muted-foreground max-w-sm">
+                  Crea un periodo para planear tus ingresos y gastos, y asignar cada
+                  compromiso a un ingreso específico.
+                </p>
+              </div>
+              <PeriodSetupDialog currency={currency} />
+            </div>
+          )}
+
+          {planData && (
+            <div className={isExpired ? "opacity-60" : undefined}>
+              <PeriodHeader data={planData} isExpired={isExpired} />
+              {!isExpired && (
+                <EnvelopeBoard
+                  data={planData}
+                  accounts={accounts}
+                  categories={categories}
+                />
+              )}
+            </div>
           )}
         </div>
-      )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
@@ -9,13 +9,19 @@ import { BudgetSummaryBar } from "@/components/budget/budget-summary-bar";
 import { BudgetCategoryGrid } from "@/components/budget/budget-category-grid";
 import { TrendComparison } from "@/components/budget/trend-comparison";
 import { CategoryZoneManager } from "@/components/categories/category-zone-manager";
-import { MobilePresupuesto } from "@/components/mobile/mobile-presupuesto";
 import { MonthPlanner } from "@/components/budget/month-planner";
 import { SummaryCard } from "@/components/ui/summary-card";
 import { AttentionCard } from "@/components/ui/attention-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
+import { StateChip } from "@/components/mobile/v2/state-chip";
+import { CategoryIcon } from "@/components/categories/category-icon";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
 import { parseMonth, formatMonthLabel, getDaysRemainingInMonth } from "@/lib/utils/date";
-import type { CurrencyCode } from "@/types/domain";
+import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { AlertTriangle } from "lucide-react";
+import type { CurrencyCode, CategoryBudgetData } from "@/types/domain";
 
 const BudgetWizard = dynamic(
   () => import("@/components/budget/budget-wizard").then((m) => ({ default: m.BudgetWizard })),
@@ -81,15 +87,120 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
     );
   }
 
+  // ── Mobile data ──
+  const budgeted = outflowCategories.filter((c) => (c.budget ?? 0) > 0);
+  const totalSpent = budgeted.reduce((s, c) => s + c.spent, 0);
+  const totalBudgeted = budgeted.reduce((s, c) => s + (c.budget ?? 0), 0);
+  const progress = totalBudgeted > 0 ? Math.round((totalSpent / totalBudgeted) * 100) : 0;
+  const remaining = totalBudgeted - totalSpent;
+
+  // Distribution: essential vs wants
+  const essentialSpent = budgeted.filter((c) => c.is_essential).reduce((s, c) => s + c.spent, 0);
+  const wantsSpent = budgeted.filter((c) => !c.is_essential).reduce((s, c) => s + c.spent, 0);
+  const essentialPct = totalSpent > 0 ? Math.round((essentialSpent / totalSpent) * 100) : 0;
+  const wantsPct = totalSpent > 0 ? Math.round((wantsSpent / totalSpent) * 100) : 0;
+
+  // Sort: over-budget first, then by percentUsed descending
+  const sortedCategories = [...budgeted].sort((a, b) => {
+    const aOver = a.percentUsed >= 100 ? 1 : 0;
+    const bOver = b.percentUsed >= 100 ? 1 : 0;
+    if (aOver !== bOver) return bOver - aOver;
+    return b.percentUsed - a.percentUsed;
+  });
+
+  const pressure = progress >= 100 ? "critical" : progress >= 80 ? "watch" : "stable";
+  const chipConfig = {
+    stable: { label: "En control", variant: "sage" as const },
+    watch: { label: "Atención", variant: "warn" as const },
+    critical: { label: "Sobre límite", variant: "danger" as const },
+  } as const;
+  const chip = chipConfig[pressure];
+
   return (
     <div className="space-y-6">
       {/* Mobile view */}
-      <div className="lg:hidden">
-        <MobilePresupuesto
-          uncategorizedTransactions={uncategorized}
-          budgetCategories={outflowCategories}
-          categoryTree={categoryTree}
-        />
+      <div className="lg:hidden pb-20">
+        <MobileHeader variant="sub" title="Presupuesto" backHref="/plan" />
+
+        <div className="space-y-4 px-4 pt-4">
+          {/* Budget hero card */}
+          <div className={cn(PANEL_INSET_CLASS, "p-4")}>
+            <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+              Gastado este mes
+            </p>
+
+            <div className="mt-2 flex items-center justify-between">
+              <span
+                className={cn(
+                  "text-[42px] font-[680] leading-none tracking-[-0.06em]",
+                  progress >= 100 ? "text-z-debt" : "text-z-income"
+                )}
+              >
+                {progress}%
+              </span>
+              <div className="text-right">
+                <p className="text-lg font-semibold">
+                  {formatCurrency(totalSpent, currency)}
+                </p>
+                <p className="text-[11px] text-muted-foreground">
+                  de {formatCurrency(totalBudgeted, currency)}
+                </p>
+              </div>
+            </div>
+
+            {/* Progress bar */}
+            <div className="relative mt-3 h-2.5 rounded-full bg-[#1e221d]">
+              <div
+                className={cn(
+                  "h-full rounded-full",
+                  progress >= 100
+                    ? "bg-gradient-to-r from-z-debt/90 to-z-debt/65"
+                    : "bg-gradient-to-r from-z-income/90 to-z-income/65"
+                )}
+                style={{ width: `${Math.min(progress, 100)}%` }}
+              />
+            </div>
+
+            {/* Status + distribution */}
+            <div className="mt-3 flex items-center justify-between">
+              <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+                <span>Necesario {essentialPct}%</span>
+                <span className="text-white/15">|</span>
+                <span>Deseos {wantsPct}%</span>
+              </div>
+              <StateChip label={chip.label} variant={chip.variant} />
+            </div>
+          </div>
+
+          {/* Category list */}
+          {sortedCategories.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark mb-2">
+                Por categoría
+              </p>
+              <div className="space-y-3">
+                {sortedCategories.map((cat) => (
+                  <MobileBudgetCategoryRow key={cat.id} category={cat} currency={currency} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Remaining budget */}
+          {totalBudgeted > 0 && (
+            <div className={cn(PANEL_INSET_CLASS, "flex items-center justify-between p-3")}>
+              <span className="text-xs text-muted-foreground">Restante</span>
+              <span
+                className={cn(
+                  "text-sm font-semibold tabular-nums",
+                  remaining < 0 ? "text-z-debt" : "text-z-income"
+                )}
+              >
+                {formatCurrency(remaining, currency)}
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Desktop view */}
@@ -140,6 +251,71 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
             <CategoryZoneManager categories={allCategories} />
           </TabsContent>
         </Tabs>
+      </div>
+    </div>
+  );
+}
+
+// ─── Mobile helper ──────────────────────────────────────────────────────────
+
+function MobileBudgetCategoryRow({
+  category,
+  currency,
+}: {
+  category: CategoryBudgetData;
+  currency: CurrencyCode;
+}) {
+  const pct = category.percentUsed;
+  const isOver = pct >= 100;
+  const isWarning = pct >= 80 && pct < 100;
+
+  const barColor = isOver
+    ? "bg-z-debt"
+    : isWarning
+      ? "bg-z-alert"
+      : "bg-z-income";
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        {/* Left: icon + name */}
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="flex size-6 shrink-0 items-center justify-center rounded-md"
+            style={{ backgroundColor: `${category.color}20`, color: category.color }}
+          >
+            <CategoryIcon icon={category.icon} className="size-3.5" />
+          </span>
+          <span className="text-sm font-medium truncate">
+            {category.name_es ?? category.name}
+          </span>
+          {isOver && (
+            <AlertTriangle className="size-3.5 shrink-0 text-z-debt" />
+          )}
+        </div>
+
+        {/* Right: amounts */}
+        <div className="flex items-center gap-1 shrink-0">
+          <span
+            className={cn(
+              "text-xs font-semibold tabular-nums",
+              isOver ? "text-z-debt" : isWarning ? "text-z-alert" : "text-foreground"
+            )}
+          >
+            {formatCurrency(category.spent, currency)}
+          </span>
+          <span className="text-[10px] text-muted-foreground">
+            / {formatCurrency(category.budget!, currency)}
+          </span>
+        </div>
+      </div>
+
+      {/* Mini progress bar */}
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/5">
+        <div
+          className={cn("h-full rounded-full transition-all", barColor)}
+          style={{ width: `${Math.min(pct, 100)}%` }}
+        />
       </div>
     </div>
   );

--- a/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
@@ -5,16 +5,20 @@ import { getAttentionSnapshot } from "@/actions/attention";
 import {
   getRecurringTemplates,
   getRecurringSummary,
+  getUpcomingRecurrences,
 } from "@/actions/recurring-templates";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringList } from "@/components/recurring/recurring-list";
 import { RecurringTimelineView } from "@/components/recurring/recurring-timeline-view";
+import { MobileRecurrentesView } from "@/components/mobile/v2/plan/mobile-recurrentes-view";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { SummaryCard } from "@/components/ui/summary-card";
 import { AttentionCard } from "@/components/ui/attention-card";
 import { formatCurrency } from "@/lib/utils/currency";
+import type { PlanRecurringSummary } from "@/types/plan";
 
 export async function PlanTabRecurrentes() {
-  const [templatesResult, accountsResult, categoriesResult, summary, currency, attentionSnapshot] =
+  const [templatesResult, accountsResult, categoriesResult, summary, currency, attentionSnapshot, upcomingRecurrences] =
     await Promise.all([
       getRecurringTemplates(),
       getAccounts(),
@@ -22,18 +26,44 @@ export async function PlanTabRecurrentes() {
       getRecurringSummary(),
       getPreferredCurrency(),
       getAttentionSnapshot(),
+      getUpcomingRecurrences(30),
     ]);
 
   const templates = templatesResult.success ? templatesResult.data : [];
   const accounts = accountsResult.success ? accountsResult.data : [];
   const categories = categoriesResult.success ? categoriesResult.data : [];
 
+  // Build PlanRecurringSummary for mobile view
+  const dueSoon = upcomingRecurrences
+    .filter((entry) =>
+      entry.template.direction === "OUTFLOW" ||
+      entry.template.account.account_type === "CREDIT_CARD" ||
+      entry.template.account.account_type === "LOAN"
+    )
+    .slice(0, 6);
+  const dueSoonTotal = dueSoon.reduce((sum, entry) => sum + entry.template.amount, 0);
+
+  const recurringSummary: PlanRecurringSummary = {
+    upcoming: dueSoon,
+    totalMonthlyExpenses: summary.totalMonthlyExpenses,
+    totalMonthlyIncome: summary.totalMonthlyIncome,
+    activeCount: summary.activeCount,
+    dueSoonCount: dueSoon.length,
+    dueSoonTotal,
+  };
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between gap-4">
+      {/* Mobile view */}
+      <div className="lg:hidden">
+        <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
+        <MobileRecurrentesView summary={recurringSummary} currency={currency} />
+      </div>
+
+      {/* Desktop header */}
+      <div className="hidden lg:flex items-center justify-between gap-4">
         <div>
-          <h2 className="text-2xl font-semibold hidden lg:block">Recurrentes</h2>
-          <h2 className="text-lg font-semibold lg:hidden">Recurrentes</h2>
+          <h2 className="text-2xl font-semibold">Recurrentes</h2>
           <p className="text-sm text-muted-foreground">
             {summary.activeCount} plantillas activas
           </p>
@@ -41,26 +71,29 @@ export async function PlanTabRecurrentes() {
         <RecurringFormDialog accounts={accounts} categories={categories} />
       </div>
 
-      <div className="hidden lg:grid gap-4 lg:grid-cols-2">
-        <SummaryCard
-          metrics={[
-            { label: "Plantillas activas", value: summary.activeCount, context: "rutinas recurrentes" },
-            { label: "Salidas/mes", value: formatCurrency(summary.totalMonthlyExpenses, currency), context: "compromiso fijo" },
-            { label: "Entradas/mes", value: formatCurrency(summary.totalMonthlyIncome, currency), context: "ingreso recurrente" },
-          ]}
-        />
-        <AttentionCard
-          signals={attentionSnapshot.signals.filter((s: { page: string }) => s.page === "recurrentes")}
+      {/* Desktop view */}
+      <div className="hidden lg:block space-y-6">
+        <div className="grid gap-4 lg:grid-cols-2">
+          <SummaryCard
+            metrics={[
+              { label: "Plantillas activas", value: summary.activeCount, context: "rutinas recurrentes" },
+              { label: "Salidas/mes", value: formatCurrency(summary.totalMonthlyExpenses, currency), context: "compromiso fijo" },
+              { label: "Entradas/mes", value: formatCurrency(summary.totalMonthlyIncome, currency), context: "ingreso recurrente" },
+            ]}
+          />
+          <AttentionCard
+            signals={attentionSnapshot.signals.filter((s: { page: string }) => s.page === "recurrentes")}
+          />
+        </div>
+
+        <RecurringTimelineView templates={templates} accounts={accounts} />
+
+        <RecurringList
+          templates={templates}
+          accounts={accounts}
+          categories={categories}
         />
       </div>
-
-      <RecurringTimelineView templates={templates} accounts={accounts} />
-
-      <RecurringList
-        templates={templates}
-        accounts={accounts}
-        categories={categories}
-      />
     </div>
   );
 }

--- a/webapp/src/components/settings/settings-mobile-accordion.tsx
+++ b/webapp/src/components/settings/settings-mobile-accordion.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface SettingsSection {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function SettingsMobileAccordion({ sections }: { sections: SettingsSection[] }) {
+  const [openId, setOpenId] = useState<string>(sections[0]?.id ?? "");
+
+  return (
+    <div className="space-y-2">
+      {sections.map((section) => {
+        const isOpen = openId === section.id;
+        return (
+          <Collapsible
+            key={section.id}
+            open={isOpen}
+            onOpenChange={(open) => setOpenId(open ? section.id : "")}
+          >
+            <div className="rounded-xl border border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+              <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 p-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+                    {section.icon}
+                  </div>
+                  <span className="font-semibold">{section.title}</span>
+                </div>
+                <ChevronDown
+                  className={cn(
+                    "size-4 text-muted-foreground transition-transform duration-200",
+                    isOpen && "rotate-180"
+                  )}
+                />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="border-t border-white/6 px-4 pb-4 pt-3">
+                  {section.children}
+                </div>
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
+        );
+      })}
+    </div>
+  );
+}

--- a/webapp/src/components/transactions/transaction-category-picker.tsx
+++ b/webapp/src/components/transactions/transaction-category-picker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { categorizeTransaction, uncategorizeTransaction } from "@/actions/categorize";
+import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import type { CategoryWithChildren, TransactionDirection } from "@/types/domain";
+
+interface TransactionCategoryPickerProps {
+  transactionId: string;
+  currentCategoryId: string | null;
+  categories: CategoryWithChildren[];
+  direction?: TransactionDirection;
+}
+
+export function TransactionCategoryPicker({
+  transactionId,
+  currentCategoryId,
+  categories,
+  direction,
+}: TransactionCategoryPickerProps) {
+  const [value, setValue] = useState(currentCategoryId);
+  const [, startTransition] = useTransition();
+
+  function handleChange(categoryId: string | null) {
+    setValue(categoryId);
+    startTransition(async () => {
+      if (categoryId) {
+        await categorizeTransaction(transactionId, categoryId);
+      } else {
+        await uncategorizeTransaction(transactionId);
+      }
+    });
+  }
+
+  return (
+    <CategoryZonePicker
+      categories={categories}
+      value={value}
+      onValueChange={handleChange}
+      direction={direction}
+      variant="popover"
+      triggerClassName="w-full h-9"
+    />
+  );
+}

--- a/webapp/src/components/ui/summary-card.tsx
+++ b/webapp/src/components/ui/summary-card.tsx
@@ -24,7 +24,7 @@ export function SummaryCard({ label = "Resumen del período", metrics, className
       <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-olive-deep">
         {label}
       </p>
-      <div className="mt-3 grid grid-cols-3 gap-3">
+      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
         {metrics.map((m) => (
           <CompactMetricBox
             key={m.label}

--- a/webapp/src/hooks/use-chart-focus-mode.ts
+++ b/webapp/src/hooks/use-chart-focus-mode.ts
@@ -1,0 +1,28 @@
+// src/hooks/use-chart-focus-mode.ts
+"use client";
+
+import { useEffect, useCallback, useState } from "react";
+
+export function useChartFocusMode(isExpanded: boolean) {
+  const [overlayVisible, setOverlayVisible] = useState(false);
+
+  useEffect(() => {
+    if (isExpanded) {
+      document.body.style.overflow = "hidden";
+      const timer = setTimeout(() => setOverlayVisible(true), 50);
+      return () => clearTimeout(timer);
+    } else {
+      document.body.style.overflow = "";
+      setOverlayVisible(false);
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isExpanded]);
+
+  const handleOverlayClick = useCallback((onCollapse: () => void) => {
+    return () => onCollapse();
+  }, []);
+
+  return { overlayVisible, handleOverlayClick };
+}

--- a/webapp/src/lib/supabase/auth.ts
+++ b/webapp/src/lib/supabase/auth.ts
@@ -103,16 +103,36 @@ export async function getUserSafelyStrict(
  * server render, so the dashboard (which fires 8+ parallel data fetches)
  * only verifies the JWT once per page load instead of once per function.
  *
- * Uses getSession() (local JWT check, ~0ms) instead of getUser() (~300ms
- * network call to Supabase Auth). If the session is revoked, the admin
- * client queries in cached functions will still work (they bypass auth),
- * and the middleware will catch the revoked token on the next request.
+ * Returns accessToken so "use cache" functions can create their own
+ * authenticated Supabase client via createCachedClient(accessToken).
  */
 export const getAuthenticatedClient = cache(async (): Promise<{
   supabase: SupabaseClient<Database>;
   user: User | null;
+  accessToken: string | null;
 }> => {
   const supabase = await createClient();
-  const user = await getUserSafely(supabase);
-  return { supabase, user };
+
+  // Fast path: getSession() — local JWT check, ~0ms, also gives us the token
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase.auth as any).suppressGetSessionWarning = true;
+    const { data, error } = await supabase.auth.getSession();
+    if (!error && data.session?.user) {
+      return {
+        supabase,
+        user: data.session.user,
+        accessToken: data.session.access_token,
+      };
+    }
+    if (error && isIgnorableAuthError(error)) {
+      return { supabase, user: null, accessToken: null };
+    }
+  } catch {
+    // getSession() failed — fall through to getUser()
+  }
+
+  // Slow path: getUser() network call — no access token available here
+  const user = await getUserSafelyStrict(supabase);
+  return { supabase, user, accessToken: null };
 });

--- a/webapp/src/lib/supabase/auth.ts
+++ b/webapp/src/lib/supabase/auth.ts
@@ -132,7 +132,18 @@ export const getAuthenticatedClient = cache(async (): Promise<{
     // getSession() failed — fall through to getUser()
   }
 
-  // Slow path: getUser() network call — no access token available here
+  // Slow path: getUser() network call — may refresh the session
   const user = await getUserSafelyStrict(supabase);
+  if (user) {
+    // getUser() may have refreshed the session — retry to get token
+    try {
+      const { data } = await supabase.auth.getSession();
+      if (data.session?.access_token) {
+        return { supabase, user, accessToken: data.session.access_token };
+      }
+    } catch {
+      // No token available — continue without caching
+    }
+  }
   return { supabase, user, accessToken: null };
 });

--- a/webapp/src/lib/supabase/cached.ts
+++ b/webapp/src/lib/supabase/cached.ts
@@ -1,0 +1,30 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+/**
+ * Create a Supabase client authenticated with a user's access token.
+ * Used inside "use cache" functions where request-scoped cookies are unavailable.
+ *
+ * The token provides auth.uid() context needed for zeta_decrypt() on encrypted
+ * views, while allowing the response to be cached across requests.
+ *
+ * Cache entries are keyed by (userId, accessToken), so they auto-expire when
+ * the JWT rotates (~1h). Mutations invalidate via revalidateTag() immediately.
+ */
+export function createCachedClient(accessToken: string) {
+  return createSupabaseClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      global: {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    },
+  );
+}

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -14,7 +14,7 @@ export type Database = {
   }
   public: {
     Tables: {
-      accounts: {
+      accounts_enc: {
         Row: {
           account_type: Database["public"]["Enums"]["account_type"]
           available_balance: number | null
@@ -40,6 +40,7 @@ export type Database = {
           loan_end_date: string | null
           loan_start_date: string | null
           mask: string | null
+          mask_hmac: string | null
           maturity_date: string | null
           monthly_payment: number | null
           name: string
@@ -47,6 +48,7 @@ export type Database = {
           pdf_password: string | null
           provider: Database["public"]["Enums"]["data_provider"]
           provider_account_id: string | null
+          provider_account_id_hmac: string | null
           show_in_dashboard: boolean
           updated_at: string
           user_id: string
@@ -76,6 +78,7 @@ export type Database = {
           loan_end_date?: string | null
           loan_start_date?: string | null
           mask?: string | null
+          mask_hmac?: string | null
           maturity_date?: string | null
           monthly_payment?: number | null
           name: string
@@ -83,6 +86,7 @@ export type Database = {
           pdf_password?: string | null
           provider?: Database["public"]["Enums"]["data_provider"]
           provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
           show_in_dashboard?: boolean
           updated_at?: string
           user_id: string
@@ -112,6 +116,7 @@ export type Database = {
           loan_end_date?: string | null
           loan_start_date?: string | null
           mask?: string | null
+          mask_hmac?: string | null
           maturity_date?: string | null
           monthly_payment?: number | null
           name?: string
@@ -119,11 +124,151 @@ export type Database = {
           pdf_password?: string | null
           provider?: Database["public"]["Enums"]["data_provider"]
           provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
           show_in_dashboard?: boolean
           updated_at?: string
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      accounts: {
+        Row: {
+          account_type: Database["public"]["Enums"]["account_type"]
+          available_balance: number | null
+          color: string | null
+          connection_status: Database["public"]["Enums"]["connection_status"]
+          created_at: string
+          credit_limit: number | null
+          currency_balances: Json | null
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          current_balance: number
+          cutoff_day: number | null
+          debit_card_mask: string | null
+          display_order: number
+          expected_return_rate: number | null
+          icon: string | null
+          id: string
+          initial_investment: number | null
+          institution_name: string | null
+          interest_rate: number | null
+          is_active: boolean
+          last_synced_at: string | null
+          loan_amount: number | null
+          loan_end_date: string | null
+          loan_start_date: string | null
+          mask: string | null
+          mask_hmac: string | null
+          maturity_date: string | null
+          monthly_payment: number | null
+          name: string
+          payment_day: number | null
+          pdf_password: string | null
+          provider: Database["public"]["Enums"]["data_provider"]
+          provider_account_id: string | null
+          provider_account_id_hmac: string | null
+          show_in_dashboard: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_type: Database["public"]["Enums"]["account_type"]
+          available_balance?: number | null
+          color?: string | null
+          connection_status?: Database["public"]["Enums"]["connection_status"]
+          created_at?: string
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          current_balance?: number
+          cutoff_day?: number | null
+          debit_card_mask?: string | null
+          display_order?: number
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string
+          initial_investment?: number | null
+          institution_name?: string | null
+          interest_rate?: number | null
+          is_active?: boolean
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: string | null
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name: string
+          payment_day?: number | null
+          pdf_password?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_type?: Database["public"]["Enums"]["account_type"]
+          available_balance?: number | null
+          color?: string | null
+          connection_status?: Database["public"]["Enums"]["connection_status"]
+          created_at?: string
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          current_balance?: number
+          cutoff_day?: number | null
+          debit_card_mask?: string | null
+          display_order?: number
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string
+          initial_investment?: number | null
+          institution_name?: string | null
+          interest_rate?: number | null
+          is_active?: boolean
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: string | null
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: string
+          payment_day?: number | null
+          pdf_password?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "accounts_user_id_fkey"
             columns: ["user_id"]
@@ -240,6 +385,64 @@ export type Database = {
             referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "bug_reports_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      capture_tokens_enc: {
+        Row: {
+          created_at: string
+          default_account_id: string | null
+          id: string
+          label: string
+          last_used_at: string | null
+          revoked_at: string | null
+          token: string
+          token_hash: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_account_id?: string | null
+          id?: string
+          label: string
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token: string
+          token_hash?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_account_id?: string | null
+          id?: string
+          label?: string
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: string
+          token_hash?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
         ]
       }
       capture_tokens: {
@@ -251,16 +454,18 @@ export type Database = {
           last_used_at: string | null
           revoked_at: string | null
           token: string
+          token_hash: string
           user_id: string
         }
         Insert: {
           created_at?: string
           default_account_id?: string | null
           id?: string
-          label?: string
+          label: string
           last_used_at?: string | null
           revoked_at?: string | null
           token: string
+          token_hash?: string
           user_id: string
         }
         Update: {
@@ -271,9 +476,17 @@ export type Database = {
           last_used_at?: string | null
           revoked_at?: string | null
           token?: string
+          token_hash?: string
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "capture_tokens_default_account_id_fkey"
             columns: ["default_account_id"]
@@ -357,6 +570,13 @@ export type Database = {
             referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "categories_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
         ]
       }
       category_rules: {
@@ -400,6 +620,13 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "category_rules_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -567,10 +794,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "destinatario_rules_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "destinatario_rules_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatario_rules_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -597,6 +838,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "destinatario_tags_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "destinatario_tags_tag_id_fkey"
             columns: ["tag_id"]
             isOneToOne: false
@@ -605,13 +853,14 @@ export type Database = {
           },
         ]
       }
-      destinatarios: {
+      destinatarios_enc: {
         Row: {
           created_at: string
           default_category_id: string | null
           id: string
           is_active: boolean
           name: string
+          name_hmac: string | null
           notes: string | null
           updated_at: string
           user_id: string
@@ -622,6 +871,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           name: string
+          name_hmac?: string | null
           notes?: string | null
           updated_at?: string
           user_id: string
@@ -632,6 +882,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           name?: string
+          name_hmac?: string | null
           notes?: string | null
           updated_at?: string
           user_id?: string
@@ -649,6 +900,142 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      destinatarios: {
+        Row: {
+          created_at: string
+          default_category_id: string | null
+          id: string
+          is_active: boolean
+          name: string
+          name_hmac: string | null
+          notes: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_category_id?: string | null
+          id?: string
+          is_active?: boolean
+          name: string
+          name_hmac?: string | null
+          notes?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_category_id?: string | null
+          id?: string
+          is_active?: boolean
+          name?: string
+          name_hmac?: string | null
+          notes?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "destinatarios_default_category_id_fkey"
+            columns: ["default_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      email_ingest_addresses_enc: {
+        Row: {
+          account_id: string | null
+          address_key: string
+          allowed_sender: string | null
+          auto_import: boolean
+          created_at: string
+          gmail_verification_at: string | null
+          gmail_verification_url: string | null
+          id: string
+          is_active: boolean
+          pdf_import_enabled: boolean
+          user_id: string
+        }
+        Insert: {
+          account_id?: string | null
+          address_key: string
+          allowed_sender?: string | null
+          auto_import?: boolean
+          created_at?: string
+          gmail_verification_at?: string | null
+          gmail_verification_url?: string | null
+          id?: string
+          is_active?: boolean
+          pdf_import_enabled?: boolean
+          user_id: string
+        }
+        Update: {
+          account_id?: string | null
+          address_key?: string
+          allowed_sender?: string | null
+          auto_import?: boolean
+          created_at?: string
+          gmail_verification_at?: string | null
+          gmail_verification_url?: string | null
+          id?: string
+          is_active?: boolean
+          pdf_import_enabled?: boolean
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -702,6 +1089,20 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "email_ingest_addresses_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: true
@@ -750,10 +1151,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "email_ingest_logs_email_ingest_id_fkey"
+            columns: ["email_ingest_id"]
+            isOneToOne: false
+            referencedRelation: "email_ingest_addresses_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "email_ingest_logs_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_logs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -882,10 +1297,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pending_email_statements_email_ingest_id_fkey"
+            columns: ["email_ingest_id"]
+            isOneToOne: false
+            referencedRelation: "email_ingest_addresses_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "pending_email_statements_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pending_email_statements_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -933,6 +1362,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pending_email_transactions_email_ingest_id_fkey"
+            columns: ["email_ingest_id"]
+            isOneToOne: false
+            referencedRelation: "email_ingest_addresses_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "pending_email_transactions_suggested_account_id_fkey"
             columns: ["suggested_account_id"]
             isOneToOne: false
@@ -940,10 +1376,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pending_email_transactions_suggested_account_id_fkey"
+            columns: ["suggested_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "pending_email_transactions_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pending_email_transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1070,6 +1520,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "planning_entries_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "planning_entries_category_id_fkey"
             columns: ["category_id"]
             isOneToOne: false
@@ -1088,6 +1545,13 @@ export type Database = {
             columns: ["recurring_template_id"]
             isOneToOne: false
             referencedRelation: "recurring_transaction_templates"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "planning_entries_recurring_template_id_fkey"
+            columns: ["recurring_template_id"]
+            isOneToOne: false
+            referencedRelation: "recurring_transaction_templates_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1194,7 +1658,71 @@ export type Database = {
             referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "product_events_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
         ]
+      }
+      profiles_enc: {
+        Row: {
+          app_purpose: string | null
+          avatar_url: string | null
+          budget_mode: string | null
+          created_at: string
+          dashboard_config: Json | null
+          email: string
+          estimated_monthly_expenses: number | null
+          estimated_monthly_income: number | null
+          full_name: string | null
+          id: string
+          locale: string
+          monthly_salary: number | null
+          onboarding_completed: boolean
+          preferred_currency: Database["public"]["Enums"]["currency_code"]
+          timezone: string
+          updated_at: string
+        }
+        Insert: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string
+          dashboard_config?: Json | null
+          email: string
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: string | null
+          id: string
+          locale?: string
+          monthly_salary?: number | null
+          onboarding_completed?: boolean
+          preferred_currency?: Database["public"]["Enums"]["currency_code"]
+          timezone?: string
+          updated_at?: string
+        }
+        Update: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string
+          dashboard_config?: Json | null
+          email?: string
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: string | null
+          id?: string
+          locale?: string
+          monthly_salary?: number | null
+          onboarding_completed?: boolean
+          preferred_currency?: Database["public"]["Enums"]["currency_code"]
+          timezone?: string
+          updated_at?: string
+        }
+        Relationships: []
       }
       profiles: {
         Row: {
@@ -1252,6 +1780,119 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      }
+      recurring_transaction_templates_enc: {
+        Row: {
+          account_id: string
+          amount: number
+          category_id: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          day_of_month: number | null
+          day_of_week: number | null
+          description: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id: string
+          is_active: boolean
+          merchant_name: string | null
+          start_date: string
+          transfer_source_account_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date: string
+          transfer_source_account_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date?: string
+          transfer_source_account_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       recurring_transaction_templates: {
         Row: {
@@ -1323,6 +1964,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "recurring_transaction_templates_category_id_fkey"
             columns: ["category_id"]
             isOneToOne: false
@@ -1337,10 +1985,149 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "recurring_transaction_templates_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      statement_snapshots_enc: {
+        Row: {
+          account_id: string
+          available_credit: number | null
+          created_at: string
+          credit_limit: number | null
+          currency_code: string
+          final_balance: number | null
+          id: string
+          imported_count: number
+          initial_amount: number | null
+          installments_in_default: number | null
+          interest_charged: number | null
+          interest_rate: number | null
+          late_interest_rate: number | null
+          loan_number: string | null
+          minimum_payment: number | null
+          payment_due_date: string | null
+          period_from: string | null
+          period_to: string | null
+          previous_balance: number | null
+          purchases_and_charges: number | null
+          remaining_balance: number | null
+          skipped_count: number
+          source_filename: string | null
+          total_credits: number | null
+          total_debits: number | null
+          total_payment_due: number | null
+          transaction_count: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          available_credit?: number | null
+          created_at?: string
+          credit_limit?: number | null
+          currency_code?: string
+          final_balance?: number | null
+          id?: string
+          imported_count?: number
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: string | null
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number
+          source_filename?: string | null
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          available_credit?: number | null
+          created_at?: string
+          credit_limit?: number | null
+          currency_code?: string
+          final_balance?: number | null
+          id?: string
+          imported_count?: number
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: string | null
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number
+          source_filename?: string | null
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1448,6 +2235,20 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "statement_snapshots_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
@@ -1490,6 +2291,13 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_groups_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1543,6 +2351,13 @@ export type Database = {
             referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "tags_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
         ]
       }
       transaction_tags: {
@@ -1573,9 +2388,16 @@ export type Database = {
             referencedRelation: "transactions"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "transaction_tags_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
+            referencedColumns: ["id"]
+          },
         ]
       }
-      transactions: {
+      transactions_enc: {
         Row: {
           account_id: string
           amount: number
@@ -1586,6 +2408,7 @@ export type Database = {
           categorization_source: Database["public"]["Enums"]["categorization_source"]
           category_id: string | null
           clean_description: string | null
+          clean_description_hmac: string | null
           created_at: string
           currency_code: Database["public"]["Enums"]["currency_code"]
           destinatario_id: string | null
@@ -1602,6 +2425,7 @@ export type Database = {
           merchant_category_code: string | null
           merchant_logo_url: string | null
           merchant_name: string | null
+          merchant_name_hmac: string | null
           notes: string | null
           original_amount: number | null
           posting_date: string | null
@@ -1628,6 +2452,7 @@ export type Database = {
           categorization_source?: Database["public"]["Enums"]["categorization_source"]
           category_id?: string | null
           clean_description?: string | null
+          clean_description_hmac?: string | null
           created_at?: string
           currency_code: Database["public"]["Enums"]["currency_code"]
           destinatario_id?: string | null
@@ -1644,6 +2469,7 @@ export type Database = {
           merchant_category_code?: string | null
           merchant_logo_url?: string | null
           merchant_name?: string | null
+          merchant_name_hmac?: string | null
           notes?: string | null
           original_amount?: number | null
           posting_date?: string | null
@@ -1670,6 +2496,7 @@ export type Database = {
           categorization_source?: Database["public"]["Enums"]["categorization_source"]
           category_id?: string | null
           clean_description?: string | null
+          clean_description_hmac?: string | null
           created_at?: string
           currency_code?: Database["public"]["Enums"]["currency_code"]
           destinatario_id?: string | null
@@ -1686,6 +2513,7 @@ export type Database = {
           merchant_category_code?: string | null
           merchant_logo_url?: string | null
           merchant_name?: string | null
+          merchant_name_hmac?: string | null
           notes?: string | null
           original_amount?: number | null
           posting_date?: string | null
@@ -1711,10 +2539,230 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "transactions_category_id_fkey"
             columns: ["category_id"]
             isOneToOne: false
             referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_secondary_category_id_fkey"
+            columns: ["secondary_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      transactions: {
+        Row: {
+          account_id: string
+          amount: number
+          amount_in_base_currency: number | null
+          capture_input_text: string | null
+          capture_method: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence: number | null
+          categorization_source: Database["public"]["Enums"]["categorization_source"]
+          category_id: string | null
+          clean_description: string | null
+          clean_description_hmac: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate: number
+          id: string
+          idempotency_key: string
+          installment_current: number | null
+          installment_group_id: string | null
+          installment_total: number | null
+          is_excluded: boolean
+          is_recurring: boolean
+          is_subscription: boolean
+          merchant_category_code: string | null
+          merchant_logo_url: string | null
+          merchant_name: string | null
+          merchant_name_hmac: string | null
+          notes: string | null
+          original_amount: number | null
+          posting_date: string | null
+          provider: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id: string | null
+          raw_description: string | null
+          reconciled_into_transaction_id: string | null
+          reconciliation_score: number | null
+          recurrence_group_id: string | null
+          secondary_category_id: string | null
+          status: Database["public"]["Enums"]["transaction_status"]
+          tags: string[] | null
+          transaction_date: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          amount_in_base_currency?: number | null
+          capture_input_text?: string | null
+          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence?: number | null
+          categorization_source?: Database["public"]["Enums"]["categorization_source"]
+          category_id?: string | null
+          clean_description?: string | null
+          clean_description_hmac?: string | null
+          created_at?: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          destinatario_id?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate?: number
+          id?: string
+          idempotency_key: string
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean
+          is_recurring?: boolean
+          is_subscription?: boolean
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: string | null
+          merchant_name_hmac?: string | null
+          notes?: string | null
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id?: string | null
+          raw_description?: string | null
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"]
+          tags?: string[] | null
+          transaction_date: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          amount_in_base_currency?: number | null
+          capture_input_text?: string | null
+          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence?: number | null
+          categorization_source?: Database["public"]["Enums"]["categorization_source"]
+          category_id?: string | null
+          clean_description?: string | null
+          clean_description_hmac?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          destinatario_id?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate?: number
+          id?: string
+          idempotency_key?: string
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean
+          is_recurring?: boolean
+          is_subscription?: boolean
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: string | null
+          merchant_name_hmac?: string | null
+          notes?: string | null
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id?: string | null
+          raw_description?: string | null
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"]
+          tags?: string[] | null
+          transaction_date?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
             referencedColumns: ["id"]
           },
           {
@@ -1732,10 +2780,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "transactions_secondary_category_id_fkey"
             columns: ["secondary_category_id"]
             isOneToOne: false
             referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
           {
@@ -1790,10 +2852,165 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "unrecognized_emails_email_ingest_id_fkey"
+            columns: ["email_ingest_id"]
+            isOneToOne: false
+            referencedRelation: "email_ingest_addresses_enc"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "unrecognized_emails_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "unrecognized_emails_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_encryption_keys: {
+        Row: {
+          created_at: string | null
+          encrypted_dek: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          encrypted_dek: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          encrypted_dek?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      wishlist_items_enc: {
+        Row: {
+          account_id: string | null
+          amount: number
+          bought_at: string | null
+          category_id: string | null
+          created_at: string
+          currency_code: string
+          desire_type: string | null
+          enriched: boolean
+          enriched_at: string | null
+          funding_type: string | null
+          id: string
+          image_url: string | null
+          installments: number | null
+          last_nudge_dismissed_at: string | null
+          last_score: number | null
+          last_scored_at: string | null
+          last_verdict: string | null
+          name: string
+          ready_at: string | null
+          status: string
+          transaction_id: string | null
+          updated_at: string
+          urgency: string | null
+          url: string | null
+          user_id: string
+          why: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount: number
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string
+          currency_code?: string
+          desire_type?: string | null
+          enriched?: boolean
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name: string
+          ready_at?: string | null
+          status?: string
+          transaction_id?: string | null
+          updated_at?: string
+          urgency?: string | null
+          url?: string | null
+          user_id: string
+          why?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string
+          currency_code?: string
+          desire_type?: string | null
+          enriched?: boolean
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: string
+          ready_at?: string | null
+          status?: string
+          transaction_id?: string | null
+          updated_at?: string
+          urgency?: string | null
+          url?: string | null
+          user_id?: string
+          why?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1892,10 +3109,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "wishlist_items_category_id_fkey"
             columns: ["category_id"]
             isOneToOne: false
             referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
             referencedColumns: ["id"]
           },
           {
@@ -1949,6 +3180,13 @@ export type Database = {
             referencedRelation: "wishlist_items"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "wishlist_reflections_wishlist_item_id_fkey"
+            columns: ["wishlist_item_id"]
+            isOneToOne: false
+            referencedRelation: "wishlist_items_enc"
+            referencedColumns: ["id"]
+          },
         ]
       }
     }
@@ -1956,7 +3194,17 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      zeta_decrypt: { Args: { ciphertext: string }; Returns: string }
+      zeta_encrypt: { Args: { plaintext: string }; Returns: string }
+      zeta_encrypt_as: {
+        Args: { plaintext: string; target_user_id: string }
+        Returns: string
+      }
+      zeta_hmac: { Args: { plaintext: string }; Returns: string }
+      zeta_hmac_as: {
+        Args: { plaintext: string; target_user_id: string }
+        Returns: string
+      }
     }
     Enums: {
       account_type:

--- a/webapp/src/types/domain.ts
+++ b/webapp/src/types/domain.ts
@@ -116,6 +116,8 @@ export type CategoryBudgetData = {
 // Transaction with account join (used by main transaction views)
 export type TransactionWithAccount = Transaction & {
   account: Pick<Account, "id" | "name" | "icon" | "color">;
+  category: Pick<Category, "id" | "name" | "name_es" | "icon" | "color"> | null;
+  destinatario: { id: string; name: string } | null;
 };
 
 // Transaction with joined relations


### PR DESCRIPTION
## Summary
- **Performance**: Transaction detail page loads instantly via `loading.tsx` + Suspense splitting — hero renders with 1 query (~3ms), edit/picker forms stream in
- **Encryption fix**: All 14 `"use cache"` action files switched from `createAdminClient()` (returned NULL for encrypted columns) to `createCachedClient(accessToken)` — stable data (accounts, destinatarios, profiles, etc.) now cached correctly across navigations
- **DB optimization**: `zeta_decrypt()` caches DEK per transaction via `set_config()` — accounts query 17.3ms → 8.4ms (-52%)
- **Transaction caching**: `getTransactions()` and `getTransaction()` now use `"use cache"` with `cacheTag("transactions")` — same month/filters = cache hit on re-navigation
- **PostgREST fix**: Joins through encrypted views require explicit FK hints (`!fk_name`) — fixed and documented in CLAUDE.md
- **UI**: Transaction row expanded view uses icon-only actions (👤 # ✏️), matching CategorizarDetail style
- **Rules**: Added Performance Rules, UI Rules (no hardcoded colors), and encryption gotchas to CLAUDE.md
- Includes parallel work: plan page redesign, mobile polish components

## Test plan
- [ ] Navigate to Movimientos — transactions should load (not empty)
- [ ] Click "Ver detalle" — should show skeleton instantly, then stream content
- [ ] Navigate back to Movimientos — should be fast (cached)
- [ ] Expand a transaction row — should show icon-only actions (👤 # ✏️)
- [ ] Expand a categorizar item in herramientas — should show Categoría picker + icon actions
- [ ] Verify account names, destinatario names display correctly (not NULL) on all pages
- [ ] Check debt page, recurring templates, profile — encrypted fields should render

🤖 Generated with [Claude Code](https://claude.com/claude-code)