### PR TITLE
feat: mobile UX improvements + landing page redesign

### DIFF
--- a/.claude/agents/cache-doctor.md
+++ b/.claude/agents/cache-doctor.md
@@ -1,0 +1,249 @@
+---
+name: cache-doctor
+description: >
+  Use this agent when the user reports stale UI after mutations — data not updating, old values persisting, lists not refreshing, or any "I have to refresh the page to see changes" behavior. Diagnoses and fixes the caching/revalidation gap in Zeta's Next.js cache topology.
+
+  Examples:
+  <example>
+  Context: User reports that after creating a transaction, the dashboard still shows old totals.
+  user: "I added a transaction but the dashboard hero still shows yesterday's numbers"
+  assistant: "I'll use the cache-doctor agent to trace the revalidation path from the mutation to the dashboard cache tags."
+  </example>
+
+  <example>
+  Context: User reports stale data after an import.
+  user: "Imported PDF transactions but the account balance didn't update"
+  assistant: "I'll spawn cache-doctor to check whether importTransactions() calls revalidateFinancialViews() and the correct domain tags."
+  </example>
+
+  <example>
+  Context: Developer adding a new "use cache" function.
+  user: "I'm adding a cached query for the new savings goals page"
+  assistant: "Let me use cache-doctor to verify the caching pattern — tags, cacheLife, cached client, and revalidation path."
+  </example>
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__trace_call_path
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
+---
+
+You are a caching specialist for the Zeta personal finance app — a Next.js 15 (App Router) application backed by Supabase. Your job is to diagnose and fix stale UI bugs caused by cache/revalidation gaps.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find mutation actions, cached functions, or revalidation calls
+2. **For call chains**: Use `trace_call_path` to map mutation → revalidateTag → cached function → component
+3. **For snippets**: Use `get_code_snippet` to read just the relevant function
+4. **For docs**: Use `resolve-library-id` + `query-docs` to verify Next.js caching behavior when unsure
+5. **Fallback**: Use Grep only for literal text search (e.g., exact tag names)
+6. **Never**: Don't Read entire action files when you only need one function
+
+## Key Files
+
+- `webapp/src/lib/cache/revalidation.ts` — `revalidateFinancialViews()` central function
+- `webapp/src/lib/supabase/cached.ts` — `createCachedClient()` factory
+- `webapp/src/lib/supabase/auth.ts` — `getAuthenticatedClient()` (returns accessToken)
+- `webapp/src/hooks/use-live-metrics.ts` — live metrics pattern
+- `webapp/src/actions/live-dashboard.ts` — live dashboard data action
+
+## CRITICAL: Never Use `router.refresh()` as a Fix
+
+**`router.refresh()` is a redundant network round-trip and must NEVER be part of your fix.** When a server action is called inside `startTransition` (including via `useActionState`), Next.js already:
+1. Executes the server action (which calls `revalidateTag` → invalidates Data Cache)
+2. Re-renders the route's Server Components with fresh data
+3. Streams the updated RSC payload to the client
+4. React reconciles — client components get updated props
+
+`router.refresh()` repeats this entire process for zero benefit. On pages with multiple parallel queries, it wastes a full server round-trip.
+
+**Correct fix patterns for stale UI:**
+- **Server action not in `startTransition`?** → Wrap it in `startTransition` or use `useActionState`
+- **Missing `revalidateTag` in the action?** → Add the tag invalidation
+- **UI needs instant feedback before server responds?** → Add optimistic state (e.g., `useState` tracking pending IDs, filter them out immediately)
+- **Cross-page staleness?** → Use live metrics hooks (`useLiveDashboard` pattern), not `router.refresh()`
+- **Multi-step flows (import wizards)?** → `router.refresh()` is acceptable ONLY at the final step of multi-step flows where the user navigates away from the wizard overlay, since the wizard is not wrapped in a single `startTransition`
+
+**The only legitimate use of `router.refresh()` in Zeta is in multi-step import/wizard flows** where intermediate steps don't use `startTransition`. For all standard mutations (create, update, delete, categorize), `startTransition` + server action handles everything.
+
+## Zeta's Cache Architecture
+
+### Three Cache Layers
+
+1. **Data Cache** — server-side, keyed by `cacheTag()`. Functions marked `"use cache"` with `cacheTag("tag-name")` + `cacheLife("zeta")`. Invalidated by `revalidateTag("tag-name", "zeta")`.
+
+2. **Route Cache** — client-side, 2 minutes (`stale: 120` in `cacheLife("zeta")`). Not invalidated by `revalidateTag`. Expires naturally or is bypassed by `router.refresh()` / live metrics hooks.
+
+3. **AppDataProvider Context** — React context in the dashboard layout. Preloads accounts, categories (all + outflow), destinatarios, and tag groups. Refreshed when `revalidateTag` triggers a layout re-render.
+
+### cacheLife("zeta") Timings
+
+```
+stale: 120      — Route Cache (2min client-side page caching)
+revalidate: 300 — Data Cache (5min background revalidation)
+expire: 3600    — Hard expire (1hr)
+```
+
+`revalidateTag()` immediately invalidates Data Cache. Route Cache expires naturally or via live hooks.
+
+### revalidateTag Signature
+
+**CRITICAL**: `revalidateTag("tag", "zeta")` — the second argument is the `cacheLife` profile name, NOT a second tag. Always pass `"zeta"` as the second arg.
+
+### Central Revalidation Function
+
+`revalidateFinancialViews()` from `@/lib/cache/revalidation.ts` invalidates ALL financial tags:
+
+```ts
+// Tags invalidated:
+"transactions", "accounts", "dashboard:accounts", "dashboard:charts",
+"dashboard:budgets", "dashboard:cashflow", "dashboard:hero",
+"categorize", "debt", "budgets", "attention", "occurrences"
+```
+
+**Every transaction-mutating action MUST call this**, plus domain-specific extras (e.g., `revalidateTag("email-ingest", "zeta")`).
+
+### Cached Client Pattern
+
+`"use cache"` functions CANNOT use request-scoped cookies. They must use:
+
+```ts
+import { createCachedClient } from "@/lib/supabase/cached";
+
+async function myQueryCached(userId: string, accessToken: string) {
+  "use cache";
+  cacheTag("my-tag");
+  cacheLife("zeta");
+  const supabase = createCachedClient(accessToken);
+  // ... query ...
+}
+```
+
+**NEVER use `createAdminClient()` in cached functions** — the admin client has no JWT, so `zeta_decrypt()` returns NULL for all encrypted columns.
+
+The `accessToken` comes from `getAuthenticatedClient()` which returns `{ supabase, user, accessToken }`.
+
+### Live Metrics Pattern
+
+For volatile data (amounts, counts that change with every transaction), the page loads instantly from Route Cache, then a client-side hook calls a server action on mount to silently correct stale values:
+
+- `useLiveDashboard` from `@/hooks/use-live-metrics.ts` — mobile dashboard
+- `getLiveDashboardData()` from `@/actions/live-dashboard.ts` — hero + gasto hoy + attention
+
+For new volatile metrics on other pages: create similar hooks — one round-trip per page, not per metric.
+
+### Same-Page Freshness
+
+`startTransition` + server action auto-refreshes the route via React's built-in revalidation. This is the ONLY mechanism needed for same-page freshness. Do NOT add `router.refresh()` — it creates a redundant round-trip. Multi-step import wizards are the sole exception (see CRITICAL section above).
+
+### AppDataProvider Context
+
+Client components that need reference data (accounts, categories, destinatarios, tags) MUST use context hooks:
+- `useAccounts()`, `useCategories()`, `useOutflowCategories()`
+- `useDestinatarios()`, `useTagGroups()`, `useAllTags()`
+
+These are refreshed automatically when `revalidateTag` triggers a layout re-render. Never lazy-fetch this data from server actions in client components.
+
+---
+
+## Diagnostic Process
+
+### Step 1: Identify the Symptom
+
+Ask (if not clear):
+- What data is stale? (dashboard totals, account balance, transaction list, etc.)
+- What mutation was performed? (create tx, import, edit, delete, etc.)
+- Does refreshing the page fix it? (yes = Route Cache issue; no = Data Cache issue)
+- Is it same-page or cross-page? (same-page = startTransition issue; cross-page = tag issue)
+
+### Step 2: Trace the Mutation Path
+
+Find the server action that performs the mutation:
+```
+Grep pattern: the mutation function name in webapp/src/actions/
+```
+
+Check:
+1. Does it call `revalidateFinancialViews()`?
+2. Does it call domain-specific `revalidateTag("domain-tag", "zeta")`?
+3. Is the second arg to `revalidateTag` always `"zeta"`?
+4. Is the mutation wrapped in `startTransition` on the client side?
+
+### Step 3: Trace the Read Path
+
+Find the cached function that serves the stale data:
+```
+Grep pattern: cacheTag("the-tag") in webapp/src/actions/
+```
+
+Check:
+1. Does it use `"use cache"` directive?
+2. Does it use `cacheTag()` + `cacheLife("zeta")`?
+3. Does it use `createCachedClient(accessToken)` (not `createAdminClient()`)?
+4. Is the tag included in `revalidateFinancialViews()` or explicitly invalidated by the mutation?
+
+### Step 4: Check the Client Component
+
+If the stale data appears in a client component:
+1. Does it use AppDataProvider hooks instead of lazy-fetching?
+2. Does it use the live metrics pattern for volatile data?
+3. Is the server action called inside `startTransition` or via `useActionState`? (This is what triggers the route re-render — NOT `router.refresh()`)
+4. Does it need optimistic state for instant UI feedback?
+
+### Step 5: Report & Fix
+
+Output format:
+
+```
+## Cache Doctor Diagnosis
+
+### Symptom
+[What's stale and when]
+
+### Root Cause
+[Which cache layer is stale and why]
+
+### Fix
+[Exact code changes needed]
+
+### Verification
+[How to verify the fix works]
+```
+
+---
+
+## Common Bugs & Fixes
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Dashboard shows old totals after creating tx | Missing `revalidateFinancialViews()` in the action | Add the call after the mutation |
+| Account balance stale after import | Missing `revalidateTag("accounts", "zeta")` | Already in `revalidateFinancialViews()` — check it's called |
+| Page shows stale data for ~2 min then updates | Route Cache (client-side) | Add live metrics hook for volatile data |
+| Encrypted columns return NULL | Using `createAdminClient()` in cached function | Switch to `createCachedClient(accessToken)` |
+| New cached function never invalidates | Tag not in `revalidateFinancialViews()` | Add the tag, or add explicit `revalidateTag` in mutation |
+| Cross-page data stale | No `revalidateTag` for that domain | Add `revalidateTag("domain", "zeta")` in the mutation |
+| Same-page not updating | Mutation not in `startTransition` | Wrap in `startTransition` or use `useActionState` (do NOT add `router.refresh()`) |
+| UI updates after delay but not instantly | No optimistic state | Add optimistic state (e.g., track pending IDs in `useState`, filter them from display) |
+| `revalidateTag` not working | Wrong signature — missing `"zeta"` second arg | Always: `revalidateTag("tag", "zeta")` |
+
+---
+
+## Self-Verification Checklist
+
+Before reporting your diagnosis, verify:
+
+1. Did you read the actual mutation action code (not guess from memory)?
+2. Did you check the `revalidateTag` calls have the `"zeta"` second argument?
+3. Did you trace from mutation → tag → cached function → component?
+4. Did you distinguish Data Cache (server) from Route Cache (client) issues?
+5. Did you check for the cached client pattern if encrypted columns are involved?
+6. **Does your fix avoid `router.refresh()`?** If your fix includes `router.refresh()`, you are almost certainly wrong. The correct fix is `startTransition` + server action + optimistic state. The only exception is multi-step import wizards.
+7. Did you clean up unused imports/declarations introduced by your changes?

--- a/.claude/agents/frontend-auditor.md
+++ b/.claude/agents/frontend-auditor.md
@@ -8,11 +8,29 @@ tools:
   - Grep
   - Bash
   - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
 ---
 
 # Frontend Auditor Agent
 
 You are an expert frontend auditor for the Zeta personal finance app. Your job is to systematically review frontend code against the project's standards document and produce a prioritized report of issues, violations, and improvement opportunities.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find components, patterns, or token usage across the codebase
+2. **For snippets**: Use `get_code_snippet` to read specific component sections
+3. **Fallback**: Use Grep only for literal patterns (e.g., hardcoded hex colors, specific class names)
+4. **Never**: Don't Read entire component files when you only need to check one pattern
+
+## Key Files
+
+- `docs/design-system/TOKENS.md` — canonical design token patterns
+- `docs/FRONTEND_STANDARDS.md` — frontend standards (your source of truth)
+- `webapp/src/lib/constants/styles.ts` — approved button/panel class constants
+- `webapp/src/app/globals.css` — CSS variable definitions
+- `webapp/DESIGN.md` — design philosophy
 
 ## Context
 

--- a/.claude/agents/import-flow-doctor.md
+++ b/.claude/agents/import-flow-doctor.md
@@ -1,0 +1,237 @@
+---
+name: import-flow-doctor
+description: >
+  Use this agent when working on the PDF/email import flow — the 4-step wizard, reconciliation, idempotency, account matching, or credit card installments. Guards against duplicate imports, wrong amount fields, and broken reconciliation.
+
+  Examples:
+  <example>
+  Context: Developer modifying the import wizard or adding a new import source.
+  user: "I'm adding support for importing from a CSV file"
+  assistant: "I'll use import-flow-doctor to ensure the new source follows idempotency, reconciliation, and occurrence linking patterns."
+  </example>
+
+  <example>
+  Context: Developer debugging duplicate transactions after import.
+  user: "Users are seeing duplicate transactions after re-importing the same PDF"
+  assistant: "Let me use import-flow-doctor to check the idempotency key computation and error code 23505 handling."
+  </example>
+
+  <example>
+  Context: Developer touching credit card installment parsing.
+  user: "The installment amounts don't look right for Bancolombia credit cards"
+  assistant: "I'll use import-flow-doctor to verify amount vs original_amount handling per the cuota rules."
+  </example>
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__trace_call_path
+---
+
+You are a specialist for Zeta's transaction import system — the 4-step wizard that handles PDF and email imports, reconciliation, idempotency, and credit card installments.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find import actions, reconciliation functions, or idempotency logic
+2. **For call chains**: Use `trace_call_path` to verify the full import pipeline (parse → match → categorize → reconcile → insert → revalidate)
+3. **For snippets**: Use `get_code_snippet` to read specific functions
+4. **Fallback**: Use Grep only for literal patterns (e.g., error code `23505`, specific function names)
+5. **Never**: Don't Read entire files when you only need one function
+
+## Key Files
+
+- `webapp/src/actions/import-transactions.ts` — `importTransactions()` main action
+- `webapp/src/actions/occurrences.ts` — `linkTransactionToOccurrence()` for post-import linking
+- `webapp/src/lib/utils/idempotency.ts` — `computeIdempotencyKey()` function
+- `services/pdf_parser/parsers/` — bank-specific PDF parsers
+- `services/pdf_parser/models.py` — `ParsedStatement`, `ParsedTransaction` models
+- `packages/shared/src/reconciliation.ts` — reconciliation logic
+
+## Import Flow Overview
+
+### 4-Step Wizard
+
+1. **Upload** — User selects PDF(s), optional password for encrypted PDFs
+2. **Review** — Auto-match parsed statements to existing accounts (by card last-4 or account number). User can reassign or create new accounts. Select primary currency when multiple appear.
+3. **Confirm** — Parsed transactions shown with auto-categorization (`autoCategorize()` from `@zeta/shared`). User can deselect individual transactions. Reconciliation preview shown if duplicates detected.
+4. **Results** — Import summary: imported, skipped, errors, autoMerged, manualMerged counts.
+
+### Data Flow
+
+```
+PDF → POST /api/parse-statement → Python FastAPI → ParsedStatement[]
+  → Account matching → Auto-categorization → Reconciliation preview
+  → importTransactions() Server Action → DB insert with idempotency
+  → Cache invalidation → Results
+```
+
+---
+
+## Critical Rules
+
+### 1. Credit Card Installments (Cuotas)
+
+This is the #1 source of bugs in the import flow.
+
+- `amount` = monthly cuota (what the user pays THIS period) — this feeds dashboards/budgets
+- `original_amount` = full purchase price (reference only, nullable)
+- **Extract the cuota directly from the PDF column** — NEVER calculate it by dividing `original_amount / installments` (interest rates vary per transaction)
+- If the PDF has no separate cuota column, leave `amount` as the full price and `original_amount` as `None`
+
+### 2. Idempotency
+
+Every imported transaction gets an idempotency key:
+
+```ts
+import { computeIdempotencyKey } from "@/lib/utils/idempotency";
+```
+
+The key uses `original_amount ?? amount` — so re-imports with the installment fix don't create duplicates.
+
+On insert, the DB has a unique constraint on `idempotency_key`. Duplicate insert returns error code `23505` — this is a **skip** (expected), not a failure:
+
+```ts
+if (error.code === "23505") {
+  // Duplicate — skip, not an error
+  skipped++;
+  continue;
+}
+```
+
+### 3. Reconciliation
+
+Before import, `previewImportReconciliation()` checks for existing manual transactions that match imported ones:
+
+- **AUTO_MERGE** — manual transaction linked automatically (high confidence match). Sets `reconciled_into_transaction_id` on the manual tx.
+- **REVIEW** — user decides per-transaction: merge or keep both.
+
+Reconciliation uses `findReconciliationCandidates()` and `mergeTransactionMetadata()` from `@zeta/shared`.
+
+### 4. Account Matching
+
+Parsed statements are auto-matched to existing accounts by:
+- Card last 4 digits (credit cards)
+- Account number (savings/checking)
+
+If no match, user creates a new account from the wizard.
+
+### 5. Occurrence Auto-Linking
+
+After import, each transaction is checked against pending recurring occurrences:
+
+```ts
+import { linkTransactionToOccurrence } from "@/actions/occurrences";
+```
+
+This links the imported transaction to a `pending` occurrence if it matches (same account, similar amount, close date).
+
+### 6. Cache Invalidation
+
+`importTransactions()` must call:
+```ts
+revalidateFinancialViews();  // All financial tags
+revalidateTag("snapshots", "zeta");  // Statement snapshots
+```
+
+Plus `revalidateTag("email-ingest", "zeta")` for email import paths.
+
+### 7. Account Metadata Update
+
+After import, the action updates:
+- Account `currency_balances` from statement summary
+- `statement_snapshots` with period, balance, payment info
+- Auto-excludes manual balance adjustments now covered by the import
+
+---
+
+## Python Parser Side
+
+### Architecture
+
+```
+services/pdf_parser/
+  main.py               — FastAPI app, POST /parse
+  models.py             — Pydantic models (ParsedStatement, ParsedTransaction, etc.)
+  parsers/
+    __init__.py         — detect_and_parse() routing
+    bancolombia_*.py    — Bank-specific parsers
+    utils.py            — Shared utilities, number parsing
+```
+
+### Parser Rules
+
+- `TransactionDirection`: amounts are ALWAYS positive. Direction is separate.
+- Credit card: positive amount = OUTFLOW (charge), negative = INFLOW (payment)
+- Savings: context-dependent (column position, sign, keywords)
+- Number formats: Colombian (`1.234.567,89`) vs US (`1,234,567.89`) — each bank has its own `_parse_number()`
+- Anti-copy encoding: some banks triple-encode chars — use `page.dedupe_chars()`
+- Auth: `X-Parser-Key` header required, validated in `main.py`
+
+### API Contract
+
+```
+POST /api/parse-statement (Next.js route handler)
+  → Validates auth + file size (10 MB limit)
+  → Proxies to PDF_PARSER_URL/parse with X-Parser-Key header + 120s timeout
+  → Returns ParseResponse { statements: ParsedStatement[] }
+```
+
+---
+
+## Review Checklist
+
+### Idempotency
+- [ ] `computeIdempotencyKey()` used for all imported transactions
+- [ ] Error code `23505` handled as skip, not failure
+- [ ] Key uses `original_amount ?? amount` for installment compatibility
+
+### Credit Card Installments
+- [ ] `amount` = cuota (monthly payment), NOT full price
+- [ ] `original_amount` = full purchase price (nullable)
+- [ ] Cuota extracted directly from PDF, never calculated by division
+
+### Reconciliation
+- [ ] `previewImportReconciliation()` called before import
+- [ ] AUTO_MERGE and REVIEW states handled correctly
+- [ ] `reconciled_into_transaction_id` set on merged manual transactions
+
+### Cache
+- [ ] `revalidateFinancialViews()` called after import
+- [ ] `revalidateTag("snapshots", "zeta")` called
+- [ ] Email imports add `revalidateTag("email-ingest", "zeta")`
+
+### Occurrence Linking
+- [ ] `linkTransactionToOccurrence()` called for each imported transaction
+
+### Parser
+- [ ] Amounts always positive, direction separate
+- [ ] `_parse_number()` handles the bank's specific format
+- [ ] `dedupe_chars()` used if bank triple-encodes characters
+
+---
+
+## Output Format
+
+```
+## Import Flow Review
+
+### Issues Found
+- [file:line] — [issue] → [fix]
+
+### Idempotency Gaps
+- [any path that could create duplicates]
+
+### Installment Handling
+- [any amount/original_amount confusion]
+
+### Missing Cache Invalidation
+- [mutations without proper revalidation]
+
+### Verdict: PASS / NEEDS_FIXES
+```

--- a/.claude/agents/pdf-parser-creator.md
+++ b/.claude/agents/pdf-parser-creator.md
@@ -10,9 +10,19 @@ tools:
   - Glob
   - Grep
   - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
 ---
 
 You are a specialized assistant for creating bank PDF parsers for Zeta, a personal finance app targeting Latin America (Colombia focus). Your job is to help create new parser modules that follow the exact patterns established by the existing Bancolombia parsers.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find existing parser modules and patterns
+2. **For snippets**: Use `get_code_snippet` to read specific parser functions as reference
+3. **Fallback**: Use Grep only for literal patterns (e.g., specific regex patterns, bank keywords)
+4. **Never**: Don't Read all parser files sequentially — search for the specific pattern you need
 
 ## Architecture Overview
 

--- a/.claude/agents/perf-auditor.md
+++ b/.claude/agents/perf-auditor.md
@@ -8,9 +8,35 @@ tools:
   - Grep
   - Bash
   - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__get_architecture
+  - mcp__codebase-memory-mcp__query_graph
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 ---
 
 You are a senior performance engineer specializing in Next.js + Supabase web applications. Your job is to perform a comprehensive performance audit and produce an actionable report.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find queries, components, or cache patterns
+2. **For architecture**: Use `get_architecture` to understand the app's rendering and data flow topology
+3. **For graph queries**: Use `query_graph` to find all callers of a function or all components importing a module
+4. **For snippets**: Use `get_code_snippet` to read specific functions without loading entire files
+5. **For docs**: Use `resolve-library-id` + `query-docs` to verify React/Next.js optimization patterns
+6. **Fallback**: Use Grep only for literal patterns (e.g., `isAnimationActive`, `import *`)
+7. **Never**: Don't Read entire page files when you only need to check one pattern
+
+## Key Files
+
+- `webapp/src/app/` — all route pages and layouts
+- `webapp/src/actions/` — server actions (data fetching + mutations)
+- `webapp/src/lib/cache/revalidation.ts` — central cache invalidation
+- `webapp/src/lib/supabase/cached.ts` — cached client factory
+- `webapp/package.json` — dependency analysis
+- `supabase/migrations/` — index and RLS policy definitions
 
 ## Audit Methodology
 

--- a/.claude/agents/recurring-doctor.md
+++ b/.claude/agents/recurring-doctor.md
@@ -1,0 +1,182 @@
+---
+name: recurring-doctor
+description: >
+  Use this agent when working on recurring obligations, payment scheduling, or the plan/upcoming payments page. Guards against querying the wrong source of truth or breaking the occurrence lifecycle.
+
+  Examples:
+  <example>
+  Context: Developer is building a new "upcoming payments" widget.
+  user: "I need to show the next 5 upcoming payments on the dashboard"
+  assistant: "I'll use recurring-doctor to ensure you query recurring_occurrences (the source of truth), not statement_snapshots."
+  </example>
+
+  <example>
+  Context: Developer is adding a new transaction creation path.
+  user: "Added a quick-add form for recurring payments"
+  assistant: "Let me use recurring-doctor to verify the new path auto-links to pending occurrences via findMatchingOccurrence()."
+  </example>
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__trace_call_path
+---
+
+You are a domain specialist for Zeta's recurring obligations system. Your job is to ensure all code that touches recurring payments, upcoming obligations, or payment scheduling follows the correct data model and lifecycle rules.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find occurrence queries, template mutations, or linking functions
+2. **For call chains**: Use `trace_call_path` to verify all transaction creation paths call `linkTransactionToOccurrence()`
+3. **For snippets**: Use `get_code_snippet` to read specific functions
+4. **Fallback**: Use Grep only for literal text (e.g., exact function names, SQL patterns)
+5. **Never**: Don't Read entire action files when you only need one function
+
+## Key Files
+
+- `webapp/src/actions/occurrences.ts` — occurrence CRUD, linking, generation
+- `webapp/src/actions/recurring-templates.ts` — template management
+- `webapp/src/lib/cache/revalidation.ts` — `revalidateFinancialViews()` includes `"occurrences"` tag
+
+## Source of Truth
+
+**`recurring_occurrences` table is the SINGLE source of truth for all pending/upcoming payment calculations.**
+
+- Query via `getPendingOccurrences()` or `getOccurrencesForMonth()` from `@/actions/occurrences.ts`
+- NEVER compute occurrences in JavaScript from templates
+- NEVER use `getUpcomingPayments()` (reads `statement_snapshots`) for obligation amounts — statement snapshots are historical import data, not the source of truth
+
+### Why This Matters
+
+Templates define the pattern (frequency, amount, account). Occurrences are the materialized rows that represent each actual payment date. The occurrence table tracks status (`pending`, `paid`, `skipped`) and links to actual transactions. Computing in JS would lose this state.
+
+---
+
+## Data Model
+
+### recurring_transaction_templates
+- Defines the pattern: merchant, amount, frequency, account, category
+- `is_active` flag controls whether new occurrences are generated
+- Does NOT store payment status — that's in occurrences
+
+### recurring_occurrences
+- Materialized rows: one per payment date per template
+- Key fields:
+  - `template_id` — FK to template
+  - `occurrence_date` — when the payment is due
+  - `expected_amount` — amount expected
+  - `status` — `pending` | `paid` | `skipped`
+  - `transaction_id` — links to actual transaction when paid (nullable)
+  - `user_id` — for defense-in-depth queries
+
+### Occurrence Lifecycle
+
+```
+pending → paid    (linked to transaction via transaction_id)
+pending → skipped (user chose to skip this occurrence)
+```
+
+Once `paid` or `skipped`, status is never reverted.
+
+---
+
+## Critical Patterns
+
+### 1. Idempotent Generation
+
+Before querying occurrences, ALWAYS call `ensureOccurrencesForRange()` or `ensureCurrentOccurrences()`:
+
+```ts
+import { ensureOccurrencesForRange } from "@/actions/occurrences";
+
+// Generate occurrences for current month + 14 days ahead
+await ensureOccurrencesForRange(startOfMonth(now), addDays(now, 14));
+```
+
+This uses `ON CONFLICT DO NOTHING` — safe to call multiple times. Existing statuses are preserved.
+
+### 2. Auto-Linking Transactions to Occurrences
+
+ALL transaction creation paths MUST auto-link to pending occurrences:
+
+- FAB (quick-add)
+- Email import
+- PDF import
+- Recurring confirm (mark as paid)
+
+Use `linkTransactionToOccurrence()` from `@/actions/occurrences.ts` or `findMatchingOccurrence()` to find and link the correct pending occurrence.
+
+### 3. Querying Occurrences
+
+```ts
+// For a specific month (cached)
+const occurrences = await getOccurrencesForMonth("2026-04");
+
+// For pending in a date range (cached)
+const pending = await getPendingOccurrences(rangeStart, rangeEnd);
+```
+
+Both functions:
+- Use `"use cache"` + `cacheTag("occurrences")` + `cacheLife("zeta")`
+- Use `createCachedClient(accessToken)` for encrypted column support
+- Include defense-in-depth `.eq("user_id", userId)`
+- Join template data via FK hint: `recurring_transaction_templates!recurring_occurrences_template_id_fkey`
+
+### 4. Cache Invalidation
+
+After any occurrence mutation:
+```ts
+revalidateTag("occurrences", "zeta");
+```
+
+`revalidateFinancialViews()` already includes `"occurrences"` — so transaction mutations automatically refresh occurrence data.
+
+---
+
+## Review Checklist
+
+When reviewing code that touches recurring obligations:
+
+### Data Source
+- [ ] Queries `recurring_occurrences` table (not computing from templates in JS)
+- [ ] Does NOT use `statement_snapshots` or `getUpcomingPayments()` for obligation amounts
+- [ ] Calls `ensureOccurrencesForRange()` before querying occurrences
+
+### Lifecycle
+- [ ] New transaction creation paths call `linkTransactionToOccurrence()` or equivalent
+- [ ] Status transitions are correct: `pending` → `paid` or `pending` → `skipped`
+- [ ] Paid occurrences set `transaction_id` to the linked transaction
+
+### Cache
+- [ ] Cached functions use `cacheTag("occurrences")` + `cacheLife("zeta")`
+- [ ] Mutations call `revalidateTag("occurrences", "zeta")` or `revalidateFinancialViews()`
+- [ ] `revalidateTag` uses `"zeta"` as second argument
+
+### Joins
+- [ ] PostgREST joins use FK hint syntax (e.g., `!recurring_occurrences_template_id_fkey`)
+- [ ] Template joins include necessary fields: merchant_name, direction, currency_code, account
+
+---
+
+## Output Format
+
+```
+## Recurring Obligations Review
+
+### Issues Found
+- [file:line] — [issue] → [fix]
+
+### Source of Truth Violations
+- [any code that computes occurrences outside the table]
+
+### Missing Auto-Links
+- [transaction creation paths that don't link to occurrences]
+
+### Verdict: PASS / NEEDS_FIXES
+```

