### PR TITLE
fix: dashboard pending emails show "Desconocido" instead of destination

### DIFF
--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -127,7 +127,7 @@ async function getAttentionItemsCached(
       const parsed = e.parsed_data as Record<string, unknown> | null;
       return {
         id: e.id,
-        merchant: (parsed?.merchant as string) ?? "Desconocido",
+        merchant: (parsed?.merchant as string) || (parsed?.destination as string) || "Desconocido",
         amount: (parsed?.amount as number) ?? 0,
         direction:
           (parsed?.direction as "INFLOW" | "OUTFLOW") ?? "OUTFLOW",

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -940,6 +940,7 @@ export async function dismissEmailTransaction(
   if (error) return { success: false, error: error.message };
 
   revalidateTag("email-ingest", "zeta");
+  revalidateTag("attention", "zeta");
   return { success: true, data: null };
 }
 


### PR DESCRIPTION
The attention-items mapper only checked parsed.merchant, falling back to
"Desconocido" when null. Bancolombia email transactions often have
merchant=null with the actual reference in the destination field. Now
falls back through destination before showing "Desconocido", matching
the same logic used on the transactions page.

https://claude.ai/code/session_014cYzuzN71LqSy5Wbbffh6C