### PR TITLE
fix: plan shows stale paid occurrences + empty chip CTA

### DIFF
--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -95,6 +95,7 @@ async function getRecurringTemplateCached(
 async function getUpcomingRecurrencesCached(
   userId: string,
   days: number,
+  todayStr: string,
   accessToken: string
 ): Promise<UpcomingRecurrence[]> {
   "use cache";
@@ -103,9 +104,9 @@ async function getUpcomingRecurrencesCached(
 
   const supabase = createCachedClient(accessToken);
 
-  const now = new Date();
+  const now = new Date(`${todayStr}T00:00:00`);
   const rangeEnd = addDays(now, days);
-  const rangeStartStr = toISODateString(now);
+  const rangeStartStr = todayStr;
   const rangeEndStr = toISODateString(rangeEnd);
 
   const occurrenceKey = (templateId: string, date: string) => `${templateId}|${date}`;
@@ -410,6 +411,7 @@ export async function toggleRecurringTemplate(
   await ensureCurrentOccurrences();
 
   revalidateTag("recurring", "zeta");
+  revalidateTag("occurrences", "zeta");
   revalidateTag("dashboard:hero", "zeta");
   revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
@@ -902,7 +904,7 @@ export async function getUpcomingRecurrences(
 ): Promise<UpcomingRecurrence[]> {
   const { user, accessToken } = await getAuthenticatedClient();
   if (!user || !accessToken) return [];
-  return getUpcomingRecurrencesCached(user.id, days, accessToken);
+  return getUpcomingRecurrencesCached(user.id, days, toISODateString(new Date()), accessToken);
 }
 
 /**

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -97,20 +97,40 @@ async function getUpcomingRecurrencesCached(
   accessToken: string
 ): Promise<UpcomingRecurrence[]> {
   "use cache";
-  cacheTag("recurring");
+  cacheTag("recurring", "occurrences");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
-  const { data: templates } = await supabase
-    .from("recurring_transaction_templates")
-    .select(TEMPLATE_SELECT)
-    .eq("user_id", userId)
-    .eq("is_active", true);
-
-  if (!templates || templates.length === 0) return [];
 
   const now = new Date();
   const rangeEnd = addDays(now, days);
+  const rangeStartStr = now.toISOString().split("T")[0];
+  const rangeEndStr = rangeEnd.toISOString().split("T")[0];
+
+  // Fetch templates and already-resolved occurrences in parallel
+  const [{ data: templates }, { data: resolvedOccurrences }] = await Promise.all([
+    supabase
+      .from("recurring_transaction_templates")
+      .select(TEMPLATE_SELECT)
+      .eq("user_id", userId)
+      .eq("is_active", true),
+    supabase
+      .from("recurring_occurrences")
+      .select("template_id, occurrence_date, status")
+      .eq("user_id", userId)
+      .in("status", ["paid", "skipped"])
+      .gte("occurrence_date", rangeStartStr)
+      .lte("occurrence_date", rangeEndStr),
+  ]);
+
+  if (!templates || templates.length === 0) return [];
+
+  // Build a set of "templateId|date" keys for paid/skipped occurrences
+  const resolvedKeys = new Set(
+    (resolvedOccurrences ?? []).map(
+      (o) => `${o.template_id}|${o.occurrence_date}`
+    )
+  );
 
   const upcoming: UpcomingRecurrence[] = [];
 
@@ -124,6 +144,8 @@ async function getUpcomingRecurrencesCached(
     );
 
     for (const date of dates) {
+      // Skip occurrences already marked as paid or skipped
+      if (resolvedKeys.has(`${template.id}|${date}`)) continue;
       upcoming.push({ template, next_date: date });
     }
   }

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -111,7 +111,7 @@ async function getUpcomingRecurrencesCached(
 
   const occurrenceKey = (templateId: string, date: string) => `${templateId}|${date}`;
 
-  const [{ data: templates }, { data: resolvedOccurrences }] = await Promise.all([
+  const [templatesRes, resolvedRes] = await Promise.all([
     supabase
       .from("recurring_transaction_templates")
       .select(TEMPLATE_SELECT)
@@ -125,6 +125,12 @@ async function getUpcomingRecurrencesCached(
       .gte("occurrence_date", rangeStartStr)
       .lte("occurrence_date", rangeEndStr),
   ]);
+
+  if (templatesRes.error) throw templatesRes.error;
+  if (resolvedRes.error) throw resolvedRes.error;
+
+  const templates = templatesRes.data;
+  const resolvedOccurrences = resolvedRes.data;
 
   if (!templates || templates.length === 0) return [];
 

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -15,6 +15,7 @@ import {
   TRANSFER_CATEGORY_ID,
 } from "@zeta/shared";
 import { addDays } from "date-fns";
+import { toISODateString } from "@/lib/utils/date";
 import { z } from "zod";
 import { uuidStr } from "@/lib/validators/shared";
 import type { ActionResult } from "@/types/actions";
@@ -104,10 +105,11 @@ async function getUpcomingRecurrencesCached(
 
   const now = new Date();
   const rangeEnd = addDays(now, days);
-  const rangeStartStr = now.toISOString().split("T")[0];
-  const rangeEndStr = rangeEnd.toISOString().split("T")[0];
+  const rangeStartStr = toISODateString(now);
+  const rangeEndStr = toISODateString(rangeEnd);
 
-  // Fetch templates and already-resolved occurrences in parallel
+  const occurrenceKey = (templateId: string, date: string) => `${templateId}|${date}`;
+
   const [{ data: templates }, { data: resolvedOccurrences }] = await Promise.all([
     supabase
       .from("recurring_transaction_templates")
@@ -116,7 +118,7 @@ async function getUpcomingRecurrencesCached(
       .eq("is_active", true),
     supabase
       .from("recurring_occurrences")
-      .select("template_id, occurrence_date, status")
+      .select("template_id, occurrence_date")
       .eq("user_id", userId)
       .in("status", ["paid", "skipped"])
       .gte("occurrence_date", rangeStartStr)
@@ -125,11 +127,8 @@ async function getUpcomingRecurrencesCached(
 
   if (!templates || templates.length === 0) return [];
 
-  // Build a set of "templateId|date" keys for paid/skipped occurrences
   const resolvedKeys = new Set(
-    (resolvedOccurrences ?? []).map(
-      (o) => `${o.template_id}|${o.occurrence_date}`
-    )
+    (resolvedOccurrences ?? []).map((o) => occurrenceKey(o.template_id, o.occurrence_date))
   );
 
   const upcoming: UpcomingRecurrence[] = [];
@@ -144,8 +143,7 @@ async function getUpcomingRecurrencesCached(
     );
 
     for (const date of dates) {
-      // Skip occurrences already marked as paid or skipped
-      if (resolvedKeys.has(`${template.id}|${date}`)) continue;
+      if (resolvedKeys.has(occurrenceKey(template.id, date))) continue;
       upcoming.push({ template, next_date: date });
     }
   }

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -16,6 +16,39 @@ interface PlanExpandableChipsProps {
 
 type ChipType = "income" | "payment" | null;
 
+const CHIP_CONFIG = {
+  income: {
+    label: "Próximo ingreso",
+    emptyAction: "Mapear ingreso",
+    emptyHint: "Agrega un ingreso recurrente",
+    expandedLabel: "Ingresos esperados",
+    emptyMessage: "No tienes ingresos recurrentes configurados",
+    text: "text-emerald-400",
+    textMuted: "text-emerald-400/80",
+    textEmpty: "text-emerald-400/60",
+    borderActive: "border-emerald-500/50 bg-emerald-950/30",
+    borderInactive: "border-white/6 bg-emerald-950/20",
+    panelBorder: "border-emerald-500/20 bg-emerald-950/20",
+    ctaBg: "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30",
+  },
+  payment: {
+    label: "Próximo pago",
+    emptyAction: "Mapear pago",
+    emptyHint: "Agrega un pago recurrente",
+    expandedLabel: "Pagos programados",
+    emptyMessage: "No tienes pagos recurrentes configurados",
+    text: "text-red-400",
+    textMuted: "text-red-400/80",
+    textEmpty: "text-red-400/60",
+    borderActive: "border-red-500/50 bg-red-950/30",
+    borderInactive: "border-white/6 bg-red-950/20",
+    panelBorder: "border-red-500/20 bg-red-950/20",
+    ctaBg: "bg-red-500/20 text-red-400 hover:bg-red-500/30",
+  },
+} as const;
+
+const OPPOSITE: Record<"income" | "payment", ChipType> = { income: "payment", payment: "income" };
+
 export function PlanExpandableChips({
   incomes,
   payments,
@@ -23,98 +56,57 @@ export function PlanExpandableChips({
 }: PlanExpandableChipsProps) {
   const [expanded, setExpanded] = useState<ChipType>(null);
 
-  const nextIncome = incomes[0] ?? null;
-  const nextPayment = payments[0] ?? null;
+  const items = { income: incomes, payment: payments } as const;
+  const toggle = (type: ChipType) => setExpanded((prev) => (prev === type ? null : type));
 
-  const toggle = (type: ChipType) => {
-    setExpanded((prev) => (prev === type ? null : type));
-  };
-
-  const expandedList = expanded === "income" ? incomes : expanded === "payment" ? payments : [];
-  const expandedLabel = expanded === "income" ? "Ingresos esperados" : "Pagos programados";
-  const expandedColor = expanded === "income" ? "text-emerald-400" : "text-red-400";
+  const expandedList = expanded ? items[expanded] : [];
+  const config = expanded ? CHIP_CONFIG[expanded] : null;
 
   return (
     <div className="space-y-2">
       <div className="grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          onClick={() => toggle("income")}
-          className={cn(
-            "rounded-xl border p-3 text-left transition-all",
-            expanded === "income"
-              ? "border-emerald-500/50 bg-emerald-950/30"
-              : "border-white/6 bg-emerald-950/20",
-            expanded === "payment" && "opacity-50"
-          )}
-        >
-          {nextIncome ? (
-            <>
-              <p className="text-lg font-bold text-emerald-400">
-                {formatCurrency(nextIncome.template.amount ?? 0, currency)}
-              </p>
-              <p className="text-[10px] text-emerald-400/80">Próximo ingreso</p>
-              <p className="text-[9px] text-muted-foreground">
-                {nextIncome.template.description} · {formatDate(new Date(nextIncome.next_date), "dd MMM")}
-              </p>
-            </>
-          ) : (
-            <>
-              <div className="flex items-center gap-1 text-emerald-400/60">
-                <Plus className="size-4" />
-                <p className="text-xs font-semibold">Mapear ingreso</p>
-              </div>
-              <p className="text-[10px] text-muted-foreground mt-1">
-                Agrega un ingreso recurrente
-              </p>
-            </>
-          )}
-        </button>
-
-        <button
-          type="button"
-          onClick={() => toggle("payment")}
-          className={cn(
-            "rounded-xl border p-3 text-left transition-all",
-            expanded === "payment"
-              ? "border-red-500/50 bg-red-950/30"
-              : "border-white/6 bg-red-950/20",
-            expanded === "income" && "opacity-50"
-          )}
-        >
-          {nextPayment ? (
-            <>
-              <p className="text-lg font-bold text-red-400">
-                {formatCurrency(nextPayment.template.amount ?? 0, currency)}
-              </p>
-              <p className="text-[10px] text-red-400/80">Próximo pago</p>
-              <p className="text-[9px] text-muted-foreground">
-                {nextPayment.template.description} · {formatDate(new Date(nextPayment.next_date), "dd MMM")}
-              </p>
-            </>
-          ) : (
-            <>
-              <div className="flex items-center gap-1 text-red-400/60">
-                <Plus className="size-4" />
-                <p className="text-xs font-semibold">Mapear pago</p>
-              </div>
-              <p className="text-[10px] text-muted-foreground mt-1">
-                Agrega un pago recurrente
-              </p>
-            </>
-          )}
-        </button>
+        {(["income", "payment"] as const).map((type) => {
+          const c = CHIP_CONFIG[type];
+          const next = items[type][0] ?? null;
+          return (
+            <button
+              key={type}
+              type="button"
+              onClick={() => toggle(type)}
+              className={cn(
+                "rounded-xl border p-3 text-left transition-all",
+                expanded === type ? c.borderActive : c.borderInactive,
+                expanded === OPPOSITE[type] && "opacity-50"
+              )}
+            >
+              {next ? (
+                <>
+                  <p className={cn("text-lg font-bold", c.text)}>
+                    {formatCurrency(next.template.amount ?? 0, currency)}
+                  </p>
+                  <p className={cn("text-[10px]", c.textMuted)}>{c.label}</p>
+                  <p className="text-[9px] text-muted-foreground">
+                    {next.template.description} · {formatDate(new Date(next.next_date), "dd MMM")}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <div className={cn("flex items-center gap-1", c.textEmpty)}>
+                    <Plus className="size-4" />
+                    <p className="text-xs font-semibold">{c.emptyAction}</p>
+                  </div>
+                  <p className="text-[10px] text-muted-foreground mt-1">{c.emptyHint}</p>
+                </>
+              )}
+            </button>
+          );
+        })}
       </div>
 
-      {expanded && (
-        <div className={cn(
-          "rounded-xl border p-3",
-          expanded === "income"
-            ? "border-emerald-500/20 bg-emerald-950/20"
-            : "border-red-500/20 bg-red-950/20"
-        )}>
-          <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", expandedColor)}>
-            {expandedLabel}
+      {expanded && config && (
+        <div className={cn("rounded-xl border p-3", config.panelBorder)}>
+          <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", config.text)}>
+            {config.expandedLabel}
           </p>
           {expandedList.length > 0 ? (
             <>
@@ -128,7 +120,7 @@ export function PlanExpandableChips({
                         {item.template.account && ` · ${item.template.account.name}`}
                       </p>
                     </div>
-                    <p className={cn("text-sm font-semibold", expandedColor)}>
+                    <p className={cn("text-sm font-semibold", config.text)}>
                       {formatCurrency(item.template.amount ?? 0, currency)}
                     </p>
                   </div>
@@ -136,7 +128,7 @@ export function PlanExpandableChips({
               </div>
               <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
                 <span className="text-muted-foreground">Total</span>
-                <span className={cn("font-bold", expandedColor)}>
+                <span className={cn("font-bold", config.text)}>
                   {formatCurrency(
                     expandedList.reduce((sum, item) => sum + (item.template.amount ?? 0), 0),
                     currency
@@ -146,18 +138,12 @@ export function PlanExpandableChips({
             </>
           ) : (
             <div className="py-3 text-center">
-              <p className="text-xs text-muted-foreground mb-2">
-                {expanded === "income"
-                  ? "No tienes ingresos recurrentes configurados"
-                  : "No tienes pagos recurrentes configurados"}
-              </p>
+              <p className="text-xs text-muted-foreground mb-2">{config.emptyMessage}</p>
               <Link
                 href="/recurrentes"
                 className={cn(
                   "inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
-                  expanded === "income"
-                    ? "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30"
-                    : "bg-red-500/20 text-red-400 hover:bg-red-500/30"
+                  config.ctaBg
                 )}
               >
                 <Plus className="size-3.5" />

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
@@ -46,16 +48,26 @@ export function PlanExpandableChips({
             expanded === "payment" && "opacity-50"
           )}
         >
-          <p className="text-lg font-bold text-emerald-400">
-            {nextIncome
-              ? formatCurrency(nextIncome.template.amount ?? 0, currency)
-              : "—"}
-          </p>
-          <p className="text-[10px] text-emerald-400/80">Próximo ingreso</p>
-          {nextIncome && (
-            <p className="text-[9px] text-muted-foreground">
-              {nextIncome.template.description} · {formatDate(new Date(nextIncome.next_date), "dd MMM")}
-            </p>
+          {nextIncome ? (
+            <>
+              <p className="text-lg font-bold text-emerald-400">
+                {formatCurrency(nextIncome.template.amount ?? 0, currency)}
+              </p>
+              <p className="text-[10px] text-emerald-400/80">Próximo ingreso</p>
+              <p className="text-[9px] text-muted-foreground">
+                {nextIncome.template.description} · {formatDate(new Date(nextIncome.next_date), "dd MMM")}
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-1 text-emerald-400/60">
+                <Plus className="size-4" />
+                <p className="text-xs font-semibold">Mapear ingreso</p>
+              </div>
+              <p className="text-[10px] text-muted-foreground mt-1">
+                Agrega un ingreso recurrente
+              </p>
+            </>
           )}
         </button>
 
@@ -70,21 +82,31 @@ export function PlanExpandableChips({
             expanded === "income" && "opacity-50"
           )}
         >
-          <p className="text-lg font-bold text-red-400">
-            {nextPayment
-              ? formatCurrency(nextPayment.template.amount ?? 0, currency)
-              : "—"}
-          </p>
-          <p className="text-[10px] text-red-400/80">Próximo pago</p>
-          {nextPayment && (
-            <p className="text-[9px] text-muted-foreground">
-              {nextPayment.template.description} · {formatDate(new Date(nextPayment.next_date), "dd MMM")}
-            </p>
+          {nextPayment ? (
+            <>
+              <p className="text-lg font-bold text-red-400">
+                {formatCurrency(nextPayment.template.amount ?? 0, currency)}
+              </p>
+              <p className="text-[10px] text-red-400/80">Próximo pago</p>
+              <p className="text-[9px] text-muted-foreground">
+                {nextPayment.template.description} · {formatDate(new Date(nextPayment.next_date), "dd MMM")}
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-1 text-red-400/60">
+                <Plus className="size-4" />
+                <p className="text-xs font-semibold">Mapear pago</p>
+              </div>
+              <p className="text-[10px] text-muted-foreground mt-1">
+                Agrega un pago recurrente
+              </p>
+            </>
           )}
         </button>
       </div>
 
-      {expanded && expandedList.length > 0 && (
+      {expanded && (
         <div className={cn(
           "rounded-xl border p-3",
           expanded === "income"
@@ -94,31 +116,55 @@ export function PlanExpandableChips({
           <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", expandedColor)}>
             {expandedLabel}
           </p>
-          <div className="divide-y divide-white/5">
-            {expandedList.map((item, i) => (
-              <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-2">
-                <div>
-                  <p className="text-xs font-medium">{item.template.description}</p>
-                  <p className="text-[10px] text-muted-foreground">
-                    {formatDate(new Date(item.next_date), "dd MMM yyyy")}
-                    {item.template.account && ` · ${item.template.account.name}`}
-                  </p>
-                </div>
-                <p className={cn("text-sm font-semibold", expandedColor)}>
-                  {formatCurrency(item.template.amount ?? 0, currency)}
-                </p>
+          {expandedList.length > 0 ? (
+            <>
+              <div className="divide-y divide-white/5">
+                {expandedList.map((item, i) => (
+                  <div key={`${item.template.id}-${i}`} className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="text-xs font-medium">{item.template.description}</p>
+                      <p className="text-[10px] text-muted-foreground">
+                        {formatDate(new Date(item.next_date), "dd MMM yyyy")}
+                        {item.template.account && ` · ${item.template.account.name}`}
+                      </p>
+                    </div>
+                    <p className={cn("text-sm font-semibold", expandedColor)}>
+                      {formatCurrency(item.template.amount ?? 0, currency)}
+                    </p>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-          <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
-            <span className="text-muted-foreground">Total</span>
-            <span className={cn("font-bold", expandedColor)}>
-              {formatCurrency(
-                expandedList.reduce((sum, item) => sum + (item.template.amount ?? 0), 0),
-                currency
-              )}
-            </span>
-          </div>
+              <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
+                <span className="text-muted-foreground">Total</span>
+                <span className={cn("font-bold", expandedColor)}>
+                  {formatCurrency(
+                    expandedList.reduce((sum, item) => sum + (item.template.amount ?? 0), 0),
+                    currency
+                  )}
+                </span>
+              </div>
+            </>
+          ) : (
+            <div className="py-3 text-center">
+              <p className="text-xs text-muted-foreground mb-2">
+                {expanded === "income"
+                  ? "No tienes ingresos recurrentes configurados"
+                  : "No tienes pagos recurrentes configurados"}
+              </p>
+              <Link
+                href="/recurrentes"
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+                  expanded === "income"
+                    ? "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30"
+                    : "bg-red-500/20 text-red-400 hover:bg-red-500/30"
+                )}
+              >
+                <Plus className="size-3.5" />
+                Crear en Recurrentes
+              </Link>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -10,6 +10,9 @@ import { revalidateTag } from "next/cache";
  * Callers should add domain-specific extras after calling this:
  *   revalidateFinancialViews();
  *   revalidateTag("email-ingest", "zeta");   // domain extra
+ *
+ * NOTE: revalidateTag(tag, profile) — the second arg is the cacheLife
+ * profile name ("zeta"), NOT a second tag. Always pass "zeta".
  */
 export function revalidateFinancialViews() {
   revalidateTag("transactions", "zeta");


### PR DESCRIPTION
## Summary
- **Stale occurrences bug**: `getUpcomingRecurrencesCached` computed upcoming dates from templates without checking `recurring_occurrences` for paid/skipped status. Now cross-references the occurrences table in parallel and excludes resolved items. Also registers both `"recurring"` and `"occurrences"` cache tags so either revalidation path invalidates correctly.
- **Empty chip CTA**: Próximo ingreso/pago chips now show a "+ Mapear ingreso/pago" prompt with a link to `/recurrentes` when no upcoming items exist, instead of a dead "—" that couldn't expand.
- **Docs**: Added clarifying comment on `revalidateTag(tag, profile)` signature in `revalidation.ts`.

## Test plan
- [ ] Mark a recurring payment as paid from `/recurrentes`, then navigate to `/plan` — the paid item should no longer appear in the upcoming list
- [ ] Verify próximo ingreso chip shows "+ Mapear ingreso" when no income templates exist, and expands to show empty state with link to `/recurrentes`
- [ ] Same for próximo pago chip
- [ ] Verify chips still work normally when data exists (amount, description, expanded list with total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)