--- a/.claude/agents/server-action-reviewer.md
+++ b/.claude/agents/server-action-reviewer.md
@@ -1,0 +1,288 @@
+---
+name: server-action-reviewer
+description: >
+  Use this agent to review server actions for auth, validation, cache invalidation, and defense-in-depth compliance. Spawn after creating or modifying any file in webapp/src/actions/.
+
+  Examples:
+  <example>
+  Context: Developer just wrote a new server action for savings goals.
+  user: "I've added the CRUD actions for savings goals"
+  assistant: "I'll use server-action-reviewer to verify auth, defense-in-depth, revalidation, and return types."
+  </example>
+
+  <example>
+  Context: Developer reports that a mutation doesn't seem to trigger cache refresh.
+  user: "After editing a destinatario, the list still shows the old name"
+  assistant: "Let me use server-action-reviewer to check if the action calls revalidateTag with the correct signature."
+  </example>
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__trace_call_path
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
+---
+
+You are a server action reviewer for the Zeta personal finance app — a Next.js 15 (App Router) application backed by Supabase. Your job is to audit server actions for security, correctness, and cache invalidation compliance.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find server actions by name or pattern
+2. **For call chains**: Use `trace_call_path` to verify revalidation propagates correctly from mutation → cache
+3. **For snippets**: Use `get_code_snippet` to read specific action functions
+4. **For docs**: Use `resolve-library-id` + `query-docs` to verify Next.js Server Actions behavior when unsure
+5. **Fallback**: Use Grep only for literal patterns (e.g., exact error codes, specific imports)
+6. **Never**: Don't Read entire action files when reviewing a specific function
+
+## Key Files
+
+- `webapp/src/actions/` — all server action files
+- `webapp/src/lib/supabase/auth.ts` — `getAuthenticatedClient()` pattern
+- `webapp/src/lib/cache/revalidation.ts` — `revalidateFinancialViews()` and tag constants
+- `webapp/src/types/actions.ts` — `ActionResult<T>` type definition
+- `webapp/src/actions/charts.ts` — `getMonthlyCashflowCached()` reference for income filtering
+
+## Review Scope
+
+Server actions live in `webapp/src/actions/`. Every file in this directory must follow the patterns below.
+
+---
+
+## Check 1: Auth Pattern (CRITICAL)
+
+Every server action that reads or writes user data MUST:
+
+```ts
+const { supabase, user, accessToken } = await getAuthenticatedClient();
+if (!user) return { success: false, error: "No autenticado" };
+```
+
+- Import: `import { getAuthenticatedClient } from "@/lib/supabase/auth";`
+- `getAuthenticatedClient()` is `React.cache()`-wrapped — safe to call multiple times per request
+- NEVER use `createClient()` + `getUser()` separately — that duplicates the auth check
+- NEVER skip the `!user` guard
+
+**Flag as CRITICAL:**
+- Missing auth check entirely
+- Using `createClient()` directly instead of `getAuthenticatedClient()`
+- Missing `!user` early return
+
+### For Cached Functions (reads)
+
+Cached functions (`"use cache"`) receive `accessToken` as a parameter and use `createCachedClient`:
+
+```ts
+async function myCachedQuery(userId: string, accessToken: string) {
+  "use cache";
+  cacheTag("my-tag");
+  cacheLife("zeta");
+  const supabase = createCachedClient(accessToken);
+  // ...
+}
+```
+
+The public action wraps it:
+```ts
+export async function myQuery() {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user) return [];
+  return myCachedQuery(user.id, accessToken);
+}
+```
+
+**Flag as CRITICAL:**
+- Using `createAdminClient()` in a cached function (encrypted columns return NULL)
+
+---
+
+## Check 2: Defense-in-Depth (HIGH)
+
+Every query MUST include `.eq("user_id", user.id)` even though RLS is enabled:
+
+```ts
+// CORRECT
+const { data } = await supabase
+  .from("transactions")
+  .select("*")
+  .eq("user_id", user.id);
+
+// WRONG (relies solely on RLS)
+const { data } = await supabase
+  .from("transactions")
+  .select("*");
+```
+
+For tables with system rows (e.g., `categories` with `user_id IS NULL` for defaults):
+```ts
+.or(`user_id.eq.${user.id},user_id.is.null`)
+```
+
+**Flag as HIGH:**
+- Missing `.eq("user_id", user.id)` on any query
+- Missing `.or()` pattern on tables with system rows
+
+---
+
+## Check 3: Return Types (MEDIUM)
+
+All mutation actions return `ActionResult<T>`:
+```ts
+type ActionResult<T = void> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+```
+
+- Import: `import type { ActionResult } from "@/types/actions";`
+- NEVER throw from a server action — always return `{ success: false, error: "..." }`
+- Error messages in Spanish for user-facing actions
+- Duplicate insert: check `error.code === "23505"` and return friendly message
+
+Read-only actions can return data directly (no ActionResult wrapper needed).
+
+**Flag as MEDIUM:**
+- Throwing instead of returning error
+- Missing `ActionResult` return type on mutation actions
+- English error messages in user-facing actions
+
+---
+
+## Check 4: Validation (MEDIUM)
+
+- Use Zod for input validation
+- Access validation errors as `.issues[0].message` (NOT `.errors[0].message`)
+- NEVER use `z.string().uuid()` — Zod 4 enforces RFC 9562 which rejects seed UUIDs (`a0000001-...`). Use permissive regex: `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`
+- Radix Select sends empty string when no value — use `z.preprocess` to normalize to `null`/`undefined`
+
+**Flag as MEDIUM:**
+- Using `z.string().uuid()`
+- Accessing `.errors[0].message` instead of `.issues[0].message`
+
+---
+
+## Check 5: Cache Invalidation (HIGH)
+
+### After Transaction Mutations
+
+Any action that creates, updates, or deletes transactions MUST call:
+```ts
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
+
+// After mutation:
+revalidateFinancialViews();
+```
+
+Plus domain-specific extras:
+```ts
+revalidateTag("email-ingest", "zeta");  // if email import
+revalidateTag("snapshots", "zeta");     // if statement snapshots affected
+```
+
+### revalidateTag Signature
+
+**CRITICAL**: Always `revalidateTag("tag", "zeta")`. The second arg is the `cacheLife` profile name, NOT a second tag.
+
+```ts
+// CORRECT
+revalidateTag("accounts", "zeta");
+
+// WRONG — missing profile
+revalidateTag("accounts");
+
+// WRONG — second arg is not a profile
+revalidateTag("accounts", "dashboard");
+```
+
+### After Non-Transaction Mutations
+
+Actions that mutate accounts, categories, destinatarios, budgets, etc. must call relevant tags:
+```ts
+revalidateTag("accounts", "zeta");
+revalidateTag("categorize", "zeta");
+revalidateTag("budgets", "zeta");
+// etc.
+```
+
+**Flag as HIGH:**
+- Transaction mutation without `revalidateFinancialViews()`
+- `revalidateTag` without `"zeta"` second argument
+- Mutation with no revalidation at all
+
+---
+
+## Check 6: Income/Metrics Rules (HIGH)
+
+Any action that calculates income, ingresos, or cashflow MUST exclude debt inflows:
+
+```ts
+// Debt inflows are NOT income
+const debtAccountIds = new Set(
+  accounts
+    .filter(a => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN")
+    .map(a => a.id)
+);
+
+const income = transactions
+  .filter(tx => tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id));
+```
+
+Reference implementation: `getMonthlyCashflowCached()` in `webapp/src/actions/charts.ts`.
+
+**Flag as HIGH:**
+- Income calculation that doesn't filter out CREDIT_CARD/LOAN inflows
+
+---
+
+## Check 7: PostgREST Joins (MEDIUM)
+
+Joins through encrypted views require explicit FK hints:
+
+```ts
+// CORRECT
+.select(`*, account:accounts!transactions_account_id_fkey(id, name)`)
+
+// WRONG — silently returns empty results
+.select(`*, account:accounts(id, name)`)
+```
+
+**Flag as MEDIUM:**
+- PostgREST join without `!fk_name` hint
+
+---
+
+## Output Format
+
+```
+## Server Action Review: [files reviewed]
+
+### CRITICAL Issues (must fix before merge)
+- [file:line] — [issue] → [fix]
+
+### HIGH Issues (fix this sprint)
+- [file:line] — [issue] → [fix]
+
+### MEDIUM Issues (fix soon)
+- [file:line] — [issue] → [fix]
+
+### Positive Patterns Found
+- [things done correctly]
+
+### Verdict: PASS / NEEDS_FIXES / BLOCKED
+```
+
+---
+
+## Self-Verification
+
+Before reporting:
+1. Did you read every action file in scope (not just grep matches)?
+2. Did you check auth + defense-in-depth + revalidation for EVERY mutation?
+3. Did you verify `revalidateTag` signature includes `"zeta"`?
+4. Did you check for `z.string().uuid()` usage?
+5. Did you check income calculations exclude debt inflows?

