### PR TITLE
feat: enhance dashboard discovery chips — inline purchase recommender + richer plan CTA

### DIFF
--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -1,4 +1,4 @@
-import { getDashboardHeroData } from "@/actions/charts";
+import { getDashboardHeroData, getDailySpending } from "@/actions/charts";
 import { getAttentionItems } from "@/actions/attention-items";
 import { getBurnRate } from "@/actions/burn-rate";
 import { getBudgetSummary } from "@/actions/budgets";
@@ -21,13 +21,14 @@ interface MobileZoneProps {
 }
 
 export async function MobileZone({ month, currency, recentTx }: MobileZoneProps) {
-  const [heroData, attentionItemsData, burnRateData, budgetSummary, accountsResult] =
+  const [heroData, attentionItemsData, burnRateData, budgetSummary, accountsResult, dailySpending] =
     await Promise.all([
       getDashboardHeroData(month, currency),
       getAttentionItems(),
       getBurnRate(currency),
       getBudgetSummary(month),
       getAccounts(),
+      getDailySpending(month, currency),
     ]);
 
   const allAccounts = accountsResult.success ? accountsResult.data : [];
@@ -66,20 +67,13 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
     };
   })();
 
+  // Today's spending from cached daily data
+  const todayStr = now.toISOString().slice(0, 10);
+  const spentToday = dailySpending.find((d) => d.date === todayStr)?.amount ?? 0;
+
   // Mobile total spent derivation
   const mobileTotalSpent =
     heroData.totalLiquid - heroData.totalPending - heroData.availableToSpend;
-
-  // Next payment info
-  const firstPayment = heroData.pendingObligations[0];
-  const nextPaymentDays = firstPayment
-    ? Math.max(
-        0,
-        Math.ceil(
-          (new Date(firstPayment.due_date).getTime() - Date.now()) / 86_400_000
-        )
-      )
-    : null;
 
   return (
     <>
@@ -98,12 +92,9 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
           primaryAccount,
         }}
         metrics={{
-          runwayDays: burnRateData?.discretionary.runwayDays ?? 0,
           daysInMonth,
           dayOfMonth: now.getDate(),
-          nextPaymentName: firstPayment?.name ?? null,
-          nextPaymentDays,
-          nextPaymentAmount: firstPayment?.amount ?? null,
+          spentToday,
           currency,
         }}
         attentionItems={attentionItemsData}

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -68,7 +68,7 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
   })();
 
   // Today's spending from cached daily data
-  const todayStr = now.toISOString().slice(0, 10);
+  const todayStr = now.toLocaleDateString("en-CA");
   const spentToday = dailySpending.find((d) => d.date === todayStr)?.amount ?? 0;
 
   // Mobile total spent derivation

--- a/webapp/src/components/mobile/v2/inicio/inicio-discovery.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-discovery.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { PANEL_INSET_CLASS, BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { PurchaseRecommenderDrawer } from "./purchase-recommender-drawer";
 
 // ─── Icons ───────────────────────────────────────────────────────────────────
 
@@ -23,6 +25,14 @@ function CalendarIcon() {
   );
 }
 
