### PR TITLE
fix: improve email webhook logging and surface ingest logs in settings

### DIFF
--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -247,7 +247,7 @@ export async function getEmailIngestLogs(): Promise<ActionResult<EmailIngestLog[
 
   const { data, error } = await supabase
     .from("email_ingest_logs")
-    .select("*")
+    .select("id, status, from_address, error_message, raw_body, created_at")
     .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(50);
@@ -568,7 +568,7 @@ export async function approveEmailTransaction(
   const idempotencyKey =
     pending.idempotency_key ||
     (await computeIdempotencyKey({
-      provider: "EMAIL_IMPORT",
+      provider: "EMAIL",
       transactionDate: parsed.transaction_date,
       amount: parsed.amount,
       rawDescription: parsed.raw_line,

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -250,7 +250,7 @@ export async function getEmailIngestLogs(): Promise<ActionResult<EmailIngestLog[
     .select("*")
     .eq("user_id", user.id)
     .order("created_at", { ascending: false })
-    .limit(20);
+    .limit(50);
 
   if (error) return { success: false, error: error.message };
   return { success: true, data: (data ?? []) as EmailIngestLog[] };

--- a/webapp/src/app/(dashboard)/settings/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/page.tsx
@@ -16,12 +16,13 @@ import { BugReportForm } from "@/components/settings/bug-report-form";
 import { IntegrationsCard } from "@/components/settings/integrations-card";
 import { EmailIngestCard } from "@/components/settings/email-ingest-card";
 import { UnrecognizedEmailsCard } from "@/components/settings/unrecognized-emails-card";
+import { EmailIngestLogsCard } from "@/components/settings/email-ingest-logs-card";
 import { BuildInfo } from "@/components/settings/build-info";
 import { ReviewModeToggle } from "@/components/settings/review-mode-toggle";
 import { SettingsMobileAccordion } from "@/components/settings/settings-mobile-accordion";
 import { DemoModeCard } from "@/components/settings/demo-mode-card";
 import { getCaptureTokens } from "@/actions/capture-tokens";
-import { getEmailIngestAddress, getUnrecognizedEmails } from "@/actions/email-ingest";
+import { getEmailIngestAddress, getEmailIngestLogs, getUnrecognizedEmails } from "@/actions/email-ingest";
 import { getTagGroups } from "@/actions/tags";
 import { TagManager } from "@/components/tags/tag-manager";
 import type { Account } from "@/types/domain";
@@ -39,7 +40,7 @@ export default async function SettingsPage() {
 
   if (!profile) redirect("/login");
 
-  const [tokensResult, { data: accounts }, emailIngestResult, unrecognizedResult, tagGroupsResult] = await Promise.all([
+  const [tokensResult, { data: accounts }, emailIngestResult, unrecognizedResult, emailLogsResult, tagGroupsResult] = await Promise.all([
     getCaptureTokens(),
     supabase
       .from("accounts")
@@ -49,12 +50,14 @@ export default async function SettingsPage() {
       .order("display_order"),
     getEmailIngestAddress(),
     getUnrecognizedEmails(),
+    getEmailIngestLogs(),
     getTagGroups(),
   ]);
 
   const tokens = tokensResult.success ? tokensResult.data : [];
   const emailIngestAddress = emailIngestResult.success ? emailIngestResult.data : null;
   const unrecognizedEmails = unrecognizedResult.success ? unrecognizedResult.data : [];
+  const emailLogs = emailLogsResult.success ? emailLogsResult.data : [];
   const memberSince = new Date(profile.created_at).toLocaleDateString("es-CO");
 
   const accordionSections = [
@@ -83,6 +86,7 @@ export default async function SettingsPage() {
             initialAddress={emailIngestAddress}
           />
           <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
+          <EmailIngestLogsCard initialLogs={emailLogs} />
         </div>
       ),
     },
@@ -162,6 +166,8 @@ export default async function SettingsPage() {
         />
 
         <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
+
+        <EmailIngestLogsCard initialLogs={emailLogs} />
 
         <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
           <CardHeader>

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -37,7 +37,7 @@ type ResendEmailPayload = {
     email_id: string;
     from: string;
     to: string[];
-    subject: string;
+    subject?: string;
   };
 };
 
@@ -167,6 +167,14 @@ function stripHtml(html: string): string {
 
 // ── Log helper ───────────────────────────────────────────────────────────────
 
+function buildRawBodyPreview(subject: string | null, body: string | null): string | null {
+  if (!subject && !body) return null;
+  const parts: string[] = [];
+  if (subject) parts.push(`[Subject: ${subject}]`);
+  if (body) parts.push(body);
+  return parts.join("\n").slice(0, 500);
+}
+
 async function insertLog(params: {
   userId: string | null;
   emailIngestId: string | null;
@@ -176,7 +184,7 @@ async function insertLog(params: {
   errorMessage: string | null;
 }) {
   const admin = createAdminClient();
-  await admin.from("email_ingest_logs").insert({
+  const { error } = await admin.from("email_ingest_logs").insert({
     user_id: params.userId,
     email_ingest_id: params.emailIngestId,
     from_address: params.fromAddress,
@@ -184,6 +192,9 @@ async function insertLog(params: {
     raw_body: params.rawBody ? params.rawBody.slice(0, 500) : null,
     error_message: params.errorMessage,
   });
+  if (error) {
+    console.error("[email-ingest] Failed to insert log:", error.message, params);
+  }
 }
 
 // ── Route handler ────────────────────────────────────────────────────────────
@@ -195,6 +206,7 @@ export async function POST(request: NextRequest) {
   // 1. Verify Resend webhook signature
   const isValid = await verifyResendSignature(request, rawBody);
   if (!isValid) {
+    console.warn("[email-ingest] Signature verification failed — rejecting webhook");
     return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
   }
 
@@ -202,24 +214,60 @@ export async function POST(request: NextRequest) {
   let payload: ResendEmailPayload;
   try {
     payload = JSON.parse(rawBody) as ResendEmailPayload;
-  } catch {
+  } catch (e) {
+    console.error("[email-ingest] JSON parse error:", e instanceof Error ? e.message : e);
     return NextResponse.json({ ok: true });
   }
 
   // Only handle email.received events
   if (payload.type !== "email.received") {
+    console.log(`[email-ingest] Ignoring event type: ${payload.type}`);
     return NextResponse.json({ ok: true });
   }
 
-  const { from, to, email_id: emailId } = payload.data;
+  const { from, to, subject, email_id: emailId } = payload.data;
+  console.log(`[email-ingest][${emailId}] Received email from=${from} to=${to?.[0]} subject="${subject ?? "(none)"}"`);
+
+  try {
+  return await processEmail({ emailId, from, to, subject });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error ? err.stack : undefined;
+    console.error(`[email-ingest][${emailId}] Unhandled error:`, message, stack);
+    // Best-effort DB log — may fail if the error is a DB connection issue
+    await insertLog({
+      userId: null,
+      emailIngestId: null,
+      fromAddress: from ?? "unknown",
+      status: "parse_failed",
+      rawBody: buildRawBodyPreview(subject ?? null, null),
+      errorMessage: `Unhandled error: ${message}`,
+    }).catch(() => {});
+    // Return 200 to prevent Resend retries that would keep failing
+    return NextResponse.json({ ok: true });
+  }
+}
+
+async function processEmail(ctx: {
+  emailId: string;
+  from: string;
+  to: string[];
+  subject?: string;
+}) {
+  const { emailId, from, to, subject } = ctx;
 
   // Webhook payload has metadata only — fetch full email content from Resend API
   const emailContent = await fetchEmailContent(emailId);
+
+  if (!emailContent) {
+    console.error(`[email-ingest][${emailId}] fetchEmailContent returned null — Resend API may be down or email_id invalid`);
+  }
+
   const emailText = emailContent?.text ?? null;
   const emailHtml = emailContent?.html ?? null;
   // Prefer plain text; fall back to stripped HTML
   const emailBody = emailText || (emailHtml ? stripHtml(emailHtml) : "");
-  const rawBodyPreview = emailBody?.slice(0, 500) ?? null;
+  const rawBodyPreview = buildRawBodyPreview(subject ?? null, emailBody);
 
   // 3. Extract address key from recipient (e.g. "u_abc123@domain.com" → "u_abc123")
   //    Resend lowercases the `to` on direct inbound emails, so normalize here
@@ -228,13 +276,14 @@ export async function POST(request: NextRequest) {
   const addressKey = recipientEmail.split("@")[0] ?? "";
 
   if (!addressKey) {
+    console.warn(`[email-ingest][${emailId}] No address_key in recipient: ${recipientEmail}`);
     await insertLog({
       userId: null,
       emailIngestId: null,
       fromAddress: from,
       status: "parse_failed",
       rawBody: rawBodyPreview,
-      errorMessage: "Could not extract address_key from recipient",
+      errorMessage: `Could not extract address_key from recipient: ${recipientEmail}`,
     });
     return NextResponse.json({ ok: true });
   }
@@ -252,6 +301,7 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (!ingestAddress) {
+    console.warn(`[email-ingest][${emailId}] No active ingest address for key="${addressKey}"`);
     await insertLog({
       userId: null,
       emailIngestId: null,
@@ -275,8 +325,8 @@ export async function POST(request: NextRequest) {
   // 5. Detect Gmail forwarding verification emails
   const fromLower = from.toLowerCase();
   if (fromLower.includes("forwarding-noreply@google.com")) {
-    const emailContent = emailBody || emailHtml || "";
-    const verifyMatch = emailContent.match(
+    const verificationContent = emailBody || emailHtml || "";
+    const verifyMatch = verificationContent.match(
       /https:\/\/mail\.google\.com\/mail\/vf-[^\s"<>]+/
     );
     if (verifyMatch) {
@@ -306,6 +356,7 @@ export async function POST(request: NextRequest) {
   const isBankSender = ALLOWED_SENDERS.some((s) => fromLower.includes(s));
   const isAllowedSender = allowedSender && fromLower.includes(allowedSender.toLowerCase());
   if (!isBankSender && !isAllowedSender) {
+    console.log(`[email-ingest][${emailId}] Sender rejected: "${from}" (allowed_sender=${allowedSender ?? "none"})`);
     await insertLog({
       userId,
       emailIngestId,
@@ -316,6 +367,8 @@ export async function POST(request: NextRequest) {
     });
     return NextResponse.json({ ok: true });
   }
+
+  console.log(`[email-ingest][${emailId}] Sender OK (bank=${isBankSender}, allowed=${!!isAllowedSender}), user=${userId}`);
 
   // 7. Rate limit: max 100 emails/day/user
   const withinLimit = await checkRateLimit(userId);
@@ -398,7 +451,7 @@ export async function POST(request: NextRequest) {
           user_id: userId,
           email_ingest_id: emailIngestId,
           from_address: from,
-          subject: payload.data.subject ?? null,
+          subject: subject ?? null,
           original_filename: filename,
           storage_path: storagePath,
           file_size_bytes: bytes.byteLength,
@@ -528,19 +581,46 @@ export async function POST(request: NextRequest) {
   }
 
   if (pdfProcessed && !emailBody.trim()) {
+    console.log(`[email-ingest][${emailId}] PDF processed, no text body — skipping text parse`);
+    return NextResponse.json({ ok: true });
+  }
+
+  // Log fetchEmailContent failure explicitly — email will likely fail parsing
+  if (!emailContent) {
+    console.error(`[email-ingest][${emailId}] No email content available — Resend API fetch failed. Email will be stored as unrecognized.`);
+    await insertLog({
+      userId,
+      emailIngestId,
+      fromAddress: from,
+      status: "parse_failed",
+      rawBody: rawBodyPreview,
+      errorMessage: `Resend API fetch failed for email_id=${emailId} — no text/html body available to parse`,
+    });
+    // Store as unrecognized so it's visible in the UI, even without body content
+    await admin.from("unrecognized_emails").insert({
+      user_id: userId,
+      email_ingest_id: emailIngestId,
+      from_address: from,
+      subject: subject ?? null,
+      text_body: null,
+      html_body: null,
+      status: "pending",
+    });
     return NextResponse.json({ ok: true });
   }
 
   // 8. Parse email body
+  console.log(`[email-ingest][${emailId}] Parsing email body (${emailBody.length} chars, hasText=${!!emailText}, hasHtml=${!!emailHtml})`);
   const parsed = parseBancolombiaEmail(emailBody);
 
   if (!parsed) {
+    console.log(`[email-ingest][${emailId}] No pattern matched — storing as unrecognized. Body preview: ${emailBody.slice(0, 200)}`);
     // Store full email for parser improvement review
     await admin.from("unrecognized_emails").insert({
       user_id: userId,
       email_ingest_id: emailIngestId,
       from_address: from,
-      subject: payload.data.subject ?? null,
+      subject: subject ?? null,
       text_body: emailText,
       html_body: emailHtml,
       status: "pending",
@@ -556,6 +636,8 @@ export async function POST(request: NextRequest) {
     });
     return NextResponse.json({ ok: true });
   }
+
+  console.log(`[email-ingest][${emailId}] Parsed: pattern=${parsed.pattern_type} amount=${parsed.amount} direction=${parsed.direction} card=${parsed.card_last4}`);
 
   // Clear Gmail verification URL now that real emails are flowing
   await admin
@@ -591,6 +673,7 @@ export async function POST(request: NextRequest) {
   }
 
   // 9. Auto-import or queue
+  console.log(`[email-ingest][${emailId}] autoImport=${autoImport} suggestedAccountId=${suggestedAccountId}`);
   if (autoImport && suggestedAccountId) {
     const matchedAccount = candidateAccounts?.find((a) => a.id === suggestedAccountId);
     const currencyCode = matchedAccount?.currency_code ?? parsed.currency;
@@ -634,6 +717,7 @@ export async function POST(request: NextRequest) {
 
     if (insertError) {
       if (insertError.code === "23505") {
+        console.log(`[email-ingest][${emailId}] Duplicate transaction (idempotency conflict)`);
         await insertLog({
           userId,
           emailIngestId,
@@ -643,6 +727,7 @@ export async function POST(request: NextRequest) {
           errorMessage: "Duplicate transaction (idempotency key conflict)",
         });
       } else {
+        console.error(`[email-ingest][${emailId}] Transaction insert failed: ${insertError.message} (code=${insertError.code})`);
         await insertLog({
           userId,
           emailIngestId,
@@ -654,6 +739,8 @@ export async function POST(request: NextRequest) {
       }
       return NextResponse.json({ ok: true });
     }
+
+    console.log(`[email-ingest][${emailId}] Transaction auto-imported successfully`);
 
     // Update account balance
     if (matchedAccount) {
@@ -694,7 +781,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true });
   }
 
-  // 10. Queue in pending_email_transactions
+  // 10. Queue in pending_email_transactions (auto_import off or no suggested account)
+  console.log(`[email-ingest][${emailId}] Queuing for manual review`);
   const { error: queueError } = await admin.from("pending_email_transactions").insert({
     user_id: userId,
     email_ingest_id: emailIngestId,
@@ -707,6 +795,7 @@ export async function POST(request: NextRequest) {
 
   if (queueError) {
     if (queueError.code === "23505") {
+      console.log(`[email-ingest][${emailId}] Duplicate pending transaction`);
       await insertLog({
         userId,
         emailIngestId,
@@ -716,6 +805,7 @@ export async function POST(request: NextRequest) {
         errorMessage: "Duplicate pending transaction (idempotency key conflict)",
       });
     } else {
+      console.error(`[email-ingest][${emailId}] Queue insert failed: ${queueError.message}`);
       await insertLog({
         userId,
         emailIngestId,
@@ -729,6 +819,7 @@ export async function POST(request: NextRequest) {
   }
 
   // 11. Log as queued
+  console.log(`[email-ingest][${emailId}] Queued successfully for manual review`);
   await insertLog({
     userId,
     emailIngestId,

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -260,11 +260,6 @@ async function processEmail(ctx: {
 
   // Webhook payload has metadata only — fetch full email content from Resend API
   const emailContent = await fetchEmailContent(emailId);
-
-  if (!emailContent) {
-    console.error(`[email-ingest][${emailId}] fetchEmailContent returned null — Resend API may be down or email_id invalid`);
-  }
-
   const emailText = emailContent?.text ?? null;
   const emailHtml = emailContent?.html ?? null;
   // Prefer plain text; fall back to stripped HTML

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -414,214 +414,205 @@ async function processEmail(ctx: {
     return NextResponse.json({ ok: true });
   }
 
-  // 7b. Check for PDF attachments
-  const pdfAttachments = filterPdfAttachments(emailContent.attachments);
+  // 7b. Try text parsing FIRST — it's instant (regex). PDF is the fallback.
+  console.log(`[email-ingest][${emailId}] Parsing email body (${emailBody.length} chars, hasText=${!!emailText}, hasHtml=${!!emailHtml})`);
+  const parsed = emailBody.trim() ? parseBancolombiaEmail(emailBody) : null;
 
-  const insertedPdfRows: Array<{ id: string; buffer: ArrayBuffer; filename: string }> = [];
-  let pdfProcessed = false;
+  if (parsed) {
+    console.log(`[email-ingest][${emailId}] Text parsed: pattern=${parsed.pattern_type} amount=${parsed.amount} direction=${parsed.direction} card=${parsed.card_last4} — skipping PDF fallback`);
+  }
 
-  if (pdfAttachments.length > 0 && pdfImportEnabled) {
-    pdfProcessed = true;
-    // Store pending rows immediately, parse async via after()
-    for (const attachment of pdfAttachments) {
-      const filename = attachment.filename || "attachment.pdf";
-      // Decode once — reuse buffer for hash, storage, and after() closure
-      const bytes = Buffer.from(attachment.content, "base64");
-      const contentHash = await computePdfHash(bytes.buffer);
+  // 7c. If text parsing failed, fall back to PDF attachments
+  if (!parsed) {
+    const pdfAttachments = filterPdfAttachments(emailContent.attachments);
 
-      // Check idempotency: skip if we already have this PDF
-      const { data: existing } = await admin
-        .from("pending_email_statements")
-        .select("id")
-        .eq("user_id", userId)
-        .eq("idempotency_hash", contentHash)
-        .not("status", "in", "(dismissed)")
-        .maybeSingle();
+    if (pdfAttachments.length > 0 && pdfImportEnabled) {
+      console.log(`[email-ingest][${emailId}] Text parse failed — falling back to ${pdfAttachments.length} PDF attachment(s)`);
+      const insertedPdfRows: Array<{ id: string; buffer: ArrayBuffer; filename: string }> = [];
 
-      if (existing) {
-        await insertLog({
-          userId,
-          emailIngestId,
-          fromAddress: from,
-          status: "duplicate",
-          rawBody: rawBodyPreview,
-          errorMessage: `Duplicate PDF: ${filename}`,
-        });
-        continue;
-      }
+      for (const attachment of pdfAttachments) {
+        const filename = attachment.filename || "attachment.pdf";
+        const bytes = Buffer.from(attachment.content, "base64");
+        const contentHash = await computePdfHash(bytes.buffer);
 
-      // Store PDF in Supabase Storage
-      const timestamp = Date.now();
-      const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
-      const storagePath = `${userId}/${timestamp}-${safeName}`;
+        // Check idempotency: skip if we already have this PDF
+        const { data: existing } = await admin
+          .from("pending_email_statements")
+          .select("id")
+          .eq("user_id", userId)
+          .eq("idempotency_hash", contentHash)
+          .not("status", "in", "(dismissed)")
+          .maybeSingle();
 
-      const { error: uploadError } = await admin.storage
-        .from("email-pdfs")
-        .upload(storagePath, bytes.buffer, {
-          contentType: "application/pdf",
-          upsert: false,
-        });
-
-      if (uploadError) {
-        await insertLog({
-          userId,
-          emailIngestId,
-          fromAddress: from,
-          status: "pdf_parse_failed",
-          rawBody: rawBodyPreview,
-          errorMessage: `Storage upload failed: ${uploadError.message}`,
-        });
-        continue;
-      }
-
-      // Insert pending row with status 'pending'
-      const { data: inserted, error: insertError } = await admin
-        .from("pending_email_statements")
-        .insert({
-          user_id: userId,
-          email_ingest_id: emailIngestId,
-          from_address: from,
-          subject: subject ?? null,
-          original_filename: filename,
-          storage_path: storagePath,
-          file_size_bytes: bytes.byteLength,
-          status: "pending",
-          idempotency_hash: contentHash,
-        })
-        .select("id")
-        .single();
-
-      if (insertError) {
-        // Clean up orphaned storage on insert failure
-        await admin.storage.from("email-pdfs").remove([storagePath]);
-        if (insertError.code === "23505") {
+        if (existing) {
           await insertLog({
             userId,
             emailIngestId,
             fromAddress: from,
             status: "duplicate",
             rawBody: rawBodyPreview,
-            errorMessage: `Duplicate PDF statement: ${filename}`,
+            errorMessage: `Duplicate PDF: ${filename}`,
           });
-        } else {
+          continue;
+        }
+
+        // Store PDF in Supabase Storage
+        const timestamp = Date.now();
+        const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+        const storagePath = `${userId}/${timestamp}-${safeName}`;
+
+        const { error: uploadError } = await admin.storage
+          .from("email-pdfs")
+          .upload(storagePath, bytes.buffer, {
+            contentType: "application/pdf",
+            upsert: false,
+          });
+
+        if (uploadError) {
           await insertLog({
             userId,
             emailIngestId,
             fromAddress: from,
             status: "pdf_parse_failed",
             rawBody: rawBodyPreview,
-            errorMessage: `Insert error: ${insertError.message}`,
+            errorMessage: `Storage upload failed: ${uploadError.message}`,
           });
+          continue;
         }
-        continue;
+
+        // Insert pending row with status 'pending'
+        const { data: inserted, error: insertError } = await admin
+          .from("pending_email_statements")
+          .insert({
+            user_id: userId,
+            email_ingest_id: emailIngestId,
+            from_address: from,
+            subject: subject ?? null,
+            original_filename: filename,
+            storage_path: storagePath,
+            file_size_bytes: bytes.byteLength,
+            status: "pending",
+            idempotency_hash: contentHash,
+          })
+          .select("id")
+          .single();
+
+        if (insertError) {
+          await admin.storage.from("email-pdfs").remove([storagePath]);
+          if (insertError.code === "23505") {
+            await insertLog({
+              userId,
+              emailIngestId,
+              fromAddress: from,
+              status: "duplicate",
+              rawBody: rawBodyPreview,
+              errorMessage: `Duplicate PDF statement: ${filename}`,
+            });
+          } else {
+            await insertLog({
+              userId,
+              emailIngestId,
+              fromAddress: from,
+              status: "pdf_parse_failed",
+              rawBody: rawBodyPreview,
+              errorMessage: `Insert error: ${insertError.message}`,
+            });
+          }
+          continue;
+        }
+
+        insertedPdfRows.push({ id: inserted.id, buffer: bytes.buffer, filename });
+
+        await insertLog({
+          userId,
+          emailIngestId,
+          fromAddress: from,
+          status: "pdf_queued",
+          rawBody: rawBodyPreview,
+          errorMessage: null,
+        });
       }
 
-      insertedPdfRows.push({ id: inserted.id, buffer: bytes.buffer, filename });
+      // Parse PDFs asynchronously after responding to Resend
+      const rowsToProcess = [...insertedPdfRows];
+      if (rowsToProcess.length > 0) {
+        after(async () => {
+          const adminAsync = createAdminClient();
 
-      await insertLog({
-        userId,
-        emailIngestId,
-        fromAddress: from,
-        status: "pdf_queued",
-        rawBody: rawBodyPreview,
-        errorMessage: null,
-      });
-    }
+          const { data: userAccounts } = await adminAsync
+            .rpc("get_accounts_with_masks", { p_user_id: userId });
 
-    // Parse PDFs asynchronously after responding to Resend.
-    // Buffers are captured in the closure — no re-download needed.
-    const rowsToProcess = [...insertedPdfRows];
-    if (rowsToProcess.length > 0) {
-      after(async () => {
-        const adminAsync = createAdminClient();
+          await Promise.all(
+            rowsToProcess.map(async (row) => {
+              try {
+                const filenameInfo = parseStatementFilename(row.filename);
+                const accountMatch = filenameInfo && userAccounts
+                  ? matchAccountByLast4(
+                      userAccounts as Array<{ id: string; mask: string | null; pdf_password: string | null }>,
+                      filenameInfo.last4,
+                    )
+                  : null;
 
-        // Use RPC to decrypt masks/passwords — admin client can't use zeta_decrypt()
-        const { data: userAccounts } = await adminAsync
-          .rpc("get_accounts_with_masks", { p_user_id: userId });
+                const password = accountMatch?.pdfPassword ?? undefined;
 
-        await Promise.all(
-          rowsToProcess.map(async (row) => {
-            try {
-              // Match filename → account → password
-              const filenameInfo = parseStatementFilename(row.filename);
-              const accountMatch = filenameInfo && userAccounts
-                ? matchAccountByLast4(
-                    userAccounts as Array<{ id: string; mask: string | null; pdf_password: string | null }>,
-                    filenameInfo.last4,
-                  )
-                : null;
+                if (isPdfEncrypted(row.buffer) && !password) {
+                  await adminAsync
+                    .from("pending_email_statements")
+                    .update({
+                      status: "needs_password",
+                      error_message: "PDF protegido con contraseña",
+                      updated_at: new Date().toISOString(),
+                    })
+                    .eq("id", row.id)
+                    .eq("user_id", userId);
+                  return;
+                }
 
-              const password = accountMatch?.pdfPassword ?? undefined;
+                const parseResult = await parsePdfBuffer({
+                  buffer: row.buffer,
+                  filename: row.filename,
+                  password,
+                });
 
-              // Fast encryption check — skip parser round-trip if encrypted without password
-              if (isPdfEncrypted(row.buffer) && !password) {
+                if (parseResult.success) {
+                  await adminAsync
+                    .from("pending_email_statements")
+                    .update({
+                      status: "parsed",
+                      parsed_data: parseResult.statements as unknown as Json,
+                      parsed_at: new Date().toISOString(),
+                      updated_at: new Date().toISOString(),
+                    })
+                    .eq("id", row.id)
+                    .eq("user_id", userId);
+                } else {
+                  await adminAsync
+                    .from("pending_email_statements")
+                    .update({
+                      status: parseResult.needsPassword ? "needs_password" : "parse_failed",
+                      error_message: parseResult.error,
+                      updated_at: new Date().toISOString(),
+                    })
+                    .eq("id", row.id)
+                    .eq("user_id", userId);
+                }
+              } catch {
                 await adminAsync
                   .from("pending_email_statements")
-                  .update({
-                    status: "needs_password",
-                    error_message: "PDF protegido con contraseña",
-                    updated_at: new Date().toISOString(),
-                  })
-                  .eq("id", row.id)
-                  .eq("user_id", userId);
-                return;
-              }
-
-              const parseResult = await parsePdfBuffer({
-                buffer: row.buffer,
-                filename: row.filename,
-                password,
-              });
-
-              if (parseResult.success) {
-                await adminAsync
-                  .from("pending_email_statements")
-                  .update({
-                    status: "parsed",
-                    parsed_data: parseResult.statements as unknown as Json,
-                    parsed_at: new Date().toISOString(),
-                    updated_at: new Date().toISOString(),
-                  })
-                  .eq("id", row.id)
-                  .eq("user_id", userId);
-              } else {
-                await adminAsync
-                  .from("pending_email_statements")
-                  .update({
-                    status: parseResult.needsPassword ? "needs_password" : "parse_failed",
-                    error_message: parseResult.error,
-                    updated_at: new Date().toISOString(),
-                  })
+                  .update({ status: "parse_failed", error_message: "Error inesperado al procesar", updated_at: new Date().toISOString() })
                   .eq("id", row.id)
                   .eq("user_id", userId);
               }
-            } catch {
-              await adminAsync
-                .from("pending_email_statements")
-                .update({ status: "parse_failed", error_message: "Error inesperado al procesar", updated_at: new Date().toISOString() })
-                .eq("id", row.id)
-                .eq("user_id", userId);
-            }
-          }),
-        );
-      });
+            }),
+          );
+        });
+      }
+
+      return NextResponse.json({ ok: true });
     }
 
-    // Skip text parsing if PDFs came from a statement sender (no text alerts in those emails)
-  }
-
-  if (pdfProcessed && !emailBody.trim()) {
-    console.log(`[email-ingest][${emailId}] PDF processed, no text body — skipping text parse`);
-    return NextResponse.json({ ok: true });
-  }
-
-  // 8. Parse email body
-  console.log(`[email-ingest][${emailId}] Parsing email body (${emailBody.length} chars, hasText=${!!emailText}, hasHtml=${!!emailHtml})`);
-  const parsed = parseBancolombiaEmail(emailBody);
-
-  if (!parsed) {
-    console.log(`[email-ingest][${emailId}] No pattern matched — storing as unrecognized. Body preview: ${emailBody.slice(0, 200)}`);
-    // Store full email for parser improvement review
+    // No PDFs either — store as unrecognized
+    console.log(`[email-ingest][${emailId}] No pattern matched, no PDF fallback — storing as unrecognized. Body preview: ${emailBody.slice(0, 200)}`);
     const { error: unrecognizedError } = await admin.from("unrecognized_emails").insert({
       user_id: userId,
       email_ingest_id: emailIngestId,
@@ -646,8 +637,6 @@ async function processEmail(ctx: {
     revalidateTag("email-ingest", "zeta");
     return NextResponse.json({ ok: true });
   }
-
-  console.log(`[email-ingest][${emailId}] Parsed: pattern=${parsed.pattern_type} amount=${parsed.amount} direction=${parsed.direction} card=${parsed.card_last4}`);
 
   // Clear Gmail verification URL now that real emails are flowing
   await admin

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -19,6 +19,8 @@ import { computeIdempotencyKey } from "@/lib/utils/idempotency";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 import { autoCategorize } from "@zeta/shared";
 import { matchTransactionToDestinatario } from "@/actions/destinatarios";
+import { linkTransactionToOccurrence } from "@/actions/occurrences";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import type { Json } from "@/types/database";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -229,7 +231,7 @@ export async function POST(request: NextRequest) {
   console.log(`[email-ingest][${emailId}] Received email from=${from} to=${to?.[0]} subject="${subject ?? "(none)"}"`);
 
   try {
-  return await processEmail({ emailId, from, to, subject });
+    return await processEmail({ emailId, from, to, subject });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const stack = err instanceof Error ? err.stack : undefined;
@@ -373,6 +375,7 @@ async function processEmail(ctx: {
   // 7. Rate limit: max 100 emails/day/user
   const withinLimit = await checkRateLimit(userId);
   if (!withinLimit) {
+    console.log(`[email-ingest][${emailId}] Rate limited (${RATE_LIMIT_PER_DAY}/day)`);
     await insertLog({
       userId,
       emailIngestId,
@@ -384,8 +387,35 @@ async function processEmail(ctx: {
     return NextResponse.json({ ok: true });
   }
 
-  // 7. Check for PDF attachments
-  const pdfAttachments = filterPdfAttachments(emailContent?.attachments ?? []);
+  // 7a. If Resend API failed, log and store as unrecognized — don't proceed with empty data
+  if (!emailContent) {
+    console.error(`[email-ingest][${emailId}] No email content available — Resend API fetch failed`);
+    await insertLog({
+      userId,
+      emailIngestId,
+      fromAddress: from,
+      status: "parse_failed",
+      rawBody: rawBodyPreview,
+      errorMessage: `Resend API fetch failed for email_id=${emailId} — no content available`,
+    });
+    const { error: unrecognizedError } = await admin.from("unrecognized_emails").insert({
+      user_id: userId,
+      email_ingest_id: emailIngestId,
+      from_address: from,
+      subject: subject ?? null,
+      text_body: null,
+      html_body: null,
+      status: "pending",
+    });
+    if (unrecognizedError) {
+      console.error(`[email-ingest][${emailId}] Failed to insert unrecognized_email:`, unrecognizedError.message);
+    }
+    revalidateTag("email-ingest", "zeta");
+    return NextResponse.json({ ok: true });
+  }
+
+  // 7b. Check for PDF attachments
+  const pdfAttachments = filterPdfAttachments(emailContent.attachments);
 
   const insertedPdfRows: Array<{ id: string; buffer: ArrayBuffer; filename: string }> = [];
   let pdfProcessed = false;
@@ -585,30 +615,6 @@ async function processEmail(ctx: {
     return NextResponse.json({ ok: true });
   }
 
-  // Log fetchEmailContent failure explicitly — email will likely fail parsing
-  if (!emailContent) {
-    console.error(`[email-ingest][${emailId}] No email content available — Resend API fetch failed. Email will be stored as unrecognized.`);
-    await insertLog({
-      userId,
-      emailIngestId,
-      fromAddress: from,
-      status: "parse_failed",
-      rawBody: rawBodyPreview,
-      errorMessage: `Resend API fetch failed for email_id=${emailId} — no text/html body available to parse`,
-    });
-    // Store as unrecognized so it's visible in the UI, even without body content
-    await admin.from("unrecognized_emails").insert({
-      user_id: userId,
-      email_ingest_id: emailIngestId,
-      from_address: from,
-      subject: subject ?? null,
-      text_body: null,
-      html_body: null,
-      status: "pending",
-    });
-    return NextResponse.json({ ok: true });
-  }
-
   // 8. Parse email body
   console.log(`[email-ingest][${emailId}] Parsing email body (${emailBody.length} chars, hasText=${!!emailText}, hasHtml=${!!emailHtml})`);
   const parsed = parseBancolombiaEmail(emailBody);
@@ -616,7 +622,7 @@ async function processEmail(ctx: {
   if (!parsed) {
     console.log(`[email-ingest][${emailId}] No pattern matched — storing as unrecognized. Body preview: ${emailBody.slice(0, 200)}`);
     // Store full email for parser improvement review
-    await admin.from("unrecognized_emails").insert({
+    const { error: unrecognizedError } = await admin.from("unrecognized_emails").insert({
       user_id: userId,
       email_ingest_id: emailIngestId,
       from_address: from,
@@ -625,6 +631,9 @@ async function processEmail(ctx: {
       html_body: emailHtml,
       status: "pending",
     });
+    if (unrecognizedError) {
+      console.error(`[email-ingest][${emailId}] Failed to insert unrecognized_email:`, unrecognizedError.message);
+    }
 
     await insertLog({
       userId,
@@ -634,6 +643,7 @@ async function processEmail(ctx: {
       rawBody: rawBodyPreview,
       errorMessage: "Email body did not match any known Bancolombia pattern",
     });
+    revalidateTag("email-ingest", "zeta");
     return NextResponse.json({ ok: true });
   }
 
@@ -695,7 +705,7 @@ async function processEmail(ctx: {
       if (categoryId) categorizationSource = "SYSTEM_DEFAULT";
     }
 
-    const { error: insertError } = await admin.from("transactions").insert({
+    const { data: insertedTx, error: insertError } = await admin.from("transactions").insert({
       user_id: userId,
       account_id: suggestedAccountId,
       amount: parsed.amount,
@@ -713,7 +723,7 @@ async function processEmail(ctx: {
       is_subscription: false,
       categorization_source: categorizationSource,
       status: "POSTED",
-    });
+    }).select("id").single();
 
     if (insertError) {
       if (insertError.code === "23505") {
@@ -741,6 +751,17 @@ async function processEmail(ctx: {
     }
 
     console.log(`[email-ingest][${emailId}] Transaction auto-imported successfully`);
+
+    // Link to pending recurring occurrence if applicable
+    if (insertedTx) {
+      await linkTransactionToOccurrence(
+        suggestedAccountId,
+        parsed.transaction_date,
+        parsed.amount,
+        parsed.direction,
+        insertedTx.id,
+      );
+    }
 
     // Update account balance
     if (matchedAccount) {
@@ -770,13 +791,8 @@ async function processEmail(ctx: {
     });
 
     // Invalidate caches so dashboard reflects the new transaction
+    revalidateFinancialViews();
     revalidateTag("email-ingest", "zeta");
-    revalidateTag("dashboard:hero", "zeta");
-    revalidateTag("dashboard:charts", "zeta");
-    revalidateTag("dashboard:accounts", "zeta");
-    revalidateTag("dashboard:cashflow", "zeta");
-    revalidateTag("dashboard:budgets", "zeta");
-    revalidateTag("accounts", "zeta");
 
     return NextResponse.json({ ok: true });
   }
@@ -829,5 +845,6 @@ async function processEmail(ctx: {
     errorMessage: null,
   });
 
+  revalidateTag("email-ingest", "zeta");
   return NextResponse.json({ ok: true });
 }

--- a/webapp/src/components/settings/email-ingest-logs-card.tsx
+++ b/webapp/src/components/settings/email-ingest-logs-card.tsx
@@ -8,16 +8,16 @@ import { cn } from "@/lib/utils";
 import type { EmailIngestLog } from "@/types/domain";
 
 const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
-  imported: { label: "Importado", className: "bg-emerald-400/20 text-emerald-400" },
-  queued: { label: "En cola", className: "bg-blue-400/20 text-blue-400" },
-  parsed: { label: "Parseado", className: "bg-blue-400/20 text-blue-400" },
-  duplicate: { label: "Duplicado", className: "bg-zinc-400/20 text-zinc-400" },
-  parse_failed: { label: "Error", className: "bg-red-400/20 text-red-400" },
+  imported: { label: "Importado", className: "bg-emerald-500/20 text-emerald-500" },
+  queued: { label: "En cola", className: "bg-z-brass/20 text-z-brass" },
+  parsed: { label: "Parseado", className: "bg-z-brass/20 text-z-brass" },
+  duplicate: { label: "Duplicado", className: "bg-white/6 text-muted-foreground" },
+  parse_failed: { label: "Error", className: "bg-red-500/20 text-red-500" },
   sender_rejected: { label: "Remitente rechazado", className: "bg-amber-400/20 text-amber-400" },
   rate_limited: { label: "Límite excedido", className: "bg-amber-400/20 text-amber-400" },
-  pdf_queued: { label: "PDF en cola", className: "bg-blue-400/20 text-blue-400" },
-  pdf_parse_failed: { label: "PDF error", className: "bg-red-400/20 text-red-400" },
-  pdf_imported: { label: "PDF importado", className: "bg-emerald-400/20 text-emerald-400" },
+  pdf_queued: { label: "PDF en cola", className: "bg-z-brass/20 text-z-brass" },
+  pdf_parse_failed: { label: "PDF error", className: "bg-red-500/20 text-red-500" },
+  pdf_imported: { label: "PDF importado", className: "bg-emerald-500/20 text-emerald-500" },
 };
 
 interface EmailIngestLogsCardProps {
@@ -53,7 +53,7 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
             <div className="flex items-center gap-2">
               <CardTitle>Historial de correos</CardTitle>
               {errorCount > 0 && (
-                <span className="rounded-full bg-red-400/20 px-2 py-0.5 text-xs font-semibold text-red-400">
+                <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-xs font-semibold text-red-500">
                   {errorCount} {errorCount === 1 ? "error" : "errores"}
                 </span>
               )}
@@ -71,7 +71,7 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
             const isExpanded = expanded.has(log.id);
             const config = STATUS_CONFIG[log.status] ?? {
               label: log.status,
-              className: "bg-zinc-400/20 text-zinc-400",
+              className: "bg-white/6 text-muted-foreground",
             };
 
             return (
@@ -105,7 +105,7 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
                     {log.error_message && (
                       <div className="space-y-1">
                         <p className="text-xs font-medium text-muted-foreground">Error</p>
-                        <p className="rounded-md border border-border/40 bg-black/20 px-3 py-2 text-xs text-red-400">
+                        <p className="rounded-md border border-white/6 bg-black/20 px-3 py-2 text-xs text-red-500">
                           {log.error_message}
                         </p>
                       </div>
@@ -113,7 +113,7 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
                     {log.raw_body && (
                       <div className="space-y-1">
                         <p className="text-xs font-medium text-muted-foreground">Contenido recibido</p>
-                        <pre className="max-h-36 overflow-y-auto whitespace-pre-wrap rounded-md border border-border/40 bg-black/20 p-3 text-xs leading-relaxed">
+                        <pre className="max-h-36 overflow-y-auto whitespace-pre-wrap rounded-md border border-white/6 bg-black/20 p-3 text-xs leading-relaxed">
                           {log.raw_body}
                         </pre>
                       </div>

--- a/webapp/src/components/settings/email-ingest-logs-card.tsx
+++ b/webapp/src/components/settings/email-ingest-logs-card.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, ScrollText } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatDate } from "@/lib/utils/date";
+import { cn } from "@/lib/utils";
+import type { EmailIngestLog } from "@/types/domain";
+
+const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+  imported: { label: "Importado", className: "bg-emerald-400/20 text-emerald-400" },
+  queued: { label: "En cola", className: "bg-blue-400/20 text-blue-400" },
+  parsed: { label: "Parseado", className: "bg-blue-400/20 text-blue-400" },
+  duplicate: { label: "Duplicado", className: "bg-zinc-400/20 text-zinc-400" },
+  parse_failed: { label: "Error", className: "bg-red-400/20 text-red-400" },
+  sender_rejected: { label: "Remitente rechazado", className: "bg-amber-400/20 text-amber-400" },
+  rate_limited: { label: "Límite excedido", className: "bg-amber-400/20 text-amber-400" },
+  pdf_queued: { label: "PDF en cola", className: "bg-blue-400/20 text-blue-400" },
+  pdf_parse_failed: { label: "PDF error", className: "bg-red-400/20 text-red-400" },
+  pdf_imported: { label: "PDF importado", className: "bg-emerald-400/20 text-emerald-400" },
+};
+
+interface EmailIngestLogsCardProps {
+  initialLogs: EmailIngestLog[];
+}
+
+export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  if (initialLogs.length === 0) return null;
+
+  const errorCount = initialLogs.filter(
+    (l) => l.status === "parse_failed" || l.status === "sender_rejected" || l.status === "pdf_parse_failed"
+  ).length;
+
+  function toggleExpand(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+            <ScrollText className="size-4 text-z-brass" />
+          </div>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <CardTitle>Historial de correos</CardTitle>
+              {errorCount > 0 && (
+                <span className="rounded-full bg-red-400/20 px-2 py-0.5 text-xs font-semibold text-red-400">
+                  {errorCount} {errorCount === 1 ? "error" : "errores"}
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Últimos {initialLogs.length} correos procesados por el webhook. Revisa aquí si un correo no generó transacción.
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        <div className="divide-y divide-white/6">
+          {initialLogs.map((log) => {
+            const isExpanded = expanded.has(log.id);
+            const config = STATUS_CONFIG[log.status] ?? {
+              label: log.status,
+              className: "bg-zinc-400/20 text-zinc-400",
+            };
+
+            return (
+              <div key={log.id} className="px-6 py-3">
+                <button
+                  onClick={() => toggleExpand(log.id)}
+                  className="flex w-full items-center gap-3 text-left"
+                >
+                  {isExpanded ? (
+                    <ChevronUp className="size-4 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className={cn("rounded-full px-2 py-0.5 text-[10px] font-semibold", config.className)}>
+                        {config.label}
+                      </span>
+                      <span className="truncate text-sm text-muted-foreground">
+                        {log.from_address}
+                      </span>
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground/60">
+                      {formatDate(log.created_at)}
+                    </p>
+                  </div>
+                </button>
+
+                {isExpanded && (
+                  <div className="mt-3 space-y-2 pl-7">
+                    {log.error_message && (
+                      <div className="space-y-1">
+                        <p className="text-xs font-medium text-muted-foreground">Error</p>
+                        <p className="rounded-md border border-border/40 bg-black/20 px-3 py-2 text-xs text-red-400">
+                          {log.error_message}
+                        </p>
+                      </div>
+                    )}
+                    {log.raw_body && (
+                      <div className="space-y-1">
+                        <p className="text-xs font-medium text-muted-foreground">Contenido recibido</p>
+                        <pre className="max-h-36 overflow-y-auto whitespace-pre-wrap rounded-md border border-border/40 bg-black/20 p-3 text-xs leading-relaxed">
+                          {log.raw_body}
+                        </pre>
+                      </div>
+                    )}
+                    {!log.error_message && !log.raw_body && (
+                      <p className="text-xs text-muted-foreground italic">
+                        Sin detalles adicionales
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Emails were silently failing at multiple points in the webhook with no
DB logs or UI visibility. This adds structured console logging at every
decision point, a top-level try/catch for unhandled errors, explicit
handling when Resend API fetch fails, and a new EmailIngestLogsCard
on the settings page so all email_ingest_logs (sender_rejected,
rate_limited, parse_failed, etc.) are visible to the user.

https://claude.ai/code/session_01KuRqDKsomwbtpi83YjTDDj