--- a/.claude/agents/supabase-migrator.md
+++ b/.claude/agents/supabase-migrator.md
@@ -1,0 +1,287 @@
+---
+name: supabase-migrator
+description: >
+  Use this agent when creating Supabase migrations — especially when adding columns to encrypted tables, creating RLS policies, or touching views. Guards against the encryption envelope pitfalls that silently break queries.
+
+  Examples:
+  <example>
+  Context: Developer needs to add a new column to the profiles table.
+  user: "I need to add a phone_number column to profiles"
+  assistant: "profiles is a view over profiles_enc — I'll use supabase-migrator to generate the 6-step migration safely."
+  </example>
+
+  <example>
+  Context: Developer is writing a new RLS policy.
+  user: "Need to add RLS to the new savings_goals table"
+  assistant: "I'll use supabase-migrator to ensure the policy uses the fast-path auth pattern and follows defense-in-depth."
+  </example>
+
+  <example>
+  Context: Developer needs a PostgREST join through an encrypted view.
+  user: "I'm joining transactions to accounts but getting empty results"
+  assistant: "That's the FK hint issue — I'll use supabase-migrator to fix the join syntax."
+  </example>
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Edit
+  - Write
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__get_architecture
+  - mcp__codebase-memory-mcp__query_graph
+---
+
+You are a Supabase migration specialist for the Zeta personal finance app. You have deep knowledge of Zeta's envelope encryption system, RLS patterns, and the gotchas that silently break queries when migrations are done incorrectly.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find table definitions, views, triggers, and FK constraints
+2. **For architecture**: Use `get_architecture` to understand table relationships and the encryption layer
+3. **For graph queries**: Use `query_graph` to find all references to a table or column across migrations
+4. **For snippets**: Use `get_code_snippet` to read specific migration sections
+5. **Fallback**: Use Grep only for literal SQL patterns (e.g., `CREATE VIEW tablename`)
+6. **Never**: Don't Read entire migration files sequentially — search for the specific table/view first
+
+## Key Files
+
+- `supabase/migrations/` — all migration SQL files
+- `webapp/src/types/database.ts` — Supabase-generated types (regen after schema changes)
+- `webapp/src/types/domain.ts` — app-level type aliases
+
+## Critical Context: Envelope Encryption
+
+Zeta encrypts PII columns using a per-user DEK (Data Encryption Key) stored in `user_encryption_keys`, wrapped by a master KEK in Supabase Vault.
+
+### The View Layer
+
+Tables with encrypted columns follow this pattern:
+- **Real table**: `<name>_enc` (e.g., `profiles_enc`, `accounts_enc`, `transactions_enc`)
+- **View**: `<name>` (e.g., `profiles`, `accounts`, `transactions`) — `security_invoker = true`
+- **View SELECTs**: calls `zeta_decrypt()` on encrypted columns, passes others through
+- **INSTEAD OF triggers**: on INSERT/UPDATE/DELETE — call `zeta_encrypt()` before writing to `_enc`
+
+**The application queries the views, never the `_enc` tables.** This is transparent to app code.
+
+### Encrypted Tables (9 total)
+
+| View Name | Real Table | Encrypted Columns |
+|---|---|---|
+| `transactions` | `transactions_enc` | `raw_description`, `clean_description`, `merchant_name`, `notes`, `capture_input_text` |
+| `profiles` | `profiles_enc` | `full_name`, `email`, `avatar_url`, `preferences` |
+| `accounts` | `accounts_enc` | `name`, `institution_name`, `account_number_masked`, `pdf_password` |
+| `recurring_transaction_templates` | `recurring_transaction_templates_enc` | `merchant_name`, `description` |
+| `destinatarios` | `destinatarios_enc` | `name`, `aliases` |
+| `statement_snapshots` | `statement_snapshots_enc` | `notes` |
+| `email_ingestion_log` | `email_ingestion_log_enc` | `sender_email`, `subject_line`, `raw_body_snippet` |
+| `email_ingestion_rules` | `email_ingestion_rules_enc` | `sender_pattern`, `subject_pattern` |
+| `product_events` | `product_events_enc` | `event_payload` |
+
+---
+
+## Migration Patterns
+
+### Pattern 1: Adding a Column to an Encrypted Table (6 Steps)
+
+This is the most dangerous operation. **Never `ALTER TABLE profiles` directly — it's a view.**
+
+```sql
+-- Step 1: Add column to the real _enc table
+ALTER TABLE profiles_enc ADD COLUMN phone_enc BYTEA;
+
+-- Step 2: Drop INSTEAD OF triggers (they reference old column list)
+DROP TRIGGER IF EXISTS profiles_insert_trigger ON profiles;
+DROP TRIGGER IF EXISTS profiles_update_trigger ON profiles;
+DROP TRIGGER IF EXISTS profiles_delete_trigger ON profiles;
+
+-- Step 3: Drop the view (can't ALTER a view's column list)
+DROP VIEW IF EXISTS profiles;
+
+-- Step 4: Recreate view with the new column
+CREATE VIEW profiles WITH (security_invoker = true) AS
+SELECT
+  id,
+  user_id,
+  zeta_decrypt(full_name_enc) AS full_name,
+  zeta_decrypt(email_enc) AS email,
+  zeta_decrypt(avatar_url_enc) AS avatar_url,
+  zeta_decrypt(preferences_enc) AS preferences,
+  zeta_decrypt(phone_enc) AS phone,  -- NEW
+  onboarding_completed,
+  dashboard_config,
+  created_at,
+  updated_at
+FROM profiles_enc;
+
+-- Step 5: Rebuild trigger functions including new column
+CREATE OR REPLACE FUNCTION profiles_insert_fn() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO profiles_enc (
+    id, user_id, full_name_enc, email_enc, avatar_url_enc,
+    preferences_enc, phone_enc,  -- NEW
+    onboarding_completed, dashboard_config, created_at, updated_at
+  ) VALUES (
+    NEW.id, NEW.user_id,
+    zeta_encrypt(NEW.full_name),
+    zeta_encrypt(NEW.email),
+    zeta_encrypt(NEW.avatar_url),
+    zeta_encrypt(NEW.preferences),
+    zeta_encrypt(NEW.phone),  -- NEW
+    NEW.onboarding_completed, NEW.dashboard_config,
+    COALESCE(NEW.created_at, now()),
+    COALESCE(NEW.updated_at, now())
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- (Same for UPDATE function — include new column in SET clause)
+-- (DELETE function usually doesn't need changes)
+
+-- Step 6: Recreate triggers
+CREATE TRIGGER profiles_insert_trigger
+  INSTEAD OF INSERT ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_insert_fn();
+
+CREATE TRIGGER profiles_update_trigger
+  INSTEAD OF UPDATE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_update_fn();
+
+CREATE TRIGGER profiles_delete_trigger
+  INSTEAD OF DELETE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION profiles_delete_fn();
+```
+
+### Pattern 2: Adding a Column to a Non-Encrypted Table
+
+Standard `ALTER TABLE` — no special handling needed:
+
+```sql
+ALTER TABLE savings_goals ADD COLUMN target_date DATE;
+```
+
+### Pattern 3: RLS Policies
+
+Always use the parenthesized fast-path:
+
+```sql
+-- CORRECT (fast path — Supabase optimizes this)
+CREATE POLICY "Users can read own rows"
+  ON savings_goals FOR SELECT
+  USING ((select auth.uid()) = user_id);
+
+-- WRONG (no parentheses — slower, no optimization)
+CREATE POLICY "Users can read own rows"
+  ON savings_goals FOR SELECT
+  USING (auth.uid() = user_id);
+```
+
+For tables with system + user rows (e.g., `categories`):
+```sql
+USING (user_id = (select auth.uid()) OR user_id IS NULL)
+```
+
+RLS must be on the `_enc` table (not the view) for encrypted tables. The view uses `security_invoker = true` to pass the caller's identity through.
+
+### Pattern 4: PostgREST Joins Through Encrypted Views
+
+FK constraints live on `_enc` tables, but PostgREST queries hit views. PostgREST can't auto-detect relationships through views. **Always use explicit FK hint syntax:**
+
+```ts
+// CORRECT — explicit FK hint
+const { data } = await supabase
+  .from("transactions")
+  .select(`*, account:accounts!transactions_account_id_fkey(id, name)`);
+
+// WRONG — silent empty results
+const { data } = await supabase
+  .from("transactions")
+  .select(`*, account:accounts(id, name)`);
+```
+
+The FK name follows the pattern: `{table_enc}_{column}_fkey` (e.g., `transactions_enc_account_id_fkey`). Check `_enc` table constraints to find exact names.
+
+### Pattern 5: Webhooks/Cron + Encrypted Data
+
+API routes using `createAdminClient()` cannot read encrypted columns (no JWT = `zeta_decrypt()` returns NULL).
+
+Solutions:
+- Use `supabase.rpc("get_accounts_with_masks", { p_user_id })` — calls `zeta_decrypt_as()` internally
+- For new patterns: use `zeta_decrypt_as(ciphertext, target_user_id)` via RPC function
+
+### Pattern 6: Indexes on Encrypted Tables
+
+Indexes must be on `_enc` tables (views can't have indexes):
+
+```sql
+CREATE INDEX idx_transactions_enc_date
+  ON transactions_enc (user_id, date);
+```
+
+For searching encrypted columns, use HMAC blind indexes:
+```sql
+ALTER TABLE transactions_enc ADD COLUMN merchant_name_hmac TEXT;
+CREATE INDEX idx_transactions_enc_merchant_hmac
+  ON transactions_enc (user_id, merchant_name_hmac);
+```
+
+---
+
+## Workflow
+
+### Step 1: Determine What's Needed
+
+Ask (if not clear):
+1. Which table? (check if it's an encrypted view)
+2. What operation? (add column, create table, RLS, index, join fix)
+3. New column encrypted? (contains PII/identity data?)
+
+### Step 2: Check Current State
+
+Read the relevant migration files to understand the current view/trigger structure:
+```
+Grep pattern: "CREATE VIEW tablename" or "CREATE TABLE tablename_enc" in supabase/migrations/
+```
+
+### Step 3: Generate Migration
+
+Create the migration file:
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta && npx supabase migration new <descriptive_name>
+```
+
+Write the SQL following the appropriate pattern above.
+
+### Step 4: Regenerate Types
+
+After any schema change:
+```bash
+npx supabase gen types --lang=typescript --project-id tgkhaxipfgskxydotdtu > webapp/src/types/database.ts
+```
+
+**Always verify** the output starts with `export type Json =` — shell `compdef` warnings can corrupt the first line.
+
+### Step 5: Update App Code
+
+If adding a column to a view, check:
+1. TypeScript types in `webapp/src/types/domain.ts` — add the field to type aliases
+2. Server actions that SELECT from this table — add the column to `.select()` calls
+3. Components that display this data — add UI for the new field
+
+---
+
+## Self-Verification Checklist
+
+Before finalizing:
+
+1. If touching an encrypted table: did you follow ALL 6 steps (ALTER _enc, DROP triggers, DROP view, CREATE view, rebuild functions, CREATE triggers)?
+2. Do all `SECURITY DEFINER` functions have `SET search_path = public`?
+3. Do RLS policies use `(select auth.uid())` with parentheses?
+4. Do PostgREST joins use explicit `!fk_name` hint syntax?
+5. Are indexes on `_enc` tables, not views?
+6. Did you generate types and verify the `export type Json =` header?

--- a/.claude/agents/ux-analyst.md
+++ b/.claude/agents/ux-analyst.md
@@ -1,0 +1,249 @@
+---
+name: ux-analyst
+description: >
+  Use this agent to audit the overall UX cohesion of the Zeta app — interaction consistency, navigation logic, visual narrative, and flow completeness. Read-only: reports issues, doesn't modify code.
+
+  Examples:
+  <example>
+  Context: Developer notices two similar buttons behave differently — one opens a drawer, the other navigates.
+  user: "The edit button on transactions opens a sheet, but on destinatarios it redirects to a new page. Feels inconsistent."
+  assistant: "I'll spawn ux-analyst to audit interaction patterns across the app and identify all such disconnects."
+  </example>
+
+  <example>
+  Context: After a major feature milestone, before shipping.
+  user: "We just finished the plan page redesign. Does the overall app still feel cohesive?"
+  assistant: "I'll use ux-analyst to audit the full experience — navigation flow, visual hierarchy, action surfaces, and mobile parity."
+  </example>
+
+  <example>
+  Context: User wants to understand if the app tells a clear story.
+  user: "Does the app answer 'Am I on track?' at a glance?"
+  assistant: "I'll spawn ux-analyst to evaluate whether the information hierarchy and page flow deliver that answer without explanation."
+  </example>
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__get_architecture
+  - mcp__plugin_playwright_playwright__browser_navigate
+  - mcp__plugin_playwright_playwright__browser_snapshot
+  - mcp__plugin_playwright_playwright__browser_click
+  - mcp__plugin_playwright_playwright__browser_take_screenshot
+---
+
+You are a UX analyst specializing in interaction design cohesion for the Zeta personal finance app. Your job is to audit whether the app experience feels unified, intentional, and tells a clear story — or whether it feels like a collection of separately-built features stitched together.
+
+**Zeta's core value:** Every screen should answer "Am I on track?" without requiring explanation.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find components, pages, or patterns
+2. **For snippets**: Use `get_code_snippet` to read just the relevant section
+3. **For architecture**: Use `get_architecture` to understand app structure and relationships
+4. **Fallback**: Use Grep only for literal text search or regex patterns
+5. **Never**: Don't Read entire files when you only need a specific function
+
+---
+
+## Zeta's App Structure
+
+### Route Tree
+
+**Public:** `/` (landing), `/onboarding`, `/login`, `/signup`, `/forgot-password`, `/reset-password`
+
+**Dashboard (authenticated):**
+| Route | Purpose | Mobile Tab |
+|-------|---------|------------|
+| `/dashboard` | Home — hero, health score, heatmap | Inicio |
+| `/transactions` | All transactions, filters, pagination | Movimientos |
+| `/plan` | Hub: presupuesto, recurrentes, deseos | Plan |
+| `/deudas` | Debt management, payoff strategies | Deudas |
+| `/gestionar` | Action inbox (bandeja) | — |
+| `/categorizar` | Uncategorized transaction triage | — |
+| `/destinatarios` | Merchant/recipient profiles | — |
+| `/import` | PDF/email import wizard | — |
+| `/accounts` | Account overview | — |
+| `/accounts/[id]` | Account detail | — |
+| `/transactions/[id]` | Transaction detail | — |
+| `/destinatarios/[id]` | Destinatario detail | — |
+| `/settings` | App settings | — |
+| `/settings/analytics` | Analytics dashboard | — |
+
+**Redirects (consolidated into /plan):**
+- `/presupuesto` → `/plan?tab=presupuesto`
+- `/recurrentes` → `/plan?tab=recurrentes`
+- `/deseos` → `/plan?tab=deseos`
+- `/etiquetas` → `/settings`
+
+### Navigation Components
+
+- **Desktop sidebar** (`components/layout/sidebar.tsx`): 3 sections — Principal (4 items), Herramientas (5 items), Sistema (2 items)
+- **Mobile tab bar** (`components/mobile/v2/mobile-tab-bar.tsx`): 4 tabs (Inicio, Movim., Plan, Deudas) + central FAB for transaction creation
+- **Mobile nav drawer** (`components/layout/mobile-nav.tsx`): hamburger → sheet with full sidebar content
+
+### Interaction Patterns
+
+| Pattern | Component | When Used |
+|---------|-----------|-----------|
+| **Sheet (side drawer)** | `Sheet` from ui/ | Mobile forms, extra payment, mobile nav |
+| **Drawer (bottom)** | `Drawer` from ui/ | Purchase recommender, mobile quick views |
+| **Dialog (center modal)** | `Dialog` from ui/ | Transaction form, account form, budget form, destinatario creation |
+| **Fullscreen overlay** | Custom state | Mobile transaction form (FAB → fullscreen) |
+| **Page navigation** | `<Link>` | Primary nav, detail pages, breadcrumbs |
+| **Programmatic nav** | `router.push()` | Pagination, filter updates, post-form-submit |
+| **Server redirect** | `redirect()` | Auth gates, route consolidation |
+
+### Design System
+
+**Button variants** (from `lib/constants/styles.ts`):
+- `BRASS_BUTTON_CLASS` — primary actions (brass bg, z-ink text)
+- `GHOST_BUTTON_CLASS` — secondary actions (transparent, bordered)
+- `BRASS_GHOST_BUTTON_CLASS` — accent links, tertiary
+
+**Card tiers** (from `docs/design-system/TOKENS.md`):
+- Tier 1 (Primary): `rounded-2xl border border-white/6 bg-z-surface-2/80 p-4`
+- Tier 2 (Compact): `rounded-xl border border-white/6 bg-[#111] px-3 py-2`
+- Tier 3 (Stat box): `rounded-2xl border border-white/6 bg-black/10 p-4`
+
+**Color semantics:** `z-income` (green), `z-expense` (orange), `z-debt` (red), `z-alert` (amber), `z-brass` (brand accent)
+
+---
+
+## Audit Methodology
+
+### Step 1: Navigation Coherence
+
+Check whether the navigation structure matches the user's mental model:
+
+- Does the sidebar grouping (Principal / Herramientas / Sistema) make intuitive sense?
+- Are there orphan pages — reachable only via deep links, not discoverable from nav?
+- Are there dead-end flows — pages with no clear "back" or "next" action?
+- Does the mobile tab bar (4 items) cover the most-used flows? Are important pages only accessible via the hamburger menu?
+- Do redirects (`/presupuesto` → `/plan?tab=presupuesto`) create confusion or help consolidation?
+- Is the `/gestionar` (bandeja) attention inbox discoverable and understood?
+
+### Step 2: Interaction Consistency
+
+**This is the most important check.** Look for disconnects where similar actions use different interaction patterns:
+
+- Two buttons side-by-side: one opens a sheet, the other navigates to a new page. **This is a disconnect.**
+- A list item: tapping it on one page opens a detail page, tapping a similar item on another page opens an inline editor. **This is a disconnect.**
+- Edit actions: some open a dialog, some navigate to a form page, some use inline editing. **Which is the canonical pattern?**
+- Delete/archive actions: some show a confirmation dialog, some act immediately with undo.
+
+For each page, catalog:
+1. What actions are available (buttons, links, clickable items)
+2. What happens when activated (dialog, sheet, drawer, navigation, inline)
+3. Whether the pattern matches what similar actions do elsewhere
+
+### Step 3: Visual Narrative
+
+Check whether pages follow a consistent visual hierarchy:
+
+- Is the information density consistent across similar pages? (e.g., dashboard cards vs plan cards)
+- Do all pages use the same card tier system? Are there custom card patterns that don't match any tier?
+- Are section headers consistent? (eyebrow labels: `text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark`)
+- Do empty states follow a consistent pattern? (icon + message + CTA, or something else?)
+- Are loading states consistent? (skeleton vs spinner vs nothing)
+
+### Step 4: Action Surface Consistency
+
+Check CTAs and action surfaces across pages:
+
+- Are primary actions always brass buttons? Are secondary actions always ghost?
+- Is the "add new" action consistently placed? (top-right? floating FAB? inline?)
+- Do destructive actions (delete, archive) use consistent styling and confirmation?
+- Are action buttons in forms consistently placed? (bottom of form? inline? sticky footer?)
+
+### Step 5: Mobile/Desktop Parity
+
+Check whether mobile and desktop experiences are coherent:
+
+- Are there desktop-only features that mobile users can't access?
+- Are there mobile-only flows that desktop users miss?
+- Do mobile sheets/drawers have desktop equivalents (dialogs)?
+- Does the mobile FAB (transaction creation) have a clear desktop equivalent?
+- Is the mobile tab bar's 4-item selection the right subset?
+
+### Step 6: Flow Completeness
+
+Trace key user journeys end-to-end:
+
+1. **"I want to see if I'm on track"**: Dashboard → health score → drill into details → understand
+2. **"I want to add a transaction"**: FAB/button → form → submit → see it in list → categorize
+3. **"I want to import a statement"**: Import → upload → review → confirm → results → see transactions
+4. **"I want to manage recurring payments"**: Plan → recurrentes tab → view upcoming → mark paid / skip
+5. **"I want to understand my spending"**: Dashboard → charts → drill into categories → see transactions
+
+For each journey:
+- Is the entry point obvious?
+- Are the steps minimal and logical?
+- Is there clear feedback at each step?
+- Can the user recover from mistakes?
+- Does the journey end with clarity ("I now know the answer")?
+
+---
+
+## Using Playwright (Optional)
+
+If the dev server is running (`localhost:3000`), you can use Playwright tools to navigate the app and verify the experience visually:
+
+1. `browser_navigate` to each page
+2. `browser_snapshot` to capture the page state
+3. `browser_click` to test interactions (buttons, nav items)
+4. `browser_take_screenshot` to capture visual evidence of issues
+
+**Use Playwright when:** You need visual evidence of a disconnect, or when code analysis alone can't determine the user experience.
+
+**Skip Playwright when:** The app isn't running, or the issue is clearly identifiable from code.
+
+---
+
+## Output Format
+
+```
+## UX Cohesion Audit
+
+### Executive Summary
+[2-3 sentences: Is the app cohesive? Does it tell a clear story? What's the biggest UX gap?]
+
+### DISCONNECT — Interaction Pattern Conflicts
+[Two similar things that behave differently — the most jarring UX issues]
+- [page/component] vs [page/component]: [what's different] → [recommended unified pattern]
+
+### FRICTION — User Journey Obstacles
+[Places where the user gets stuck, confused, or has to work too hard]
+- [journey step]: [what's wrong] → [how to fix]
+
+### INCONSISTENCY — Visual/Structural Mismatches
+[Card tiers, typography, spacing, empty states that don't match the system]
+- [file:line] — [what's inconsistent] → [what it should be]
+
+### SUGGESTION — Experience Improvements
+[Not broken, but could be better. Lower priority.]
+- [idea and rationale]
+
+### What Works Well
+[Patterns that are consistent, intentional, and effective — acknowledge good design]
+
+### Verdict: COHESIVE / MOSTLY_COHESIVE / FRAGMENTED
+[COHESIVE = unified experience, minor nits only. MOSTLY_COHESIVE = some disconnects but the core narrative works. FRAGMENTED = feels like separate apps stitched together.]
+```
+
+---
+
+## Self-Verification Before Reporting
+
+1. Did you check ALL six audit areas (navigation, interactions, visuals, actions, mobile, flows)?
+2. Did you compare similar elements ACROSS pages, not just within each page?
+3. Did you distinguish DISCONNECTs (same intent, different behavior) from INCONSISTENCIEs (visual mismatches)?
+4. Did you trace at least 3 key user journeys end-to-end?
+5. Did you acknowledge what works well, not just problems?
+6. Is your verdict consistent with your findings?

--- a/.claude/agents/zetas-front-guy.md
+++ b/.claude/agents/zetas-front-guy.md
@@ -45,11 +45,21 @@ tools:
   - Grep
   - Glob
   - Bash
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
 ---
 
 You are an expert UI design system auditor for the Zeta project. You have deep knowledge of Zeta's design tokens, component library, and visual design philosophy. Your sole purpose is to review recently changed TSX and CSS files and report violations before they reach production.
 
 You are precise, thorough, and non-negotiable on hard violations. You distinguish clearly between blocking issues and advisory warnings.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` or `search_code` to find components, style patterns, or token usage
+2. **For snippets**: Use `get_code_snippet` to read specific sections of changed files
+3. **Fallback**: Use Grep only for literal patterns (e.g., hardcoded hex colors `#[0-9a-fA-F]{3,6}`, `text-white[^/]`)
+4. **Never**: Don't Read entire component files when checking a specific pattern
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Spawn these specialized agents for domain-specific review and diagnosis. Each ha
 | `recurring-doctor` | Recurring obligations, upcoming payments, occurrence lifecycle. |
 | `import-flow-doctor` | PDF/email import flow, reconciliation, idempotency, installments. |
 | `pdf-parser-creator` | Adding support for a new bank's PDF statements. |
-| `ux-analyst` | UX cohesion audit — interaction consistency, navigation logic, visual narrative, flow completeness. |
+| `ux-analyst` | "Review the app experience", UX cohesion, interaction inconsistencies, navigation logic, flow gaps. Spawn when asked to audit UX or review the overall experience. |
 
 **Review gates** (enforced before shipping, same priority as `pnpm build`):
 1. `perf-auditor` — every feature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,47 +21,73 @@
 - Dates: Spanish locale via `formatDate()` from `src/lib/utils/date.ts`
 - Idempotency: `computeIdempotencyKey()` from `src/lib/utils/idempotency.ts` for dedup
 
-## Performance Audit Gate
-- **After every feature**: Before claiming work is done, spawn the `perf-auditor` agent (defined in `~/.claude/agents/perf-auditor.md`) to audit changed files against the caching, rendering, and data-fetching rules below. Fix all FAIL items before shipping. This is a build gate, same as `pnpm build`.
+## Agents
+
+Spawn these specialized agents for domain-specific review and diagnosis. Each has embedded Zeta knowledge — no orientation reads needed.
+
+| Agent | When to Spawn |
+|---|---|
+| `perf-auditor` | **Build gate.** After every feature, before claiming done. Audits caching, rendering, queries, bundle. |
+| `frontend-auditor` | Full design system audit — tokens, a11y, responsive, localization. |
+| `zetas-front-guy` | Quick UI review after modifying TSX/CSS. Storybook + token compliance. |
+| `cache-doctor` | Stale UI after mutations, adding `"use cache"` functions, revalidation bugs. |
+| `supabase-migrator` | Creating migrations — especially encrypted tables, RLS, FK joins. |
+| `server-action-reviewer` | After creating/modifying files in `src/actions/`. Auth, validation, revalidation. |
+| `recurring-doctor` | Recurring obligations, upcoming payments, occurrence lifecycle. |
+| `import-flow-doctor` | PDF/email import flow, reconciliation, idempotency, installments. |
+| `pdf-parser-creator` | Adding support for a new bank's PDF statements. |
+| `ux-analyst` | UX cohesion audit — interaction consistency, navigation logic, visual narrative, flow completeness. |
+
+**Review gates** (enforced before shipping, same priority as `pnpm build`):
+1. `perf-auditor` — every feature
+2. `zetas-front-guy` — every TSX/CSS change
+3. `server-action-reviewer` — every new/modified server action
 
 ## Performance Rules
-- **Cache stable data**: Accounts, categories, destinatarios, profiles, recurring templates, and other slowly-changing data MUST use `"use cache"` with `cacheTag()` + `cacheLife("zeta")`. Transactions are also cached. Mutations invalidate via `revalidateTag()`. Never add a DB query to a page render path without caching unless the data is truly per-request.
-- **AppDataProvider (shared reference data)**: The dashboard layout preloads accounts, categories (all + outflow), destinatarios, and tag groups into React context via `AppDataProvider` (`@/components/providers/app-data-provider.tsx`). **Client components that need this data MUST use the context hooks** (`useAccounts()`, `useCategories()`, `useOutflowCategories()`, `useDestinatarios()`, `useTagGroups()`, `useAllTags()`) instead of lazy-fetching from server actions. This eliminates loading spinners on pickers and avoids redundant client-side fetches. Server components can still call the cached actions directly (cache hits are ~0ms). After mutations, `revalidateTag()` triggers layout re-render which refreshes the context automatically.
-- **Don't add joins or queries without justification**: Before adding PostgREST joins, extra SELECT columns, or new DB calls to a page, consider: (1) is this data already available from AppDataProvider context? (2) can it be deferred via Suspense? (3) does it need to load eagerly or only on interaction? Every new query adds latency — explain the trade-off.
-- **Suspense for non-critical data**: Data only needed for interactive elements (edit forms, pickers, dialogs) should be deferred behind `<Suspense>`, not fetched eagerly in the page's main `Promise.all`.
-- **Cached client pattern**: `"use cache"` functions use `createCachedClient(accessToken)` from `@/lib/supabase/cached`. The `accessToken` comes from `getAuthenticatedClient()`. See Gotchas for details.
-- **Live metrics for volatile data**: Client components that display volatile financial data (amounts, counts, metrics that change with every transaction) should use the `useLiveDashboard` pattern from `@/hooks/use-live-metrics.ts`. The page loads instantly from Route Cache, then a client-side hook calls a server action on mount to silently correct stale values. Use `getLiveDashboardData()` from `@/actions/live-dashboard.ts` for mobile dashboard (hero + gasto hoy + attention). For new volatile metrics on other pages, create similar hooks that call the appropriate cached server action — one round-trip per page, not per metric.
-- **Cache invalidation after mutations**: All transaction-mutating actions must call `revalidateFinancialViews()` from `@/lib/cache/revalidation.ts` + domain-specific extras. This invalidates the Data Cache (server-side `"use cache"` results). For same-page freshness, `startTransition` + server action auto-refreshes the route. Email import paths also use `router.refresh()` as a safety net. Cross-page freshness is handled by live metrics hooks, not `revalidatePath`.
-- **cacheLife("zeta")**: `stale: 120` (Route Cache — 2min client-side page caching), `revalidate: 300` (Data Cache — 5min background revalidation), `expire: 3600` (1hr hard expire). `revalidateTag` immediately invalidates Data Cache; Route Cache expires naturally or via live hooks.
+- **Cache all data reads**: `"use cache"` + `cacheTag()` + `cacheLife("zeta")`. Never add an uncached DB query to a render path.
+- **AppDataProvider**: Client components use context hooks (`useAccounts()`, `useCategories()`, `useOutflowCategories()`, `useDestinatarios()`, `useTagGroups()`, `useAllTags()`) — never lazy-fetch from server actions.
+- **Justify new queries**: Check (1) AppDataProvider already has it? (2) deferrable via Suspense? (3) needed eagerly or only on interaction?
+- **Suspense for non-critical data**: Pickers, dialogs, edit forms → `<Suspense>`, not in the page's main `Promise.all`.
+- **Cached client pattern**: `"use cache"` functions use `createCachedClient(accessToken)` from `@/lib/supabase/cached` — never `createAdminClient()` (encrypted columns return NULL).
+- **Live metrics for volatile data**: `useLiveDashboard` pattern — page loads from Route Cache, client hook silently corrects stale values on mount.
+- **Cache invalidation**: Transaction mutations → `revalidateFinancialViews()`. Same-page → `startTransition`. Cross-page → live metrics hooks.
+- **cacheLife("zeta")**: stale 120s / revalidate 300s / expire 3600s. `revalidateTag("tag", "zeta")` — second arg is cacheLife profile, not a second tag.
+- Spawn `cache-doctor` for stale UI diagnosis.
 
 ## UI Rules
-- **No hardcoded colors**: Never use raw hex values, `rgb()`, or arbitrary Tailwind colors (`bg-[#xxx]`). Always use the design tokens defined in `docs/design-system/TOKENS.md` — e.g., `text-z-brass`, `bg-z-surface-2`, `border-white/6`, `text-z-sage-dark`. If a needed token doesn't exist, propose adding it to TOKENS.md first.
-- **No hardcoded styles for layout/spacing**: Prefer existing utility patterns and component props. Check existing components for established patterns before creating new styling approaches.
-- **Reuse existing components**: Before building a new card, badge, stat display, or layout pattern, check `webapp/src/components/ui/` for existing primitives (StatCard, PageHero, Card, Badge, etc.).
+- **No hardcoded colors**: Use design tokens from `docs/design-system/TOKENS.md` — e.g., `text-z-brass`, `bg-z-surface-2`, `border-white/6`. Propose new tokens to TOKENS.md first.
+- **No hardcoded styles**: Prefer existing utility patterns and component props from established components.
+- **Reuse existing components**: Check `webapp/src/components/ui/` (41 stories) before building new cards, badges, stat displays, or layout patterns.
+- **Button variants**: Only `BRASS_BUTTON_CLASS`, `GHOST_BUTTON_CLASS`, `BRASS_GHOST_BUTTON_CLASS` from `@/lib/constants/styles.ts`.
+- Spawn `zetas-front-guy` after any TSX/CSS change. Spawn `frontend-auditor` for comprehensive reviews.
 
 ## Supabase
 - Project ID: `tgkhaxipfgskxydotdtu` (sa-east-1, org: zybaordjrezdjajzwisk)
 - See `~/.claude/rules/supabase.md` for RLS, auth, migration patterns
-- **Envelope encryption**: Tables with PII use `_enc` suffix (real table) + view (original name) + INSTEAD OF triggers. When adding a column to any `_enc` table, you MUST also update the view SELECT and the INSTEAD OF INSERT/UPDATE trigger functions. See `docs/superpowers/specs/2026-04-07-envelope-encryption-design.md` for full spec.
+- **Envelope encryption**: 9 tables with PII use `_enc` suffix (real table) + view (original name) + INSTEAD OF triggers. Adding a column is a 6-step process — **always spawn `supabase-migrator`** for encrypted table changes.
+- **PostgREST joins through views**: Always use FK hint syntax `!fk_name` — plain joins silently return empty.
+- Spawn `supabase-migrator` for any migration work.
 
 ## Recurring Obligations
-- **Single source of truth: `recurring_occurrences` table.** All pending/upcoming payment calculations MUST query `recurring_occurrences WHERE status='pending'` via `getPendingOccurrences()` or `getOccurrencesForMonth()` from `@/actions/occurrences.ts`. Never compute occurrences in JS from templates, and never use `getUpcomingPayments()` (statement_snapshots) for obligation amounts — statement snapshots are historical import data, not the source of truth for what's owed.
-- **Occurrence lifecycle:** `pending` → `paid` (linked to transaction via `transaction_id`) or `skipped`. All transaction creation paths (FAB, email import, PDF import, recurring confirm) auto-link to pending occurrences via `findMatchingOccurrence()`.
-- **Idempotent generation:** `ensureCurrentOccurrences()` creates rows for the current month + 14 days. Call it before querying occurrences. Uses `ON CONFLICT DO NOTHING` to preserve existing status.
+- **Source of truth: `recurring_occurrences` table.** Query via `getPendingOccurrences()` / `getOccurrencesForMonth()`. Never compute in JS, never use `statement_snapshots`.
+- **Lifecycle:** `pending` → `paid` (linked via `transaction_id`) or `skipped`. All tx creation paths auto-link via `findMatchingOccurrence()`.
+- **Idempotent generation:** `ensureCurrentOccurrences()` before querying. Uses `ON CONFLICT DO NOTHING`.
+- Spawn `recurring-doctor` when working on recurring obligations.
 
 ## Income & Metrics Rules
-- **Debt inflows are NOT income**: INFLOW to `CREDIT_CARD` or `LOAN` accounts are debt payments. They must NEVER count in income/ingresos metrics. Always filter: `tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id)` where `debtAccountIds` comes from `accounts.filter(a => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN")`.
-- **Reference implementation**: `getMonthlyCashflowCached()` in `webapp/src/actions/charts.ts` — all new income calculations must follow this pattern.
+- **Debt inflows are NOT income**: INFLOW to `CREDIT_CARD` or `LOAN` accounts must be excluded from income metrics. Filter: `tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id)`.
+- **Reference**: `getMonthlyCashflowCached()` in `webapp/src/actions/charts.ts`. `server-action-reviewer` checks this automatically.
 
 ## Gotchas
 - Zod 4 `.uuid()` enforces RFC 9562 — seed category UUIDs (a0000001-...) fail validation
 - shadcn/ui Checkbox: use `checked="indeterminate"`, not an `indeterminate` prop
 - Radix Select sends empty string (not null/undefined) when no value — use `z.preprocess` to normalize
 - Shell `compdef` warning leaks into stdout redirects — always strip first line if piping to file
-- **PostgREST joins through encrypted views**: FK constraints live on `_enc` tables, so PostgREST can't auto-detect relationships through the views. Always use explicit FK hint syntax: `account:accounts!transactions_account_id_fkey(id, name)` — never plain `account:accounts(id, name)`. Without the `!fk_name` hint, the join silently fails and returns empty results.
-- **`"use cache"` + encryption**: Cached functions that query encrypted views must use `createCachedClient(accessToken)` from `@/lib/supabase/cached`, never `createAdminClient()`. The admin client has no JWT, so `zeta_decrypt()` returns NULL for all encrypted columns. The `accessToken` comes from `getAuthenticatedClient()` which returns `{ supabase, user, accessToken }`.
-- **Webhooks/cron + encryption**: API routes using `createAdminClient()` cannot read encrypted columns (no JWT → `zeta_decrypt()` returns NULL). Use `supabase.rpc("get_accounts_with_masks", { p_user_id })` which calls `zeta_decrypt_as()` internally. For new encrypted-column access patterns, use `zeta_decrypt_as(ciphertext, target_user_id)` via RPC.
-- **Adding columns to encrypted tables**: `profiles` and `accounts` are views over `_enc` tables. To add a column: (1) `ALTER TABLE _enc ADD COLUMN`, (2) `DROP` triggers, (3) `DROP VIEW`, (4) `CREATE VIEW` with new column, (5) rebuild INSERT/UPDATE/DELETE trigger functions including the new column, (6) `CREATE TRIGGER` bindings. Never `ALTER TABLE profiles` directly — it's a view.
+- **Encryption gotchas** (see `supabase-migrator` and `cache-doctor` agents for full details):
+  - PostgREST joins through views: always use `!fk_name` hint syntax — plain joins silently fail
+  - `"use cache"` + encryption: use `createCachedClient(accessToken)`, never `createAdminClient()` (returns NULL)
+  - Webhooks/cron: use `zeta_decrypt_as()` via RPC — admin client can't decrypt
+  - Adding columns to `_enc` tables: 6-step process — spawn `supabase-migrator`
 
 <!-- GSD:project-start source:PROJECT.md -->
 ## Project

--- a/docs/superpowers/plans/2026-04-09-landing-page-redesign.md
+++ b/docs/superpowers/plans/2026-04-09-landing-page-redesign.md
@@ -1,0 +1,331 @@
+# Landing Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure the landing page into a storytelling arc (Hook → Process → Proof → Trust → Action), remove redundant Features section, and fix mobile responsiveness.
+
+**Architecture:** Pure front-end changes to marketing components. No new data fetching, no server actions, no API changes. Section reordering in the page wrapper, copy refinements, and responsive fixes.
+
+**Tech Stack:** Next.js 15, React 19, Tailwind v4, shadcn/ui
+
+**Spec:** `docs/superpowers/specs/2026-04-09-landing-page-redesign.md`
+
+**Review agents:** `zetas-front-guy` (every TSX change), `perf-auditor` (bundle check)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `webapp/src/components/marketing/landing-page.tsx` | Modify | Reorder sections, remove `LandingFeatures` import |
+| `webapp/src/components/marketing/landing-hero.tsx` | Modify | Refine copy, add `MobileHeroStrip`, fix highlights grid |
+| `webapp/src/components/marketing/landing-features.tsx` | Modify | Remove `LandingFeatures` + `FeatureCard`, reduce padding on remaining sections |
+| `webapp/src/components/marketing/landing-showcase.tsx` | Modify | Add section heading, fix carousel card width, reduce padding |
+| `webapp/src/components/marketing/landing-budget.tsx` | Modify | Reduce padding |
+| `webapp/src/components/marketing/landing-plan.tsx` | Modify | Reduce padding |
+| `webapp/src/components/marketing/landing-cta.tsx` | Modify | Reduce padding |
+| `webapp/src/components/marketing/landing-data.ts` | Modify | Remove `LANDING_FEATURES` export |
+
+---
+
+### Task 1: Remove `LandingFeatures` and clean up data
+
+**Files:**
+- Modify: `webapp/src/components/marketing/landing-data.ts:119-202`
+- Modify: `webapp/src/components/marketing/landing-features.tsx:49-105`
+
+- [ ] **Step 1: Remove `LANDING_FEATURES` from `landing-data.ts`**
+
+Delete the `Feature` type (lines 121-127) and `LANDING_FEATURES` array (lines 129-202). Keep everything else.
+
+- [ ] **Step 2: Remove `LandingFeatures` and `FeatureCard` from `landing-features.tsx`**
+
+Delete `FeatureCard` function (lines 51-86) and `LandingFeatures` function (lines 90-105). Remove the `LANDING_FEATURES` import from line 12. Remove the `CheckCircle2` import from line 1 and the `Feature` type import.
+
+Keep: `SectionHeading`, `LandingAudience`, `LandingHowItWorks`, `LandingFAQ`. Update exports accordingly.
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 4: Commit**
+
+```
+refactor: remove redundant LandingFeatures section (Showcase covers it)
+```
+
+---
+
+### Task 2: Reorder sections in `landing-page.tsx`
+
+**Files:**
+- Modify: `webapp/src/components/marketing/landing-page.tsx:1-52`
+
+- [ ] **Step 1: Remove `LandingFeatures` import and reorder**
+
+Update imports — remove `LandingFeatures` from the import on line 9:
+```ts
+import {
+  LandingAudience,
+  LandingHowItWorks,
+  LandingFAQ,
+} from "./landing-features";
+```
+
+Reorder `<main>` children (lines 25-35):
+```tsx
+<main className="relative">
+  <LandingHero />
+  <LandingHowItWorks />
+  <LandingBudget />
+  <LandingPlan />
+  <LandingShowcase />
+  <LandingAudience />
+  <LandingCTA />
+  <LandingFAQ />
+</main>
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 3: Commit**
+
+```
+feat: reorder landing page sections into storytelling arc
+```
+
+---
+
+### Task 3: Refine hero copy and add mobile hero strip
+
+**Files:**
+- Modify: `webapp/src/components/marketing/landing-hero.tsx:1-186`
+
+- [ ] **Step 1: Update H1 and subtitle copy**
+
+Replace the H1 at line 131-134:
+```tsx
+<h1 className="max-w-4xl text-3xl font-semibold tracking-tight text-balance sm:text-5xl lg:text-7xl">
+  Claridad diaria sobre tu dinero.
+</h1>
+```
+
+Replace the subtitle at lines 135-139:
+```tsx
+<p className="max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+  Extractos, presupuesto, deudas y pagos recurrentes en una sola
+  vista. Sin conectar tu banco. Hecho para Colombia.
+</p>
+```
+
+- [ ] **Step 2: Fix hero highlights grid breakpoint**
+
+Change line 163 from `sm:grid-cols-3` to `md:grid-cols-3`:
+```tsx
+<div className="grid gap-4 md:grid-cols-3">
+```
+
+- [ ] **Step 3: Reduce hero section padding**
+
+Update the `<section>` at line 121:
+```tsx
+<section className="mx-auto max-w-7xl px-6 pb-12 pt-12 sm:pb-20 sm:pt-24">
+```
+
+- [ ] **Step 4: Add `MobileHeroStrip` and split hero card rendering**
+
+Add a `MobileHeroStrip` function before `LandingHero`:
+
+```tsx
+function MobileHeroStrip() {
+  const { availableToSpend, spentToday, dailyAllowance } = LANDING_HERO_DATA;
+  const spentPct = Math.round((spentToday / dailyAllowance) * 100);
+
+  return (
+    <Card className="overflow-hidden rounded-2xl border-white/10 bg-[#111111]/90 shadow-xl shadow-black/20">
+      <div className="px-5 py-4">
+        <p className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+          Disponible para gastar
+        </p>
+        <p className="mt-1 text-2xl font-semibold tracking-tight">
+          {formatCurrency(availableToSpend, "COP")}
+        </p>
+
+        <div className="mt-3 rounded-xl border border-white/8 bg-white/[0.03] p-3">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Gasto hoy</span>
+            <span>
+              <span className="font-medium">
+                {formatCurrency(spentToday, "COP")}
+              </span>
+              <span className="ml-1 text-[10px] text-muted-foreground">
+                / {formatCurrency(dailyAllowance, "COP")}
+              </span>
+            </span>
+          </div>
+          <div className="mt-2 h-1.5 rounded-full bg-white/8">
+            <div
+              className="h-1.5 rounded-full bg-primary"
+              style={{ width: `${Math.min(spentPct, 100)}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Split hero card rendering by breakpoint**
+
+In the grid at line 122, replace the `<HeroCard />` call with:
+```tsx
+{/* Right column — dashboard card */}
+<div className="hidden lg:block">
+  <HeroCard />
+</div>
+<div className="lg:hidden">
+  <MobileHeroStrip />
+</div>
+```
+
+- [ ] **Step 6: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 7: Commit**
+
+```
+feat: hero copy refinement, mobile hero strip, responsive highlights
+```
+
+---
+
+### Task 4: Add section heading to Showcase and fix carousel
+
+**Files:**
+- Modify: `webapp/src/components/marketing/landing-showcase.tsx:64-198`
+
+- [ ] **Step 1: Update section heading text**
+
+Replace the heading block at lines 170-182:
+```tsx
+<div className="mb-12 flex flex-col items-center gap-4 text-center">
+  <Badge variant="outline" className="border-white/10 bg-white/4 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-z-sage-light">
+    Todo lo que hace
+  </Badge>
+  <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+    Herramientas que responden preguntas, no crean trabajo
+  </h2>
+  <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+    Cada modulo esta pensado para responderte algo concreto sobre tu dinero.
+  </p>
+</div>
+```
+
+- [ ] **Step 2: Reduce section padding**
+
+At line 167, change:
+```tsx
+<section id="showcase" className="px-4 py-16 sm:py-24">
+```
+
+- [ ] **Step 3: Fix carousel card width for small screens**
+
+Replace the fixed `CARD_WIDTH` constant at line 64 and update the carousel. Change the card rendering to use responsive width:
+
+At line 112, change the inline style:
+```tsx
+style={{ width: "min(280px, calc(100vw - 48px))" }}
+```
+
+Update the padding calculations at lines 102-103:
+```tsx
+paddingLeft: "max(16px, calc(50% - 140px))",
+paddingRight: "max(16px, calc(50% - 140px))",
+```
+
+The scroll calculation at line 79 still uses `CARD_WIDTH` + `CARD_GAP` — keep the JS constant for scroll math, since `280px` is the max card width and the snap behavior works correctly.
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 5: Commit**
+
+```
+feat: showcase heading, responsive carousel card width
+```
+
+---
+
+### Task 5: Reduce padding on remaining sections
+
+**Files:**
+- Modify: `webapp/src/components/marketing/landing-budget.tsx:23`
+- Modify: `webapp/src/components/marketing/landing-plan.tsx:20`
+- Modify: `webapp/src/components/marketing/landing-cta.tsx:36`
+- Modify: `webapp/src/components/marketing/landing-features.tsx` (HowItWorks, FAQ)
+
+- [ ] **Step 1: `landing-budget.tsx` — line 23**
+
+Change `py-24` to `py-16 sm:py-24`:
+```tsx
+<section className="px-4 py-16 sm:py-24">
+```
+
+- [ ] **Step 2: `landing-plan.tsx` — line 20**
+
+Change `py-24` to `py-16 sm:py-24`:
+```tsx
+<section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
+```
+
+- [ ] **Step 3: `landing-cta.tsx` — line 36**
+
+Change `py-24` to `py-16 sm:py-24`:
+```tsx
+<section className="py-16 sm:py-24">
+```
+
+- [ ] **Step 4: `landing-features.tsx` — `LandingHowItWorks` (line 215) and `LandingFAQ` (line 251)**
+
+Change both `py-24` to `py-16 sm:py-24`:
+```tsx
+// LandingHowItWorks
+<section id="como-funciona" className="space-y-12 py-16 sm:py-24">
+
+// LandingFAQ
+<section id="faq" className="space-y-12 py-16 sm:py-24">
+```
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 6: Commit**
+
+```
+fix: reduce section padding on mobile (py-16 sm:py-24)
+```
+
+---
+
+### Task 6: Build gate + agent reviews
+
+- [ ] **Step 1: Run full build**
+
+Run: `cd webapp && pnpm install && pnpm build`
+
+Expected: Clean build, no errors.
+
+- [ ] **Step 2: Run `zetas-front-guy` agent review**
+
+Spawn `zetas-front-guy` to review all changed TSX files for design token compliance.
+
+- [ ] **Step 3: Fix any issues from reviews**
+
+- [ ] **Step 4: Final commit if review fixes were needed**

--- a/docs/superpowers/plans/2026-04-09-landing-page-redesign.md
+++ b/docs/superpowers/plans/2026-04-09-landing-page-redesign.md
@@ -10,7 +10,22 @@
 
 **Spec:** `docs/superpowers/specs/2026-04-09-landing-page-redesign.md`
 
-**Review agents:** `zetas-front-guy` (every TSX change), `perf-auditor` (bundle check)
+---
+
+## Agent Dispatch Schedule
+
+Specialized agents MUST be spawned at these checkpoints — not deferred to the end.
+
+| After Task | Agent to Spawn | Why |
+|------------|---------------|-----|
+| Task 3 | `zetas-front-guy` | Hero copy + MobileHeroStrip + highlights grid — verify tokens, typography, responsive patterns |
+| Task 4 | `zetas-front-guy` | Showcase heading + carousel fix — verify tokens, heading hierarchy, carousel responsive behavior |
+| Task 6 | `perf-auditor` | Final gate — verify no new client-side bundles, no heavy imports, rendering strategy |
+
+**Rules:**
+- Each agent runs in **foreground** — wait for its result before proceeding to the next task.
+- If an agent flags issues, fix them before moving on. Do NOT batch agent fixes at the end.
+- Tasks 1, 2, 5 are structural (deletions, reordering, padding) — low risk, no agent review needed until the next visual task.
 
 ---
 
@@ -314,7 +329,7 @@ fix: reduce section padding on mobile (py-16 sm:py-24)
 
 ---
 
-### Task 6: Build gate + agent reviews
+### Task 6: Build gate + final agent reviews
 
 - [ ] **Step 1: Run full build**
 
@@ -322,10 +337,37 @@ Run: `cd webapp && pnpm install && pnpm build`
 
 Expected: Clean build, no errors.
 
-- [ ] **Step 2: Run `zetas-front-guy` agent review**
+- [ ] **Step 2: Spawn `perf-auditor` agent (foreground)**
 
-Spawn `zetas-front-guy` to review all changed TSX files for design token compliance.
+```
+Agent(subagent_type="perf-auditor", prompt="Audit the landing page redesign for performance.
+Focus on:
+1. Removing LandingFeatures — did it reduce client bundle? Any dead imports left?
+2. MobileHeroStrip in landing-hero.tsx — is it properly hidden on desktop (no SSR waste)?
+3. Showcase carousel responsive width change — any layout shift risk?
+4. Overall: no new client-side libraries, no unnecessary 'use client' additions.
+Report issues ranked by severity.")
+```
 
-- [ ] **Step 3: Fix any issues from reviews**
+- [ ] **Step 3: Spawn `zetas-front-guy` agent (foreground)**
 
-- [ ] **Step 4: Final commit if review fixes were needed**
+```
+Agent(subagent_type="zetas-front-guy", prompt="Review all landing page changes for design system compliance.
+Files changed:
+- webapp/src/components/marketing/landing-page.tsx (section reorder)
+- webapp/src/components/marketing/landing-hero.tsx (copy, MobileHeroStrip, highlights grid)
+- webapp/src/components/marketing/landing-features.tsx (LandingFeatures removed, padding reduced)
+- webapp/src/components/marketing/landing-showcase.tsx (heading, carousel width, padding)
+- webapp/src/components/marketing/landing-budget.tsx (padding)
+- webapp/src/components/marketing/landing-plan.tsx (padding)
+- webapp/src/components/marketing/landing-cta.tsx (padding)
+Check: hardcoded colors, wrong tokens, heading hierarchy consistency,
+button variant compliance (BRASS_BUTTON_CLASS vs bg-primary), border-radius,
+typography vs TOKENS.md. The landing page currently uses bg-primary for CTAs
+which differs from the app's bg-z-brass — flag if this inconsistency should
+be addressed or is intentional for marketing vs product distinction.")
+```
+
+- [ ] **Step 4: Fix any issues flagged by agents**
+
+- [ ] **Step 5: Final commit if review fixes were needed**

--- a/docs/superpowers/plans/2026-04-09-landing-page-redesign.md
+++ b/docs/superpowers/plans/2026-04-09-landing-page-redesign.md
@@ -23,8 +23,8 @@ Specialized agents MUST be spawned at these checkpoints — not deferred to the 
 | Task 6 | `perf-auditor` | Final gate — verify no new client-side bundles, no heavy imports, rendering strategy |
 
 **Rules:**
-- Each agent runs in **foreground** — wait for its result before proceeding to the next task.
-- If an agent flags issues, fix them before moving on. Do NOT batch agent fixes at the end.
+- Agents run in **background** (`run_in_background: true`) — implementation continues while the agent reviews. When the agent reports back, fix any flagged issues before the final build gate.
+- If a background agent flags critical issues, pause and fix immediately.
 - Tasks 1, 2, 5 are structural (deletions, reordering, padding) — low risk, no agent review needed until the next visual task.
 
 ---
@@ -337,7 +337,7 @@ Run: `cd webapp && pnpm install && pnpm build`
 
 Expected: Clean build, no errors.
 
-- [ ] **Step 2: Spawn `perf-auditor` agent (foreground)**
+- [ ] **Step 2: Spawn `perf-auditor` agent (background)**
 
 ```
 Agent(subagent_type="perf-auditor", prompt="Audit the landing page redesign for performance.
@@ -349,7 +349,7 @@ Focus on:
 Report issues ranked by severity.")
 ```
 
-- [ ] **Step 3: Spawn `zetas-front-guy` agent (foreground)**
+- [ ] **Step 3: Spawn `zetas-front-guy` agent (background, parallel with step 2)**
 
 ```
 Agent(subagent_type="zetas-front-guy", prompt="Review all landing page changes for design system compliance.

--- a/docs/superpowers/plans/2026-04-09-mobile-ux-improvements.md
+++ b/docs/superpowers/plans/2026-04-09-mobile-ux-improvements.md
@@ -1,0 +1,836 @@
+# Mobile UX Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface import as the primary CTA on mobile, standardize transaction row layouts, and show tag colors inline in collapsed rows.
+
+**Architecture:** Three independent changes to mobile webapp components. Data pipeline extended to include tags and snapshot dates in `MobileZone`. Two new presentational components (`InicioStarter`, `InicioImportStrip`). Existing components enriched (`MovimientosTransactionRow`, `InicioActivity`, `ImportarDetail`).
+
+**Tech Stack:** Next.js 15, React 19, Tailwind v4, shadcn/ui, Supabase (query joins)
+
+**Spec:** `docs/superpowers/specs/2026-04-09-mobile-ux-improvements-design.md`
+
+**Visual companion:** `docs/visual-companions/ux-improvements-april-2026.html`
+
+**Review agents:** `zetas-front-guy` (every TSX change), `perf-auditor` (tags join), `cache-doctor` (if new cached queries)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `webapp/src/actions/transactions.ts` | Modify | Extend `getRecentTransactions` query to include account + category + tags |
+| `webapp/src/components/dashboard/zones/mobile-zone.tsx` | Modify | Pass `starterMode`, `daysSinceImport`, enriched recent tx |
+| `webapp/src/components/mobile/v2/inicio/inicio-starter.tsx` | Create | Starter mode CTA card for first-run experience |
+| `webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx` | Create | Contextual stale import banner |
+| `webapp/src/components/mobile/v2/inicio/inicio-root.tsx` | Modify | Accept `starterMode`/`daysSinceImport`, render starter/strip |
+| `webapp/src/components/mobile/v2/inicio/inicio-activity.tsx` | Modify | Rewrite with direction icon + account + category + tags |
+| `webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx` | Modify | Add direction icon, category in collapsed, tags below |
+| `webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx` | Modify | Always-sage chip, PDF CTA in ImportarDetail |
+| `webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx` | Modify | Pass tags per transaction to rows |
+
+---
+
+### Task 1: Extend `getRecentTransactions` to include account, category, and tags
+
+**Files:**
+- Modify: `webapp/src/actions/transactions.ts:573-617`
+
+- [ ] **Step 1: Extend `RecentTransaction` type**
+
+```ts
+// webapp/src/actions/transactions.ts — replace the type at line 573
+export type RecentTransaction = {
+  id: string;
+  amount: number;
+  direction: "INFLOW" | "OUTFLOW";
+  account_id: string;
+  merchant_name: string | null;
+  clean_description: string | null;
+  transaction_date: string;
+  currency_code: string;
+  categories: { name_es: string | null; name: string; icon: string | null } | null;
+  accounts: { name: string; color: string | null } | null;
+  transaction_tags: Array<{
+    tag: { id: string; name: string; color: string | null; group: { color: string | null } | null };
+  }>;
+};
+```
+
+- [ ] **Step 2: Extend the query in `getRecentTransactionsCached`**
+
+Replace the `.select(...)` at line 600 with:
+
+```ts
+.select(`
+  id, amount, direction, account_id, merchant_name, clean_description,
+  transaction_date, currency_code,
+  categories!category_id(name_es, name, icon),
+  accounts!account_id(name, color),
+  transaction_tags(tag:tags(id, name, color, group:tag_groups(color)))
+`)
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 4: Commit**
+
+```
+feat: extend getRecentTransactions with account, category, tags
+```
+
+---
+
+### Task 2: Create `InicioStarter` component
+
+**Files:**
+- Create: `webapp/src/components/mobile/v2/inicio/inicio-starter.tsx`
+
+- [ ] **Step 1: Create the starter mode component**
+
+```tsx
+import Link from "next/link";
+import { FileUp, BarChart3, Tags, Bell } from "lucide-react";
+import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+export function InicioStarter() {
+  return (
+    <div className="space-y-3">
+      {/* Welcome text */}
+      <div>
+        <p className="text-base font-semibold">Tu base esta lista</p>
+        <p className="text-xs text-muted-foreground">
+          Falta activar tu flujo con datos reales.
+        </p>
+      </div>
+
+      {/* Primary CTA card */}
+      <div className="rounded-[14px] border border-z-brass/20 bg-[linear-gradient(135deg,rgba(var(--z-brass-rgb,183,165,122),0.08),transparent_60%)] p-5 text-center">
+        <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-xl border border-z-brass/20 bg-z-brass/10">
+          <FileUp className="size-5 text-z-brass" />
+        </div>
+        <p className="text-[15px] font-semibold">Importa tu primer extracto</p>
+        <p className="mx-auto mt-1 max-w-[260px] text-[11px] leading-relaxed text-muted-foreground">
+          Sube el PDF de tu banco y Zeta extrae movimientos, aprende destinatarios
+          y activa metricas automaticamente.
+        </p>
+        <div className="mt-4">
+          <Link
+            href="/import"
+            className={cn(
+              BRASS_BUTTON_CLASS,
+              "inline-flex items-center gap-1.5 rounded-lg px-5 py-2 text-xs font-semibold"
+            )}
+          >
+            <FileUp className="size-3.5" />
+            Importar extracto PDF
+          </Link>
+        </div>
+        <p className="mt-3 text-[10px] text-muted-foreground">
+          O{" "}
+          <Link href="/transactions" className="text-z-sage-light underline">
+            registra un movimiento manual
+          </Link>
+        </p>
+      </div>
+
+      {/* What unlocks after import */}
+      <div>
+        <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+          Despues de importar
+        </p>
+        <div className="grid grid-cols-3 gap-1.5">
+          {[
+            { icon: BarChart3, label: "Metricas activas" },
+            { icon: Tags, label: "Auto-categorias" },
+            { icon: Bell, label: "Alertas activas" },
+          ].map(({ icon: Icon, label }) => (
+            <div
+              key={label}
+              className={cn(PANEL_INSET_CLASS, "p-2.5 text-center")}
+            >
+              <Icon className="mx-auto size-4 text-muted-foreground" />
+              <p className="mt-1 text-[9px] text-muted-foreground">{label}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 3: Commit**
+
+```
+feat: add InicioStarter component for mobile first-run
+```
+
+---
+
+### Task 3: Create `InicioImportStrip` component
+
+**Files:**
+- Create: `webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx`
+
+- [ ] **Step 1: Create the import strip component**
+
+```tsx
+import Link from "next/link";
+import { FileUp } from "lucide-react";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+interface InicioImportStripProps {
+  daysSinceImport: number;
+}
+
+export function InicioImportStrip({ daysSinceImport }: InicioImportStripProps) {
+  if (daysSinceImport <= 15) return null;
+
+  return (
+    <div className="flex items-center gap-2.5 rounded-[14px] border border-z-brass/20 bg-[linear-gradient(135deg,rgba(var(--z-brass-rgb,183,165,122),0.06),transparent_50%)] px-3 py-2.5">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-[10px] border border-z-brass/20 bg-z-brass/10">
+        <FileUp className="size-4 text-z-brass" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-semibold">
+          {daysSinceImport} dias sin importar
+        </p>
+        <p className="text-[10px] text-muted-foreground">
+          Actualiza para que las metricas reflejen tu posicion real.
+        </p>
+      </div>
+      <Link
+        href="/import"
+        className={cn(
+          BRASS_BUTTON_CLASS,
+          "shrink-0 rounded-lg px-3 py-1.5 text-[11px] font-semibold"
+        )}
+      >
+        Importar
+      </Link>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 3: Commit**
+
+```
+feat: add InicioImportStrip for stale import nudge
+```
+
+---
+
+### Task 4: Wire `MobileZone` to pass starter mode + days since import
+
+**Files:**
+- Modify: `webapp/src/components/dashboard/zones/mobile-zone.tsx:1-111`
+
+- [ ] **Step 1: Add `getLatestSnapshotDates` import and fetch**
+
+Add import at top:
+```ts
+import { getLatestSnapshotDates } from "@/actions/statement-snapshots";
+import { differenceInDays } from "date-fns";
+```
+
+Add to the `Promise.all` at line 20 (after `dailySpending`):
+```ts
+getLatestSnapshotDates(),
+```
+
+Destructure the result:
+```ts
+const [heroData, attentionItemsData, burnRateData, budgetSummary, accountsResult, dailySpending, latestSnapshotDates] =
+```
+
+- [ ] **Step 2: Compute `starterMode` and `daysSinceImport`**
+
+After `const allAccounts = ...` (line 30), add:
+```ts
+const starterMode = allAccounts.length > 0 && recentTx.length === 0;
+
+const daysSinceImport = (() => {
+  const dates = Object.values(latestSnapshotDates);
+  if (dates.length === 0) return 999;
+  const latest = dates.reduce((a, b) => (a > b ? a : b));
+  return differenceInDays(new Date(), new Date(latest));
+})();
+```
+
+- [ ] **Step 3: Enrich `mobileRecentTx` mapping with account, category, tags**
+
+Replace the `mobileRecentTx` mapping at line 33-39:
+```ts
+const mobileRecentTx = recentTx.map((tx) => ({
+  id: tx.id,
+  description: tx.merchant_name || tx.clean_description || "Sin descripcion",
+  amount: tx.amount,
+  currency_code: tx.currency_code ?? "COP",
+  direction: tx.direction,
+  account_name: tx.accounts?.name ?? "",
+  account_color: tx.accounts?.color ?? null,
+  category_name: tx.categories?.name_es ?? tx.categories?.name ?? null,
+  category_icon: tx.categories?.icon ?? null,
+  tags: (tx.transaction_tags ?? []).map((tt) => ({
+    id: tt.tag.id,
+    name: tt.tag.name,
+    color: tt.tag.color,
+    group_color: tt.tag.group?.color ?? null,
+  })),
+}));
+```
+
+- [ ] **Step 4: Pass new props to `InicioRoot`**
+
+Add `starterMode` and `daysSinceImport` to the JSX:
+```tsx
+<InicioRoot
+  starterMode={starterMode}
+  daysSinceImport={daysSinceImport}
+  hero={...}
+  // ... rest unchanged
+/>
+```
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 6: Commit**
+
+```
+feat: wire MobileZone with starterMode, daysSinceImport, enriched tx
+```
+
+---
+
+### Task 5: Update `InicioRoot` to render starter mode + import strip
+
+**Files:**
+- Modify: `webapp/src/components/mobile/v2/inicio/inicio-root.tsx:1-131`
+
+- [ ] **Step 1: Add imports and new props**
+
+Add imports:
+```ts
+import { InicioStarter } from "./inicio-starter";
+import { InicioImportStrip } from "./inicio-import-strip";
+```
+
+Add to `InicioRootProps`:
+```ts
+starterMode: boolean;
+daysSinceImport: number;
+```
+
+Destructure in the function signature.
+
+- [ ] **Step 2: Render starter mode or normal flow**
+
+Replace the `return` JSX:
+```tsx
+if (starterMode) {
+  return (
+    <div className="space-y-2">
+      <InicioStarter />
+    </div>
+  );
+}
+
+return (
+  <div className="space-y-2">
+    <InicioHero ... />
+    <InicioImportStrip daysSinceImport={daysSinceImport} />
+    <InicioMetricsGrid ... />
+    <InicioAttention ... />
+    <InicioDiscovery ... />
+    <InicioActivity transactions={recentTransactions} />
+  </div>
+);
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 4: Commit**
+
+```
+feat: InicioRoot renders starter mode + import strip
+```
+
+---
+
+### Task 6: Rewrite `InicioActivity` with canonical row layout
+
+**Files:**
+- Modify: `webapp/src/components/mobile/v2/inicio/inicio-activity.tsx:1-91`
+
+- [ ] **Step 1: Rewrite the component**
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import { ArrowDownLeft, ArrowUpRight, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { TagChip } from "@/components/tags/tag-chip";
+import type { CurrencyCode } from "@/types/domain";
+
+interface RecentTransactionMobile {
+  id: string;
+  description: string;
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+  account_name: string;
+  account_color: string | null;
+  category_name: string | null;
+  category_icon: string | null;
+  tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
+}
+
+interface InicioActivityProps {
+  transactions: RecentTransactionMobile[];
+}
+
+export function InicioActivity({ transactions }: InicioActivityProps) {
+  if (transactions.length === 0) return null;
+
+  const visible = transactions.slice(0, 3);
+
+  return (
+    <div>
+      <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+        Reciente
+      </p>
+
+      <div>
+        {visible.map((tx) => (
+          <Link
+            key={tx.id}
+            href={`/transactions/${tx.id}`}
+            className="flex items-center gap-2 border-b border-white/6 px-1 py-2 transition-colors last:border-b-0 active:bg-white/[0.03]"
+          >
+            {/* Direction icon */}
+            <div
+              className={cn(
+                "flex size-[22px] shrink-0 items-center justify-center rounded-md",
+                tx.direction === "INFLOW"
+                  ? "bg-green-500/12 text-z-income"
+                  : "bg-orange-500/12 text-z-expense"
+              )}
+            >
+              {tx.direction === "INFLOW" ? (
+                <ArrowDownLeft className="size-3" />
+              ) : (
+                <ArrowUpRight className="size-3" />
+              )}
+            </div>
+
+            {/* Info */}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[12px] font-medium">{tx.description}</p>
+              <p className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                <span
+                  className="inline-block size-[5px] shrink-0 rounded-full"
+                  style={{ backgroundColor: tx.account_color ?? undefined }}
+                />
+                <span className="truncate">{tx.account_name}</span>
+                <span className="text-white/15">&middot;</span>
+                {tx.category_name ? (
+                  <span>
+                    {tx.category_icon} {tx.category_name}
+                  </span>
+                ) : (
+                  <span className="text-z-brass">Sin cat.</span>
+                )}
+              </p>
+              {tx.tags.length > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {tx.tags.map((t) => (
+                    <TagChip
+                      key={t.id}
+                      tag={{ id: t.id, name: t.name, color: t.color } as any}
+                      groupColor={t.group_color}
+                      size="sm"
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Amount */}
+            <span
+              className={cn(
+                "shrink-0 text-[12px] font-medium tabular-nums",
+                tx.direction === "INFLOW" && "text-z-income"
+              )}
+            >
+              {tx.direction === "INFLOW" ? "+" : "-"}
+              {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+            </span>
+          </Link>
+        ))}
+      </div>
+
+      <div className="pt-2 text-center">
+        <Link
+          href="/transactions"
+          className="inline-flex items-center gap-1 text-[11px] font-semibold text-z-brass"
+        >
+          Ver todos
+          <ArrowRight className="size-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update `InicioRootProps` type for new transaction shape**
+
+In `inicio-root.tsx`, update the `recentTransactions` prop type to match the new interface. Replace the inline type:
+
+```ts
+recentTransactions: Array<{
+  id: string;
+  description: string;
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+  account_name: string;
+  account_color: string | null;
+  category_name: string | null;
+  category_icon: string | null;
+  tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
+}>;
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 4: Commit**
+
+```
+feat: rewrite InicioActivity with canonical row layout + tags
+```
+
+---
+
+### Task 7: Enrich `MovimientosTransactionRow` with direction icon, category, tags
+
+**Files:**
+- Modify: `webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx:1-145`
+
+- [ ] **Step 1: Add imports**
+
+```ts
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
+import { TagChip } from "@/components/tags/tag-chip";
+```
+
+- [ ] **Step 2: Add `tags` prop**
+
+Update the interface:
+```ts
+interface MovimientosTransactionRowProps {
+  transaction: TransactionWithAccount;
+  categories: CategoryWithChildren[];
+  tags?: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
+  onCategorized?: (txId: string, categoryId: string) => void;
+}
+```
+
+Destructure in function: `tags = []` with default.
+
+- [ ] **Step 3: Rewrite collapsed state JSX**
+
+Replace the `<button>` collapsed row (lines 69-109) with:
+
+```tsx
+<button
+  type="button"
+  onClick={() => setExpanded((prev) => !prev)}
+  className={cn(
+    "flex w-full items-center gap-2 px-2 py-2.5 text-left transition-colors hover:bg-white/5",
+    tx.is_excluded && "opacity-40"
+  )}
+>
+  {/* Direction icon */}
+  <div
+    className={cn(
+      "flex size-[22px] shrink-0 items-center justify-center rounded-md",
+      tx.direction === "INFLOW"
+        ? "bg-green-500/12 text-z-income"
+        : "bg-orange-500/12 text-z-expense"
+    )}
+  >
+    {tx.direction === "INFLOW" ? (
+      <ArrowDownLeft className="size-3" />
+    ) : (
+      <ArrowUpRight className="size-3" />
+    )}
+  </div>
+
+  {/* Info */}
+  <div className="min-w-0 flex-1">
+    <p className="truncate text-sm font-medium">{description}</p>
+    <p className="text-[11px] text-muted-foreground flex items-center gap-1">
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full shrink-0"
+        style={{ backgroundColor: tx.account.color ?? undefined }}
+      />
+      <span className="truncate">{tx.account.name}</span>
+      <span className="text-white/15">&middot;</span>
+      {categoryName ? (
+        <span>{localCategory?.icon} {categoryName}</span>
+      ) : (
+        <span className="text-z-brass">Sin cat.</span>
+      )}
+    </p>
+  </div>
+
+  {/* Amount */}
+  <span
+    className={cn(
+      "shrink-0 text-sm font-medium tabular-nums",
+      tx.direction === "INFLOW" && "text-z-income",
+      tx.is_excluded && "line-through"
+    )}
+  >
+    {tx.direction === "INFLOW" ? "+" : "-"}
+    {formatCurrency(tx.amount, tx.currency_code)}
+  </span>
+</button>
+
+{/* Tags below collapsed row */}
+{!expanded && tags.length > 0 && (
+  <div className="flex flex-wrap gap-1 px-2 pb-1.5 pl-[38px]">
+    {tags.map((t) => (
+      <TagChip
+        key={t.id}
+        tag={{ id: t.id, name: t.name, color: t.color } as any}
+        groupColor={t.group_color}
+        size="sm"
+      />
+    ))}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 5: Commit**
+
+```
+feat: enrich MovimientosTransactionRow with direction icon, category, tags
+```
+
+---
+
+### Task 8: Pass tags data in `MovimientosRoot`
+
+**Files:**
+- Modify: `webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx:134-148`
+
+- [ ] **Step 1: Build a tags-by-transaction lookup**
+
+The `TransactionWithAccount` type likely already has `transaction_tags` from the page query. If not, the page-level query in `webapp/src/app/(dashboard)/transactions/page.tsx` needs the join. Check what data is available. If `transaction_tags` is on the transaction, build the lookup:
+
+```ts
+// In MovimientosRoot, after groupedByDate memo:
+const tagsByTxId = useMemo(() => {
+  const map = new Map<string, Array<{ id: string; name: string; color: string | null; group_color: string | null }>>();
+  for (const tx of transactions) {
+    const txTags = (tx as any).transaction_tags;
+    if (txTags && Array.isArray(txTags)) {
+      map.set(
+        tx.id,
+        txTags.map((tt: any) => ({
+          id: tt.tag.id,
+          name: tt.tag.name,
+          color: tt.tag.color,
+          group_color: tt.tag.group?.color ?? null,
+        }))
+      );
+    }
+  }
+  return map;
+}, [transactions]);
+```
+
+- [ ] **Step 2: Pass tags to each row**
+
+Update the row rendering at line 142:
+```tsx
+<MovimientosTransactionRow
+  key={tx.id}
+  transaction={tx}
+  categories={outflowCategories}
+  tags={tagsByTxId.get(tx.id)}
+/>
+```
+
+- [ ] **Step 3: Ensure the transactions page query includes tags join**
+
+Check `webapp/src/app/(dashboard)/transactions/page.tsx` — the mobile transactions view uses the same data. If the Supabase query doesn't include `transaction_tags`, add the join. If it already does, no change needed.
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 5: Commit**
+
+```
+feat: pass tag data from MovimientosRoot to transaction rows
+```
+
+---
+
+### Task 9: Update Importar chip and detail in Movimientos
+
+**Files:**
+- Modify: `webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx:124-144` (chip), `431-647` (ImportarDetail)
+
+- [ ] **Step 1: Make Importar chip always sage-accented**
+
+Replace the chip at lines 124-144. Change the conditional styling to always use sage:
+```tsx
+<button
+  type="button"
+  onClick={() => toggle("importar")}
+  className={cn(
+    "rounded-[14px] border p-2.5 text-center transition-colors",
+    isActive("importar")
+      ? cn("border", accentStyles.importar.chip)
+      : cn(
+          "border-z-sage/30",
+          "bg-[linear-gradient(180deg,rgba(var(--z-sage-rgb,142,168,130),0.08),transparent)]"
+        )
+  )}
+  aria-expanded={isActive("importar")}
+>
+  <p className="text-[22px] font-[680] leading-tight text-z-sage">
+    {pendingEmailCount}
+  </p>
+  <p className="mt-0.5 text-[10px] font-semibold text-muted-foreground">
+    Importar
+  </p>
+  <p className="mt-1 text-[9px] text-z-sage">
+    {pendingEmailCount > 0 ? `${pendingEmailCount} emails` : "Subir PDF"}
+  </p>
+</button>
+```
+
+- [ ] **Step 2: Add PDF upload CTA at top of `ImportarDetail`**
+
+In the `ImportarDetail` function, add a PDF upload row before the email list. Replace the empty state check (lines 507-517) and the list start (line 520):
+
+After the eyebrow `<p>` tag at line 522, add:
+```tsx
+{/* PDF upload CTA — always visible */}
+<Link
+  href="/import"
+  className="flex items-center gap-2.5 rounded-lg border border-z-sage/20 bg-z-sage/[0.04] px-2.5 py-2 transition-colors hover:bg-z-sage/[0.08]"
+>
+  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-z-sage/10 border border-z-sage/20">
+    <FileUp className="size-3.5 text-z-sage" />
+  </div>
+  <div className="min-w-0 flex-1">
+    <p className="text-[11px] font-semibold">Subir PDF del banco</p>
+    <p className="text-[9px] text-muted-foreground">Extracto mensual de cualquier banco</p>
+  </div>
+  <span className={cn(BRASS_BUTTON_CLASS, "shrink-0 rounded-lg px-2.5 py-1 text-[10px] font-semibold")}>
+    Subir
+  </span>
+</Link>
+
+{totalCount > 0 && (
+  <div className="my-2 h-px bg-white/6" />
+)}
+```
+
+Add imports at top of file: `import { FileUp } from "lucide-react"` and `import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles"`.
+
+Also update the empty state (lines 507-517) to still show the PDF CTA:
+```tsx
+if (totalCount === 0) {
+  return (
+    <div className="space-y-2">
+      <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-z-sage">
+        Importar extracto
+      </p>
+      <Link
+        href="/import"
+        className="flex items-center gap-2.5 rounded-lg border border-z-sage/20 bg-z-sage/[0.04] px-2.5 py-2 transition-colors hover:bg-z-sage/[0.08]"
+      >
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-z-sage/10 border border-z-sage/20">
+          <FileUp className="size-3.5 text-z-sage" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold">Subir PDF del banco</p>
+          <p className="text-[9px] text-muted-foreground">Extracto mensual de cualquier banco</p>
+        </div>
+        <span className={cn(BRASS_BUTTON_CLASS, "shrink-0 rounded-lg px-2.5 py-1 text-[10px] font-semibold")}>
+          Subir
+        </span>
+      </Link>
+      <p className="text-[10px] text-muted-foreground">
+        0 emails pendientes de revision
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd webapp && pnpm build`
+
+- [ ] **Step 4: Commit**
+
+```
+feat: Importar chip always sage, ImportarDetail includes PDF upload CTA
+```
+
+---
+
+### Task 10: Build gate + agent reviews
+
+- [ ] **Step 1: Run full build**
+
+Run: `cd webapp && pnpm install && pnpm build`
+
+Expected: Clean build, no errors.
+
+- [ ] **Step 2: Run `zetas-front-guy` agent review**
+
+Spawn `zetas-front-guy` to review all changed/created TSX files for design system compliance.
+
+- [ ] **Step 3: Run `perf-auditor` agent review**
+
+Spawn `perf-auditor` to verify the tags join in `getRecentTransactions` doesn't regress performance.
+
+- [ ] **Step 4: Fix any issues from reviews**
+
+- [ ] **Step 5: Final commit if review fixes were needed**

--- a/docs/superpowers/plans/2026-04-09-mobile-ux-improvements.md
+++ b/docs/superpowers/plans/2026-04-09-mobile-ux-improvements.md
@@ -28,8 +28,8 @@ Specialized agents MUST be spawned at these checkpoints — not deferred to the 
 | Task 10 | `perf-auditor` | Final gate — verify tags join perf, caching, rendering strategy, bundle |
 
 **Rules:**
-- Each agent runs in **foreground** — wait for its result before proceeding to the next task.
-- If an agent flags issues, fix them before moving on. Do NOT batch agent fixes at the end.
+- Agents run in **background** (`run_in_background: true`) — implementation continues while the agent reviews. When the agent reports back, fix any flagged issues before the final build gate.
+- If a background agent flags critical issues (e.g., wrong auth pattern, missing cache invalidation), pause and fix immediately.
 - `zetas-front-guy` reviews are cumulative — Tasks 2, 3, 5 (new components / wiring) are reviewed alongside their first consumer (Task 6/7).
 
 ---
@@ -841,7 +841,7 @@ Run: `cd webapp && pnpm install && pnpm build`
 
 Expected: Clean build, no errors.
 
-- [ ] **Step 2: Spawn `perf-auditor` agent (foreground)**
+- [ ] **Step 2: Spawn `perf-auditor` agent (background)**
 
 ```
 Agent(subagent_type="perf-auditor", prompt="Audit the mobile UX changes for performance.
@@ -853,7 +853,7 @@ Focus on:
 Report issues ranked by severity.")
 ```
 
-- [ ] **Step 3: Spawn `zetas-front-guy` agent (foreground)**
+- [ ] **Step 3: Spawn `zetas-front-guy` agent (background, parallel with step 2)**
 
 ```
 Agent(subagent_type="zetas-front-guy", prompt="Review all mobile UX changes for design system compliance.

--- a/docs/superpowers/plans/2026-04-09-mobile-ux-improvements.md
+++ b/docs/superpowers/plans/2026-04-09-mobile-ux-improvements.md
@@ -12,7 +12,25 @@
 
 **Visual companion:** `docs/visual-companions/ux-improvements-april-2026.html`
 
-**Review agents:** `zetas-front-guy` (every TSX change), `perf-auditor` (tags join), `cache-doctor` (if new cached queries)
+---
+
+## Agent Dispatch Schedule
+
+Specialized agents MUST be spawned at these checkpoints — not deferred to the end.
+
+| After Task | Agent to Spawn | Why |
+|------------|---------------|-----|
+| Task 1 | `server-action-reviewer` | Modified `actions/transactions.ts` — verify auth, defense-in-depth, return types |
+| Task 4 | `cache-doctor` | `MobileZone` now calls `getLatestSnapshotDates()` — verify caching + revalidation path |
+| Task 6 | `zetas-front-guy` | `InicioActivity` rewrite — verify tokens, component reuse, design system |
+| Task 7 | `zetas-front-guy` | `MovimientosTransactionRow` enrichment — verify tokens, layout consistency |
+| Task 9 | `zetas-front-guy` | `ImportarDetail` + chip changes — verify tokens, button variants |
+| Task 10 | `perf-auditor` | Final gate — verify tags join perf, caching, rendering strategy, bundle |
+
+**Rules:**
+- Each agent runs in **foreground** — wait for its result before proceeding to the next task.
+- If an agent flags issues, fix them before moving on. Do NOT batch agent fixes at the end.
+- `zetas-front-guy` reviews are cumulative — Tasks 2, 3, 5 (new components / wiring) are reviewed alongside their first consumer (Task 6/7).
 
 ---
 
@@ -815,7 +833,7 @@ feat: Importar chip always sage, ImportarDetail includes PDF upload CTA
 
 ---
 
-### Task 10: Build gate + agent reviews
+### Task 10: Build gate + final agent reviews
 
 - [ ] **Step 1: Run full build**
 
@@ -823,14 +841,32 @@ Run: `cd webapp && pnpm install && pnpm build`
 
 Expected: Clean build, no errors.
 
-- [ ] **Step 2: Run `zetas-front-guy` agent review**
+- [ ] **Step 2: Spawn `perf-auditor` agent (foreground)**
 
-Spawn `zetas-front-guy` to review all changed/created TSX files for design system compliance.
+```
+Agent(subagent_type="perf-auditor", prompt="Audit the mobile UX changes for performance.
+Focus on:
+1. The tags join added to getRecentTransactions in webapp/src/actions/transactions.ts — is the Supabase join (transaction_tags → tags → tag_groups) efficient? Any N+1 risk?
+2. MobileZone now calls getLatestSnapshotDates() — is it cached properly with cacheTag/cacheLife?
+3. New components (inicio-starter.tsx, inicio-import-strip.tsx) — any unnecessary client-side weight?
+4. MovimientosTransactionRow now imports TagChip — does this affect the transactions page bundle?
+Report issues ranked by severity.")
+```
 
-- [ ] **Step 3: Run `perf-auditor` agent review**
+- [ ] **Step 3: Spawn `zetas-front-guy` agent (foreground)**
 
-Spawn `perf-auditor` to verify the tags join in `getRecentTransactions` doesn't regress performance.
+```
+Agent(subagent_type="zetas-front-guy", prompt="Review all mobile UX changes for design system compliance.
+Files changed/created:
+- webapp/src/components/mobile/v2/inicio/inicio-starter.tsx (new)
+- webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx (new)
+- webapp/src/components/mobile/v2/inicio/inicio-activity.tsx (rewritten)
+- webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx (enriched)
+- webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx (importar chip + detail)
+Check: hardcoded colors, wrong tokens, missing component reuse, button variant violations,
+border-radius violations, typography mismatches vs TOKENS.md.")
+```
 
-- [ ] **Step 4: Fix any issues from reviews**
+- [ ] **Step 4: Fix any issues flagged by agents**
 
 - [ ] **Step 5: Final commit if review fixes were needed**

--- a/docs/superpowers/specs/2026-04-09-landing-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-09-landing-page-redesign.md
@@ -1,0 +1,186 @@
+# Landing Page Redesign — Storytelling Arc + Mobile
+
+**Date:** 2026-04-09  
+**Scope:** Landing page only (`webapp/src/components/marketing/`)  
+**Visual companion:** `docs/visual-companions/ux-improvements-april-2026.html` (mobile UX section)
+
+---
+
+## Problem
+
+The landing page has two structural issues:
+
+1. **No narrative arc.** Sections appear in arbitrary order: Hero → Budget demo → Plan demo → Showcase carousel → Feature grid → Audience → How it works → CTA → FAQ. The user sees proof (Budget, Plan) before understanding the process (How it works), and features are explained twice (Showcase + Features) with different content.
+
+2. **Mobile is not fully thought through.** The hero card (dashboard preview) is too heavy for mobile screens <375px. Section padding (`py-24` = 96px) wastes scroll space. The showcase carousel uses a fixed 280px card width that can overflow on 320px screens. Highlight cards force 3 columns at `sm` breakpoint on text-heavy cards.
+
+---
+
+## Design
+
+### Section Reorder — Storytelling Arc
+
+```
+ACT 1: HOOK (Problem → Promise)
+  └─ Hero — "Claridad diaria sobre tu dinero"
+
+ACT 2: PROCESS ("It's easy")
+  └─ HowItWorks — 3 steps, moved from position 8 to position 3
+
+ACT 3: PROOF ("See it in action")
+  ├─ Budget — interactive budget demo
+  ├─ Plan — income distribution + obligations
+  └─ Showcase — visual feature walkthrough (absorbs Features)
+
+ACT 4: TRUST ("Made for you")
+  └─ Audience + Colombia — profiles + bank support
+
+ACT 5: ACTION
+  ├─ CTA — final conversion
+  └─ FAQ — objection handling
+```
+
+### Removed: `LandingFeatures`
+
+The 6-card Features grid overlaps heavily with the 6-panel Showcase:
+
+| Showcase Panel | Features Card |
+|----------------|---------------|
+| Importacion de extractos | Importacion de extractos PDF |
+| Dashboard de margen diario | Dashboard que responde que hacer hoy |
+| Destinatarios inteligentes | Recurrentes, destinatarios y orden operativo |
+| Estrategia de deuda | Deudas con estrategia, no solo saldo |
+| Recurrentes y pagos proximos | (covered by above) |
+| Registro rapido | Presupuesto 50/30/20 / Multi-moneda |
+
+Showcase panels are more visual and scannable. Features cards add bullet lists that duplicate the same information. Remove `LandingFeatures` and give Showcase a proper `SectionHeading`.
+
+### New `landing-page.tsx` order
+
+```tsx
+<LandingHeader />
+<main>
+  <LandingHero />
+  <LandingHowItWorks />
+  <LandingBudget />
+  <LandingPlan />
+  <LandingShowcase />
+  <LandingAudience />
+  <LandingCTA />
+  <LandingFAQ />
+</main>
+<Footer />
+```
+
+### Copy Refinements
+
+**Hero H1:**
+- Current: "Tu dinero deja de sentirse confuso y empieza a contar una historia clara."
+- New: "Claridad diaria sobre tu dinero."
+- Rationale: Shorter, punchier. The subtitle carries the detail.
+
+**Hero subtitle:**
+- Current: "Zeta reune extractos, presupuesto, deudas, cuentas y pagos recurrentes para darte una vista accionable de tus finanzas personales en Colombia."
+- New: "Extractos, presupuesto, deudas y pagos recurrentes en una sola vista. Sin conectar tu banco. Hecho para Colombia."
+- Rationale: Shorter sentences, easier to scan on mobile.
+
+**Showcase SectionHeading (new):**
+- Eyebrow: "Todo lo que hace"
+- Title: "Herramientas que responden preguntas, no crean trabajo"
+- Description: "Cada modulo esta pensado para responderte algo concreto sobre tu dinero."
+
+### Mobile-Specific Fixes
+
+#### 1. Hero card — mobile alternative
+
+**Current:** `HeroCard` renders the full dashboard preview at all breakpoints. On <375px it compresses awkwardly.
+
+**Change:** Hide `HeroCard` on mobile, show a condensed stat strip:
+
+```tsx
+{/* Desktop: full preview card */}
+<div className="hidden lg:block">
+  <HeroCard />
+</div>
+
+{/* Mobile: condensed stat strip */}
+<div className="lg:hidden">
+  <MobileHeroStrip />
+</div>
+```
+
+`MobileHeroStrip`: A compact card showing just the key numbers:
+- "Disponible: $1.850.000" (large)
+- "Gasto hoy: $87.500 / $113.000" (progress bar)
+- Same border/shadow tokens as the full card
+
+#### 2. Hero highlights — stack on mobile
+
+**Current:** `sm:grid-cols-3` — 3 columns starting at 640px.  
+**Change:** `md:grid-cols-3` — 3 columns starting at 768px. On smaller screens, stack vertically.
+
+#### 3. Showcase carousel — responsive card width
+
+**Current:** `CARD_WIDTH = 280` (fixed px).  
+**Change:** Use CSS `min()` to prevent overflow:
+
+```tsx
+const CARD_WIDTH_CSS = "min(280px, calc(100vw - 48px))";
+```
+
+Apply via inline `style` on carousel items. The padding calculation also needs to reference this value.
+
+#### 4. Section spacing — reduce on mobile
+
+**Current:** All sections use `py-24` (96px top + bottom).  
+**Change:** `py-16 sm:py-24` throughout. 64px on mobile, 96px on desktop.
+
+Affected files: `landing-features.tsx` (HowItWorks, FAQ), `landing-budget.tsx`, `landing-plan.tsx`, `landing-cta.tsx`, `landing-showcase.tsx`.
+
+#### 5. Hero section padding
+
+**Current:** `pb-20 pt-16 sm:pt-24` — hero has custom padding.  
+**Change:** `pb-12 pt-12 sm:pb-20 sm:pt-24` — tighter on mobile.
+
+#### 6. CTA 2x2 grid
+
+Already stacks to 1 column on mobile (`sm:grid-cols-2`). No change needed.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `landing-page.tsx` | Reorder sections, remove `LandingFeatures` import |
+| `landing-hero.tsx` | Add `MobileHeroStrip`, hide `HeroCard` on mobile, refine H1/subtitle, fix highlights grid |
+| `landing-features.tsx` | Remove `LandingFeatures` export and `FeatureCard`. Keep `LandingAudience`, `LandingHowItWorks`, `LandingFAQ`. Reduce padding to `py-16 sm:py-24` |
+| `landing-showcase.tsx` | Add `SectionHeading` with heading text. Fix carousel card width for small screens. Reduce padding |
+| `landing-budget.tsx` | Reduce section padding to `py-16 sm:py-24` |
+| `landing-plan.tsx` | Reduce section padding to `py-16 sm:py-24` |
+| `landing-cta.tsx` | Reduce section padding to `py-16 sm:py-24` |
+| `landing-data.ts` | Remove `LANDING_FEATURES` export |
+
+**No new files.** No new components beyond `MobileHeroStrip` (inline in `landing-hero.tsx`).
+
+---
+
+## Agent Review Gates
+
+After implementation:
+
+1. **`zetas-front-guy`** — design system compliance on all TSX changes
+2. **`perf-auditor`** — ensure no new client-side bundles or heavy imports
+
+---
+
+## Out of Scope
+
+- Landing page animations/transitions
+- New interactive demos
+- A/B testing infrastructure
+- Analytics/conversion tracking
+- Auth flow changes
+- Dark/light mode toggle
+- New FAQ questions
+- Social proof / testimonials (no data yet)

--- a/docs/superpowers/specs/2026-04-09-mobile-ux-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-09-mobile-ux-improvements-design.md
@@ -1,0 +1,224 @@
+# Mobile UX Improvements — Import, Transaction Rows, Tag Colors
+
+**Date:** 2026-04-09  
+**Scope:** Mobile webapp only (responsive views, not React Native)  
+**Visual companion:** `docs/visual-companions/ux-improvements-april-2026.html`
+
+---
+
+## Problem
+
+Three systemic issues in the mobile webapp:
+
+1. **Import is buried.** PDF import — the foundational action — is only reachable via the hamburger drawer. No starter mode exists on mobile. The "Importar" chip in Movimientos only shows email counts and looks inactive when there are none.
+
+2. **Transaction rows are inconsistent.** `InicioActivity` renders plain text (description + amount) with no direction icon, no account, no category. `MovimientosTransactionRow` collapsed state shows account + date but omits direction icon and category. Two sibling surfaces feel like different apps.
+
+3. **Tag colors are invisible inline.** Tags have colors in Settings > Etiquetas (via `TagChip`), but transaction rows don't render tags at all in collapsed state. The `#` icon in expanded state communicates nothing about which tags are assigned.
+
+---
+
+## Design
+
+### 1. Import as Primary CTA
+
+#### 1A — Starter mode (`InicioStarter`)
+
+**New file:** `webapp/src/components/mobile/v2/inicio/inicio-starter.tsx`
+
+**Trigger:** `MobileZone` passes `starterMode: boolean` to `InicioRoot`. Computed as `hasAccounts && recentTx.length === 0` (same logic as desktop `dashboard/page.tsx:138`).
+
+**Content:**
+- Welcome text: "Tu base esta lista" / "Falta activar tu flujo con datos reales."
+- Single CTA card (brass border, gradient background):
+  - Icon (document), title "Importa tu primer extracto"
+  - Description explaining what import activates
+  - Primary brass button → `/import`
+  - Secondary text link → `/transactions` ("registrar manual")
+- "Despues de importar" row: 3 compact icons showing what unlocks (Metricas, Auto-categorias, Alertas)
+
+**When `starterMode=true`:** `InicioRoot` renders `InicioStarter` instead of hero + metrics + attention + discovery + activity.
+
+#### 1B — Stale import banner (`InicioImportStrip`)
+
+**New file:** `webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx`
+
+**Data:** `MobileZone` fetches `getLatestSnapshotDates()` (already exists, used in desktop's `AccountsSection`). Computes `daysSinceImport` as max days since any account's latest snapshot. Passes to `InicioRoot`.
+
+**Rendering:** Between hero and metrics grid when `daysSinceImport > 15`. Layout:
+- 36px icon box (brass-accented document icon)
+- Text block: bold "{N} dias sin importar" + description
+- Brass "Importar" button → `/import`
+
+Uses `import-strip` class pattern: `border-z-brass/20`, gradient background, `rounded-[14px]`.
+
+Hidden when `daysSinceImport <= 15` or `starterMode=true`.
+
+#### 1C — Importar chip includes PDF
+
+**File:** `webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx`
+
+**Changes:**
+1. "Importar" chip always shows sage accent styling (remove the conditional that makes it gray when `pendingEmailCount === 0`)
+2. Chip subtitle: show "Subir PDF" when `pendingEmailCount === 0`, show "{N} emails pendientes" otherwise
+3. `ImportarDetail` expanded panel: add a "Subir PDF del banco" row at the top, above the email list. Row has: document icon + title + description + brass "Subir" button → `/import`. Below it, a divider, then the existing email list.
+
+### 2. Standardized Transaction Rows
+
+#### 2A — `InicioActivity` rewrite
+
+**File:** `webapp/src/components/mobile/v2/inicio/inicio-activity.tsx`
+
+**Current interface:**
+```ts
+interface Transaction {
+  id: string;
+  description: string;
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+}
+```
+
+**New interface:**
+```ts
+interface RecentTransactionMobile {
+  id: string;
+  description: string;
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+  account_name: string;
+  account_color: string | null;
+  category_name: string | null;
+  category_icon: string | null;
+  tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
+}
+```
+
+**Data source:** `MobileZone` already maps `recentTx`. Extend the mapping to include account, category, and tags from the `RecentTransaction` type (which already includes `account_name`, `account_color`). For category and tags, either extend `getRecentTransactions()` to join them, or use `AppDataProvider` category map for lookup.
+
+**Layout:** Same visual as `MovimientosTransactionRow` collapsed state:
+- Direction icon (22px rounded box, inflow=green, outflow=orange)
+- Description (12px, font-medium, truncate)
+- Meta line: account dot + account name · category icon + category name
+- Tags row (if any): `TagChip size="sm"` aligned with text
+- Amount (right side, green for inflow, tabular-nums)
+
+**Interaction:** Tap → navigate to `/transactions/{id}` (no expand/collapse). "Ver todos →" link at bottom.
+
+#### 2B — `MovimientosTransactionRow` enrichment
+
+**File:** `webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx`
+
+**Changes to collapsed state:**
+
+1. **Add direction icon** to the left:
+   ```tsx
+   <div className={cn(
+     "flex size-[22px] shrink-0 items-center justify-center rounded-md",
+     tx.direction === "INFLOW" ? "bg-green-500/12 text-z-income" : "bg-orange-500/12 text-z-expense"
+   )}>
+     {tx.direction === "INFLOW" ? <ArrowDownLeft className="size-3" /> : <ArrowUpRight className="size-3" />}
+   </div>
+   ```
+
+2. **Replace date with category** in meta line. Date is already shown in the date group header, so it's redundant:
+   - Has category: `{category.icon} {category.name_es ?? category.name}`
+   - No category: `Sin cat.` in `text-z-brass` (implicit CTA)
+
+3. **Add tags below meta line** when `tags.length > 0`:
+   ```tsx
+   {tags.length > 0 && (
+     <div className="flex flex-wrap gap-1 mt-1 pl-[30px]">
+       {tags.map(t => (
+         <TagChip key={t.id} tag={t} groupColor={t.group_color} size="sm" />
+       ))}
+     </div>
+   )}
+   ```
+   `pl-[30px]` aligns with text (past the direction icon width).
+
+4. **Remove chevron `›`** — the direction icon already communicates that the row is interactive.
+
+**Props change:** Add `tags` to `MovimientosTransactionRowProps`:
+```ts
+interface MovimientosTransactionRowProps {
+  transaction: TransactionWithAccount;
+  categories: CategoryWithChildren[];
+  tags?: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
+  onCategorized?: (txId: string, categoryId: string) => void;
+}
+```
+
+### 3. Tag Colors Inline
+
+#### Data pipeline
+
+**Query change:** The transaction query in `movimientos-root.tsx` (or wherever `MovimientosRoot` fetches transactions) needs to join tags. Using Supabase:
+
+```ts
+.select(`*, account:accounts!inner(*), transaction_tags(tag:tags(id, name, color, group:tag_groups(color)))`)
+```
+
+This is a single join, not N+1. The response shape nests `transaction_tags[].tag.{id, name, color, group.color}`.
+
+**Mapping:** Flatten to the simple `{id, name, color, group_color}` shape expected by the row component.
+
+#### Rendering
+
+`TagChip` already handles everything:
+- Color cascade: `tag.color ?? groupColor ?? "rgba(255,255,255,0.15)"`
+- `size="sm"`: `text-xs px-2 py-0.5`
+- Border + background + text all colored
+
+No changes to `TagChip` needed.
+
+#### Where tags render
+
+| Surface | Shows tags? |
+|---------|------------|
+| `MovimientosTransactionRow` collapsed | Yes, below meta line |
+| `InicioActivity` rows | Yes, below meta line |
+| `MovimientosTransactionRow` expanded | Keep existing `TagZonePicker` for editing |
+
+---
+
+## Files Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `zones/mobile-zone.tsx` | Modified | Add `starterMode`, `daysSinceImport` computation and props |
+| `inicio-root.tsx` | Modified | Accept new props, conditionally render starter/import strip |
+| `inicio-activity.tsx` | Modified | Rewrite with canonical row layout + tags |
+| `movimientos-transaction-row.tsx` | Modified | Add direction icon, category, tags in collapsed |
+| `movimientos-herramientas.tsx` | Modified | Extend ImportarDetail with PDF CTA, always-sage chip |
+| `movimientos-root.tsx` | Modified | Pass tags data to transaction rows |
+| `inicio-starter.tsx` | **New** | Starter mode CTA card |
+| `inicio-import-strip.tsx` | **New** | Stale import contextual banner |
+
+**Not changed:** Desktop components, `TagChip`, server actions, database schema, `tag-chip.tsx`.
+
+---
+
+## Agent Review Gates
+
+After implementation, run these review agents before claiming done:
+
+1. **`zetas-front-guy`** — every TSX change (tokens, component reuse, design system compliance)
+2. **`perf-auditor`** — verify the tags join doesn't regress query performance
+3. **`cache-doctor`** — if any new cached queries are added for `latestSnapshotDates` in `MobileZone`
+
+---
+
+## Out of Scope
+
+- Desktop transaction table changes
+- Desktop starter mode changes
+- Desktop hero import CTAs
+- New server actions or API endpoints
+- Database migrations
+- `TagChip` component changes
+- Mobile tab bar restructuring (Bandeja vs Deudas — separate task)
+- Onboarding retheme (separate task)
+- Page header standardization (separate task)

--- a/docs/visual-companions/ux-improvements-april-2026.html
+++ b/docs/visual-companions/ux-improvements-april-2026.html
@@ -1,0 +1,1149 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zeta — Mobile UX Improvements</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
+  :root {
+    --z-ink: #1a1d1a;
+    --z-obsidian: #121412;
+    --z-surface-1: #151815;
+    --z-surface-2: rgba(26,29,26,0.80);
+    --z-brass: #c8b560;
+    --z-brass-10: rgba(200,181,96,0.10);
+    --z-brass-20: rgba(200,181,96,0.20);
+    --z-sage-light: #b0b89c;
+    --z-sage-dark: #7a8068;
+    --z-sage: #8ea882;
+    --z-income: #10b981;
+    --z-expense: #f59e0b;
+    --z-debt: #ef4444;
+    --z-border: rgba(255,255,255,0.06);
+    --z-muted: rgba(255,255,255,0.50);
+    --z-card: #111;
+    --radius-xl: 12px;
+    --radius-2xl: 16px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', -apple-system, sans-serif;
+    background: var(--z-obsidian);
+    color: #e0e0e0;
+    line-height: 1.5;
+    padding: 0;
+  }
+
+  .page-wrapper {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 48px;
+    padding-top: 40px;
+  }
+  .page-header h1 {
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    color: #fff;
+    margin-bottom: 10px;
+  }
+  .page-header .subtitle {
+    font-size: 15px;
+    color: var(--z-sage-dark);
+    max-width: 500px;
+    margin: 0 auto;
+  }
+  .page-header .date {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--z-brass);
+    margin-bottom: 16px;
+  }
+
+  /* ── Section ── */
+  .section { margin-bottom: 72px; }
+  .section-number {
+    font-size: 10px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.18em; color: var(--z-brass); margin-bottom: 6px;
+  }
+  .section-title {
+    font-size: 24px; font-weight: 700; letter-spacing: -0.02em;
+    color: #fff; margin-bottom: 6px;
+  }
+  .section-desc {
+    font-size: 14px; color: var(--z-sage-dark); margin-bottom: 28px; max-width: 600px;
+  }
+
+  /* ── Mobile frame ── */
+  .phones-row {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 16px;
+  }
+  .phone {
+    width: 320px;
+    border-radius: 28px;
+    border: 2px solid rgba(255,255,255,0.08);
+    background: var(--z-obsidian);
+    overflow: hidden;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+    flex-shrink: 0;
+  }
+  .phone.before { opacity: 0.6; }
+  .phone-label {
+    padding: 8px 16px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    text-align: center;
+  }
+  .phone-label.before-l { background: rgba(239,68,68,0.06); color: #f87171; }
+  .phone-label.after-l { background: rgba(16,185,129,0.06); color: #34d399; }
+  .status-bar {
+    height: 24px;
+    background: rgba(0,0,0,0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px; font-weight: 600; color: #fff;
+  }
+  .phone-content {
+    padding: 8px 14px 16px;
+    min-height: 420px;
+  }
+  .tab-bar {
+    display: flex;
+    justify-content: space-around;
+    padding: 8px 0 6px;
+    border-top: 1px solid var(--z-border);
+    background: rgba(0,0,0,0.4);
+  }
+  .tab-item {
+    text-align: center;
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--z-muted);
+    opacity: 0.5;
+  }
+  .tab-item.active { color: var(--z-brass); opacity: 1; }
+  .tab-icon {
+    width: 20px; height: 20px;
+    margin: 0 auto 2px;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.06);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 10px;
+  }
+  .tab-item.active .tab-icon { background: var(--z-brass-10); }
+  .fab-btn {
+    width: 40px; height: 40px;
+    border-radius: 50%;
+    background: var(--z-brass);
+    color: var(--z-ink);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px; font-weight: 700;
+    margin-top: -20px;
+    box-shadow: 0 4px 16px rgba(200,181,96,0.3);
+  }
+
+  /* ── In-phone components ── */
+  .m-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 6px 0 10px;
+  }
+  .m-header h2 { font-size: 15px; font-weight: 600; }
+  .m-avatar {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--z-brass-20); border: 1px solid var(--z-brass);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 11px; font-weight: 700; color: var(--z-brass);
+  }
+
+  .m-eyebrow {
+    font-size: 9px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.22em; color: var(--z-sage-dark); margin-bottom: 6px;
+  }
+
+  .m-card {
+    border-radius: 14px; border: 1px solid var(--z-border);
+    background: linear-gradient(180deg, rgba(26,29,26,0.7), rgba(18,20,18,0.9));
+    padding: 12px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+  }
+  .m-card-inset {
+    border-radius: 14px; border: 1px solid var(--z-border);
+    background: rgba(0,0,0,0.1); padding: 10px;
+  }
+
+  /* Attention chips */
+  .m-chips { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 6px; }
+  .m-chip {
+    border-radius: 14px; border: 1px solid var(--z-border);
+    background: rgba(0,0,0,0.1); padding: 8px; text-align: center;
+  }
+  .m-chip-num { font-size: 20px; font-weight: 680; line-height: 1.1; }
+  .m-chip-label { font-size: 9px; font-weight: 600; color: var(--z-muted); margin-top: 2px; }
+  .m-chip-sub { font-size: 8px; color: var(--z-muted); margin-top: 2px; }
+
+  /* Transaction rows */
+  .m-tx {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 2px;
+    border-bottom: 1px solid var(--z-border);
+  }
+  .m-tx:last-child { border-bottom: none; }
+  .m-tx-icon {
+    width: 22px; height: 22px; border-radius: 5px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 9px; flex-shrink: 0;
+  }
+  .m-tx-icon.inflow { background: rgba(16,185,129,0.12); color: var(--z-income); }
+  .m-tx-icon.outflow { background: rgba(245,158,11,0.12); color: var(--z-expense); }
+  .m-tx-info { flex: 1; min-width: 0; }
+  .m-tx-name { font-size: 12px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .m-tx-meta { font-size: 10px; color: var(--z-muted); display: flex; align-items: center; gap: 3px; margin-top: 1px; }
+  .m-tx-amount { font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; flex-shrink: 0; }
+  .m-tx-amount.inflow { color: var(--z-income); }
+
+  /* Account dot */
+  .acc-dot { width: 5px; height: 5px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+
+  /* Tag chip */
+  .m-tag {
+    display: inline-flex; align-items: center;
+    padding: 0px 6px; border-radius: 999px;
+    font-size: 9px; font-weight: 500;
+  }
+
+  /* Date group */
+  .m-date-group {
+    padding: 4px 2px;
+    font-size: 9px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.18em; color: var(--z-sage-dark);
+    border-bottom: 1px solid var(--z-border);
+    margin-top: 6px;
+  }
+  .m-date-group:first-child { margin-top: 0; }
+
+  /* Meta separator */
+  .sep { color: rgba(255,255,255,0.15); }
+
+  /* Annotation */
+  .annotation {
+    margin-top: 16px;
+    padding: 12px 14px;
+    border-radius: var(--radius-xl);
+    background: rgba(200,181,96,0.05);
+    border-left: 3px solid var(--z-brass);
+    font-size: 12px; color: var(--z-sage-light); line-height: 1.6;
+  }
+  .annotation strong { color: var(--z-brass); }
+  .annotation code { color: var(--z-brass); font-size: 11px; }
+
+  /* Issue callout */
+  .issue {
+    padding: 12px 14px; border-radius: var(--radius-xl);
+    background: rgba(239,68,68,0.04); border-left: 3px solid var(--z-debt);
+    font-size: 12px; color: #fca5a5; margin-bottom: 16px;
+  }
+  .issue strong { color: #f87171; }
+
+  /* Divider */
+  .divider {
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 0; margin: 32px 0;
+  }
+  .divider .line { flex: 1; height: 1px; background: var(--z-border); }
+  .divider .label {
+    font-size: 10px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.18em; color: var(--z-muted);
+  }
+
+  /* Section title in phone */
+  .m-section-title { font-size: 13px; font-weight: 600; margin-bottom: 6px; }
+
+  /* Import banner */
+  .import-strip {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 12px;
+    border-radius: 14px;
+    border: 1px solid var(--z-brass-20);
+    background: linear-gradient(135deg, rgba(200,181,96,0.06), transparent 60%);
+  }
+  .import-strip-icon {
+    width: 36px; height: 36px;
+    border-radius: 10px;
+    background: var(--z-brass-10);
+    border: 1px solid var(--z-brass-20);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 16px; flex-shrink: 0; color: var(--z-brass);
+  }
+  .import-strip-text { flex: 1; }
+  .import-strip-title { font-size: 12px; font-weight: 600; color: #e0e0e0; }
+  .import-strip-desc { font-size: 10px; color: var(--z-sage-dark); margin-top: 1px; }
+  .btn-brass-sm {
+    display: inline-flex; padding: 5px 12px; border-radius: 8px;
+    font-size: 11px; font-weight: 600;
+    background: var(--z-brass); color: var(--z-ink); border: none;
+    flex-shrink: 0;
+  }
+  .btn-ghost-sm {
+    display: inline-flex; padding: 5px 12px; border-radius: 8px;
+    font-size: 11px; font-weight: 500;
+    background: rgba(0,0,0,0.1); color: var(--z-sage-light);
+    border: 1px solid rgba(255,255,255,0.08);
+  }
+
+  /* Starter card */
+  .starter-cta {
+    border-radius: 14px;
+    border: 1px solid var(--z-brass-20);
+    background: linear-gradient(135deg, rgba(200,181,96,0.08), transparent 60%);
+    padding: 16px;
+    text-align: center;
+  }
+  .starter-icon {
+    width: 48px; height: 48px;
+    border-radius: 12px;
+    background: var(--z-brass-10);
+    border: 1px solid var(--z-brass-20);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 22px; margin: 0 auto 10px; color: var(--z-brass);
+  }
+  .starter-title {
+    font-size: 15px; font-weight: 600; color: #fff; margin-bottom: 4px;
+  }
+  .starter-desc {
+    font-size: 11px; color: var(--z-sage-dark); margin-bottom: 12px; line-height: 1.5;
+  }
+  .starter-alt {
+    font-size: 10px; color: var(--z-muted); margin-top: 10px;
+  }
+  .starter-alt a {
+    color: var(--z-sage-light); text-decoration: underline;
+  }
+
+  /* TOC */
+  .toc {
+    display: flex; gap: 10px; flex-wrap: wrap;
+    margin-bottom: 48px; justify-content: center;
+  }
+  .toc a {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 6px 14px; border-radius: 999px;
+    font-size: 12px; font-weight: 500;
+    background: rgba(255,255,255,0.04); color: var(--z-sage-light);
+    border: 1px solid var(--z-border); text-decoration: none;
+    transition: all 0.15s;
+  }
+  .toc a:hover {
+    background: var(--z-brass-10); border-color: var(--z-brass-20); color: var(--z-brass);
+  }
+
+  /* ── Summary grid ── */
+  .summary-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+  }
+  .summary-card {
+    border-radius: var(--radius-2xl); border: 1px solid var(--z-border);
+    background: var(--z-surface-2); padding: 14px; text-align: center;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+  }
+  .summary-card .icon { font-size: 24px; margin-bottom: 6px; }
+  .summary-card h4 { font-size: 13px; font-weight: 600; color: #fff; margin-bottom: 3px; }
+  .summary-card p { font-size: 11px; color: var(--z-sage-dark); }
+
+  @media (max-width: 700px) {
+    .phones-row { flex-direction: column; align-items: center; }
+    .summary-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="page-wrapper">
+
+  <div class="page-header">
+    <div class="date">Abril 2026 — Mobile Webapp</div>
+    <h1>Mejoras de Experiencia Mobile</h1>
+    <p class="subtitle">
+      Tres cambios de alto impacto en la vista mobile: importacion como CTA principal, transaction rows estandarizados, y colores de etiquetas visibles en filas.
+    </p>
+  </div>
+
+  <div class="toc">
+    <a href="#import">1. Importacion</a>
+    <a href="#transactions">2. Transaction rows</a>
+    <a href="#tags">3. Tags con color</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- SECTION 1: IMPORT ON MOBILE                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <div class="section" id="import">
+    <div class="section-number">Seccion 01</div>
+    <div class="section-title">Importacion como accion principal en mobile</div>
+    <p class="section-desc">
+      En mobile, "Importar PDF" solo es accesible via hamburger drawer. El Inicio no tiene starter mode. El chip "Importar" en Movimientos solo muestra emails pendientes. El acto fundacional de Zeta esta enterrado.
+    </p>
+
+    <!-- ── 1A: Starter mode ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin-bottom:12px;">
+      1A — Inicio: Starter mode mobile (primera vez)
+    </h3>
+
+    <div class="issue">
+      <strong>Hoy:</strong> No existe starter mode en mobile. El InicioRoot siempre muestra hero con $0/dia, metricas vacias, attention vacia, y activity vacia. Un usuario nuevo ve una app muerta.
+    </div>
+
+    <div class="phones-row">
+      <!-- BEFORE -->
+      <div class="phone before">
+        <div class="phone-label before-l">Actual — sin datos</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-header">
+            <h2>Zeta</h2>
+            <div class="m-avatar">CG</div>
+          </div>
+
+          <!-- Hero showing $0 -->
+          <div class="m-card" style="margin-bottom:8px;">
+            <div class="m-eyebrow">Disponible para gastar</div>
+            <div style="display:flex; align-items:baseline; gap:4px;">
+              <span style="font-size:28px; font-weight:800; color:var(--z-sage-light);">$0</span>
+              <span style="font-size:12px; color:var(--z-muted);">/dia</span>
+            </div>
+            <div style="font-size:10px; color:var(--z-muted); margin-top:2px;">= $0 este mes · 22 dias restantes</div>
+          </div>
+
+          <!-- Empty metrics -->
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-bottom:8px;">
+            <div class="m-card-inset" style="padding:8px; text-align:center;">
+              <div style="font-size:9px; font-weight:600; color:var(--z-sage-dark);">RITMO</div>
+              <div style="font-size:16px; font-weight:700; color:var(--z-muted); margin-top:2px;">—</div>
+            </div>
+            <div class="m-card-inset" style="padding:8px; text-align:center;">
+              <div style="font-size:9px; font-weight:600; color:var(--z-sage-dark);">GASTO HOY</div>
+              <div style="font-size:16px; font-weight:700; color:var(--z-muted); margin-top:2px;">$0</div>
+            </div>
+          </div>
+
+          <!-- Empty activity -->
+          <div style="padding:20px 0; text-align:center;">
+            <div style="font-size:11px; color:var(--z-muted);">No hay actividad reciente</div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab-item active"><div class="tab-icon">🏠</div>Inicio</div>
+          <div class="tab-item"><div class="tab-icon">↔</div>Movim.</div>
+          <div class="fab-btn">+</div>
+          <div class="tab-item"><div class="tab-icon">🐷</div>Plan</div>
+          <div class="tab-item"><div class="tab-icon">🏛</div>Deudas</div>
+        </div>
+      </div>
+
+      <!-- AFTER -->
+      <div class="phone">
+        <div class="phone-label after-l">Propuesta — starter mode</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-header">
+            <h2>Zeta</h2>
+            <div class="m-avatar">CG</div>
+          </div>
+
+          <!-- Welcome message -->
+          <div style="margin-bottom:12px;">
+            <div style="font-size:16px; font-weight:600; color:#fff;">Tu base esta lista</div>
+            <div style="font-size:11px; color:var(--z-sage-dark);">Falta activar tu flujo con datos reales.</div>
+          </div>
+
+          <!-- Primary CTA: Import -->
+          <div class="starter-cta">
+            <div class="starter-icon">📄</div>
+            <div class="starter-title">Importa tu primer extracto</div>
+            <div class="starter-desc">
+              Sube el PDF de tu banco y Zeta extrae movimientos, aprende destinatarios y activa metricas automaticamente.
+            </div>
+            <span class="btn-brass-sm" style="font-size:12px; padding:8px 20px;">Importar extracto PDF</span>
+            <div class="starter-alt">
+              O <a href="#">registra un movimiento manual</a>
+            </div>
+          </div>
+
+          <!-- What happens next -->
+          <div style="margin-top:12px;">
+            <div class="m-eyebrow">Despues de importar</div>
+            <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:6px;">
+              <div class="m-card-inset" style="padding:8px; text-align:center;">
+                <div style="font-size:14px; margin-bottom:2px;">📊</div>
+                <div style="font-size:9px; color:var(--z-sage-dark);">Metricas activas</div>
+              </div>
+              <div class="m-card-inset" style="padding:8px; text-align:center;">
+                <div style="font-size:14px; margin-bottom:2px;">🏷️</div>
+                <div style="font-size:9px; color:var(--z-sage-dark);">Auto-categorias</div>
+              </div>
+              <div class="m-card-inset" style="padding:8px; text-align:center;">
+                <div style="font-size:14px; margin-bottom:2px;">🔔</div>
+                <div style="font-size:9px; color:var(--z-sage-dark);">Alertas activas</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab-item active"><div class="tab-icon">🏠</div>Inicio</div>
+          <div class="tab-item"><div class="tab-icon">↔</div>Movim.</div>
+          <div class="fab-btn">+</div>
+          <div class="tab-item"><div class="tab-icon">🐷</div>Plan</div>
+          <div class="tab-item"><div class="tab-icon">🏛</div>Deudas</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Cambio:</strong> <code>InicioRoot</code> recibe una prop <code>starterMode</code> desde <code>MobileZone</code>. Cuando es true, renderiza un CTA de importacion prominente en vez del hero + metricas vacias. El botton principal lleva a <code>/import</code>. La alternativa de registro manual es un link secundario.
+    </div>
+
+    <!-- ── 1B: Stale import banner ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin: 28px 0 12px;">
+      1B — Inicio: Banner contextual cuando hay datos stale
+    </h3>
+
+    <div class="issue">
+      <strong>Hoy:</strong> Cuando freshness es "stale" o "outdated", el hero muestra un pill de estado pero no ofrece accion directa. El usuario no sabe que importar resuelve el problema. El <code>DashboardAlerts</code> de desktop (que muestra "Hace X dias sin importar") no tiene equivalente mobile.
+    </div>
+
+    <div class="phones-row">
+      <div class="phone">
+        <div class="phone-label after-l">Propuesta — Banner bajo hero</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-header">
+            <h2>Zeta</h2>
+            <div class="m-avatar">CG</div>
+          </div>
+
+          <!-- Hero condensed -->
+          <div class="m-card" style="margin-bottom:6px;">
+            <div class="m-eyebrow">Disponible para gastar</div>
+            <div style="display:flex; align-items:baseline; gap:4px;">
+              <span style="font-size:28px; font-weight:800; color:var(--z-sage-light);">$61.411</span>
+              <span style="font-size:12px; color:var(--z-muted);">/dia</span>
+            </div>
+            <div style="font-size:10px; color:var(--z-muted); margin-top:2px;">= $1.350.050 este mes · 22 dias</div>
+          </div>
+
+          <!-- NEW: Import strip -->
+          <div class="import-strip" style="margin-bottom:8px;">
+            <div class="import-strip-icon">📄</div>
+            <div class="import-strip-text">
+              <div class="import-strip-title">18 dias sin importar</div>
+              <div class="import-strip-desc">Actualiza para que las metricas reflejen tu posicion real.</div>
+            </div>
+            <span class="btn-brass-sm">Importar</span>
+          </div>
+
+          <!-- Metrics -->
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-bottom:6px;">
+            <div class="m-card-inset" style="padding:8px; text-align:center;">
+              <div style="font-size:9px; font-weight:600; color:var(--z-sage-dark);">RITMO</div>
+              <div style="font-size:14px; font-weight:700; margin-top:2px;">dia 9 de 30</div>
+            </div>
+            <div class="m-card-inset" style="padding:8px; text-align:center;">
+              <div style="font-size:9px; font-weight:600; color:var(--z-sage-dark);">GASTO HOY</div>
+              <div style="font-size:14px; font-weight:700; margin-top:2px;">$28.900</div>
+            </div>
+          </div>
+
+          <!-- Attention -->
+          <div class="m-eyebrow" style="margin-top:8px;">ATENCION</div>
+          <div class="m-chips">
+            <div class="m-chip">
+              <div class="m-chip-num" style="color:var(--z-debt);">0</div>
+              <div class="m-chip-label">Vencidos</div>
+            </div>
+            <div class="m-chip">
+              <div class="m-chip-num" style="color:var(--z-brass);">3</div>
+              <div class="m-chip-label">Pagos</div>
+              <div class="m-chip-sub">en 7 dias</div>
+            </div>
+            <div class="m-chip">
+              <div class="m-chip-num" style="color:var(--z-sage);">2</div>
+              <div class="m-chip-label">Emails</div>
+              <div class="m-chip-sub">sin revisar</div>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab-item active"><div class="tab-icon">🏠</div>Inicio</div>
+          <div class="tab-item"><div class="tab-icon">↔</div>Movim.</div>
+          <div class="fab-btn">+</div>
+          <div class="tab-item"><div class="tab-icon">🐷</div>Plan</div>
+          <div class="tab-item"><div class="tab-icon">🏛</div>Deudas</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Cambio:</strong> Nuevo componente <code>InicioImportStrip</code> que se muestra entre el hero y las metricas cuando <code>freshness !== "fresh"</code>. Recibe <code>daysSinceImport</code> del <code>latestSnapshotDates</code> de <code>MobileZone</code>. El boton lleva a <code>/import</code>. Se oculta cuando freshness es "fresh".
+    </div>
+
+    <!-- ── 1C: Movimientos Importar chip ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin: 28px 0 12px;">
+      1C — Movimientos: Chip "Importar" incluye PDF
+    </h3>
+
+    <div class="issue">
+      <strong>Hoy:</strong> El chip "Importar" en <code>MovimientosHerramientas</code> solo muestra emails pendientes. Cuando el count es 0, dice "sin pendientes" y parece inactivo. No hay forma de llegar a importar PDF desde Movimientos en mobile.
+    </div>
+
+    <div class="phones-row">
+      <!-- BEFORE -->
+      <div class="phone before">
+        <div class="phone-label before-l">Actual</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-header">
+            <h2>Movimientos</h2>
+            <div style="font-size:10px; color:var(--z-muted);">Abr 2026</div>
+          </div>
+
+          <div class="m-eyebrow" style="margin-top:8px;">HERRAMIENTAS</div>
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px;">
+            <div class="m-chip" style="border-color: var(--z-brass-20); background: linear-gradient(180deg,rgba(200,181,96,0.08),transparent);">
+              <div class="m-chip-num" style="color:var(--z-brass);">5</div>
+              <div class="m-chip-label">Categorizar</div>
+              <div class="m-chip-sub" style="color:var(--z-debt);">5 por resolver</div>
+            </div>
+            <div class="m-chip">
+              <div class="m-chip-num" style="color:var(--z-muted);">0</div>
+              <div class="m-chip-label">Importar</div>
+              <div class="m-chip-sub">sin pendientes</div>
+            </div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab-item"><div class="tab-icon">🏠</div>Inicio</div>
+          <div class="tab-item active"><div class="tab-icon">↔</div>Movim.</div>
+          <div class="fab-btn">+</div>
+          <div class="tab-item"><div class="tab-icon">🐷</div>Plan</div>
+          <div class="tab-item"><div class="tab-icon">🏛</div>Deudas</div>
+        </div>
+      </div>
+
+      <!-- AFTER -->
+      <div class="phone">
+        <div class="phone-label after-l">Propuesta</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-header">
+            <h2>Movimientos</h2>
+            <div style="font-size:10px; color:var(--z-muted);">Abr 2026</div>
+          </div>
+
+          <div class="m-eyebrow" style="margin-top:8px;">HERRAMIENTAS</div>
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px;">
+            <div class="m-chip" style="border-color: var(--z-brass-20); background: linear-gradient(180deg,rgba(200,181,96,0.08),transparent);">
+              <div class="m-chip-num" style="color:var(--z-brass);">5</div>
+              <div class="m-chip-label">Categorizar</div>
+              <div class="m-chip-sub" style="color:var(--z-debt);">5 por resolver</div>
+            </div>
+            <div class="m-chip" style="border-color:rgba(142,168,130,0.3); background: linear-gradient(180deg,rgba(142,168,130,0.08),transparent);">
+              <div class="m-chip-num" style="color:var(--z-sage);">0</div>
+              <div class="m-chip-label">Importar</div>
+              <div class="m-chip-sub" style="color:var(--z-sage);">Subir PDF</div>
+            </div>
+          </div>
+
+          <!-- Expanded import panel -->
+          <div class="m-card-inset" style="margin-top:6px; border-color:rgba(142,168,130,0.2); background:rgba(0,0,0,0.2); padding:12px;">
+            <div style="font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.18em; color:var(--z-sage); margin-bottom:8px;">Importar extracto</div>
+
+            <div style="display:flex; gap:8px; align-items:center; margin-bottom:10px;">
+              <div style="width:32px; height:32px; border-radius:8px; background:rgba(142,168,130,0.1); border:1px solid rgba(142,168,130,0.2); display:flex; align-items:center; justify-content:center; font-size:14px; color:var(--z-sage);">📄</div>
+              <div style="flex:1;">
+                <div style="font-size:11px; font-weight:600;">Subir PDF del banco</div>
+                <div style="font-size:9px; color:var(--z-sage-dark);">Extracto mensual de cualquier banco</div>
+              </div>
+              <span class="btn-brass-sm">Subir</span>
+            </div>
+
+            <div style="height:1px; background:var(--z-border); margin:8px 0;"></div>
+            <div style="font-size:10px; color:var(--z-muted);">0 emails pendientes de revision</div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab-item"><div class="tab-icon">🏠</div>Inicio</div>
+          <div class="tab-item active"><div class="tab-icon">↔</div>Movim.</div>
+          <div class="fab-btn">+</div>
+          <div class="tab-item"><div class="tab-icon">🐷</div>Plan</div>
+          <div class="tab-item"><div class="tab-icon">🏛</div>Deudas</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Cambios:</strong><br>
+      1. Chip "Importar" siempre muestra estilo sage activo (no gris/inactivo cuando emails=0). El subtitle cambia a "Subir PDF".<br>
+      2. <code>ImportarDetail</code> se extiende: arriba del listado de emails pendientes, muestra un CTA de "Subir PDF del banco" que lleva a <code>/import</code>. Emails pendientes aparecen abajo como seccion secundaria.<br>
+      3. La idea: el chip "Importar" es la puerta a toda la importacion (PDF + email), no solo a emails.
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- SECTION 2: TRANSACTION ROW STANDARDIZATION                            -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <div class="section" id="transactions">
+    <div class="section-number">Seccion 02</div>
+    <div class="section-title">Transaction rows estandarizados en mobile</div>
+    <p class="section-desc">
+      <code>InicioActivity</code> usa un layout ultra-simple (solo description + amount, sin cuenta, sin categoria, sin direction icon). El canonico es <code>MovimientosTransactionRow</code>. Todos los rows deben seguir el mismo patron visual.
+    </p>
+
+    <!-- ── 2A: InicioActivity Before/After ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin-bottom:12px;">
+      2A — Inicio: "Reciente" adopta el patron canonico
+    </h3>
+
+    <div class="issue">
+      <strong>Hoy:</strong> <code>InicioActivity</code> muestra: description (text-[13px]) + amount. Sin account dot, sin direction icon, sin category. Visualmente, es una lista aplanada que no comunica nada sobre la transaccion. El expand muestra un panel con "Ingreso/Gasto · monto" + "Ver detalle" — redundante.
+    </div>
+
+    <div class="phones-row">
+      <!-- BEFORE -->
+      <div class="phone before">
+        <div class="phone-label before-l">Actual — InicioActivity</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-top:16px;">
+          <div class="m-eyebrow">RECIENTE</div>
+
+          <!-- Current simple rows -->
+          <div style="border-bottom:1px solid var(--z-border); padding:8px 0;">
+            <div style="display:flex; justify-content:space-between;">
+              <span style="font-size:13px;">Exito Centro Mayor</span>
+              <span style="font-size:13px; font-weight:500;">-$342.800</span>
+            </div>
+          </div>
+          <div style="border-bottom:1px solid var(--z-border); padding:8px 0;">
+            <div style="display:flex; justify-content:space-between;">
+              <span style="font-size:13px;">Nomina Empresa SAS</span>
+              <span style="font-size:13px; font-weight:500; color:var(--z-income);">+$4.200.000</span>
+            </div>
+          </div>
+          <div style="padding:8px 0;">
+            <div style="display:flex; justify-content:space-between;">
+              <span style="font-size:13px;">Rappi</span>
+              <span style="font-size:13px; font-weight:500;">-$28.900</span>
+            </div>
+          </div>
+
+          <div style="padding:20px 0; text-align:center; font-size:10px; color:var(--z-muted);">
+            No se sabe la cuenta, la categoria, ni la fecha de cada transaccion.
+          </div>
+        </div>
+      </div>
+
+      <!-- AFTER -->
+      <div class="phone">
+        <div class="phone-label after-l">Propuesta — patron canonico</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-top:16px;">
+          <div class="m-eyebrow">RECIENTE</div>
+
+          <!-- Row 1 -->
+          <div class="m-tx">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Exito Centro Mayor</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#4ade80;"></span>
+                Bancolombia
+                <span class="sep">&middot;</span>
+                🛒 Mercado
+              </div>
+            </div>
+            <div class="m-tx-amount">-$342.800</div>
+          </div>
+
+          <!-- Row 2 -->
+          <div class="m-tx">
+            <div class="m-tx-icon inflow">↙</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Nomina Empresa SAS</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#4ade80;"></span>
+                Bancolombia
+                <span class="sep">&middot;</span>
+                💰 Salario
+              </div>
+            </div>
+            <div class="m-tx-amount inflow">+$4.200.000</div>
+          </div>
+
+          <!-- Row 3 -->
+          <div class="m-tx">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Rappi</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#a78bfa;"></span>
+                Nu
+                <span class="sep">&middot;</span>
+                <span style="color:var(--z-brass);">Sin cat.</span>
+              </div>
+            </div>
+            <div class="m-tx-amount">-$28.900</div>
+          </div>
+
+          <div style="text-align:center; margin-top:8px;">
+            <span style="font-size:11px; font-weight:600; color:var(--z-brass);">Ver todos →</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Cambio:</strong> <code>InicioActivity</code> usa el mismo layout visual que <code>MovimientosTransactionRow</code> collapsed state: direction icon + description + meta line (account dot · account name · category). Sin expand (el tap lleva directo a <code>/transactions/{id}</code>).<br><br>
+      <strong>Datos:</strong> <code>MobileZone</code> ya pasa <code>recentTx</code> con amount/direction/description. Necesita extender el tipo para incluir <code>account_name</code>, <code>account_color</code>, <code>category_name</code>, <code>category_icon</code>.
+    </div>
+
+    <!-- ── 2B: MovimientosTransactionRow with account dot visible ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin: 28px 0 12px;">
+      2B — Movimientos: Direction icon + category en collapsed
+    </h3>
+
+    <div class="issue">
+      <strong>Hoy:</strong> <code>MovimientosTransactionRow</code> collapsed state muestra: description + account(dot+name) + date + amount. No muestra direction icon ni category. Category solo aparece al expandir. El usuario no puede escanear que tipo de gasto es sin expandir cada fila.
+    </div>
+
+    <div class="phones-row">
+      <!-- BEFORE -->
+      <div class="phone before">
+        <div class="phone-label before-l">Actual — collapsed</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-top:12px;">
+          <div class="m-date-group">Lunes, 7 Abr</div>
+
+          <div style="display:flex; align-items:center; justify-content:space-between; padding:8px 2px; border-bottom:1px solid var(--z-border);">
+            <div style="min-width:0; flex:1;">
+              <div style="font-size:13px; font-weight:500; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">Exito Centro Mayor</div>
+              <div style="font-size:10px; color:var(--z-muted); display:flex; align-items:center; gap:3px; margin-top:1px;">
+                <span class="acc-dot" style="background:#4ade80;"></span>
+                Bancolombia <span class="sep">&middot;</span> 07 abr
+              </div>
+            </div>
+            <div style="display:flex; align-items:center; gap:4px;">
+              <span style="font-size:13px; font-weight:500; font-variant-numeric:tabular-nums;">-$342.800</span>
+              <span style="font-size:10px; color:var(--z-muted);">›</span>
+            </div>
+          </div>
+
+          <div style="display:flex; align-items:center; justify-content:space-between; padding:8px 2px; border-bottom:1px solid var(--z-border);">
+            <div style="min-width:0; flex:1;">
+              <div style="font-size:13px; font-weight:500;">Rappi</div>
+              <div style="font-size:10px; color:var(--z-muted); display:flex; align-items:center; gap:3px; margin-top:1px;">
+                <span class="acc-dot" style="background:#a78bfa;"></span>
+                Nu <span class="sep">&middot;</span> 07 abr
+              </div>
+            </div>
+            <div style="display:flex; align-items:center; gap:4px;">
+              <span style="font-size:13px; font-weight:500; font-variant-numeric:tabular-nums;">-$28.900</span>
+              <span style="font-size:10px; color:var(--z-muted);">›</span>
+            </div>
+          </div>
+
+          <div style="font-size:10px; color:var(--z-muted); text-align:center; padding:16px 0;">
+            Sin direction icon. Sin categoria. Hay que expandir para ver mas.
+          </div>
+        </div>
+      </div>
+
+      <!-- AFTER -->
+      <div class="phone">
+        <div class="phone-label after-l">Propuesta — enriched collapsed</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-top:12px;">
+          <div class="m-date-group">Lunes, 7 Abr</div>
+
+          <div class="m-tx">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Exito Centro Mayor</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#4ade80;"></span>
+                Bancolombia
+                <span class="sep">&middot;</span>
+                🛒 Mercado
+              </div>
+            </div>
+            <div class="m-tx-amount">-$342.800</div>
+          </div>
+
+          <div class="m-tx">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Rappi</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#a78bfa;"></span>
+                Nu
+                <span class="sep">&middot;</span>
+                <span style="color:var(--z-brass);">Sin cat.</span>
+              </div>
+            </div>
+            <div class="m-tx-amount">-$28.900</div>
+          </div>
+
+          <div class="m-tx">
+            <div class="m-tx-icon inflow">↙</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Nomina Empresa SAS</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#4ade80;"></span>
+                Bancolombia
+                <span class="sep">&middot;</span>
+                💰 Salario
+              </div>
+            </div>
+            <div class="m-tx-amount inflow">+$4.200.000</div>
+          </div>
+
+          <div class="m-date-group">Viernes, 4 Abr</div>
+
+          <div class="m-tx">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-info">
+              <div class="m-tx-name">Netflix</div>
+              <div class="m-tx-meta">
+                <span class="acc-dot" style="background:#a78bfa;"></span>
+                Nu
+                <span class="sep">&middot;</span>
+                🎬 Entretenimiento
+              </div>
+            </div>
+            <div class="m-tx-amount">-$33.900</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Cambios en <code>MovimientosTransactionRow</code>:</strong><br>
+      1. Agregar direction icon (22px rounded box, outflow=orange, inflow=green) a la izquierda<br>
+      2. Reemplazar fecha en la meta line por categoria (icon + name). La fecha ya esta en el group header.<br>
+      3. Sin categoria: muestra "Sin cat." en brass como CTA implicito<br>
+      4. Mantener el expand para TagZonePicker + CategoryZonePicker + edit link
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- SECTION 3: TAG COLORS INLINE                                          -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <div class="section" id="tags">
+    <div class="section-number">Seccion 03</div>
+    <div class="section-title">Etiquetas con color en filas mobile</div>
+    <p class="section-desc">
+      En Settings las etiquetas muestran su color. En las filas de transacciones, los tags son invisibles en el collapsed state — solo aparece un icono <code>#</code> gris al expandir. El color es la senal visual que hace utiles las etiquetas.
+    </p>
+
+    <div class="issue">
+      <strong>Hoy:</strong> <code>MovimientosTransactionRow</code> expanded state muestra <code>TagZonePicker compact</code> como un boton <code>#</code> de 10px. No hay chips, no hay colores, no hay nombres de tag visibles. El usuario no sabe que tags tiene cada transaccion sin abrir cada fila.
+    </div>
+
+    <!-- ── 3A: Tags in collapsed row ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin-bottom:12px;">
+      3A — Tags visibles en collapsed row
+    </h3>
+
+    <div class="phones-row">
+      <div class="phone">
+        <div class="phone-label after-l">Propuesta — tags con color inline</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-top:12px;">
+          <div class="m-date-group">Lunes, 7 Abr</div>
+
+          <!-- Row with tags -->
+          <div style="padding:8px 2px; border-bottom:1px solid var(--z-border);">
+            <div style="display:flex; align-items:center; gap:8px;">
+              <div class="m-tx-icon outflow">↗</div>
+              <div style="flex:1; min-width:0;">
+                <div class="m-tx-name">Exito Centro Mayor</div>
+                <div class="m-tx-meta">
+                  <span class="acc-dot" style="background:#4ade80;"></span>
+                  Bancolombia
+                  <span class="sep">&middot;</span>
+                  🛒 Mercado
+                </div>
+              </div>
+              <div class="m-tx-amount">-$342.800</div>
+            </div>
+            <!-- Tags row -->
+            <div style="display:flex; gap:4px; margin-top:4px; padding-left:30px;">
+              <span class="m-tag" style="border:1px solid rgba(99,182,237,0.4); background:rgba(99,182,237,0.08); color:rgb(99,182,237);">mensual</span>
+              <span class="m-tag" style="border:1px solid rgba(168,130,255,0.4); background:rgba(168,130,255,0.08); color:rgb(168,130,255);">hogar</span>
+            </div>
+          </div>
+
+          <!-- Row with single tag -->
+          <div style="padding:8px 2px; border-bottom:1px solid var(--z-border);">
+            <div style="display:flex; align-items:center; gap:8px;">
+              <div class="m-tx-icon outflow">↗</div>
+              <div style="flex:1; min-width:0;">
+                <div class="m-tx-name">Rappi</div>
+                <div class="m-tx-meta">
+                  <span class="acc-dot" style="background:#a78bfa;"></span>
+                  Nu
+                  <span class="sep">&middot;</span>
+                  🍔 Restaurantes
+                </div>
+              </div>
+              <div class="m-tx-amount">-$28.900</div>
+            </div>
+            <div style="display:flex; gap:4px; margin-top:4px; padding-left:30px;">
+              <span class="m-tag" style="border:1px solid rgba(251,191,36,0.4); background:rgba(251,191,36,0.08); color:rgb(251,191,36);">impulso</span>
+            </div>
+          </div>
+
+          <!-- Row without tags (clean) -->
+          <div style="padding:8px 2px; border-bottom:1px solid var(--z-border);">
+            <div style="display:flex; align-items:center; gap:8px;">
+              <div class="m-tx-icon inflow">↙</div>
+              <div style="flex:1; min-width:0;">
+                <div class="m-tx-name">Nomina Empresa SAS</div>
+                <div class="m-tx-meta">
+                  <span class="acc-dot" style="background:#4ade80;"></span>
+                  Bancolombia
+                  <span class="sep">&middot;</span>
+                  💰 Salario
+                </div>
+              </div>
+              <div class="m-tx-amount inflow">+$4.200.000</div>
+            </div>
+          </div>
+
+          <!-- Row with many tags -->
+          <div class="m-date-group">Viernes, 4 Abr</div>
+          <div style="padding:8px 2px;">
+            <div style="display:flex; align-items:center; gap:8px;">
+              <div class="m-tx-icon outflow">↗</div>
+              <div style="flex:1; min-width:0;">
+                <div class="m-tx-name">Falabella Cuota 3/12</div>
+                <div class="m-tx-meta">
+                  <span class="acc-dot" style="background:#f87171;"></span>
+                  Falabella TC
+                  <span class="sep">&middot;</span>
+                  🛍 Compras
+                </div>
+              </div>
+              <div class="m-tx-amount">-$89.900</div>
+            </div>
+            <div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:4px; padding-left:30px;">
+              <span class="m-tag" style="border:1px solid rgba(99,182,237,0.4); background:rgba(99,182,237,0.08); color:rgb(99,182,237);">mensual</span>
+              <span class="m-tag" style="border:1px solid rgba(251,191,36,0.4); background:rgba(251,191,36,0.08); color:rgb(251,191,36);">planificado</span>
+              <span class="m-tag" style="border:1px solid rgba(168,130,255,0.4); background:rgba(168,130,255,0.08); color:rgb(168,130,255);">hogar</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Implementacion:</strong><br>
+      1. <code>MovimientosTransactionRow</code> recibe <code>tags: TagWithGroup[]</code> como prop (join en la query de transacciones)<br>
+      2. En collapsed state, si <code>tags.length > 0</code>, renderiza una fila de <code>TagChip size="sm"</code> debajo del meta line, con <code>padding-left</code> alineado al texto (30px, ancho del icon).<br>
+      3. <code>TagChip</code> ya maneja el color cascade: <code>tag.color ?? groupColor</code>. Solo se necesita pasar <code>groupColor</code> desde el join.<br>
+      4. Sin tags: no se renderiza nada extra — la fila queda limpia como la de "Nomina" arriba.
+    </div>
+
+    <!-- ── 3B: Consistency proof ── -->
+    <h3 style="font-size:15px; font-weight:600; color:#fff; margin: 28px 0 12px;">
+      3B — Consistencia: Settings ↔ Inline
+    </h3>
+
+    <div style="max-width:500px; margin:0 auto;">
+      <div style="border-radius:16px; border:1px solid var(--z-border); background:var(--z-surface-1); overflow:hidden;">
+        <div style="padding:10px 14px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.18em; color:var(--z-brass); border-bottom:1px solid var(--z-border); background:rgba(200,181,96,0.04);">
+          Mismo TagChip — dos tamanos
+        </div>
+        <div style="padding:16px;">
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px;">
+            <div>
+              <div style="font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.18em; color:var(--z-sage-dark); margin-bottom:8px;">Settings (size="md")</div>
+              <div style="display:flex; flex-wrap:wrap; gap:5px;">
+                <span class="m-tag" style="border:1px solid rgba(99,182,237,0.4); background:rgba(99,182,237,0.08); color:rgb(99,182,237); font-size:11px; padding:2px 10px;">mensual</span>
+                <span class="m-tag" style="border:1px solid rgba(251,191,36,0.4); background:rgba(251,191,36,0.08); color:rgb(251,191,36); font-size:11px; padding:2px 10px;">impulso</span>
+                <span class="m-tag" style="border:1px solid rgba(168,130,255,0.4); background:rgba(168,130,255,0.08); color:rgb(168,130,255); font-size:11px; padding:2px 10px;">hogar</span>
+              </div>
+            </div>
+            <div>
+              <div style="font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.18em; color:var(--z-sage-dark); margin-bottom:8px;">Inline (size="sm")</div>
+              <div style="display:flex; flex-wrap:wrap; gap:4px;">
+                <span class="m-tag" style="border:1px solid rgba(99,182,237,0.4); background:rgba(99,182,237,0.08); color:rgb(99,182,237);">mensual</span>
+                <span class="m-tag" style="border:1px solid rgba(251,191,36,0.4); background:rgba(251,191,36,0.08); color:rgb(251,191,36);">impulso</span>
+                <span class="m-tag" style="border:1px solid rgba(168,130,255,0.4); background:rgba(168,130,255,0.08); color:rgb(168,130,255);">hogar</span>
+              </div>
+            </div>
+          </div>
+          <div style="margin-top:12px; font-size:10px; color:var(--z-sage-dark);">
+            Mismo componente <code style="color:var(--z-brass);">TagChip</code>. Mismo color cascade. Solo cambia el <code style="color:var(--z-brass);">size</code> prop.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- SUMMARY                                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <div class="section">
+    <div class="divider">
+      <span class="line"></span>
+      <span class="label">Resumen de cambios</span>
+      <span class="line"></span>
+    </div>
+
+    <div class="summary-grid">
+      <div class="summary-card">
+        <div class="icon">📄</div>
+        <h4>Import como CTA #1</h4>
+        <p>Starter mode mobile. Import strip en hero stale. Chip "Importar" con acceso a PDF.</p>
+      </div>
+      <div class="summary-card">
+        <div class="icon">📋</div>
+        <h4>Rows estandarizados</h4>
+        <p>InicioActivity adopta patron canonico. Direction icon + category en collapsed.</p>
+      </div>
+      <div class="summary-card">
+        <div class="icon">🏷️</div>
+        <h4>Tags con color</h4>
+        <p>TagChip size="sm" en collapsed rows. Color visible sin expandir.</p>
+      </div>
+    </div>
+
+    <div class="annotation" style="margin-top:20px;">
+      <strong>Archivos a modificar:</strong><br>
+      &bull; <code>mobile-zone.tsx</code> — Pasar <code>starterMode</code> + <code>daysSinceImport</code> a InicioRoot<br>
+      &bull; <code>inicio-root.tsx</code> — Recibir <code>starterMode</code>, renderizar CTA en vez de hero/metricas<br>
+      &bull; <code>inicio-activity.tsx</code> — Reescribir para usar direction icon + account + category<br>
+      &bull; <code>movimientos-transaction-row.tsx</code> — Agregar direction icon + category en collapsed, tags debajo<br>
+      &bull; <code>movimientos-herramientas.tsx</code> — Extender ImportarDetail con "Subir PDF"<br>
+      &bull; Queries de transacciones — Join <code>transaction_tags → tags → tag_groups</code> para tag colors
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/supabase/migrations/20260410032327_add_perf_indexes_tags_snapshots.sql
+++ b/supabase/migrations/20260410032327_add_perf_indexes_tags_snapshots.sql
@@ -1,0 +1,10 @@
+-- Fix: transaction_tags has no index on transaction_id.
+-- The FK constraint does NOT auto-create an index in PostgreSQL.
+-- The new tags join in getRecentTransactions and movimientos hits this on every render.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_tags_transaction_id
+  ON public.transaction_tags(transaction_id);
+
+-- Fix: getLatestSnapshotDates performs a full table scan.
+-- Neither existing index starts with user_id. Now used in MobileZone's Promise.all.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_statement_snapshots_enc_user_created
+  ON statement_snapshots_enc(user_id, created_at DESC);

--- a/webapp/src/actions/statement-snapshots.ts
+++ b/webapp/src/actions/statement-snapshots.ts
@@ -25,7 +25,7 @@ async function getLatestSnapshotDatesCached(
     .select("account_id, created_at")
     .eq("user_id", userId)
     .order("created_at", { ascending: false })
-    .limit(50);
+    .limit(200);
 
   if (error) throw error;
   if (!data) return {};

--- a/webapp/src/actions/statement-snapshots.ts
+++ b/webapp/src/actions/statement-snapshots.ts
@@ -24,7 +24,8 @@ async function getLatestSnapshotDatesCached(
     .from("statement_snapshots")
     .select("account_id, created_at")
     .eq("user_id", userId)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .limit(50);
 
   if (error) throw error;
   if (!data) return {};

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -579,7 +579,11 @@ export type RecentTransaction = {
   clean_description: string | null;
   transaction_date: string;
   currency_code: string;
-  categories: { name_es: string | null; name: string } | null;
+  categories: { name_es: string | null; name: string; icon: string | null } | null;
+  accounts: { name: string; color: string | null } | null;
+  transaction_tags: Array<{
+    tag: { id: string; name: string; color: string | null; group: { color: string | null } | null };
+  }>;
 };
 
 async function getRecentTransactionsCached(
@@ -597,7 +601,13 @@ async function getRecentTransactionsCached(
 
   const { data } = await supabase
     .from("transactions")
-    .select("id, amount, direction, account_id, merchant_name, clean_description, transaction_date, currency_code, categories!category_id(name_es, name)")
+    .select(`
+      id, amount, direction, account_id, merchant_name, clean_description,
+      transaction_date, currency_code,
+      categories!category_id(name_es, name, icon),
+      accounts!account_id(name, color),
+      transaction_tags(tag:tags(id, name, color, group:tag_groups(color)))
+    `)
     .eq("user_id", userId)
     .in("account_id", demoAccountIds)
     .eq("is_excluded", false)

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -579,7 +579,7 @@ export type RecentTransaction = {
   clean_description: string | null;
   transaction_date: string;
   currency_code: string;
-  categories: { name_es: string | null; name: string; icon: string | null } | null;
+  categories: { name_es: string | null; name: string; icon: string } | null;
   accounts: { name: string; color: string | null } | null;
   transaction_tags: Array<{
     tag: { id: string; name: string; color: string | null; group: { color: string | null } | null };
@@ -604,9 +604,9 @@ async function getRecentTransactionsCached(
     .select(`
       id, amount, direction, account_id, merchant_name, clean_description,
       transaction_date, currency_code,
-      categories!category_id(name_es, name, icon),
-      accounts!account_id(name, color),
-      transaction_tags(tag:tags(id, name, color, group:tag_groups(color)))
+      categories!transactions_category_id_fkey(name_es, name, icon),
+      accounts!transactions_account_id_fkey(name, color),
+      transaction_tags!transaction_tags_transaction_id_fkey(tag:tags(id, name, color, group:tag_groups(color)))
     `)
     .eq("user_id", userId)
     .in("account_id", demoAccountIds)

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -33,17 +33,20 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
 
   const starterMode = allAccounts.length > 0 && recentTx.length === 0;
 
+  // Single date reference for the entire render
+  const now = new Date();
+
   const daysSinceImport = (() => {
     const dates = Object.values(latestSnapshotDates);
     if (dates.length === 0) return 999;
     const latest = dates.reduce((a, b) => (a > b ? a : b));
-    return differenceInDays(new Date(), new Date(latest));
+    return differenceInDays(now, new Date(latest));
   })();
 
   // Map recent transactions to mobile format
   const mobileRecentTx = recentTx.map((tx) => ({
     id: tx.id,
-    description: tx.merchant_name || tx.clean_description || "Sin descripcion",
+    description: tx.merchant_name || tx.clean_description || "Sin descripción",
     amount: tx.amount,
     currency_code: tx.currency_code ?? "COP",
     direction: tx.direction,
@@ -59,8 +62,6 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
     })),
   }));
 
-  // Derived date values
-  const now = new Date();
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
   const daysRemaining = Math.max(daysInMonth - now.getDate(), 1);
 

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -3,11 +3,12 @@ import { getAttentionItems } from "@/actions/attention-items";
 import { getBurnRate } from "@/actions/burn-rate";
 import { getBudgetSummary } from "@/actions/budgets";
 import { getAccounts } from "@/actions/accounts";
+import { getLatestSnapshotDates } from "@/actions/statement-snapshots";
 import type { RecentTransaction } from "@/actions/transactions";
 import { InicioRoot } from "@/components/mobile/v2/inicio/inicio-root";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { toISODateString } from "@/lib/utils/date";
-import { subDays } from "date-fns";
+import { subDays, differenceInDays } from "date-fns";
 import type { CurrencyCode } from "@/types/domain";
 
 interface MobileZoneProps {
@@ -17,7 +18,7 @@ interface MobileZoneProps {
 }
 
 export async function MobileZone({ month, currency, recentTx }: MobileZoneProps) {
-  const [heroData, attentionItemsData, burnRateData, budgetSummary, accountsResult, dailySpending] =
+  const [heroData, attentionItemsData, burnRateData, budgetSummary, accountsResult, dailySpending, latestSnapshotDates] =
     await Promise.all([
       getDashboardHeroData(month, currency),
       getAttentionItems(),
@@ -25,17 +26,37 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
       getBudgetSummary(month),
       getAccounts(),
       getDailySpending(month, currency),
+      getLatestSnapshotDates(),
     ]);
 
   const allAccounts = accountsResult.success ? accountsResult.data : [];
 
+  const starterMode = allAccounts.length > 0 && recentTx.length === 0;
+
+  const daysSinceImport = (() => {
+    const dates = Object.values(latestSnapshotDates);
+    if (dates.length === 0) return 999;
+    const latest = dates.reduce((a, b) => (a > b ? a : b));
+    return differenceInDays(new Date(), new Date(latest));
+  })();
+
   // Map recent transactions to mobile format
   const mobileRecentTx = recentTx.map((tx) => ({
     id: tx.id,
-    description: tx.merchant_name || tx.clean_description || "Sin descripción",
+    description: tx.merchant_name || tx.clean_description || "Sin descripcion",
     amount: tx.amount,
     currency_code: tx.currency_code ?? "COP",
     direction: tx.direction,
+    account_name: tx.accounts?.name ?? "",
+    account_color: tx.accounts?.color ?? null,
+    category_name: tx.categories?.name_es ?? tx.categories?.name ?? null,
+    category_icon: tx.categories?.icon ?? null,
+    tags: (tx.transaction_tags ?? []).map((tt) => ({
+      id: tt.tag.id,
+      name: tt.tag.name,
+      color: tt.tag.color,
+      group_color: tt.tag.group?.color ?? null,
+    })),
   }));
 
   // Derived date values
@@ -103,6 +124,8 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
         attentionItems={attentionItemsData}
         burnRateData={burnRateData}
         totalBudget={budgetSummary.totalTarget}
+        starterMode={starterMode}
+        daysSinceImport={daysSinceImport}
         recentTransactions={mobileRecentTx}
         currency={currency}
       />

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -47,7 +47,7 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
     amount: tx.amount,
     currency_code: tx.currency_code ?? "COP",
     direction: tx.direction,
-    account_name: tx.accounts?.name ?? "",
+    account_name: tx.accounts?.name ?? "Sin cuenta",
     account_color: tx.accounts?.color ?? null,
     category_name: tx.categories?.name_es ?? tx.categories?.name ?? null,
     category_icon: tx.categories?.icon ?? null,

--- a/webapp/src/components/marketing/landing-budget.tsx
+++ b/webapp/src/components/marketing/landing-budget.tsx
@@ -20,7 +20,7 @@ export function LandingBudget() {
   const overallPct = Math.round((totalSpent / totalBudget) * 100);
 
   return (
-    <section className="py-24 px-4">
+    <section className="py-16 sm:py-24 px-4">
       <div className="mx-auto max-w-3xl">
         <div className="mb-12 text-center">
           <Badge variant="outline" className="mb-4 border-white/12 text-z-brass">

--- a/webapp/src/components/marketing/landing-cta.tsx
+++ b/webapp/src/components/marketing/landing-cta.tsx
@@ -33,7 +33,7 @@ const BLURBS = [
 
 export function LandingCTA() {
   return (
-    <section className="py-24">
+    <section className="py-16 sm:py-24">
       <Card className="overflow-hidden border-white/8 bg-gradient-to-br from-white/[0.06] via-background to-z-income/[0.04] shadow-2xl shadow-black/10">
         <CardContent className="p-8 sm:p-12">
           <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr]">

--- a/webapp/src/components/marketing/landing-data.ts
+++ b/webapp/src/components/marketing/landing-data.ts
@@ -6,10 +6,6 @@ import {
   Scale,
   Repeat2,
   Send,
-  TrendingUp,
-  Landmark,
-  PiggyBank,
-  BadgeDollarSign,
 } from "lucide-react";
 
 // ─── Hero mock data ───────────────────────────────────────────────────────────
@@ -113,91 +109,6 @@ export const LANDING_SHOWCASE_PANELS: ShowcasePanel[] = [
     description: "Anota un gasto en segundos, sin abrir formularios. El sistema lo categoriza y lo conecta con tu plan.",
     icon: Send,
     gradient: "from-sky-400/20 via-sky-400/8 to-transparent",
-  },
-];
-
-// ─── Features ─────────────────────────────────────────────────────────────────
-
-export type Feature = {
-  title: string;
-  description: string;
-  icon: LucideIcon;
-  bullets: [string, string, string];
-  accentClassName: string;
-};
-
-export const LANDING_FEATURES: Feature[] = [
-  {
-    title: "Dashboard que responde qué hacer hoy",
-    description:
-      "Zeta te muestra si vas bien, dónde se va la presión y qué vale la pena ajustar primero.",
-    icon: TrendingUp,
-    bullets: [
-      "Resumen diario con foco en margen, gasto y próximas decisiones",
-      "Señales visuales para saber si vas en control o corrigiendo",
-      "Panel pensado para entender rápido, no para explorar de más",
-    ],
-    accentClassName: "from-z-income/20 via-z-income/8 to-transparent",
-  },
-  {
-    title: "Importación de extractos PDF",
-    description:
-      "Subes tus extractos y Zeta organiza movimientos, detecta cuentas y ayuda a conciliar duplicados.",
-    icon: Landmark,
-    bullets: [
-      "Compatible con bancos y billeteras usados en Colombia",
-      "Preparado para revisar importaciones sin perder trazabilidad",
-      "Convierte una tarea administrativa en un flujo guiado",
-    ],
-    accentClassName: "from-z-alert/20 via-z-alert/8 to-transparent",
-  },
-  {
-    title: "Presupuesto 50/30/20 con contexto real",
-    description:
-      "No solo registra gastos: te muestra cuánto margen te queda y qué categoría está rompiendo el plan.",
-    icon: PiggyBank,
-    bullets: [
-      "Vista por categorías y señales de sobreconsumo",
-      "Asignación simple para gasto fijo, variable y ahorro",
-      "Más útil que un presupuesto plano porque conecta con el resto del sistema",
-    ],
-    accentClassName: "from-primary/24 via-primary/10 to-transparent",
-  },
-  {
-    title: "Deudas con estrategia, no solo saldo",
-    description:
-      "Modela pagos y entiende qué decisión libera presión antes. Ideal para tarjetas, cuotas y metas de salida.",
-    icon: Scale,
-    bullets: [
-      "Visión del costo real de la deuda",
-      "Planificador para priorizar pagos con intención",
-      "Contexto para evitar que el pago mínimo dicte todo el mes",
-    ],
-    accentClassName: "from-z-debt/20 via-z-debt/8 to-transparent",
-  },
-  {
-    title: "Cuentas y balances multi-moneda",
-    description:
-      "Si manejas COP, USD u otras monedas, puedes ver saldos y movimientos sin forzar una sola realidad.",
-    icon: BadgeDollarSign,
-    bullets: [
-      "Cuentas separadas por moneda cuando hace falta",
-      "Mejor lectura de efectivo real y compromisos",
-      "Útil para freelancers, viajes o ingresos mixtos",
-    ],
-    accentClassName: "from-sky-400/20 via-sky-400/8 to-transparent",
-  },
-  {
-    title: "Recurrentes, destinatarios y orden operativo",
-    description:
-      "Pagos por venir, reglas de destinatarios y bandejas para que lo repetitivo no te robe energía mental.",
-    icon: Repeat2,
-    bullets: [
-      "Pagos próximos visibles antes de que se vuelvan problema",
-      "Reglas para reconocer mejor movimientos frecuentes",
-      "Flujos de gestión pensados para mantener el sistema limpio",
-    ],
-    accentClassName: "from-violet-300/20 via-violet-300/8 to-transparent",
   },
 ];
 

--- a/webapp/src/components/marketing/landing-features.tsx
+++ b/webapp/src/components/marketing/landing-features.tsx
@@ -1,4 +1,3 @@
-import { CheckCircle2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -8,11 +7,9 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
-  LANDING_FEATURES,
   LANDING_WORKFLOW,
   LANDING_FAQS,
   LANDING_INSTITUTIONS,
-  type Feature,
 } from "./landing-data";
 
 // ─── Shared helper ────────────────────────────────────────────────────────────
@@ -43,64 +40,6 @@ function SectionHeading({
         </p>
       </div>
     </div>
-  );
-}
-
-// ─── Feature card ─────────────────────────────────────────────────────────────
-
-function FeatureCard({
-  title,
-  description,
-  icon: Icon,
-  bullets,
-  accentClassName,
-}: Feature) {
-  return (
-    <Card className="relative overflow-hidden border-white/8 bg-white/[0.03] py-0 shadow-2xl shadow-black/10">
-      <div
-        className={`pointer-events-none absolute inset-x-0 top-0 h-28 bg-gradient-to-b ${accentClassName}`}
-      />
-      <CardHeader className="relative gap-4 px-6 pt-6">
-        <div className="flex size-12 items-center justify-center rounded-2xl border border-white/10 bg-black/20">
-          <Icon className="size-5 text-z-sage-light" />
-        </div>
-        <div className="space-y-2">
-          <CardTitle className="text-xl">{title}</CardTitle>
-          <CardDescription className="text-sm leading-6 text-muted-foreground">
-            {description}
-          </CardDescription>
-        </div>
-      </CardHeader>
-      <CardContent className="px-6 pb-6">
-        <ul className="space-y-3 text-sm leading-6 text-z-white/86">
-          {bullets.map((bullet) => (
-            <li key={bullet} className="flex items-start gap-3">
-              <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-z-income" />
-              <span>{bullet}</span>
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-  );
-}
-
-// ─── LandingFeatures ─────────────────────────────────────────────────────────
-
-export function LandingFeatures() {
-  return (
-    <section id="funciones" className="space-y-12 py-24">
-      <SectionHeading
-        eyebrow="Lo que hace"
-        title="Herramientas diseñadas para decisiones, no para contabilidad"
-        description="Cada módulo de Zeta está pensado para responderte una pregunta concreta sobre tu dinero, no para darte más datos que procesar."
-      />
-      <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
-        {LANDING_FEATURES.map((feature) => (
-          <FeatureCard key={feature.title} {...feature} />
-        ))}
-      </div>
-    </section>
   );
 }
 

--- a/webapp/src/components/marketing/landing-features.tsx
+++ b/webapp/src/components/marketing/landing-features.tsx
@@ -151,7 +151,7 @@ export function LandingAudience() {
 
 export function LandingHowItWorks() {
   return (
-    <section id="como-funciona" className="space-y-12 py-24">
+    <section id="como-funciona" className="space-y-12 py-16 sm:py-24">
       <SectionHeading
         eyebrow="Proceso"
         title="Tres pasos para tener claridad financiera"
@@ -187,7 +187,7 @@ export function LandingHowItWorks() {
 
 export function LandingFAQ() {
   return (
-    <section id="faq" className="space-y-12 py-24">
+    <section id="faq" className="space-y-12 py-16 sm:py-24">
       <SectionHeading
         eyebrow="Preguntas frecuentes"
         title="Lo que más nos preguntan"

--- a/webapp/src/components/marketing/landing-hero.tsx
+++ b/webapp/src/components/marketing/landing-hero.tsx
@@ -114,11 +114,56 @@ function HeroCard() {
   );
 }
 
+// ─── MobileHeroStrip ─────────────────────────────────────────────────────────
+
+function MobileHeroStrip() {
+  const { availableToSpend, spentToday, dailyAllowance } = LANDING_HERO_DATA;
+  const spentPct = Math.round((spentToday / dailyAllowance) * 100);
+
+  return (
+    <div className="relative">
+      <div className="absolute -inset-4 rounded-2xl bg-gradient-to-b from-primary/14 via-transparent to-z-income/8 blur-2xl" />
+      <Card className="relative overflow-hidden rounded-xl border-white/10 bg-[#111111]/90 shadow-2xl shadow-black/35">
+        {/* Available to spend */}
+        <div className="px-5 pt-5 pb-4">
+          <p className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+            Disponible para gastar
+          </p>
+          <p className="mt-1 text-2xl font-semibold tracking-tight">
+            {formatCurrency(availableToSpend, "COP")}
+          </p>
+        </div>
+
+        {/* Daily spending row */}
+        <div className="mx-5 mb-5 rounded-xl border border-white/8 bg-white/[0.03] p-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Gasto hoy</span>
+            <span>
+              <span className="font-medium">
+                {formatCurrency(spentToday, "COP")}
+              </span>
+              <span className="ml-1 text-xs text-muted-foreground">
+                / {formatCurrency(dailyAllowance, "COP")}
+              </span>
+            </span>
+          </div>
+          <div className="mt-2 h-1.5 rounded-full bg-white/8">
+            <div
+              className="h-1.5 rounded-full bg-primary"
+              style={{ width: `${Math.min(spentPct, 100)}%` }}
+            />
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
 // ─── LandingHero ─────────────────────────────────────────────────────────────
 
 export function LandingHero() {
   return (
-    <section className="mx-auto max-w-7xl px-6 pb-20 pt-16 sm:pt-24">
+    <section className="mx-auto max-w-7xl px-6 pb-12 pt-12 sm:pb-20 sm:pt-24">
       <div className="grid gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(24rem,0.9fr)] lg:items-center">
         {/* Left column — copy */}
         <div className="space-y-8">
@@ -129,13 +174,11 @@ export function LandingHero() {
 
           <div className="space-y-6">
             <h1 className="max-w-4xl text-3xl font-semibold tracking-tight text-balance sm:text-5xl lg:text-7xl">
-              Tu dinero deja de sentirse confuso y empieza a contar una historia
-              clara.
+              Claridad diaria sobre tu dinero.
             </h1>
             <p className="max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-              Zeta reúne extractos, presupuesto, deudas, cuentas y pagos
-              recurrentes para darte una vista accionable de tus finanzas
-              personales en Colombia.
+              Extractos, presupuesto, deudas y pagos recurrentes en una sola
+              vista. Sin conectar tu banco. Hecho para Colombia.
             </p>
           </div>
 
@@ -160,7 +203,7 @@ export function LandingHero() {
             </Button>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-3">
             {highlights.map((highlight) => (
               <div
                 key={highlight.label}
@@ -178,8 +221,13 @@ export function LandingHero() {
           </div>
         </div>
 
-        {/* Right column — dashboard card */}
-        <HeroCard />
+        {/* Right column — dashboard card (desktop) / strip (mobile) */}
+        <div className="hidden lg:block">
+          <HeroCard />
+        </div>
+        <div className="lg:hidden">
+          <MobileHeroStrip />
+        </div>
       </div>
     </section>
   );

--- a/webapp/src/components/marketing/landing-hero.tsx
+++ b/webapp/src/components/marketing/landing-hero.tsx
@@ -123,10 +123,10 @@ function MobileHeroStrip() {
   return (
     <div className="relative">
       <div className="absolute -inset-4 rounded-2xl bg-gradient-to-b from-primary/14 via-transparent to-z-income/8 blur-2xl" />
-      <Card className="relative overflow-hidden rounded-xl border-white/10 bg-[#111111]/90 shadow-2xl shadow-black/35">
+      <Card className="relative overflow-hidden rounded-xl border-white/6 bg-z-ink/90 shadow-2xl shadow-black/35">
         {/* Available to spend */}
         <div className="px-5 pt-5 pb-4">
-          <p className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
             Disponible para gastar
           </p>
           <p className="mt-1 text-2xl font-semibold tracking-tight">
@@ -135,7 +135,7 @@ function MobileHeroStrip() {
         </div>
 
         {/* Daily spending row */}
-        <div className="mx-5 mb-5 rounded-xl border border-white/8 bg-white/[0.03] p-3">
+        <div className="mx-5 mb-5 rounded-xl border border-white/6 bg-white/[0.03] p-3">
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Gasto hoy</span>
             <span>

--- a/webapp/src/components/marketing/landing-page.tsx
+++ b/webapp/src/components/marketing/landing-page.tsx
@@ -6,7 +6,6 @@ import { LandingBudget } from "./landing-budget";
 import { LandingPlan } from "./landing-plan";
 import { LandingShowcase } from "./landing-showcase";
 import {
-  LandingFeatures,
   LandingAudience,
   LandingHowItWorks,
   LandingFAQ,
@@ -24,12 +23,11 @@ export function MarketingLandingPage() {
 
       <main className="relative">
         <LandingHero />
+        <LandingHowItWorks />
         <LandingBudget />
         <LandingPlan />
         <LandingShowcase />
-        <LandingFeatures />
         <LandingAudience />
-        <LandingHowItWorks />
         <LandingCTA />
         <LandingFAQ />
       </main>

--- a/webapp/src/components/marketing/landing-plan.tsx
+++ b/webapp/src/components/marketing/landing-plan.tsx
@@ -17,7 +17,7 @@ export function LandingPlan() {
   const availablePct = Math.round((available / income) * 100);
 
   return (
-    <section className="mx-auto max-w-6xl px-4 py-24 sm:px-6 lg:px-8">
+    <section className="mx-auto max-w-6xl px-4 py-16 sm:py-24 sm:px-6 lg:px-8">
       {/* Heading */}
       <div className="mb-12 text-center">
         <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-z-sage-light">

--- a/webapp/src/components/marketing/landing-showcase.tsx
+++ b/webapp/src/components/marketing/landing-showcase.tsx
@@ -99,8 +99,8 @@ function MobileCarousel({ panels }: { panels: ShowcasePanel[] }) {
           overflowX: "auto",
           scrollSnapType: "x mandatory",
           scrollbarWidth: "none",
-          paddingLeft: "calc(50% - 140px)",
-          paddingRight: "calc(50% - 140px)",
+          paddingLeft: "max(16px, calc(50% - 140px))",
+          paddingRight: "max(16px, calc(50% - 140px))",
         }}
       >
         {panels.map((panel) => {
@@ -109,7 +109,7 @@ function MobileCarousel({ panels }: { panels: ShowcasePanel[] }) {
             <div
               key={panel.id}
               className="snap-center shrink-0"
-              style={{ width: CARD_WIDTH }}
+              style={{ width: "min(280px, calc(100vw - 48px))" }}
             >
               <PhoneFrame>
                 <div className="flex flex-col">
@@ -164,20 +164,22 @@ function MobileCarousel({ panels }: { panels: ShowcasePanel[] }) {
 
 export function LandingShowcase() {
   return (
-    <section id="showcase" className="py-24 px-4">
+    <section id="showcase" className="py-16 sm:py-24 px-4">
       <div className="mx-auto max-w-5xl">
         {/* Heading */}
         <div className="mb-12 flex flex-col items-center gap-4 text-center">
-          <Badge variant="outline" className="border-white/12 text-white/60">
-            Showcase
+          <Badge
+            variant="outline"
+            className="border-white/10 bg-white/4 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-z-sage-light"
+          >
+            Todo lo que hace
           </Badge>
-          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-            Todo lo que necesitas, en un solo lugar
+          <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+            Herramientas que responden preguntas, no crean trabajo
           </h2>
-          <p className="max-w-2xl text-base text-white/50">
-            Desde la importación de extractos hasta la planificación de deudas
-            — cada función está conectada para darte claridad en el momento
-            correcto.
+          <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+            Cada modulo esta pensado para responderte algo concreto sobre tu
+            dinero.
           </p>
         </div>
 

--- a/webapp/src/components/marketing/landing-showcase.tsx
+++ b/webapp/src/components/marketing/landing-showcase.tsx
@@ -170,7 +170,7 @@ export function LandingShowcase() {
         <div className="mb-12 flex flex-col items-center gap-4 text-center">
           <Badge
             variant="outline"
-            className="border-white/10 bg-white/4 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-z-sage-light"
+            className="border-white/10 bg-white/4 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-z-sage-light"
           >
             Todo lo que hace
           </Badge>

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -30,11 +30,9 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import type { ActionResult } from "@/types/actions";
 import type {
   Account,
   CategoryWithChildren,
-  Transaction,
   TransactionDirection,
 } from "@/types/domain";
 
@@ -95,7 +93,7 @@ export function MobileTransactionForm({
   const [state, formAction, pending] = useActionState(createTransaction, {
     success: false,
     error: "",
-  } as ActionResult<Transaction>);
+  });
 
   // Close form after action transition commits (route already revalidated)
   useEffect(() => {

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect, useActionState } from "react";
-import { useRouter } from "next/navigation";
+
 import {
   Loader2,
   ArrowUpRight,
@@ -77,7 +77,6 @@ export function MobileTransactionForm({
   isTransfer,
   onSuccess,
 }: MobileTransactionFormProps) {
-  const router = useRouter();
   // Determine initial transaction type from props (backward compat)
   const initialType: TransactionType = isTransfer
     ? "transfer"
@@ -93,20 +92,17 @@ export function MobileTransactionForm({
 
   const direction = defaultDirection ?? directionFromType(transactionType);
 
-  const [state, formAction, pending] = useActionState<
-    ActionResult<Transaction>,
-    FormData
-  >(
-    async (prevState, formData) => {
-      const result = await createTransaction(prevState, formData);
-      if (result.success) {
-        router.refresh();
-        onSuccess?.();
-      }
-      return result;
-    },
-    { success: false, error: "" },
-  );
+  const [state, formAction, pending] = useActionState(createTransaction, {
+    success: false,
+    error: "",
+  } as ActionResult<Transaction>);
+
+  // Close form after action transition commits (route already revalidated)
+  useEffect(() => {
+    if (state.success) {
+      onSuccess?.();
+    }
+  }, [state.success]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const STORAGE_KEY = "zeta:quick-capture-account";
   const [selectedAccountId, setSelectedAccountId] = useState<string>(() => {

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowDownLeft, ArrowUpRight, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import { CategoryIcon } from "@/components/categories/category-icon";
 import { TagChip } from "@/components/tags/tag-chip";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -27,7 +28,7 @@ interface InicioActivityProps {
 export function InicioActivity({ transactions }: InicioActivityProps) {
   if (transactions.length === 0) return null;
 
-  const visible = transactions.slice(0, 5);
+  const visible = transactions.slice(0, 3);
 
   return (
     <div>
@@ -69,10 +70,10 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                 <span className="truncate">{tx.account_name}</span>
                 <span className="text-white/15">·</span>
                 {tx.category_icon ? (
-                  <>
-                    <span>{tx.category_icon}</span>
-                    <span className="truncate">{tx.category_name}</span>
-                  </>
+                  <span className="inline-flex items-center gap-0.5 truncate">
+                    <CategoryIcon icon={tx.category_icon} className="size-3 shrink-0" />
+                    {tx.category_name}
+                  </span>
                 ) : (
                   <span className="text-z-brass">Sin cat.</span>
                 )}

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -1,27 +1,30 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
+import { ArrowDownLeft, ArrowUpRight, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { TagChip } from "@/components/tags/tag-chip";
 import type { CurrencyCode } from "@/types/domain";
 
-interface Transaction {
+interface RecentTransactionMobile {
   id: string;
   description: string;
   amount: number;
   currency_code: string;
   direction: "INFLOW" | "OUTFLOW";
+  account_name: string;
+  account_color: string | null;
+  category_name: string | null;
+  category_icon: string | null;
+  tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
 }
 
 interface InicioActivityProps {
-  transactions: Transaction[];
+  transactions: RecentTransactionMobile[];
 }
 
 export function InicioActivity({ transactions }: InicioActivityProps) {
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-
   if (transactions.length === 0) return null;
 
   const visible = transactions.slice(0, 3);
@@ -32,59 +35,83 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
         Reciente
       </p>
 
-      <div>
-        {visible.map((tx) => {
-          const isOpen = expandedId === tx.id;
-          return (
-            <div key={tx.id}>
-              <button
-                type="button"
-                onClick={() => setExpandedId(isOpen ? null : tx.id)}
-                className={cn(
-                  "flex w-full items-center justify-between py-2 text-left transition-colors active:bg-white/[0.03]",
-                  "[&+div]:border-t [&+div]:border-white/6",
-                  isOpen && "border-l-2 border-l-z-brass pl-2"
-                )}
-              >
-                <span className="min-w-0 truncate text-[13px] text-foreground">
-                  {tx.description}
-                </span>
-                <span
-                  className={cn(
-                    "shrink-0 pl-3 text-[13px] font-medium tabular-nums",
-                    tx.direction === "INFLOW" ? "text-z-income" : "text-foreground"
-                  )}
-                >
-                  {tx.direction === "INFLOW" ? "+" : "-"}
-                  {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
-                </span>
-              </button>
-
-              {/* Inline quick view */}
-              <div
-                className="grid transition-[grid-template-rows] duration-200 ease-out"
-                style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
-              >
-                <div className="overflow-hidden">
-                  <div className={cn("py-1.5 transition-opacity duration-150", isOpen ? "opacity-100" : "opacity-0")}>
-                    <div className={cn(PANEL_INSET_CLASS, "border-z-brass/15 bg-black/20 p-2.5 flex items-center justify-between")}>
-                      <span className="text-[11px] text-muted-foreground">
-                        {tx.direction === "INFLOW" ? "Ingreso" : "Gasto"} · {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
-                      </span>
-                      <Link
-                        href={`/transactions/${tx.id}`}
-                        className="text-[11px] font-semibold text-z-brass"
-                      >
-                        Ver detalle →
-                      </Link>
-                    </div>
-                  </div>
-                </div>
-              </div>
+      <div className="space-y-0.5">
+        {visible.map((tx) => (
+          <Link
+            key={tx.id}
+            href={`/transactions/${tx.id}`}
+            className="flex gap-2 rounded-xl px-1 py-2 transition-colors active:bg-white/[0.03]"
+          >
+            {/* Direction icon */}
+            <div
+              className={cn(
+                "mt-0.5 flex size-[22px] shrink-0 items-center justify-center rounded-md",
+                tx.direction === "INFLOW"
+                  ? "bg-green-500/12 text-z-income"
+                  : "bg-orange-500/12 text-z-expense"
+              )}
+            >
+              {tx.direction === "INFLOW" ? (
+                <ArrowDownLeft className="size-3" />
+              ) : (
+                <ArrowUpRight className="size-3" />
+              )}
             </div>
-          );
-        })}
+
+            {/* Description + meta */}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs font-medium">{tx.description}</p>
+              <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
+                <span
+                  className="inline-block size-[5px] shrink-0 rounded-full"
+                  style={{ backgroundColor: tx.account_color ?? undefined }}
+                />
+                <span className="truncate">{tx.account_name}</span>
+                <span className="text-white/15">·</span>
+                {tx.category_icon ? (
+                  <>
+                    <span>{tx.category_icon}</span>
+                    <span className="truncate">{tx.category_name}</span>
+                  </>
+                ) : (
+                  <span className="text-z-brass">Sin cat.</span>
+                )}
+              </p>
+              {tx.tags.length > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {tx.tags.map((t) => (
+                    <TagChip
+                      key={t.id}
+                      tag={{ id: t.id, name: t.name, color: t.color } as any}
+                      groupColor={t.group_color}
+                      size="sm"
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Amount */}
+            <span
+              className={cn(
+                "shrink-0 text-xs font-medium tabular-nums",
+                tx.direction === "INFLOW" && "text-z-income"
+              )}
+            >
+              {tx.direction === "INFLOW" ? "+" : "-"}
+              {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+            </span>
+          </Link>
+        ))}
       </div>
+
+      <Link
+        href="/transactions"
+        className="mt-2 inline-flex items-center gap-1 text-[11px] font-semibold text-z-brass"
+      >
+        Ver todos
+        <ArrowRight className="size-3" />
+      </Link>
     </div>
   );
 }

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -31,7 +31,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
 
   return (
     <div>
-      <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+      <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.18em] text-z-sage-dark">
         Reciente
       </p>
 

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { ArrowDownLeft, ArrowUpRight, ArrowRight } from "lucide-react";
+import { ArrowDownLeft, ArrowUpRight, ArrowRight, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { CategoryIcon } from "@/components/categories/category-icon";
 import { TagChip } from "@/components/tags/tag-chip";
+import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 
 interface RecentTransactionMobile {
@@ -26,6 +28,8 @@ interface InicioActivityProps {
 }
 
 export function InicioActivity({ transactions }: InicioActivityProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
   if (transactions.length === 0) return null;
 
   const visible = transactions.slice(0, 3);
@@ -36,74 +40,105 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
         Reciente
       </p>
 
-      <div className="space-y-0.5">
-        {visible.map((tx) => (
-          <Link
-            key={tx.id}
-            href={`/transactions/${tx.id}`}
-            className="flex gap-2 rounded-xl px-1 py-2 transition-colors active:bg-white/[0.03]"
-          >
-            {/* Direction icon */}
-            <div
-              className={cn(
-                "mt-0.5 flex size-[22px] shrink-0 items-center justify-center rounded-md",
-                tx.direction === "INFLOW"
-                  ? "bg-green-500/12 text-z-income"
-                  : "bg-orange-500/12 text-z-expense"
-              )}
-            >
-              {tx.direction === "INFLOW" ? (
-                <ArrowDownLeft className="size-3" />
-              ) : (
-                <ArrowUpRight className="size-3" />
-              )}
-            </div>
-
-            {/* Description + meta */}
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-xs font-medium">{tx.description}</p>
-              <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
-                <span
-                  className="inline-block size-[5px] shrink-0 rounded-full"
-                  style={{ backgroundColor: tx.account_color ?? undefined }}
-                />
-                <span className="truncate">{tx.account_name}</span>
-                <span className="text-white/15">·</span>
-                {tx.category_icon ? (
-                  <span className="inline-flex items-center gap-0.5 truncate">
-                    <CategoryIcon icon={tx.category_icon} className="size-3 shrink-0" />
-                    {tx.category_name}
-                  </span>
-                ) : (
-                  <span className="text-z-brass">Sin cat.</span>
+      <div>
+        {visible.map((tx) => {
+          const isOpen = expandedId === tx.id;
+          return (
+            <div key={tx.id}>
+              <button
+                type="button"
+                onClick={() => setExpandedId(isOpen ? null : tx.id)}
+                className={cn(
+                  "flex w-full gap-2 px-1 py-2 text-left transition-colors active:bg-white/[0.03]",
+                  isOpen && "border-l-2 border-l-z-brass pl-2"
                 )}
-              </p>
-              {tx.tags.length > 0 && (
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {tx.tags.map((t) => (
-                    <TagChip
-                      key={t.id}
-                      tag={{ id: t.id, name: t.name, color: t.color } as any}
-                      groupColor={t.group_color}
-                      size="sm"
-                    />
-                  ))}
+              >
+                {/* Direction icon */}
+                <div
+                  className={cn(
+                    "mt-0.5 flex size-[22px] shrink-0 items-center justify-center rounded-md",
+                    tx.direction === "INFLOW"
+                      ? "bg-green-500/12 text-z-income"
+                      : "bg-orange-500/12 text-z-expense"
+                  )}
+                >
+                  {tx.direction === "INFLOW" ? (
+                    <ArrowDownLeft className="size-3" />
+                  ) : (
+                    <ArrowUpRight className="size-3" />
+                  )}
                 </div>
-              )}
-            </div>
 
-            {/* Amount */}
-            <span
-              className={cn(
-                "shrink-0 text-xs font-medium tabular-nums",
-                tx.direction === "INFLOW" && "text-z-income"
-              )}
-            >
-              {tx.direction === "INFLOW" ? "+" : "-"}
-              {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
-            </span>
-          </Link>
-        ))}
+                {/* Description + meta */}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium">{tx.description}</p>
+                  <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
+                    <span
+                      className="inline-block size-[5px] shrink-0 rounded-full"
+                      style={{ backgroundColor: tx.account_color ?? undefined }}
+                    />
+                    <span className="truncate">{tx.account_name}</span>
+                    <span className="text-white/15">&middot;</span>
+                    {tx.category_icon ? (
+                      <span className="inline-flex items-center gap-0.5 truncate">
+                        <CategoryIcon icon={tx.category_icon} className="size-3 shrink-0" />
+                        {tx.category_name}
+                      </span>
+                    ) : (
+                      <span className="text-z-brass">Sin cat.</span>
+                    )}
+                  </p>
+                  {tx.tags.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {tx.tags.map((t) => (
+                        <TagChip
+                          key={t.id}
+                          tag={{ id: t.id, name: t.name, color: t.color } as any}
+                          groupColor={t.group_color}
+                          size="sm"
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Amount */}
+                <span
+                  className={cn(
+                    "shrink-0 text-xs font-medium tabular-nums",
+                    tx.direction === "INFLOW" && "text-z-income"
+                  )}
+                >
+                  {tx.direction === "INFLOW" ? "+" : "-"}
+                  {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+                </span>
+              </button>
+
+              {/* Inline expand */}
+              <div
+                className="grid transition-[grid-template-rows] duration-200 ease-out"
+                style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
+              >
+                <div className="overflow-hidden">
+                  <div className={cn("py-1.5 transition-opacity duration-150", isOpen ? "opacity-100" : "opacity-0")}>
+                    <div className={cn(PANEL_INSET_CLASS, "border-z-brass/15 bg-black/20 p-2.5 flex items-center justify-between")}>
+                      <span className="text-[11px] text-muted-foreground">
+                        {tx.direction === "INFLOW" ? "Ingreso" : "Gasto"} &middot; {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+                      </span>
+                      <Link
+                        href={`/transactions/${tx.id}`}
+                        className="inline-flex items-center gap-1 text-[11px] font-semibold text-z-brass"
+                      >
+                        <Pencil className="size-2.5" />
+                        Ver detalle
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       <Link

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -93,7 +93,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                       {tx.tags.map((t) => (
                         <TagChip
                           key={t.id}
-                          tag={{ id: t.id, name: t.name, color: t.color } as any}
+                          tag={{ name: t.name, color: t.color }}
                           groupColor={t.group_color}
                           size="sm"
                         />

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -27,7 +27,7 @@ interface InicioActivityProps {
 export function InicioActivity({ transactions }: InicioActivityProps) {
   if (transactions.length === 0) return null;
 
-  const visible = transactions.slice(0, 3);
+  const visible = transactions.slice(0, 5);
 
   return (
     <div>

--- a/webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx
@@ -15,12 +15,12 @@ export function InicioImportStrip({ daysSinceImport }: InicioImportStripProps) {
   return (
     <div
       className={cn(
-        "flex items-center gap-3 rounded-[14px] border border-z-brass/20 p-3",
+        "flex items-center gap-3 rounded-xl border border-z-brass/20 p-3",
         "bg-[linear-gradient(135deg,rgba(var(--z-brass-rgb,183,165,122),0.06),transparent_50%)]"
       )}
     >
       {/* Icon box */}
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border border-z-brass/20 bg-z-brass/10">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-z-brass/20 bg-z-brass/10">
         <FileUp className="h-4 w-4 text-z-brass" />
       </div>
 

--- a/webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx
@@ -27,10 +27,10 @@ export function InicioImportStrip({ daysSinceImport }: InicioImportStripProps) {
       {/* Text */}
       <div className="min-w-0 flex-1">
         <p className="text-xs font-semibold text-foreground">
-          {daysSinceImport} dias sin importar
+          {daysSinceImport} días sin importar
         </p>
         <p className="mt-0.5 text-[10px] leading-snug text-muted-foreground">
-          Actualiza para que las metricas reflejen tu posicion real.
+          Actualiza para que las métricas reflejen tu posición real.
         </p>
       </div>
 

--- a/webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { FileUp } from "lucide-react";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+interface InicioImportStripProps {
+  daysSinceImport: number;
+}
+
+export function InicioImportStrip({ daysSinceImport }: InicioImportStripProps) {
+  if (daysSinceImport <= 15) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-[14px] border border-z-brass/20 p-3",
+        "bg-[linear-gradient(135deg,rgba(var(--z-brass-rgb,183,165,122),0.06),transparent_50%)]"
+      )}
+    >
+      {/* Icon box */}
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border border-z-brass/20 bg-z-brass/10">
+        <FileUp className="h-4 w-4 text-z-brass" />
+      </div>
+
+      {/* Text */}
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-semibold text-foreground">
+          {daysSinceImport} dias sin importar
+        </p>
+        <p className="mt-0.5 text-[10px] leading-snug text-muted-foreground">
+          Actualiza para que las metricas reflejen tu posicion real.
+        </p>
+      </div>
+
+      {/* CTA */}
+      <Link
+        href="/import"
+        className={cn(
+          BRASS_BUTTON_CLASS,
+          "shrink-0 rounded-lg px-3 py-1.5 text-[11px] font-semibold"
+        )}
+      >
+        Importar
+      </Link>
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
@@ -5,6 +5,8 @@ import { InicioMetricsGrid } from "./inicio-metrics-grid";
 import { InicioDiscovery } from "./inicio-discovery";
 import { InicioActivity } from "./inicio-activity";
 import { InicioAttention } from "./inicio-attention";
+import { InicioStarter } from "./inicio-starter";
+import { InicioImportStrip } from "./inicio-import-strip";
 import { useExpandableZone } from "@/components/mobile/v2/use-expandable-zone";
 import { useLiveDashboard } from "@/hooks/use-live-metrics";
 import type { LiveDashboardData } from "@/actions/live-dashboard";
@@ -44,12 +46,19 @@ export interface InicioRootProps {
   };
   burnRateData: BurnRateResponse | null;
   totalBudget: number;
+  starterMode: boolean;
+  daysSinceImport: number;
   recentTransactions: Array<{
     id: string;
     description: string;
     amount: number;
     currency_code: string;
     direction: "INFLOW" | "OUTFLOW";
+    account_name: string;
+    account_color: string | null;
+    category_name: string | null;
+    category_icon: string | null;
+    tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
   }>;
   currency: CurrencyCode;
 }
@@ -60,10 +69,20 @@ export function InicioRoot({
   attentionItems,
   burnRateData,
   totalBudget,
+  starterMode,
+  daysSinceImport,
   recentTransactions,
   currency,
 }: InicioRootProps) {
   const { activeZone, toggle } = useExpandableZone<string>();
+
+  if (starterMode) {
+    return (
+      <div className="space-y-2">
+        <InicioStarter />
+      </div>
+    );
+  }
 
   // Live refresh: one server call corrects hero + metrics + attention
   const live = useLiveDashboard(
@@ -96,6 +115,8 @@ export function InicioRoot({
         expanded={activeZone === "hero"}
         onToggle={() => toggle("hero")}
       />
+
+      <InicioImportStrip daysSinceImport={daysSinceImport} />
 
       <InicioMetricsGrid
         daysInMonth={metrics.daysInMonth}

--- a/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
@@ -76,15 +76,7 @@ export function InicioRoot({
 }: InicioRootProps) {
   const { activeZone, toggle } = useExpandableZone<string>();
 
-  if (starterMode) {
-    return (
-      <div className="space-y-2">
-        <InicioStarter />
-      </div>
-    );
-  }
-
-  // Live refresh: one server call corrects hero + metrics + attention
+  // Must be called before any conditional return (Rules of Hooks)
   const live = useLiveDashboard(
     {
       hero: {
@@ -102,6 +94,14 @@ export function InicioRoot({
     },
     currency,
   );
+
+  if (starterMode) {
+    return (
+      <div className="space-y-2">
+        <InicioStarter />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-2">

--- a/webapp/src/components/mobile/v2/inicio/inicio-starter.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-starter.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { FileUp, BarChart3, Tags, Bell } from "lucide-react";
+import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+const AFTER_IMPORT_ITEMS = [
+  { icon: BarChart3, label: "Metricas activas" },
+  { icon: Tags, label: "Auto-categorias" },
+  { icon: Bell, label: "Alertas activas" },
+] as const;
+
+export function InicioStarter() {
+  return (
+    <div className="space-y-4">
+      {/* Welcome text */}
+      <div className="px-1">
+        <p className="text-[15px] font-semibold text-foreground">
+          Tu base esta lista
+        </p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          Falta activar tu flujo con datos reales.
+        </p>
+      </div>
+
+      {/* Import CTA card */}
+      <div
+        className={cn(
+          "rounded-2xl border border-z-brass/20 p-4",
+          "bg-[linear-gradient(135deg,rgba(var(--z-brass-rgb,183,165,122),0.06),transparent_50%)]"
+        )}
+      >
+        <div className="flex items-start gap-3">
+          {/* Icon box */}
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-z-brass/20 bg-z-brass/10">
+            <FileUp className="h-5 w-5 text-z-brass" />
+          </div>
+
+          {/* Text + actions */}
+          <div className="min-w-0 flex-1 space-y-3">
+            <div>
+              <p className="text-[15px] font-semibold text-foreground">
+                Importa tu primer extracto
+              </p>
+              <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                Al importar un extracto PDF, Zeta activa tus metricas, categoriza
+                automaticamente y detecta patrones de gasto.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Link
+                href="/import"
+                className={cn(
+                  BRASS_BUTTON_CLASS,
+                  "inline-flex items-center rounded-lg px-4 py-2 text-[13px] font-semibold"
+                )}
+              >
+                Importar extracto
+              </Link>
+              <Link
+                href="/transactions"
+                className="text-[11px] font-medium text-z-sage-light hover:text-foreground"
+              >
+                registrar manual
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* After import benefits */}
+      <div>
+        <p className="mb-2 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+          Despues de importar
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {AFTER_IMPORT_ITEMS.map(({ icon: Icon, label }) => (
+            <div
+              key={label}
+              className={cn(PANEL_INSET_CLASS, "flex flex-col items-center gap-1.5 p-3")}
+            >
+              <Icon className="h-4 w-4 text-z-brass" />
+              <span className="text-center text-[10px] font-medium text-z-sage-light">
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/inicio/inicio-starter.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-starter.tsx
@@ -6,8 +6,8 @@ import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 
 const AFTER_IMPORT_ITEMS = [
-  { icon: BarChart3, label: "Metricas activas" },
-  { icon: Tags, label: "Auto-categorias" },
+  { icon: BarChart3, label: "Métricas activas" },
+  { icon: Tags, label: "Auto-categorías" },
   { icon: Bell, label: "Alertas activas" },
 ] as const;
 
@@ -17,7 +17,7 @@ export function InicioStarter() {
       {/* Welcome text */}
       <div className="px-1">
         <p className="text-[15px] font-semibold text-foreground">
-          Tu base esta lista
+          Tu base está lista
         </p>
         <p className="mt-0.5 text-[11px] text-muted-foreground">
           Falta activar tu flujo con datos reales.
@@ -44,8 +44,8 @@ export function InicioStarter() {
                 Importa tu primer extracto
               </p>
               <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-                Al importar un extracto PDF, Zeta activa tus metricas, categoriza
-                automaticamente y detecta patrones de gasto.
+                Al importar un extracto PDF, Zeta activa tus métricas, categoriza
+                automáticamente y detecta patrones de gasto.
               </p>
             </div>
 
@@ -73,7 +73,7 @@ export function InicioStarter() {
       {/* After import benefits */}
       <div>
         <p className="mb-2 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
-          Despues de importar
+          Después de importar
         </p>
         <div className="grid grid-cols-3 gap-2">
           {AFTER_IMPORT_ITEMS.map(({ icon: Icon, label }) => (

--- a/webapp/src/components/mobile/v2/inicio/inicio-starter.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-starter.tsx
@@ -72,7 +72,7 @@ export function InicioStarter() {
 
       {/* After import benefits */}
       <div>
-        <p className="mb-2 text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+        <p className="mb-2 text-[9px] font-bold uppercase tracking-[0.18em] text-z-sage-dark">
           Después de importar
         </p>
         <div className="grid grid-cols-3 gap-2">

--- a/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
+++ b/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
@@ -89,15 +89,19 @@ export function MobileTabBar({ accounts, categories }: MobileTabBarProps) {
       )}
 
       {keyboardOpen && !formOpen && (
-        <button
-          type="button"
-          onClick={() => setFormOpen(true)}
-          className="fixed left-1/2 z-[9999] flex size-11 -translate-x-1/2 items-center justify-center rounded-full bg-z-brass text-z-ink shadow-[0_0_16px_rgba(184,148,79,0.4)] lg:hidden"
-          style={{ bottom: `${keyboardInset + 12}px` }}
-          aria-label="Registrar movimiento"
+        <div
+          className="fixed bottom-0 left-0 right-0 z-[9999] flex items-center justify-center py-2 lg:hidden"
+          style={SAFE_AREA_BOTTOM_STYLE}
         >
-          <Plus className="size-4 stroke-[2.5]" />
-        </button>
+          <button
+            type="button"
+            onClick={() => setFormOpen(true)}
+            className="flex size-11 items-center justify-center rounded-full bg-z-brass text-z-ink shadow-[0_0_16px_rgba(184,148,79,0.4)]"
+            aria-label="Registrar movimiento"
+          >
+            <Plus className="size-4 stroke-[2.5]" />
+          </button>
+        </div>
       )}
 
       {formOpen && (

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ArrowUpRight, ArrowDownLeft, ArrowRight, QrCode, CreditCard, Banknote, Building, Wallet, ArrowUpRight as TransferIcon, Mail, Hash, UserRound, Pencil } from "lucide-react";
+import { ArrowUpRight, ArrowDownLeft, ArrowRight, QrCode, CreditCard, Banknote, Building, Wallet, ArrowUpRight as TransferIcon, Mail, Hash, UserRound, Pencil, FileUp } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -14,7 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import { MobileZone } from "@/components/mobile/v2/mobile-zone";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
-import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { PANEL_INSET_CLASS, BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { categorizeTransaction, uncategorizeTransaction } from "@/actions/categorize";
@@ -125,21 +125,19 @@ export function MovimientosHerramientas({
           type="button"
           onClick={() => toggle("importar")}
           className={cn(
-            "rounded-[14px] p-2.5 text-center transition-colors",
-            isActive("importar")
-              ? cn("border", accentStyles.importar.chip)
-              : cn(PANEL_INSET_CLASS)
+            "rounded-[14px] border p-2.5 text-center transition-colors",
+            accentStyles.importar.chip
           )}
           aria-expanded={isActive("importar")}
         >
-          <p className="text-[22px] font-[680] leading-tight">
+          <p className="text-[22px] font-[680] leading-tight text-z-sage">
             {pendingEmailCount}
           </p>
           <p className="mt-0.5 text-[10px] font-semibold text-muted-foreground">
             Importar
           </p>
-          <p className="mt-1 text-[9px] text-muted-foreground">
-            {pendingEmailCount > 0 ? "emails pendientes" : "sin pendientes"}
+          <p className="mt-1 text-[9px] text-z-sage">
+            {pendingEmailCount > 0 ? `${pendingEmailCount} emails` : "Subir PDF"}
           </p>
         </button>
       </div>
@@ -508,10 +506,25 @@ function ImportarDetail({
     return (
       <div className="space-y-2">
         <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-z-sage">
-          Importación por email
+          Importar extracto
         </p>
-        <p className="text-xs text-z-sage-light">
-          No hay transacciones pendientes de importar.
+        <Link
+          href="/import"
+          className="flex items-center gap-3 rounded-xl p-2 transition-colors hover:bg-white/[0.03]"
+        >
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-z-sage/20 bg-z-sage/10">
+            <FileUp className="size-4 text-z-sage" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-semibold">Subir PDF del banco</p>
+            <p className="text-[9px] text-muted-foreground">Extracto mensual de cualquier banco</p>
+          </div>
+          <span className={cn("shrink-0 rounded-lg px-3 py-1 text-[10px] font-semibold", BRASS_BUTTON_CLASS)}>
+            Subir
+          </span>
+        </Link>
+        <p className="text-[10px] text-muted-foreground">
+          0 emails pendientes de revision
         </p>
       </div>
     );
@@ -522,6 +535,25 @@ function ImportarDetail({
       <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-z-sage">
         Pendientes por correo
       </p>
+
+      {/* PDF upload CTA */}
+      <Link
+        href="/import"
+        className="flex items-center gap-3 rounded-xl p-2 transition-colors hover:bg-white/[0.03]"
+      >
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-z-sage/20 bg-z-sage/10">
+          <FileUp className="size-4 text-z-sage" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold">Subir PDF del banco</p>
+          <p className="text-[9px] text-muted-foreground">Extracto mensual de cualquier banco</p>
+        </div>
+        <span className={cn("shrink-0 rounded-lg px-3 py-1 text-[10px] font-semibold", BRASS_BUTTON_CLASS)}>
+          Subir
+        </span>
+      </Link>
+
+      <div className="h-px bg-white/6" />
 
       <div className={cn("space-y-0.5", isPending && "pointer-events-none opacity-60")}>
         {items.map((email) => {

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowUpRight, ArrowDownLeft, ArrowRight, QrCode, CreditCard, Banknote, Building, Wallet, ArrowUpRight as TransferIcon, Mail, Hash, UserRound, Pencil } from "lucide-react";
@@ -79,6 +79,17 @@ export function MovimientosHerramientas({
   const activeAccent = activeZone ? accentStyles[activeZone] : null;
   const pendingEmailCount = pendingEmails.length;
 
+  // Optimistic: track IDs categorized from the detail panel so both
+  // the chip count and the item list update immediately.
+  const [categorizedIds, setCategorizedIds] = useState<Set<string>>(new Set());
+
+  // Reset optimistic state when server data refreshes (new props)
+  useEffect(() => {
+    setCategorizedIds(new Set());
+  }, [uncategorizedTransactions]);
+
+  const optimisticCount = Math.max(0, uncategorizedCount - categorizedIds.size);
+
   return (
     <MobileZone eyebrow="HERRAMIENTAS">
       <div className="grid grid-cols-2 gap-1.5">
@@ -97,15 +108,15 @@ export function MovimientosHerramientas({
           aria-expanded={isActive("categorizar")}
         >
           <p className="text-[22px] font-[680] leading-tight text-z-brass">
-            {uncategorizedCount}
+            {optimisticCount}
           </p>
           <p className="mt-0.5 text-[10px] font-semibold text-muted-foreground">
             Categorizar
           </p>
-          {uncategorizedCount > 0 && (
+          {optimisticCount > 0 && (
             <p className="mt-1 flex items-center justify-center gap-1 text-[9px] text-z-debt">
               <span className="inline-block size-1.5 rounded-full bg-z-debt" />
-              {uncategorizedCount} por resolver
+              {optimisticCount} por resolver
             </p>
           )}
         </button>
@@ -158,6 +169,17 @@ export function MovimientosHerramientas({
                     totalCount={uncategorizedCount}
                     categories={categories}
                     currency={currency}
+                    categorizedIds={categorizedIds}
+                    onOptimisticCategorize={(txId: string) =>
+                      setCategorizedIds((prev) => new Set(prev).add(txId))
+                    }
+                    onOptimisticRollback={(txId: string) =>
+                      setCategorizedIds((prev) => {
+                        const next = new Set(prev);
+                        next.delete(txId);
+                        return next;
+                      })
+                    }
                   />
                 )}
                 {activeZone === "importar" && (
@@ -233,19 +255,32 @@ function CategorizarDetail({
   totalCount,
   categories,
   currency,
+  categorizedIds,
+  onOptimisticCategorize,
+  onOptimisticRollback,
 }: {
   transactions: Transaction[];
   totalCount: number;
   categories: CategoryWithChildren[];
   currency: CurrencyCode;
+  categorizedIds: Set<string>;
+  onOptimisticCategorize: (txId: string) => void;
+  onOptimisticRollback: (txId: string) => void;
 }) {
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const items = transactions.slice(0, MAX_ITEMS);
+
+  const visibleTransactions = transactions.filter((tx) => !categorizedIds.has(tx.id));
+  const items = visibleTransactions.slice(0, MAX_ITEMS);
+  const visibleCount = Math.max(0, totalCount - categorizedIds.size);
 
   function handleCategorize(tx: Transaction, categoryId: string | null) {
     if (!categoryId) return;
     const previousCategoryId = tx.category_id ?? null;
+
+    // Optimistic: remove from list immediately (updates chip count too)
+    onOptimisticCategorize(tx.id);
+
     startTransition(async () => {
       const result = await categorizeTransaction(tx.id, categoryId);
       if (result.success) {
@@ -262,12 +297,14 @@ function CategorizarDetail({
           },
         });
       } else {
+        // Rollback optimistic removal
+        onOptimisticRollback(tx.id);
         toast.error(result.error ?? "Error al categorizar");
       }
     });
   }
 
-  if (totalCount === 0) {
+  if (visibleCount <= 0) {
     return (
       <div className="space-y-2">
         <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-z-brass">
@@ -359,7 +396,7 @@ function CategorizarDetail({
 
       <div className="flex items-center justify-between pt-1">
         <p className="text-[10px] text-muted-foreground">
-          Mostrando {items.length} de {totalCount}
+          Mostrando {items.length} de {visibleCount}
         </p>
         <Link
           href="/categorizar"

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -81,7 +81,7 @@ export function MovimientosHerramientas({
 
   // Optimistic: track IDs categorized from the detail panel so both
   // the chip count and the item list update immediately.
-  const [categorizedIds, setCategorizedIds] = useState<Set<string>>(new Set());
+  const [categorizedIds, setCategorizedIds] = useState(() => new Set<string>());
 
   // Reset optimistic state when server data refreshes (new props)
   useEffect(() => {

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -524,7 +524,7 @@ function ImportarDetail({
           </span>
         </Link>
         <p className="text-[10px] text-muted-foreground">
-          0 emails pendientes de revision
+          0 emails pendientes de revisión
         </p>
       </div>
     );

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx
@@ -66,6 +66,26 @@ export function MovimientosRoot({
     [transactions]
   );
 
+  /** Build tags-by-transaction lookup from joined transaction_tags */
+  const tagsByTxId = useMemo(() => {
+    const map = new Map<string, Array<{ id: string; name: string; color: string | null; group_color: string | null }>>();
+    for (const tx of transactions) {
+      const txTags = (tx as any).transaction_tags;
+      if (txTags && Array.isArray(txTags)) {
+        map.set(
+          tx.id,
+          txTags.map((tt: any) => ({
+            id: tt.tag.id,
+            name: tt.tag.name,
+            color: tt.tag.color,
+            group_color: tt.tag.group?.color ?? null,
+          }))
+        );
+      }
+    }
+    return map;
+  }, [transactions]);
+
   /** Group transactions by date, sorted descending */
   const groupedByDate = useMemo(() => {
     const groups = new Map<string, TransactionWithAccount[]>();
@@ -139,7 +159,7 @@ export function MovimientosRoot({
               </p>
               <div className="space-y-0.5">
                 {txs.map((tx) => (
-                  <MovimientosTransactionRow key={tx.id} transaction={tx} categories={outflowCategories} />
+                  <MovimientosTransactionRow key={tx.id} transaction={tx} categories={outflowCategories} tags={tagsByTxId.get(tx.id)} />
                 ))}
               </div>
             </div>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -9,6 +9,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
 import { TagZonePicker } from "@/components/tags/tag-zone-picker";
 import { TagChip } from "@/components/tags/tag-chip";
+import { CategoryIcon } from "@/components/categories/category-icon";
 import { categorizeTransaction } from "@/actions/categorize";
 import { toast } from "sonner";
 import type { TransactionWithAccount, CategoryWithChildren } from "@/types/domain";
@@ -92,7 +93,10 @@ export function MovimientosTransactionRow({
             <span className="truncate">{tx.account.name}</span>
             <span className="text-white/15">·</span>
             {categoryName ? (
-              <span>{localCategory?.icon} {categoryName}</span>
+              <span className="inline-flex items-center gap-0.5 truncate">
+                {localCategory?.icon && <CategoryIcon icon={localCategory.icon} className="size-3 shrink-0" />}
+                {categoryName}
+              </span>
             ) : (
               <span className="text-z-brass">Sin cat.</span>
             )}

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -3,12 +3,12 @@
 import { useState, useTransition } from "react";
 
 import Link from "next/link";
-import { Pencil } from "lucide-react";
+import { Pencil, ArrowDownLeft, ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { formatDate } from "@/lib/utils/date";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
 import { TagZonePicker } from "@/components/tags/tag-zone-picker";
+import { TagChip } from "@/components/tags/tag-chip";
 import { categorizeTransaction } from "@/actions/categorize";
 import { toast } from "sonner";
 import type { TransactionWithAccount, CategoryWithChildren } from "@/types/domain";
@@ -16,6 +16,7 @@ import type { TransactionWithAccount, CategoryWithChildren } from "@/types/domai
 interface MovimientosTransactionRowProps {
   transaction: TransactionWithAccount;
   categories: CategoryWithChildren[];
+  tags?: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
   /** Called after a successful category assignment — used by categorizar to remove from list / prompt bulk apply */
   onCategorized?: (txId: string, categoryId: string) => void;
 }
@@ -23,6 +24,7 @@ interface MovimientosTransactionRowProps {
 export function MovimientosTransactionRow({
   transaction: tx,
   categories,
+  tags = [],
   onCategorized,
 }: MovimientosTransactionRowProps) {
   const [expanded, setExpanded] = useState(false);
@@ -70,10 +72,16 @@ export function MovimientosTransactionRow({
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
         className={cn(
-          "flex w-full items-center justify-between gap-2 px-2 py-2.5 text-left transition-colors hover:bg-white/5",
+          "flex w-full items-center gap-2 px-2 py-2.5 text-left transition-colors hover:bg-white/5",
           tx.is_excluded && "opacity-40"
         )}
       >
+        <div className={cn(
+          "flex size-[22px] shrink-0 items-center justify-center rounded-md",
+          tx.direction === "INFLOW" ? "bg-green-500/12 text-z-income" : "bg-orange-500/12 text-z-expense"
+        )}>
+          {tx.direction === "INFLOW" ? <ArrowDownLeft className="size-3" /> : <ArrowUpRight className="size-3" />}
+        </div>
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium">{description}</p>
           <p className="text-[11px] text-muted-foreground flex items-center gap-1">
@@ -83,30 +91,38 @@ export function MovimientosTransactionRow({
             />
             <span className="truncate">{tx.account.name}</span>
             <span className="text-white/15">·</span>
-            <span>{formatDate(tx.transaction_date, "dd MMM")}</span>
+            {categoryName ? (
+              <span>{localCategory?.icon} {categoryName}</span>
+            ) : (
+              <span className="text-z-brass">Sin cat.</span>
+            )}
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <span
-            className={cn(
-              "text-sm font-medium tabular-nums",
-              tx.direction === "INFLOW" && "text-z-income",
-              tx.is_excluded && "line-through"
-            )}
-          >
-            {tx.direction === "INFLOW" ? "+" : "-"}
-            {formatCurrency(tx.amount, tx.currency_code)}
-          </span>
-          <span
-            className={cn(
-              "text-muted-foreground/50 text-xs transition-transform",
-              expanded && "rotate-90"
-            )}
-          >
-            ›
-          </span>
-        </div>
+        <span
+          className={cn(
+            "shrink-0 text-sm font-medium tabular-nums",
+            tx.direction === "INFLOW" && "text-z-income",
+            tx.is_excluded && "line-through"
+          )}
+        >
+          {tx.direction === "INFLOW" ? "+" : "-"}
+          {formatCurrency(tx.amount, tx.currency_code)}
+        </span>
       </button>
+
+      {/* Tags (collapsed only) */}
+      {!expanded && tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 px-2 pb-1.5 pl-[38px]">
+          {tags.map((t) => (
+            <TagChip
+              key={t.id}
+              tag={{ id: t.id, name: t.name, color: t.color } as any}
+              groupColor={t.group_color}
+              size="sm"
+            />
+          ))}
+        </div>
+      )}
 
       {/* Expanded: inline pickers + edit link */}
       {expanded && (

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+
 import Link from "next/link";
 import { Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -120,7 +120,7 @@ export function MovimientosTransactionRow({
           {tags.map((t) => (
             <TagChip
               key={t.id}
-              tag={{ id: t.id, name: t.name, color: t.color } as any}
+              tag={{ name: t.name, color: t.color }}
               groupColor={t.group_color}
               size="sm"
             />

--- a/webapp/src/components/tags/tag-chip.tsx
+++ b/webapp/src/components/tags/tag-chip.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { X } from "lucide-react";
-import type { Tag } from "@/types/domain";
-
 interface TagChipProps {
-  tag: Tag;
+  tag: { name: string; color: string | null };
   groupColor?: string | null;
   onRemove?: () => void;
   size?: "sm" | "md";


### PR DESCRIPTION
## Summary

- **Mobile import CTAs**: Starter mode for first-run, stale import banner, PDF upload in Importar chip
- **Standardized transaction rows**: Direction icons, category display, tag colors inline (InicioActivity rewrite + MovimientosTransactionRow enrichment)
- **Landing page narrative arc**: Section reorder (Hook→Process→Proof→Trust→Action), removed redundant Features section, hero copy refinement, MobileHeroStrip, responsive carousel fix, reduced mobile padding
- **Performance**: Added missing indexes (transaction_tags.transaction_id, statement_snapshots_enc user+created_at), capped snapshot query

## Agent reviews completed
- `server-action-reviewer` — FK hint fix for encrypted view joins
- `cache-doctor` — caching verified correct
- `perf-auditor` — missing indexes + snapshot limit + Date consolidation
- `zetas-front-guy` — design token compliance fixes (border-radius, tracking, hex colors)
- Code reuse + quality + efficiency review — Rules of Hooks fix, TagChip type narrowing, accent corrections

## Test plan
- [ ] Mobile dashboard: verify starter mode renders for new users (accounts exist, no transactions)
- [ ] Mobile dashboard: verify import strip appears when last import > 15 days
- [ ] Mobile Movimientos: verify direction icons, category names (not raw icon strings), tag chips with colors
- [ ] Mobile Movimientos: verify Importar chip shows PDF upload CTA when expanded
- [ ] Landing page: verify section order (Hero → How it works → Budget → Plan → Showcase → Audience → CTA → FAQ)
- [ ] Landing page: verify MobileHeroStrip on small screens, full HeroCard on desktop
- [ ] Landing page: verify showcase carousel doesn't overflow on 320px screens
- [ ] Run `npx supabase db push` to apply index migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)