+function ArrowRightIcon() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 8h10M9 4l4 4-4 4" />
+    </svg>
+  );
+}
+
 function IconBox({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-z-brass/20 bg-z-brass/10">
@@ -30,21 +40,6 @@ function IconBox({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
-
-// ─── Detail content per card ─────────────────────────────────────────────────
-
-const details: Record<string, { text: string; href: string; label: string }> = {
-  "discovery-deseos": {
-    text: "Describe lo que quieres comprar y Zeta evalúa si cabe en tu plan.",
-    href: "/deseos",
-    label: "Ir a deseos →",
-  },
-  "discovery-mapa": {
-    text: "Tu presupuesto distribuido en el calendario.",
-    href: "/plan",
-    label: "Ver plan →",
-  },
-};
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
@@ -55,21 +50,20 @@ interface InicioDiscoveryProps {
 
 export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
   const activeId = expanded?.startsWith("discovery-") ? expanded : null;
-  const detail = activeId ? details[activeId] : null;
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   return (
     <div>
       {/* Chip row — always visible */}
       <div className="grid grid-cols-2 gap-1.5">
+        {/* ¿Puedo comprarlo? → opens purchase recommender drawer directly */}
         <button
           type="button"
-          onClick={() => onToggle("discovery-deseos")}
+          onClick={() => setDrawerOpen(true)}
           className={cn(
             PANEL_INSET_CLASS,
-            "flex w-full items-center gap-2.5 px-3 py-3 text-left transition-colors active:bg-white/[0.03]",
-            activeId === "discovery-deseos" && "ring-1 ring-z-brass/30 bg-z-brass/[0.06]"
+            "flex w-full items-center gap-2.5 px-3 py-3 text-left transition-colors active:bg-white/[0.03]"
           )}
-          aria-expanded={activeId === "discovery-deseos"}
         >
           <IconBox><LightbulbIcon /></IconBox>
           <div className="min-w-0">
@@ -78,6 +72,7 @@ export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
           </div>
         </button>
 
+        {/* Mapa del mes → expands to show plan teaser */}
         <button
           type="button"
           onClick={() => onToggle("discovery-mapa")}
@@ -90,37 +85,49 @@ export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
         >
           <IconBox><CalendarIcon /></IconBox>
           <div className="min-w-0">
-            <p className="text-[12px] font-semibold leading-tight">Mapa del mes</p>
-            <p className="mt-0.5 text-[10px] leading-tight text-muted-foreground">Tu gasto en el tiempo</p>
+            <p className="text-[12px] font-semibold leading-tight">Plan del mes</p>
+            <p className="mt-0.5 text-[10px] leading-tight text-muted-foreground">Tu estrategia financiera</p>
           </div>
         </button>
       </div>
 
-      {/* Expanded panel — FULL WIDTH below both cards */}
+      {/* Expanded panel for Plan del mes — full width below */}
       <div
         className="grid transition-[grid-template-rows] duration-200 ease-out"
-        style={{ gridTemplateRows: activeId ? "1fr" : "0fr" }}
+        style={{ gridTemplateRows: activeId === "discovery-mapa" ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden">
           <div
             className={cn(
               "mt-1.5 transition-opacity duration-150",
-              activeId ? "opacity-100 delay-75" : "opacity-0"
+              activeId === "discovery-mapa" ? "opacity-100 delay-75" : "opacity-0"
             )}
           >
-            {detail && (
-              <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 p-3 space-y-2")}>
-                <p className="text-[11px] leading-snug text-muted-foreground">
-                  {detail.text}
-                </p>
-                <Link href={detail.href} className="inline-block text-[11px] font-semibold text-z-brass">
-                  {detail.label}
-                </Link>
-              </div>
-            )}
+            <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 p-3.5 space-y-3")}>
+              <p className="text-[12px] font-medium leading-snug text-foreground/90">
+                Presupuesto, obligaciones y deuda en un solo lugar.
+              </p>
+              <p className="text-[11px] leading-relaxed text-muted-foreground">
+                Revisa cuánto tienes comprometido, cuánto puedes gastar con libertad y cómo va tu
+                estrategia de pago de deuda — todo antes de que empiece el detalle del día a día.
+              </p>
+              <Link
+                href="/plan"
+                className={cn(
+                  BRASS_BUTTON_CLASS,
+                  "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11px] font-semibold"
+                )}
+              >
+                Abrir mi plan
+                <ArrowRightIcon />
+              </Link>
+            </div>
           </div>
         </div>
       </div>
+
+      {/* Purchase recommender drawer */}
+      <PurchaseRecommenderDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
     </div>
   );
 }

--- a/webapp/src/components/mobile/v2/inicio/inicio-discovery.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-discovery.tsx
@@ -46,9 +46,10 @@ function IconBox({ children }: { children: React.ReactNode }) {
 interface InicioDiscoveryProps {
   expanded: string | null;
   onToggle: (id: string) => void;
+  currency: import("@/types/domain").CurrencyCode;
 }
 
-export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
+export function InicioDiscovery({ expanded, onToggle, currency }: InicioDiscoveryProps) {
   const activeId = expanded?.startsWith("discovery-") ? expanded : null;
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -156,7 +157,7 @@ export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
       </div>
 
       {/* Purchase recommender drawer */}
-      <PurchaseRecommenderDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
+      <PurchaseRecommenderDrawer open={drawerOpen} onOpenChange={setDrawerOpen} currency={currency} />
     </div>
   );
 }

--- a/webapp/src/components/mobile/v2/inicio/inicio-discovery.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-discovery.tsx
@@ -56,14 +56,16 @@ export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
     <div>
       {/* Chip row — always visible */}
       <div className="grid grid-cols-2 gap-1.5">
-        {/* ¿Puedo comprarlo? → opens purchase recommender drawer directly */}
+        {/* ¿Puedo comprarlo? → expands to preview, then opens drawer */}
         <button
           type="button"
-          onClick={() => setDrawerOpen(true)}
+          onClick={() => onToggle("discovery-compra")}
           className={cn(
             PANEL_INSET_CLASS,
-            "flex w-full items-center gap-2.5 px-3 py-3 text-left transition-colors active:bg-white/[0.03]"
+            "flex w-full items-center gap-2.5 px-3 py-3 text-left transition-colors active:bg-white/[0.03]",
+            activeId === "discovery-compra" && "ring-1 ring-z-brass/30 bg-z-brass/[0.06]"
           )}
+          aria-expanded={activeId === "discovery-compra"}
         >
           <IconBox><LightbulbIcon /></IconBox>
           <div className="min-w-0">
@@ -72,7 +74,7 @@ export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
           </div>
         </button>
 
-        {/* Mapa del mes → expands to show plan teaser */}
+        {/* Plan del mes → expands to show plan teaser */}
         <button
           type="button"
           onClick={() => onToggle("discovery-mapa")}
@@ -91,37 +93,64 @@ export function InicioDiscovery({ expanded, onToggle }: InicioDiscoveryProps) {
         </button>
       </div>
 
-      {/* Expanded panel for Plan del mes — full width below */}
+      {/* Expanded panel — full width below both chips */}
       <div
         className="grid transition-[grid-template-rows] duration-200 ease-out"
-        style={{ gridTemplateRows: activeId === "discovery-mapa" ? "1fr" : "0fr" }}
+        style={{ gridTemplateRows: activeId ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden">
           <div
             className={cn(
               "mt-1.5 transition-opacity duration-150",
-              activeId === "discovery-mapa" ? "opacity-100 delay-75" : "opacity-0"
+              activeId ? "opacity-100 delay-75" : "opacity-0"
             )}
           >
-            <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 p-3.5 space-y-3")}>
-              <p className="text-[12px] font-medium leading-snug text-foreground/90">
-                Presupuesto, obligaciones y deuda en un solo lugar.
-              </p>
-              <p className="text-[11px] leading-relaxed text-muted-foreground">
-                Revisa cuánto tienes comprometido, cuánto puedes gastar con libertad y cómo va tu
-                estrategia de pago de deuda — todo antes de que empiece el detalle del día a día.
-              </p>
-              <Link
-                href="/plan"
-                className={cn(
-                  BRASS_BUTTON_CLASS,
-                  "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11px] font-semibold"
-                )}
-              >
-                Abrir mi plan
-                <ArrowRightIcon />
-              </Link>
-            </div>
+            {/* ¿Puedo comprarlo? preview */}
+            {activeId === "discovery-compra" && (
+              <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 p-3.5 space-y-3")}>
+                <p className="text-[12px] font-medium leading-snug text-foreground/90">
+                  Analiza el impacto real de una compra antes de hacerla.
+                </p>
+                <p className="text-[11px] leading-relaxed text-muted-foreground">
+                  Ingresa el monto y Zeta cruza tu liquidez, deuda, presupuesto y pagos próximos para
+                  decirte si es buen momento — o si es mejor esperar.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setDrawerOpen(true)}
+                  className={cn(
+                    BRASS_BUTTON_CLASS,
+                    "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11px] font-semibold"
+                  )}
+                >
+                  Evaluar una compra
+                  <ArrowRightIcon />
+                </button>
+              </div>
+            )}
+
+            {/* Plan del mes preview */}
+            {activeId === "discovery-mapa" && (
+              <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 p-3.5 space-y-3")}>
+                <p className="text-[12px] font-medium leading-snug text-foreground/90">
+                  Presupuesto, obligaciones y deuda en un solo lugar.
+                </p>
+                <p className="text-[11px] leading-relaxed text-muted-foreground">
+                  Revisa cuánto tienes comprometido, cuánto puedes gastar con libertad y cómo va tu
+                  estrategia de pago de deuda — todo antes de que empiece el detalle del día a día.
+                </p>
+                <Link
+                  href="/plan"
+                  className={cn(
+                    BRASS_BUTTON_CLASS,
+                    "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[11px] font-semibold"
+                  )}
+                >
+                  Abrir mi plan
+                  <ArrowRightIcon />
+                </Link>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/webapp/src/components/mobile/v2/inicio/inicio-metrics-grid.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-metrics-grid.tsx
@@ -9,12 +9,9 @@ import type { BurnRateResponse } from "@/actions/burn-rate";
 import type { CurrencyCode } from "@/types/domain";
 
 interface InicioMetricsGridProps {
-  runwayDays: number;
   daysInMonth: number;
   dayOfMonth: number;
-  nextPaymentName: string | null;
-  nextPaymentDays: number | null;
-  nextPaymentAmount: number | null;
+  spentToday: number;
   currency: CurrencyCode;
   /** Burndown data — shown as expanded view of Ritmo chip */
   burnRateData: BurnRateResponse | null;
@@ -170,9 +167,7 @@ function BurndownChart({
 export function InicioMetricsGrid({
   daysInMonth,
   dayOfMonth,
-  nextPaymentName,
-  nextPaymentDays,
-  nextPaymentAmount,
+  spentToday,
   currency,
   burnRateData,
   totalBudget,
@@ -180,9 +175,10 @@ export function InicioMetricsGrid({
   onToggle,
 }: InicioMetricsGridProps) {
   const percentage = Math.round((dayOfMonth / daysInMonth) * 100);
+  const dailyBudget = totalBudget > 0 ? totalBudget / daysInMonth : 0;
   const isRitmoActive = expanded === "ritmo";
-  const isPagoActive = expanded === "pago";
-  const hasActive = isRitmoActive || isPagoActive;
+  const isGastoActive = expanded === "gasto-hoy";
+  const hasActive = isRitmoActive || isGastoActive;
 
   return (
     <div>
@@ -204,28 +200,32 @@ export function InicioMetricsGrid({
           <p className="mt-1.5 text-[11px] text-muted-foreground">día {dayOfMonth} de {daysInMonth}</p>
         </button>
 
-        {/* Próximo pago chip */}
+        {/* Gasto hoy chip */}
         <button
           type="button"
-          onClick={() => onToggle("pago")}
+          onClick={() => onToggle("gasto-hoy")}
           className={cn(
             PANEL_INSET_CLASS,
             "flex w-full flex-col items-center justify-center px-3 py-3 transition-colors",
-            isPagoActive && "ring-1 ring-z-expense/30 bg-z-expense/[0.06]"
+            isGastoActive && "ring-1 ring-z-brass/30 bg-z-brass/[0.06]"
           )}
-          aria-expanded={isPagoActive}
+          aria-expanded={isGastoActive}
         >
-          <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">Próximo pago</p>
-          {nextPaymentDays != null ? (
-            <>
-              <p className="text-[18px] font-[650] leading-tight text-z-expense">{nextPaymentDays} días</p>
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                {nextPaymentName ?? "Pago"}
-                {nextPaymentAmount != null && <> · {formatCurrency(nextPaymentAmount, currency)}</>}
-              </p>
-            </>
-          ) : (
-            <p className="text-[11px] text-muted-foreground">Sin pagos próximos</p>
+          <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">Gasto hoy</p>
+          <p className={cn(
+            "text-[18px] font-[650] leading-tight",
+            spentToday === 0
+              ? "text-z-sage-light"
+              : dailyBudget > 0 && spentToday > dailyBudget
+                ? "text-z-expense"
+                : "text-foreground"
+          )}>
+            {compact(spentToday, currency)}
+          </p>
+          {dailyBudget > 0 && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              meta {compact(dailyBudget, currency)}/día
+            </p>
           )}
         </button>
       </div>
@@ -254,16 +254,44 @@ export function InicioMetricsGrid({
               </div>
             )}
 
-            {/* Próximo pago expanded */}
-            {isPagoActive && (
-              <div className={cn(PANEL_INSET_CLASS, "border-z-expense/20 bg-black/20 p-3 space-y-2")}>
-                <p className="text-[11px] text-muted-foreground">
-                  {nextPaymentName
-                    ? `${nextPaymentName} en ${nextPaymentDays} días.`
-                    : "No hay pagos próximos programados."}
-                </p>
-                <Link href="/recurrentes" className="inline-block text-[11px] font-semibold text-z-brass">
-                  Ver pagos y recurrentes →
+            {/* Gasto hoy expanded */}
+            {isGastoActive && (
+              <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 p-3 space-y-2")}>
+                {dailyBudget > 0 ? (
+                  <>
+                    <div className="flex items-baseline justify-between">
+                      <span className="text-[11px] text-muted-foreground">Gastado hoy</span>
+                      <span className="text-sm font-semibold">{formatCurrency(spentToday, currency)}</span>
+                    </div>
+                    <div className="flex items-baseline justify-between">
+                      <span className="text-[11px] text-muted-foreground">Meta diaria</span>
+                      <span className="text-sm font-semibold text-z-sage-light">{formatCurrency(dailyBudget, currency)}</span>
+                    </div>
+                    {/* Progress bar */}
+                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/6">
+                      <div
+                        className={cn(
+                          "h-full rounded-full transition-all",
+                          spentToday <= dailyBudget ? "bg-z-income" : "bg-z-expense"
+                        )}
+                        style={{ width: `${Math.min((spentToday / dailyBudget) * 100, 100)}%` }}
+                      />
+                    </div>
+                    <p className="text-[10px] text-muted-foreground">
+                      {spentToday <= dailyBudget
+                        ? `Te quedan ${formatCurrency(dailyBudget - spentToday, currency)} del presupuesto de hoy.`
+                        : `Excediste la meta diaria por ${formatCurrency(spentToday - dailyBudget, currency)}.`}
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground">
+                    {spentToday > 0
+                      ? `Hoy has gastado ${formatCurrency(spentToday, currency)}.`
+                      : "Sin gastos registrados hoy."}
+                  </p>
+                )}
+                <Link href="/transactions" className="inline-block text-[11px] font-semibold text-z-brass">
+                  Ver movimientos →
                 </Link>
               </div>
             )}

--- a/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
@@ -96,6 +96,7 @@ export function InicioRoot({
       <InicioDiscovery
         expanded={activeZone}
         onToggle={toggle}
+        currency={currency}
       />
 
       <InicioActivity transactions={recentTransactions} />

--- a/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
@@ -34,12 +34,9 @@ export interface InicioRootProps {
     };
   };
   metrics: {
-    runwayDays: number;
     daysInMonth: number;
     dayOfMonth: number;
-    nextPaymentName: string | null;
-    nextPaymentDays: number | null;
-    nextPaymentAmount: number | null;
+    spentToday: number;
     currency: CurrencyCode;
   };
   attentionItems: {

--- a/webapp/src/components/mobile/v2/inicio/purchase-recommender-drawer.tsx
+++ b/webapp/src/components/mobile/v2/inicio/purchase-recommender-drawer.tsx
@@ -29,7 +29,7 @@ import { useAccounts, useOutflowCategories } from "@/components/providers/app-da
 import { formatCurrency } from "@/lib/utils/currency";
 import { cn } from "@/lib/utils";
 import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
-import type { Account, CategoryWithChildren } from "@/types/domain";
+import type { Account, CategoryWithChildren, CurrencyCode } from "@/types/domain";
 
 const urgencyLabels: Record<PurchaseUrgency, string> = {
   NECESSARY: "Necesidad",
@@ -66,9 +66,10 @@ const verdictMeta: Record<
 interface PurchaseRecommenderDrawerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  currency: CurrencyCode;
 }
 
-export function PurchaseRecommenderDrawer({ open, onOpenChange }: PurchaseRecommenderDrawerProps) {
+export function PurchaseRecommenderDrawer({ open, onOpenChange, currency }: PurchaseRecommenderDrawerProps) {
   const allAccounts = useAccounts();
   const categories = useOutflowCategories();
 
@@ -148,7 +149,7 @@ export function PurchaseRecommenderDrawer({ open, onOpenChange }: PurchaseRecomm
 
         <div className="flex-1 overflow-y-auto px-4 pb-6">
           {result ? (
-            <ResultView result={result} amount={amount} fundingType={fundingType} onReset={reset} />
+            <ResultView result={result} amount={amount} fundingType={fundingType} currency={currency} onReset={reset} />
           ) : (
             <FormView
               activeAccounts={activeAccounts}
@@ -327,11 +328,13 @@ function ResultView({
   result,
   amount,
   fundingType,
+  currency,
   onReset,
 }: {
   result: PurchaseDecisionResult;
   amount: string;
   fundingType: PurchaseFundingType;
+  currency: CurrencyCode;
   onReset: () => void;
 }) {
   const meta = verdictMeta[result.verdict];
@@ -351,7 +354,7 @@ function ResultView({
           </div>
           <div className="text-right">
             <p className="text-lg font-semibold">
-              {formatCurrency(result.metrics.effectiveImmediateImpact)}
+              {formatCurrency(result.metrics.effectiveImmediateImpact, currency)}
             </p>
             <p className="text-[10px] text-muted-foreground">
               {fundingType === "INSTALLMENTS" ? "primera cuota" : "impacto inmediato"}
@@ -369,8 +372,8 @@ function ResultView({
         <div className="divide-y divide-white/6">
           <BeforeAfterMobile
             label="Liquidez"
-            before={formatCurrency(result.metrics.currentLiquidBuffer)}
-            after={formatCurrency(result.metrics.projectedLiquidBuffer)}
+            before={formatCurrency(result.metrics.currentLiquidBuffer, currency)}
+            after={formatCurrency(result.metrics.projectedLiquidBuffer, currency)}
             improved={result.metrics.projectedLiquidBuffer >= result.metrics.currentLiquidBuffer}
           />
           {result.metrics.selectedAccountUtilizationBefore !== null &&
@@ -386,8 +389,8 @@ function ResultView({
             result.metrics.budgetRemainingAfterPurchase !== null && (
               <BeforeAfterMobile
                 label="Presupuesto"
-                before={formatCurrency(result.metrics.currentBudgetRemaining)}
-                after={formatCurrency(result.metrics.budgetRemainingAfterPurchase)}
+                before={formatCurrency(result.metrics.currentBudgetRemaining, currency)}
+                after={formatCurrency(result.metrics.budgetRemainingAfterPurchase, currency)}
                 improved={result.metrics.budgetRemainingAfterPurchase >= result.metrics.currentBudgetRemaining}
               />
             )}

--- a/webapp/src/components/mobile/v2/inicio/purchase-recommender-drawer.tsx
+++ b/webapp/src/components/mobile/v2/inicio/purchase-recommender-drawer.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { ArrowRight, Brain, CircleAlert, Loader2, PiggyBank, ShieldAlert } from "lucide-react";
+import { format } from "date-fns";
+import type { PurchaseDecisionResult, PurchaseFundingType, PurchaseUrgency } from "@zeta/shared";
+import { analyzePurchaseDecisionAction } from "@/actions/purchase-decision";
+import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAccounts, useOutflowCategories } from "@/components/providers/app-data-provider";
+import { formatCurrency } from "@/lib/utils/currency";
+import { cn } from "@/lib/utils";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import type { Account, CategoryWithChildren } from "@/types/domain";
+
+const urgencyLabels: Record<PurchaseUrgency, string> = {
+  NECESSARY: "Necesidad",
+  USEFUL: "Útil",
+  IMPULSE: "Capricho",
+};
+
+const verdictMeta: Record<
+  PurchaseDecisionResult["verdict"],
+  { label: string; badgeClassName: string; panelClassName: string }
+> = {
+  BUY: {
+    label: "Sí, dale",
+    badgeClassName: "border-z-income/30 bg-z-income/10 text-z-income",
+    panelClassName: "border-z-income/20 bg-z-income/5",
+  },
+  BUY_WITH_CAUTION: {
+    label: "Sí, con cautela",
+    badgeClassName: "border-z-expense/30 bg-z-expense/10 text-z-expense",
+    panelClassName: "border-z-expense/20 bg-z-expense/5",
+  },
+  WAIT: {
+    label: "Mejor espera",
+    badgeClassName: "border-orange-500/30 bg-orange-500/10 text-orange-400",
+    panelClassName: "border-orange-500/20 bg-orange-500/5",
+  },
+  NOT_RECOMMENDED: {
+    label: "No recomendado",
+    badgeClassName: "border-red-500/30 bg-red-500/10 text-red-400",
+    panelClassName: "border-red-500/20 bg-red-500/5",
+  },
+};
+
+interface PurchaseRecommenderDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function PurchaseRecommenderDrawer({ open, onOpenChange }: PurchaseRecommenderDrawerProps) {
+  const allAccounts = useAccounts();
+  const categories = useOutflowCategories();
+
+  const activeAccounts = useMemo(
+    () => allAccounts.filter((a) => a.account_type !== "LOAN"),
+    [allAccounts]
+  );
+
+  const [isPending, startTransition] = useTransition();
+  const [amount, setAmount] = useState("");
+  const [accountId, setAccountId] = useState(activeAccounts[0]?.id ?? "");
+  const [categoryId, setCategoryId] = useState<string | null>(null);
+  const [urgency, setUrgency] = useState<PurchaseUrgency>("USEFUL");
+  const [fundingType, setFundingType] = useState<PurchaseFundingType>("ONE_TIME");
+  const [installments, setInstallments] = useState("3");
+  const [result, setResult] = useState<PurchaseDecisionResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function reset() {
+    setAmount("");
+    setAccountId(activeAccounts[0]?.id ?? "");
+    setCategoryId(null);
+    setUrgency("USEFUL");
+    setFundingType("ONE_TIME");
+    setInstallments("3");
+    setResult(null);
+    setError(null);
+  }
+
+  function handleAnalyze() {
+    const numericAmount = Number(amount);
+    if (!numericAmount || numericAmount <= 0) {
+      setError("Ingresa un monto válido.");
+      return;
+    }
+    if (!accountId) {
+      setError("Selecciona una cuenta.");
+      return;
+    }
+
+    setError(null);
+    startTransition(async () => {
+      const response = await analyzePurchaseDecisionAction({
+        amount: numericAmount,
+        accountId,
+        categoryId,
+        urgency,
+        fundingType,
+        installments: fundingType === "INSTALLMENTS" ? Number(installments || "0") : null,
+        month: format(new Date(), "yyyy-MM"),
+      });
+
+      if (!response.success || !response.data) {
+        setResult(null);
+        setError(response.success ? "No fue posible analizar la compra." : response.error);
+        return;
+      }
+
+      setResult(response.data);
+    });
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={handleOpenChange}>
+      <DrawerContent className="max-h-[92dvh]">
+        <DrawerHeader>
+          <DrawerTitle>¿Puedo comprarlo?</DrawerTitle>
+          <DrawerDescription>
+            Evalúa el impacto en tu liquidez, deuda y presupuesto antes de decidir.
+          </DrawerDescription>
+        </DrawerHeader>
+
+        <div className="flex-1 overflow-y-auto px-4 pb-6">
+          {result ? (
+            <ResultView result={result} amount={amount} fundingType={fundingType} onReset={reset} />
+          ) : (
+            <FormView
+              activeAccounts={activeAccounts}
+              categories={categories}
+              amount={amount}
+              setAmount={setAmount}
+              accountId={accountId}
+              setAccountId={setAccountId}
+              categoryId={categoryId}
+              setCategoryId={setCategoryId}
+              urgency={urgency}
+              setUrgency={setUrgency}
+              fundingType={fundingType}
+              setFundingType={setFundingType}
+              installments={installments}
+              setInstallments={setInstallments}
+              error={error}
+              isPending={isPending}
+              onAnalyze={handleAnalyze}
+            />
+          )}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+// ─── Form ────────────────────────────────────────────────────────────────────
+
+function FormView({
+  activeAccounts,
+  categories,
+  amount,
+  setAmount,
+  accountId,
+  setAccountId,
+  categoryId,
+  setCategoryId,
+  urgency,
+  setUrgency,
+  fundingType,
+  setFundingType,
+  installments,
+  setInstallments,
+  error,
+  isPending,
+  onAnalyze,
+}: {
+  activeAccounts: Pick<Account, "id" | "name" | "account_type">[];
+  categories: CategoryWithChildren[];
+  amount: string;
+  setAmount: (v: string) => void;
+  accountId: string;
+  setAccountId: (v: string) => void;
+  categoryId: string | null;
+  setCategoryId: (v: string | null) => void;
+  urgency: PurchaseUrgency;
+  setUrgency: (v: PurchaseUrgency) => void;
+  fundingType: PurchaseFundingType;
+  setFundingType: (v: PurchaseFundingType) => void;
+  installments: string;
+  setInstallments: (v: string) => void;
+  error: string | null;
+  isPending: boolean;
+  onAnalyze: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="drawer-amount">Monto</Label>
+        <CurrencyInput
+          id="drawer-amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="250.000"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Cuenta</Label>
+        <Select value={accountId} onValueChange={setAccountId}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecciona una cuenta" />
+          </SelectTrigger>
+          <SelectContent>
+            {activeAccounts.map((a) => (
+              <SelectItem key={a.id} value={a.id}>{a.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <Label>Urgencia</Label>
+          <Select value={urgency} onValueChange={(v) => setUrgency(v as PurchaseUrgency)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(urgencyLabels).map(([value, label]) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Pago</Label>
+          <Select value={fundingType} onValueChange={(v) => setFundingType(v as PurchaseFundingType)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ONE_TIME">Único</SelectItem>
+              <SelectItem value="INSTALLMENTS">Cuotas</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {fundingType === "INSTALLMENTS" && (
+        <div className="space-y-2">
+          <Label htmlFor="drawer-installments">Número de cuotas</Label>
+          <Input
+            id="drawer-installments"
+            type="number"
+            min="2"
+            max="36"
+            step="1"
+            value={installments}
+            onChange={(e) => setInstallments(e.target.value)}
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Categoría (opcional)</Label>
+        <CategoryZonePicker
+          variant="popover"
+          categories={categories}
+          value={categoryId}
+          onValueChange={setCategoryId}
+          direction="OUTFLOW"
+          placeholder="Selecciona una categoría"
+          triggerClassName="w-full"
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Button className={cn("w-full gap-2", BRASS_BUTTON_CLASS)} onClick={onAnalyze} disabled={isPending}>
+        {isPending ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Analizando…
+          </>
+        ) : (
+          <>
+            Obtener recomendación
+            <Brain className="h-4 w-4" />
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+function ResultView({
+  result,
+  amount,
+  fundingType,
+  onReset,
+}: {
+  result: PurchaseDecisionResult;
+  amount: string;
+  fundingType: PurchaseFundingType;
+  onReset: () => void;
+}) {
+  const meta = verdictMeta[result.verdict];
+
+  return (
+    <div className="space-y-4">
+      {/* Verdict */}
+      <div className={cn("rounded-xl border p-4", meta.panelClassName)}>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <Badge variant="outline" className={meta.badgeClassName}>
+              {meta.label}
+            </Badge>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Score {Math.round(result.score)}/100
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-lg font-semibold">
+              {formatCurrency(result.metrics.effectiveImmediateImpact)}
+            </p>
+            <p className="text-[10px] text-muted-foreground">
+              {fundingType === "INSTALLMENTS" ? "primera cuota" : "impacto inmediato"}
+            </p>
+          </div>
+        </div>
+        <p className="mt-3 text-sm leading-relaxed">{result.summary}</p>
+      </div>
+
+      {/* Before / After */}
+      <div className="rounded-xl border p-4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-z-sage-dark">
+          Antes y después
+        </p>
+        <div className="divide-y divide-white/6">
+          <BeforeAfterMobile
+            label="Liquidez"
+            before={formatCurrency(result.metrics.currentLiquidBuffer)}
+            after={formatCurrency(result.metrics.projectedLiquidBuffer)}
+            improved={result.metrics.projectedLiquidBuffer >= result.metrics.currentLiquidBuffer}
+          />
+          {result.metrics.selectedAccountUtilizationBefore !== null &&
+            result.metrics.selectedAccountUtilizationAfter !== null && (
+              <BeforeAfterMobile
+                label="Uso de cupo"
+                before={`${Math.round(result.metrics.selectedAccountUtilizationBefore)}%`}
+                after={`${Math.round(result.metrics.selectedAccountUtilizationAfter)}%`}
+                improved={result.metrics.selectedAccountUtilizationAfter <= result.metrics.selectedAccountUtilizationBefore}
+              />
+            )}
+          {result.metrics.currentBudgetRemaining !== null &&
+            result.metrics.budgetRemainingAfterPurchase !== null && (
+              <BeforeAfterMobile
+                label="Presupuesto"
+                before={formatCurrency(result.metrics.currentBudgetRemaining)}
+                after={formatCurrency(result.metrics.budgetRemainingAfterPurchase)}
+                improved={result.metrics.budgetRemainingAfterPurchase >= result.metrics.currentBudgetRemaining}
+              />
+            )}
+        </div>
+      </div>
+
+      {/* Reasons */}
+      {result.reasons.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <ShieldAlert className="h-3.5 w-3.5 text-z-sage-dark" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-z-sage-dark">Por qué</p>
+          </div>
+          {result.reasons.map((r) => (
+            <div key={`${r.code}-${r.title}`} className="rounded-lg border border-white/6 bg-black/10 p-3">
+              <div className="mb-0.5 flex items-center gap-1.5">
+                <span className={cn(
+                  "inline-block h-2 w-2 rounded-full",
+                  r.severity === "critical" ? "bg-z-debt" : r.severity === "warning" ? "bg-z-expense" : "bg-z-income"
+                )} />
+                <p className="text-xs font-medium">{r.title}</p>
+              </div>
+              <p className="text-xs text-muted-foreground">{r.detail}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Alternatives */}
+      {result.alternatives.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <PiggyBank className="h-3.5 w-3.5 text-z-sage-dark" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-z-sage-dark">Alternativas</p>
+          </div>
+          {result.alternatives.map((alt) => (
+            <div key={`${alt.type}-${alt.title}`} className="rounded-lg border border-white/6 bg-black/10 p-3">
+              <p className="text-xs font-medium">{alt.title}</p>
+              <p className="text-xs text-muted-foreground">{alt.detail}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* New analysis */}
+      <Button variant="outline" className="w-full gap-2" onClick={onReset}>
+        <CircleAlert className="h-4 w-4" />
+        Analizar otra compra
+      </Button>
+    </div>
+  );
+}
+
+function BeforeAfterMobile({
+  label,
+  before,
+  after,
+  improved,
+}: {
+  label: string;
+  before: string;
+  after: string;
+  improved: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-2.5 first:pt-0 last:pb-0">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">{before}</span>
+        <ArrowRight className="h-3 w-3 text-muted-foreground" />
+        <span className={cn("text-xs font-semibold", improved ? "text-z-income" : "text-z-debt")}>
+          {after}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- "¿Puedo comprarlo?" chip now opens a full purchase recommender drawer
  inline (form + results) instead of redirecting to /deseos
- "Plan del mes" chip shows a richer description explaining what the plan
  covers, with a styled brass CTA button instead of a plain text link

https://claude.ai/code/session_01SnFF2i3VgzSfbuL8CU4Dss