### PR TITLE
perf: Data Cache for tags, wishlist, plan-timeline + revalidation fixes

### DIFF
--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -204,7 +204,6 @@ export async function ensureOccurrencesForRange(
 
   if (upsertError) return { success: false, error: upsertError.message };
 
-  revalidateTag("occurrences", "zeta");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/plan-timeline.ts
+++ b/webapp/src/actions/plan-timeline.ts
@@ -2,8 +2,10 @@
 
 import "server-only";
 
+import { cache } from "react";
+import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { getDailyCashflow } from "@/actions/charts";
 import { getUpcomingRecurrences } from "@/actions/recurring-templates";
 import { getExchangeRate } from "@/actions/exchange-rate";
@@ -66,13 +68,17 @@ interface PlannedEntryRow {
   recurring_template_id: string | null;
 }
 
-async function getPlannedEntriesWithRates(
+async function getPlannedEntriesCached(
   userId: string,
   monthStart: string,
   monthEnd: string,
-  chartCurrency: CurrencyCode
-): Promise<{ entries: PlannedEntryRow[]; rateMap: Map<string, number> }> {
-  const supabase = createAdminClient();
+  accessToken: string,
+): Promise<PlannedEntryRow[]> {
+  "use cache";
+  cacheTag("cashflow-planner");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
 
   const { data: rows } = await supabase
     .from("planning_entries")
@@ -87,17 +93,28 @@ async function getPlannedEntriesWithRates(
     .gte("expected_date", monthStart)
     .lte("expected_date", monthEnd);
 
-  if (!rows || rows.length === 0) return { entries: [], rateMap: new Map() };
+  if (!rows || rows.length === 0) return [];
 
-  const entries: PlannedEntryRow[] = rows.map((e) => ({
+  return rows.map((e) => ({
     entry_type: e.entry_type as PlanningEntryType,
     day: parseInt(e.expected_date.split("-")[2], 10),
     amount: Number(e.amount),
     currency_code: e.currency_code,
     recurring_template_id: e.recurring_template_id,
   }));
+}
 
-  // Batch-fetch exchange rates for foreign currencies
+async function getPlannedEntriesWithRates(
+  userId: string,
+  monthStart: string,
+  monthEnd: string,
+  chartCurrency: CurrencyCode,
+  accessToken: string,
+): Promise<{ entries: PlannedEntryRow[]; rateMap: Map<string, number> }> {
+  const entries = await getPlannedEntriesCached(userId, monthStart, monthEnd, accessToken);
+
+  if (entries.length === 0) return { entries: [], rateMap: new Map() };
+
   const foreignCurrencies = new Set(
     entries
       .filter((e) => e.currency_code !== chartCurrency)
@@ -120,12 +137,12 @@ async function getPlannedEntriesWithRates(
 
 // --- Main ---
 
-export async function getPlanTimelineData(
+export const getPlanTimelineData = cache(async (
   month?: string,
   _currency?: string
-): Promise<PlanTimelineData> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return emptyTimeline();
+): Promise<PlanTimelineData> => {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return emptyTimeline();
 
   const target = parseMonth(month);
   const now = new Date();
@@ -156,7 +173,7 @@ export async function getPlanTimelineData(
       getDailyCashflow(month),
       getUpcomingRecurrences(remainingDays > 0 ? remainingDays : 0),
       getAccounts(),
-      getPlannedEntriesWithRates(user.id, mStart, mEnd, chartCurrency),
+      getPlannedEntriesWithRates(user.id, mStart, mEnd, chartCurrency, accessToken),
     ]);
 
   const accounts = accountsResult.success ? accountsResult.data : [];
@@ -315,4 +332,4 @@ export async function getPlanTimelineData(
     daysInMonth,
     dayOfMonth,
   };
-}
+});

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -270,6 +270,7 @@ export async function createRecurringTemplate(
   await ensureCurrentOccurrences();
 
   revalidateTag("recurring", "zeta");
+  revalidateTag("occurrences", "zeta");
   revalidateTag("dashboard:hero", "zeta");
   revalidateTag("attention", "zeta");
   return { success: true, data };
@@ -342,6 +343,7 @@ export async function updateRecurringTemplate(
   await ensureCurrentOccurrences();
 
   revalidateTag("recurring", "zeta");
+  revalidateTag("occurrences", "zeta");
   revalidateTag("dashboard:hero", "zeta");
   revalidateTag("attention", "zeta");
   return { success: true, data };

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -1,35 +1,40 @@
 "use server";
 
 import { cache } from "react";
-import { revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { tagGroupSchema, tagSchema, generateSlug } from "@/lib/validators/tags";
 import type { ActionResult } from "@/types/actions";
 import type { TagGroupWithTags, Tag, TaggableEntity } from "@/types/domain";
 
 import { UNGROUPED_TAG_GROUP_ID } from "@/lib/constants/tags";
 
-// ── Queries ───────────────────────────────────────────────
+// ── Cached inner functions ───────────────────────────────
 
-export const getTagGroups = cache(async (): Promise<ActionResult<TagGroupWithTags[]>> => {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+async function getTagGroupsCached(userId: string, accessToken: string): Promise<TagGroupWithTags[]> {
+  "use cache";
+  cacheTag("tags");
+  cacheLife("zeta");
 
-  const { data: groups, error: groupsError } = await supabase
-    .from("tag_groups")
-    .select("*")
-    .or(`user_id.eq.${user.id},user_id.is.null`)
-    .order("display_order");
+  const supabase = createCachedClient(accessToken);
 
-  if (groupsError) return { success: false, error: groupsError.message };
+  const [{ data: groups, error: groupsError }, { data: tags, error: tagsError }] =
+    await Promise.all([
+      supabase
+        .from("tag_groups")
+        .select("*")
+        .or(`user_id.eq.${userId},user_id.is.null`)
+        .order("display_order"),
+      supabase
+        .from("tags")
+        .select("*")
+        .or(`user_id.eq.${userId},user_id.is.null`)
+        .order("display_order"),
+    ]);
 
-  const { data: tags, error: tagsError } = await supabase
-    .from("tags")
-    .select("*")
-    .or(`user_id.eq.${user.id},user_id.is.null`)
-    .order("display_order");
-
-  if (tagsError) return { success: false, error: tagsError.message };
+  if (groupsError) throw groupsError;
+  if (tagsError) throw tagsError;
 
   const groupIds = new Set(groups.map((g) => g.id));
   const groupsWithTags: TagGroupWithTags[] = groups.map((g) => ({
@@ -37,7 +42,6 @@ export const getTagGroups = cache(async (): Promise<ActionResult<TagGroupWithTag
     tags: tags.filter((t) => t.group_id === g.id),
   }));
 
-  // Include ungrouped tags (group_id is null or references a deleted group)
   const ungroupedTags = tags.filter((t) => !t.group_id || !groupIds.has(t.group_id));
   if (ungroupedTags.length > 0) {
     groupsWithTags.push({
@@ -52,7 +56,38 @@ export const getTagGroups = cache(async (): Promise<ActionResult<TagGroupWithTag
     });
   }
 
-  return { success: true, data: groupsWithTags };
+  return groupsWithTags;
+}
+
+async function getAllTagsCached(userId: string, accessToken: string): Promise<Tag[]> {
+  "use cache";
+  cacheTag("tags");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data, error } = await supabase
+    .from("tags")
+    .select("*")
+    .or(`user_id.eq.${userId},user_id.is.null`)
+    .order("display_order");
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+// ── Public wrappers ──────────────────────────────────────
+
+export const getTagGroups = cache(async (): Promise<ActionResult<TagGroupWithTags[]>> => {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+
+  try {
+    const data = await getTagGroupsCached(user.id, accessToken);
+    return { success: true, data };
+  } catch (error) {
+    console.error("Error loading tag groups:", error);
+    return { success: false, error: "Error al cargar las etiquetas" };
+  }
 });
 
 export const getTagsForEntity = cache(
@@ -102,16 +137,15 @@ export const getTagsForEntity = cache(
 );
 
 export const getAllTags = cache(async (): Promise<Tag[]> => {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return [];
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
 
-  const { data } = await supabase
-    .from("tags")
-    .select("*")
-    .or(`user_id.eq.${user.id},user_id.is.null`)
-    .order("display_order");
-
-  return data ?? [];
+  try {
+    return await getAllTagsCached(user.id, accessToken);
+  } catch (error) {
+    console.error("Error loading tags:", error);
+    return [];
+  }
 });
 
 // ── Tag Group Mutations ───────────────────────────────────

--- a/webapp/src/actions/wishlist.ts
+++ b/webapp/src/actions/wishlist.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import {
   analyzePurchaseDecision,
   calcUtilization,
@@ -12,6 +12,7 @@ import {
   type PurchaseUrgency,
 } from "@zeta/shared";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
 import {
   createWishlistItemSchema,
   enrichWishlistItemSchema,
@@ -78,26 +79,69 @@ function invalidateWishlist() {
   revalidateTag("wishlist", "zeta");
 }
 
-// ─── Section 1: CRUD Queries & Mutations ─────────────────────────────────────
+// ─── Cached inner functions ─────────────────────────────────────────────────
 
-export async function getWishlistItems(): Promise<WishlistItem[]> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return [];
+async function getWishlistItemsCached(
+  userId: string,
+  accessToken: string,
+): Promise<WishlistItem[]> {
+  "use cache";
+  cacheTag("wishlist");
+  cacheLife("zeta");
 
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("wishlist_items")
     .select("*")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .order("status", { ascending: true })
     .order("last_score", { ascending: false, nullsFirst: false })
     .order("created_at", { ascending: false });
 
-  if (error) {
+  if (error) throw error;
+  return (data ?? []) as WishlistItem[];
+}
+
+async function getWishlistItemsForDashboardCached(
+  userId: string,
+  accessToken: string,
+): Promise<{ items: WishlistItem[]; totalCount: number; readyCount: number }> {
+  "use cache";
+  cacheTag("wishlist");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data, error } = await supabase
+    .from("wishlist_items")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("status", "wishlist")
+    .order("last_score", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  if (error) throw error;
+
+  const all = (data ?? []) as WishlistItem[];
+  const readyCount = all.filter(
+    (item) => item.last_score != null && item.last_score >= 55
+  ).length;
+
+  return { items: all.slice(0, 2), totalCount: all.length, readyCount };
+}
+
+// ─── Section 1: CRUD Queries & Mutations ─────────────────────────────────────
+
+export async function getWishlistItems(): Promise<WishlistItem[]> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
+
+  try {
+    return await getWishlistItemsCached(user.id, accessToken);
+  } catch (error) {
     console.error("Error fetching wishlist items:", error);
     return [];
   }
-
-  return (data ?? []) as WishlistItem[];
 }
 
 export async function getWishlistItemsForDashboard(): Promise<{
@@ -105,33 +149,15 @@ export async function getWishlistItemsForDashboard(): Promise<{
   totalCount: number;
   readyCount: number;
 }> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { items: [], totalCount: 0, readyCount: 0 };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { items: [], totalCount: 0, readyCount: 0 };
 
-  const { data, error } = await supabase
-    .from("wishlist_items")
-    .select("*")
-    .eq("user_id", user.id)
-    .eq("status", "wishlist")
-    .order("last_score", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false })
-    .limit(10);
-
-  if (error) {
+  try {
+    return await getWishlistItemsForDashboardCached(user.id, accessToken);
+  } catch (error) {
     console.error("Error fetching dashboard wishlist items:", error);
     return { items: [], totalCount: 0, readyCount: 0 };
   }
-
-  const all = (data ?? []) as WishlistItem[];
-  const readyCount = all.filter(
-    (item) => item.last_score != null && item.last_score >= 55
-  ).length;
-
-  return {
-    items: all.slice(0, 2),
-    totalCount: all.length,
-    readyCount,
-  };
 }
 
 export async function createWishlistItem(


### PR DESCRIPTION
## Summary
- **Fix /plan runtime crash**: `revalidateTag("occurrences")` was called during render inside `ensureOccurrencesForRange`, which Next.js 16 forbids — removed it
- **Fix stale plan data**: `createRecurringTemplate` and `updateRecurringTemplate` were missing `revalidateTag("occurrences")` after calling `ensureCurrentOccurrences()` — added it (matching `deleteRecurringTemplate` which already had it)
- **Add `"use cache"` with `cacheTag` + `cacheLife("zeta")`** to tags, wishlist, and plan-timeline reads — eliminates ~10 live DB queries per `/plan` and `/dashboard` page load on cache hits
- **Wrap `getPlanTimelineData` in `React.cache()`** for within-request dedup (called from both `PlanMobileZone` and `PlanTabPeriodo`)
- **Replace `createAdminClient` with `createCachedClient`** in plan-timeline (admin client has no JWT → can't decrypt)
- **Parallelize** tag_groups + tags queries in `getTagGroupsCached`

## Test plan
- [ ] Navigate to `/plan` — page loads without runtime error
- [ ] Create/update a recurring template → `/plan` shows fresh occurrence data immediately
- [ ] Visit `/deseos` — wishlist items load correctly
- [ ] Visit `/etiquetas` — tag groups render correctly
- [ ] Navigate between `/plan` tabs — no duplicate data fetching
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)