### PR TITLE
feat: mobile UI improvements — avatar importar CTA, FAB screenshot/capture, upload-first import page

### DIFF
--- a/webapp/src/app/(dashboard)/import/page.tsx
+++ b/webapp/src/app/(dashboard)/import/page.tsx
@@ -1,6 +1,6 @@
 import { connection } from "next/server";
 import Link from "next/link";
-import { ArrowRight, Files, ShieldCheck, Sparkles } from "lucide-react";
+import { ArrowRight, ChevronDown, Files, ShieldCheck, Sparkles } from "lucide-react";
 import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getDestinatarioRules } from "@/actions/destinatarios";
@@ -30,83 +30,98 @@ export default async function ImportPage() {
     <div className="space-y-6 lg:space-y-8">
       <MobileHeader variant="sub" title="Importar Extracto" backHref="/gestionar" />
 
-      <PageHero
-        variant="brass"
-        pills={<><HeroPill>Actualizar base</HeroPill><HeroAccentPill>Flujo guiado</HeroAccentPill></>}
-        title="Importa el extracto y devuelve contexto a toda la app"
-        description="Este flujo trae movimientos, actualiza saldos, aprende destinatarios y te ayuda a reconciliar duplicados antes de que la foto diaria se quede vieja."
-        actions={
-          <>
-            <Button asChild className={BRASS_BUTTON_CLASS}>
-              <Link href="/accounts">
-                Revisar cuentas
-                <ArrowRight className="size-4" />
-              </Link>
-            </Button>
-            <Button asChild variant="outline" className={GHOST_BUTTON_CLASS}>
-              <Link href="/destinatarios">Afinar destinatarios</Link>
-            </Button>
-          </>
-        }
-      >
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <StatCard
-            label="Cuentas listas"
-            value={accounts.length}
-            description="Bases disponibles para asociar cada extracto al destino correcto."
-          />
-          <StatCard
-            label="Categorías activas"
-            value={categories.length}
-            description="Se usarán para preparar la revisión y la confirmación final."
-          />
-          <StatCard
-            label="Reglas aprendidas"
-            value={destinatarioRules.length}
-            description="Atajos ya disponibles para reconocer comercios y sugerir categorías."
-          />
-          <StatCard
-            label={
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                <ShieldCheck className="size-4 text-z-brass" />
-                Lo que protege el flujo
-              </div>
-            }
-            value={
-              <span className="text-sm font-normal leading-6 text-muted-foreground">
-                Revisión manual de cuenta, destinatarios y conciliación antes de escribir en la base.
-              </span>
-            }
-          />
-        </div>
+      {/* Desktop: full PageHero */}
+      <div className="hidden lg:block">
+        <PageHero
+          variant="brass"
+          pills={<><HeroPill>Actualizar base</HeroPill><HeroAccentPill>Flujo guiado</HeroAccentPill></>}
+          title="Importa el extracto y devuelve contexto a toda la app"
+          description="Este flujo trae movimientos, actualiza saldos, aprende destinatarios y te ayuda a reconciliar duplicados antes de que la foto diaria se quede vieja."
+          actions={
+            <>
+              <Button asChild className={BRASS_BUTTON_CLASS}>
+                <Link href="/accounts">
+                  Revisar cuentas
+                  <ArrowRight className="size-4" />
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className={GHOST_BUTTON_CLASS}>
+                <Link href="/destinatarios">Afinar destinatarios</Link>
+              </Button>
+            </>
+          }
+        >
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <StatCard
+              label="Cuentas listas"
+              value={accounts.length}
+              description="Bases disponibles para asociar cada extracto al destino correcto."
+            />
+            <StatCard
+              label="Categorías activas"
+              value={categories.length}
+              description="Se usarán para preparar la revisión y la confirmación final."
+            />
+            <StatCard
+              label="Reglas aprendidas"
+              value={destinatarioRules.length}
+              description="Atajos ya disponibles para reconocer comercios y sugerir categorías."
+            />
+            <StatCard
+              label={
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+                  <ShieldCheck className="size-4 text-z-brass" />
+                  Lo que protege el flujo
+                </div>
+              }
+              value={
+                <span className="text-sm font-normal leading-6 text-muted-foreground">
+                  Revisión manual de cuenta, destinatarios y conciliación antes de escribir en la base.
+                </span>
+              }
+            />
+          </div>
 
-        <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
-          <div className="rounded-2xl border border-white/6 bg-z-surface-2/55 p-4">
-            <div className="flex items-start gap-3">
-              <Files className="mt-0.5 size-4 text-z-brass" />
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-z-white">Qué resuelve este flujo</p>
-                <p className="text-sm text-muted-foreground">
-                  Sube el PDF, confirma la cuenta correcta, aprende destinatarios, revisa
-                  transacciones y resuelve duplicados antes de cerrar la importación.
-                </p>
+          <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="rounded-2xl border border-white/6 bg-z-surface-2/55 p-4">
+              <div className="flex items-start gap-3">
+                <Files className="mt-0.5 size-4 text-z-brass" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-z-white">Qué resuelve este flujo</p>
+                  <p className="text-sm text-muted-foreground">
+                    Sube el PDF, confirma la cuenta correcta, aprende destinatarios, revisa
+                    transacciones y resuelve duplicados antes de cerrar la importación.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/6 bg-z-surface-2/55 p-4">
+              <div className="flex items-start gap-3">
+                <Sparkles className="mt-0.5 size-4 text-z-brass" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-z-white">Si no tienes cuentas aún</p>
+                  <p className="text-sm text-muted-foreground">
+                    Puedes crear una durante la revisión. No hace falta salir de este flujo para
+                    empezar.
+                  </p>
+                </div>
               </div>
             </div>
           </div>
-          <div className="rounded-2xl border border-white/6 bg-z-surface-2/55 p-4">
-            <div className="flex items-start gap-3">
-              <Sparkles className="mt-0.5 size-4 text-z-brass" />
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-z-white">Si no tienes cuentas aún</p>
-                <p className="text-sm text-muted-foreground">
-                  Puedes crear una durante la revisión. No hace falta salir de este flujo para
-                  empezar.
-                </p>
-              </div>
-            </div>
-          </div>
+        </PageHero>
+      </div>
+
+      {/* Mobile: compact intro */}
+      <div className="lg:hidden">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full border border-z-brass/30 bg-z-brass/10 px-3 py-1 text-[11px] font-medium text-z-brass">
+            Flujo guiado
+          </span>
         </div>
-      </PageHero>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          Sube tu extracto o captura de pantalla para actualizar tus movimientos.
+        </p>
+      </div>
 
       <PendingEmailStatements statements={pendingStatements} />
 
@@ -115,6 +130,71 @@ export default async function ImportPage() {
         categories={categories}
         destinatarioRules={destinatarioRules}
       />
+
+      {/* Mobile: collapsible info section */}
+      <details className="group lg:hidden rounded-2xl border border-white/6 bg-z-surface-2/55">
+        <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-medium text-z-sage-light marker:content-none [&::-webkit-details-marker]:hidden">
+          Más sobre este flujo
+          <ChevronDown className="size-4 text-muted-foreground transition-transform group-open:rotate-180" />
+        </summary>
+        <div className="space-y-3 px-4 pb-4">
+          <div className="grid gap-3 grid-cols-2">
+            <StatCard
+              label="Cuentas listas"
+              value={accounts.length}
+              description="Bases disponibles para asociar cada extracto."
+            />
+            <StatCard
+              label="Categorías activas"
+              value={categories.length}
+              description="Para revisión y confirmación final."
+            />
+            <StatCard
+              label="Reglas aprendidas"
+              value={destinatarioRules.length}
+              description="Atajos para reconocer comercios."
+            />
+            <StatCard
+              label={
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+                  <ShieldCheck className="size-4 text-z-brass" />
+                  Protección
+                </div>
+              }
+              value={
+                <span className="text-sm font-normal leading-6 text-muted-foreground">
+                  Revisión manual antes de escribir en la base.
+                </span>
+              }
+            />
+          </div>
+
+          <div className="space-y-3">
+            <div className="rounded-2xl border border-white/6 bg-black/10 p-3">
+              <div className="flex items-start gap-3">
+                <Files className="mt-0.5 size-4 text-z-brass shrink-0" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-z-white">Qué resuelve este flujo</p>
+                  <p className="text-xs text-muted-foreground">
+                    Sube el archivo, confirma la cuenta, aprende destinatarios y resuelve duplicados.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/6 bg-black/10 p-3">
+              <div className="flex items-start gap-3">
+                <Sparkles className="mt-0.5 size-4 text-z-brass shrink-0" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-z-white">Si no tienes cuentas aún</p>
+                  <p className="text-xs text-muted-foreground">
+                    Puedes crear una durante la revisión sin salir del flujo.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </details>
     </div>
   );
 }

--- a/webapp/src/components/import/import-wizard.tsx
+++ b/webapp/src/components/import/import-wizard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { Check, ShieldCheck } from "lucide-react";
+import { getPendingScreenshotFile } from "@/components/mobile/mobile-sheet-provider";
 import type { Account, CategoryWithChildren, CurrencyCode } from "@/types/domain";
 import type { DestinatarioRule } from "@zeta/shared";
 import type {
@@ -25,7 +27,7 @@ import { cn } from "@/lib/utils";
 type Step = "upload" | "review" | "destinatarios" | "confirm" | "reconcile" | "results";
 
 const STEPS: { key: Step; label: string }[] = [
-  { key: "upload", label: "Subir PDF" },
+  { key: "upload", label: "Subir archivo" },
   { key: "review", label: "Revisar" },
   { key: "destinatarios", label: "Destinatarios" },
   { key: "confirm", label: "Confirmar" },
@@ -34,7 +36,7 @@ const STEPS: { key: Step; label: string }[] = [
 ];
 
 const STEP_DESCRIPTIONS: Record<Step, string> = {
-  upload: "Sube el PDF correcto y valida que el parser reconoció la estructura del extracto.",
+  upload: "Sube tu extracto PDF o captura de pantalla y valida que el parser reconoció la estructura.",
   review: "Confirma a qué cuenta pertenece cada extracto y ajusta monedas cuando haga falta.",
   destinatarios: "Enseña quién es quién para acelerar decisiones y futuras categorizaciones.",
   confirm: "Revisa transacciones, categorías y el paquete real que entrará a la base.",
@@ -46,10 +48,12 @@ export function ImportWizard({
   accounts,
   categories,
   destinatarioRules,
+  initialFile,
 }: {
   accounts: Account[];
   categories: CategoryWithChildren[];
   destinatarioRules: DestinatarioRule[];
+  initialFile?: File | null;
 }) {
   const [step, setStep] = useState<Step>("upload");
   const [parseResult, setParseResult] = useState<ParseResponse | null>(null);
@@ -65,6 +69,23 @@ export function ImportWizard({
   const currentIndex = STEPS.findIndex((s) => s.key === step);
   const currentStep = STEPS[currentIndex];
   const progressValue = ((currentIndex + 1) / STEPS.length) * 100;
+
+  // Check for screenshot file from FAB
+  const searchParams = useSearchParams();
+  const screenshotFileRef = useRef<File | null>(null);
+  const [screenshotFile, setScreenshotFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (searchParams.get("mode") === "screenshot" && !screenshotFileRef.current) {
+      const file = getPendingScreenshotFile();
+      if (file) {
+        screenshotFileRef.current = file;
+        setScreenshotFile(file);
+      }
+    }
+  }, [searchParams]);
+
+  const resolvedInitialFile = initialFile ?? screenshotFile;
 
   useEffect(() => {
     void trackClientEvent({
@@ -265,7 +286,7 @@ export function ImportWizard({
 
       <section className="rounded-[28px] border border-white/6 bg-z-surface-2/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] sm:p-6">
         {/* Step content */}
-        {step === "upload" && <StepUpload onParsed={handleParsed} />}
+        {step === "upload" && <StepUpload onParsed={handleParsed} initialFile={resolvedInitialFile} />}
         {step === "review" && parseResult && (
           <StepReview
             parseResult={parseResult}

--- a/webapp/src/components/import/step-upload.tsx
+++ b/webapp/src/components/import/step-upload.tsx
@@ -12,7 +12,8 @@ const MAX_PDF_SIZE = 10 * 1024 * 1024; // 10 MB
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB
 
 function getFileExtension(name: string): string {
-  return name.toLowerCase().slice(name.lastIndexOf("."));
+  const dotIndex = name.lastIndexOf(".");
+  return dotIndex !== -1 ? name.toLowerCase().slice(dotIndex) : "";
 }
 
 function isImageFile(name: string): boolean {
@@ -68,7 +69,7 @@ export function StepUpload({
     }
     const maxSize = isImage ? MAX_IMAGE_SIZE : MAX_PDF_SIZE;
     if (f.size > maxSize) {
-      setError(`El archivo excede el tamaño máximo de ${isImage ? "20" : "10"}MB`);
+      setError(`El archivo excede el tamaño máximo de ${maxSize / (1024 * 1024)}MB`);
       return;
     }
     setFile(f);

--- a/webapp/src/components/import/step-upload.tsx
+++ b/webapp/src/components/import/step-upload.tsx
@@ -1,15 +1,34 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { Upload, FileText, Loader2, Lock, HelpCircle, CheckCircle2 } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { Upload, FileText, Loader2, Lock, HelpCircle, CheckCircle2, ImageIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ParseResponse } from "@/types/import";
 import { trackClientEvent } from "@/lib/utils/analytics";
 
+const PDF_EXTENSIONS = new Set([".pdf"]);
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+const MAX_PDF_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB
+
+function getFileExtension(name: string): string {
+  return name.toLowerCase().slice(name.lastIndexOf("."));
+}
+
+function isImageFile(name: string): boolean {
+  return IMAGE_EXTENSIONS.has(getFileExtension(name));
+}
+
+function isPdfFile(name: string): boolean {
+  return PDF_EXTENSIONS.has(getFileExtension(name));
+}
+
 export function StepUpload({
   onParsed,
+  initialFile,
 }: {
   onParsed: (data: ParseResponse) => void;
+  initialFile?: File | null;
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [password, setPassword] = useState("");
@@ -20,6 +39,7 @@ export function StepUpload({
   const [savingForSupport, setSavingForSupport] = useState(false);
   const [savedForSupport, setSavedForSupport] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const initialFileProcessed = useRef(false);
 
   async function handleSaveForSupport() {
     if (!unsupportedFile) return;
@@ -38,12 +58,17 @@ export function StepUpload({
     setError("");
     setUnsupportedFile(null);
     setSavedForSupport(false);
-    if (!f.name.toLowerCase().endsWith(".pdf")) {
-      setError("El archivo debe ser un PDF");
+
+    const isImage = isImageFile(f.name);
+    const isPdf = isPdfFile(f.name);
+
+    if (!isImage && !isPdf) {
+      setError("Formato no soportado. Se aceptan PDF, PNG, JPG o WEBP.");
       return;
     }
-    if (f.size > 10 * 1024 * 1024) {
-      setError("El archivo excede el tamaño máximo de 10MB");
+    const maxSize = isImage ? MAX_IMAGE_SIZE : MAX_PDF_SIZE;
+    if (f.size > maxSize) {
+      setError(`El archivo excede el tamaño máximo de ${isImage ? "20" : "10"}MB`);
       return;
     }
     setFile(f);
@@ -56,18 +81,31 @@ export function StepUpload({
       metadata: {
         filename: f.name,
         file_size_bytes: f.size,
+        file_type: isImage ? "image" : "pdf",
       },
     });
   }
+
+  // Handle initialFile from FAB screenshot flow
+  useEffect(() => {
+    if (initialFile && !initialFileProcessed.current) {
+      initialFileProcessed.current = true;
+      handleFile(initialFile);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFile]);
 
   async function handleUpload() {
     if (!file) return;
     setLoading(true);
     setError("");
 
+    const isImage = isImageFile(file.name);
+    const endpoint = isImage ? "/api/parse-image" : "/api/parse-statement";
+
     const formData = new FormData();
     formData.append("file", file);
-    if (password) {
+    if (!isImage && password) {
       formData.append("password", password);
     }
 
@@ -78,10 +116,10 @@ export function StepUpload({
         step: "parse",
         entry_point: "cta",
         success: true,
-        metadata: { has_password: !!password },
+        metadata: { has_password: !isImage && !!password, file_type: isImage ? "image" : "pdf" },
       });
 
-      const res = await fetch("/api/parse-statement", {
+      const res = await fetch(endpoint, {
         method: "POST",
         body: formData,
       });
@@ -109,7 +147,7 @@ export function StepUpload({
             success: false,
             error_code: "parse_api_error",
           });
-          setError(data.error || "Error procesando el PDF");
+          setError(data.error || (isImage ? "Error procesando la imagen" : "Error procesando el PDF"));
         }
         setLoading(false);
         return;
@@ -134,7 +172,9 @@ export function StepUpload({
           error_code: "empty_parse_result",
         });
         setError(
-          "No se encontraron transacciones ni metadatos en este PDF. Verifica que sea un extracto bancario de un formato compatible."
+          isImage
+            ? "No se encontraron transacciones en esta imagen. Verifica que sea una captura de movimientos bancarios de un formato compatible."
+            : "No se encontraron transacciones ni metadatos en este PDF. Verifica que sea un extracto bancario de un formato compatible."
         );
         setLoading(false);
         return;
@@ -191,10 +231,10 @@ export function StepUpload({
         <Upload className="h-10 w-10 text-muted-foreground" />
         <div className="text-center">
           <p className="text-sm font-medium">
-            Arrastra tu extracto bancario aquí
+            Arrastra tu extracto o captura de pantalla
           </p>
           <p className="text-xs text-muted-foreground mt-1">
-            o haz clic para seleccionar un archivo PDF (máx. 10MB)
+            PDF (máx. 10MB) o imagen PNG/JPG (máx. 20MB)
           </p>
         </div>
         <Button
@@ -207,7 +247,7 @@ export function StepUpload({
         <input
           ref={inputRef}
           type="file"
-          accept=".pdf"
+          accept=".pdf,.png,.jpg,.jpeg,.webp"
           className="hidden"
           onChange={(e) => {
             const f = e.target.files?.[0];
@@ -219,7 +259,11 @@ export function StepUpload({
       {file && (
         <div className="space-y-3">
           <div className="flex items-center gap-3 rounded-md border p-3">
-            <FileText className="h-5 w-5 text-muted-foreground" />
+            {isImageFile(file.name) ? (
+              <ImageIcon className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <FileText className="h-5 w-5 text-muted-foreground" />
+            )}
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium truncate">{file.name}</p>
               <p className="text-xs text-muted-foreground">
@@ -233,26 +277,30 @@ export function StepUpload({
                   Procesando...
                 </>
               ) : (
-                "Procesar extracto"
+                "Procesar"
               )}
             </Button>
           </div>
-          <div className="flex items-center gap-3 rounded-md border p-3">
-            <Lock className="h-5 w-5 text-muted-foreground shrink-0" />
-            <div className="flex-1 min-w-0">
-              <input
-                type="password"
-                placeholder="Contraseña del PDF (opcional)"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                autoComplete="off"
-              />
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Algunos extractos están protegidos con contraseña (ej. número de cédula).
-          </p>
+          {!isImageFile(file.name) && (
+            <>
+              <div className="flex items-center gap-3 rounded-md border p-3">
+                <Lock className="h-5 w-5 text-muted-foreground shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <input
+                    type="password"
+                    placeholder="Contraseña del PDF (opcional)"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                    autoComplete="off"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Algunos extractos están protegidos con contraseña (ej. número de cédula).
+              </p>
+            </>
+          )}
         </div>
       )}
 

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -120,7 +120,7 @@ export function FabMenu({ onAction, contextActions }: FabMenuProps) {
                 type="button"
                 onClick={() => handleAction("screenshot")}
                 className={cn(
-                  "flex items-center gap-2.5 rounded-xl border border-white/8 bg-white/4 px-3 py-3",
+                  "flex items-center gap-2.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3",
                   "transition-colors active:bg-white/8",
                 )}
               >
@@ -138,7 +138,7 @@ export function FabMenu({ onAction, contextActions }: FabMenuProps) {
                 type="button"
                 onClick={() => handleAction("quick-capture")}
                 className={cn(
-                  "flex items-center gap-2.5 rounded-xl border border-white/8 bg-white/4 px-3 py-3",
+                  "flex items-center gap-2.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3",
                   "transition-colors active:bg-white/8",
                 )}
               >
@@ -171,7 +171,7 @@ export function FabMenu({ onAction, contextActions }: FabMenuProps) {
                 >
                   <span
                     className={cn(
-                      "flex size-10 items-center justify-center rounded-full text-white",
+                      "flex size-10 items-center justify-center rounded-full text-z-white",
                       action.bg,
                     )}
                   >
@@ -201,7 +201,7 @@ export function FabMenu({ onAction, contextActions }: FabMenuProps) {
                     >
                       <span
                         className={cn(
-                          "flex size-8 items-center justify-center rounded-full text-white",
+                          "flex size-8 items-center justify-center rounded-full text-z-white",
                           action.bg,
                         )}
                       >

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
-import { Plus, ArrowUpRight, ArrowDownLeft, ArrowLeftRight, Mic } from "lucide-react";
+import { Plus, ArrowUpRight, ArrowDownLeft, ArrowLeftRight, Mic, Camera, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 
-export type FabAction = "expense" | "income" | "transfer" | "voice" | "new-recurring" | "new-account";
+export type FabAction = "expense" | "income" | "transfer" | "voice" | "screenshot" | "quick-capture" | "new-recurring" | "new-account";
 
 export interface ContextAction {
   id: FabAction;
@@ -113,6 +113,46 @@ export function FabMenu({ onAction, contextActions }: FabMenuProps) {
                 </p>
               </div>
             </button>
+
+            {/* Capture options */}
+            <div className="mb-4 grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={() => handleAction("screenshot")}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-xl border border-white/8 bg-white/4 px-3 py-3",
+                  "transition-colors active:bg-white/8",
+                )}
+              >
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-z-brass/15 text-z-brass">
+                  <Camera className="size-4" strokeWidth={2} />
+                </span>
+                <div className="min-w-0 text-left">
+                  <span className="text-xs font-semibold leading-tight">Captura de pantalla</span>
+                  <p className="text-[10px] leading-tight text-muted-foreground">
+                    Sube un pantallazo
+                  </p>
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => handleAction("quick-capture")}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-xl border border-white/8 bg-white/4 px-3 py-3",
+                  "transition-colors active:bg-white/8",
+                )}
+              >
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-z-brass/15 text-z-brass">
+                  <Sparkles className="size-4" strokeWidth={2} />
+                </span>
+                <div className="min-w-0 text-left">
+                  <span className="text-xs font-semibold leading-tight">Captura rápida</span>
+                  <p className="text-[10px] leading-tight text-muted-foreground">
+                    Escribe el gasto
+                  </p>
+                </div>
+              </button>
+            </div>
 
             {/* Section 1: Acciones rápidas */}
             <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">

--- a/webapp/src/components/mobile/mobile-quick-capture-sheet.tsx
+++ b/webapp/src/components/mobile/mobile-quick-capture-sheet.tsx
@@ -6,7 +6,9 @@ import { autoCategorize, parseQuickCaptureText } from "@zeta/shared";
 import { Wand2 } from "lucide-react";
 import { createQuickCaptureTransaction } from "@/actions/transactions";
 import { trackClientEvent } from "@/lib/utils/analytics";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
@@ -133,7 +135,7 @@ export function MobileQuickCaptureSheet({
         {parseError && (
           <p className="text-xs text-destructive">{parseError}</p>
         )}
-        <Button type="button" onClick={handleParse} disabled={!input.trim()} className="w-full">
+        <Button type="button" onClick={handleParse} disabled={!input.trim()} className={cn("w-full", BRASS_BUTTON_CLASS)}>
           <Wand2 className="mr-2 size-4" />
           Interpretar
         </Button>
@@ -245,7 +247,7 @@ export function MobileQuickCaptureSheet({
       <input type="hidden" name="capture_input_text" value={preview.capture_input_text} />
       <input type="hidden" name="notes" value="" />
 
-      <Button type="submit" className="w-full" disabled={pending}>
+      <Button type="submit" className={cn("w-full", BRASS_BUTTON_CLASS)} disabled={pending}>
         {pending ? "Guardando..." : "Guardar"}
       </Button>
     </form>

--- a/webapp/src/components/mobile/mobile-quick-capture-sheet.tsx
+++ b/webapp/src/components/mobile/mobile-quick-capture-sheet.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useActionState, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { autoCategorize, parseQuickCaptureText } from "@zeta/shared";
+import { Wand2 } from "lucide-react";
+import { createQuickCaptureTransaction } from "@/actions/transactions";
+import { trackClientEvent } from "@/lib/utils/analytics";
+import { Button } from "@/components/ui/button";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import { DatePicker } from "@/components/ui/date-picker";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import type { ActionResult } from "@/types/actions";
+import type { Account, CategoryWithChildren, Transaction, TransactionDirection } from "@/types/domain";
+
+const STORAGE_KEY = "zeta:quick-capture-default-account";
+
+type PreviewState = {
+  amount: string;
+  direction: TransactionDirection;
+  transaction_date: string;
+  merchant_name: string;
+  raw_description: string;
+  category_id: string | null;
+  notes: string;
+  account_id: string;
+  capture_input_text: string;
+};
+
+export function MobileQuickCaptureSheet({
+  accounts,
+  categories,
+  onSuccess,
+}: {
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  onSuccess: () => void;
+}) {
+  const router = useRouter();
+  const [input, setInput] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState(accounts[0]?.id ?? "");
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && accounts.some((account) => account.id === stored)) {
+      setSelectedAccountId(stored);
+    }
+  }, [accounts]);
+
+  const selectedAccount = useMemo(
+    () => accounts.find((account) => account.id === selectedAccountId) ?? accounts[0],
+    [accounts, selectedAccountId]
+  );
+
+  const [state, formAction, pending] = useActionState<ActionResult<Transaction>, FormData>(
+    async (prevState, formData) => {
+      const result = await createQuickCaptureTransaction(prevState, formData);
+      if (result.success) {
+        router.refresh();
+        await trackClientEvent({
+          event_name: "quick_capture_saved",
+          flow: "categorize",
+          step: "persist",
+          entry_point: "fab",
+          success: true,
+          metadata: { capture_method: "TEXT_QUICK_CAPTURE" },
+        });
+        onSuccess();
+      }
+      return result;
+    },
+    { success: false, error: "" }
+  );
+
+  function handleParse() {
+    const result = parseQuickCaptureText(input);
+    if (!result.success) {
+      setParseError(result.error);
+      return;
+    }
+
+    const suggestedCategoryId = autoCategorize(result.data.merchant_name)?.category_id ?? null;
+    const defaultAccountId = selectedAccount?.id ?? accounts[0]?.id ?? "";
+    if (!defaultAccountId) {
+      setParseError("Crea una cuenta primero para usar la captura rápida.");
+      return;
+    }
+
+    setParseError(null);
+    setPreview({
+      amount: String(result.data.amount),
+      direction: result.data.direction,
+      transaction_date: result.data.transaction_date,
+      merchant_name: result.data.merchant_name,
+      raw_description: result.data.raw_description,
+      category_id: suggestedCategoryId,
+      notes: "",
+      account_id: defaultAccountId,
+      capture_input_text: result.data.capture_input_text,
+    });
+    window.localStorage.setItem(STORAGE_KEY, defaultAccountId);
+  }
+
+  if (!preview) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Escribe tu gasto en lenguaje natural y Zeta lo interpreta.
+        </p>
+        <Input
+          autoFocus
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleParse();
+            }
+          }}
+          placeholder='Ej: gasté 15k en café ayer'
+        />
+        {parseError && (
+          <p className="text-xs text-destructive">{parseError}</p>
+        )}
+        <Button type="button" onClick={handleParse} disabled={!input.trim()} className="w-full">
+          <Wand2 className="mr-2 size-4" />
+          Interpretar
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {!state.success && state.error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {state.error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="direction" className="text-xs">Tipo</Label>
+          <Select
+            name="direction"
+            value={preview.direction}
+            onValueChange={(value) =>
+              setPreview((prev) => prev ? { ...prev, direction: value as TransactionDirection } : prev)
+            }
+          >
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="OUTFLOW">Gasto</SelectItem>
+              <SelectItem value="INFLOW">Ingreso</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="amount" className="text-xs">Monto</Label>
+          <CurrencyInput
+            id="amount"
+            name="amount"
+            value={preview.amount}
+            onChange={(e) => setPreview((prev) => prev ? { ...prev, amount: e.target.value } : prev)}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="account_id" className="text-xs">Cuenta</Label>
+          <Select
+            name="account_id"
+            value={preview.account_id}
+            onValueChange={(value) => {
+              setPreview((prev) => prev ? { ...prev, account_id: value } : prev);
+              window.localStorage.setItem(STORAGE_KEY, value);
+            }}
+          >
+            <SelectTrigger><SelectValue placeholder="Cuenta" /></SelectTrigger>
+            <SelectContent>
+              {accounts.map((a) => (
+                <SelectItem key={a.id} value={a.id}>{a.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Fecha</Label>
+          <DatePicker
+            value={preview.transaction_date}
+            onChange={(v) => setPreview((prev) => prev ? { ...prev, transaction_date: v ?? "" } : prev)}
+            name="transaction_date"
+            placeholder="Fecha"
+          />
+        </div>
+      </div>
+
+      <input
+        type="hidden"
+        name="currency_code"
+        value={
+          accounts.find((a) => a.id === preview.account_id)?.currency_code ??
+          selectedAccount?.currency_code ??
+          "COP"
+        }
+      />
+
+      <div className="space-y-1.5">
+        <Label htmlFor="merchant_name" className="text-xs">Descripción</Label>
+        <Input
+          id="merchant_name"
+          name="merchant_name"
+          value={preview.merchant_name}
+          onChange={(e) => setPreview((prev) => prev ? { ...prev, merchant_name: e.target.value } : prev)}
+          required
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Categoría</Label>
+        <CategoryZonePicker
+          variant="popover"
+          categories={categories}
+          value={preview.category_id}
+          onValueChange={(value) => setPreview((prev) => prev ? { ...prev, category_id: value } : prev)}
+          direction={preview.direction}
+          name="category_id"
+        />
+      </div>
+
+      <input type="hidden" name="raw_description" value={preview.raw_description} />
+      <input type="hidden" name="capture_input_text" value={preview.capture_input_text} />
+      <input type="hidden" name="notes" value="" />
+
+      <Button type="submit" className="w-full" disabled={pending}>
+        {pending ? "Guardando..." : "Guardar"}
+      </Button>
+    </form>
+  );
+}

--- a/webapp/src/components/mobile/mobile-sheet-provider.tsx
+++ b/webapp/src/components/mobile/mobile-sheet-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
-import { usePathname } from "next/navigation";
+import { useState, useMemo, useCallback, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarPlus, Landmark } from "lucide-react";
 import {
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/drawer";
 import { FabMenu, type FabAction, type ContextAction } from "./fab-menu";
 import { MobileTransactionForm } from "./mobile-transaction-form";
+import { MobileQuickCaptureSheet } from "./mobile-quick-capture-sheet";
 import { RecurringForm } from "@/components/recurring/recurring-form";
 import { SpecializedAccountForm } from "@/components/accounts/specialized-account-form";
 import { VoiceCaptureSheet } from "./voice-capture-sheet";
@@ -50,9 +51,19 @@ function getContextActions(pathname: string): ContextAction[] {
 
 function getSheetTitle(action: FabAction): string {
   if (action === "voice") return "Captura por voz";
+  if (action === "quick-capture") return "Captura rápida";
   if (action === "new-recurring") return "Nueva transaccion recurrente";
   if (action === "new-account") return "Nueva cuenta";
   return TRANSACTION_ACTIONS[action as keyof typeof TRANSACTION_ACTIONS]?.title ?? "";
+}
+
+/** Module-level ref to hold the screenshot file picked from the FAB */
+let pendingScreenshotFile: File | null = null;
+
+export function getPendingScreenshotFile(): File | null {
+  const file = pendingScreenshotFile;
+  pendingScreenshotFile = null;
+  return file;
 }
 
 export function MobileSheetProvider({
@@ -62,6 +73,8 @@ export function MobileSheetProvider({
 }: MobileSheetProviderProps) {
   const [activeAction, setActiveAction] = useState<FabAction | null>(null);
   const pathname = usePathname();
+  const router = useRouter();
+  const screenshotInputRef = useRef<HTMLInputElement>(null);
 
   const contextActions = useMemo(() => getContextActions(pathname), [pathname]);
 
@@ -70,15 +83,53 @@ export function MobileSheetProvider({
     toast.success("Guardado");
   }, []);
 
+  const handleFabAction = useCallback(
+    (action: FabAction) => {
+      if (action === "screenshot") {
+        // Trigger native file picker for images, then navigate to import
+        screenshotInputRef.current?.click();
+        return;
+      }
+      setActiveAction(action);
+    },
+    [],
+  );
+
+  const handleScreenshotFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) {
+        pendingScreenshotFile = file;
+        router.push("/import?mode=screenshot");
+      }
+      // Reset input so the same file can be re-selected
+      e.target.value = "";
+    },
+    [router],
+  );
+
+  // Determine if the drawer should be open (not for screenshot action)
+  const drawerOpen = activeAction !== null && activeAction !== "screenshot";
+
   return (
     <>
       {children}
 
-      <FabMenu onAction={setActiveAction} contextActions={contextActions} />
+      <FabMenu onAction={handleFabAction} contextActions={contextActions} />
+
+      {/* Hidden file input for screenshot capture */}
+      <input
+        ref={screenshotInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleScreenshotFileChange}
+      />
 
       <Drawer
         fixed
-        open={activeAction !== null}
+        open={drawerOpen}
         onOpenChange={(open) => {
           if (!open) setActiveAction(null);
         }}
@@ -102,6 +153,14 @@ export function MobileSheetProvider({
 
             {activeAction === "voice" && (
               <VoiceCaptureSheet
+                accounts={accounts}
+                categories={categories}
+                onSuccess={handleSuccess}
+              />
+            )}
+
+            {activeAction === "quick-capture" && (
+              <MobileQuickCaptureSheet
                 accounts={accounts}
                 categories={categories}
                 onSuccess={handleSuccess}

--- a/webapp/src/components/mobile/v2/mobile-avatar-menu.tsx
+++ b/webapp/src/components/mobile/v2/mobile-avatar-menu.tsx
@@ -3,7 +3,6 @@
 import { useState, useCallback, useEffect } from "react";
 import Link from "next/link";
 import {
-  BellDot,
   ChevronRight,
   Contact,
   Inbox,
@@ -53,10 +52,7 @@ export function MobileAvatarMenu({ name, email }: MobileAvatarMenuProps) {
 
   const resolvedName = name ?? shell?.name ?? null;
   const resolvedEmail = email ?? shell?.email ?? null;
-  const attentionCount = shell?.attentionCount ?? 0;
-  const attentionSummary = shell?.attentionSummary ?? "Todo en orden por ahora";
   const initials = getInitials(resolvedName, resolvedEmail);
-  const attentionBadge = attentionCount > 9 ? "9+" : `${attentionCount}`;
 
   const close = useCallback(() => setOpen(false), []);
 
@@ -69,11 +65,6 @@ export function MobileAvatarMenu({ name, email }: MobileAvatarMenuProps) {
           aria-label="Menú de perfil"
         >
           {initials}
-          {attentionCount > 0 && (
-            <span className="absolute -right-1 -top-1 flex min-w-4 items-center justify-center rounded-full bg-z-brass px-1 text-[9px] font-bold leading-none text-z-ink">
-              {attentionBadge}
-            </span>
-          )}
         </button>
       </PopoverTrigger>
 
@@ -96,29 +87,22 @@ export function MobileAvatarMenu({ name, email }: MobileAvatarMenuProps) {
         <Separator className="bg-white/6" />
 
         <Link
-          href="/gestionar"
+          href="/import"
           onClick={close}
           className="mx-2 my-2 flex items-start gap-3 rounded-2xl border border-z-brass/20 bg-z-brass/8 px-3.5 py-3 transition-colors hover:bg-z-brass/12"
         >
           <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl bg-z-brass/12 text-z-brass">
-            <BellDot className="size-4" />
+            <Upload className="size-4" />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
-                Atención
-              </p>
-              {attentionCount > 0 && (
-                <span className="rounded-full bg-z-brass px-1.5 py-0.5 text-[10px] font-semibold text-z-ink">
-                  {attentionBadge}
-                </span>
-              )}
-            </div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+              Importar
+            </p>
             <p className="mt-1 text-sm leading-tight text-foreground">
-              {attentionSummary}
+              Sube un extracto PDF o captura de pantalla
             </p>
             <p className="mt-1 text-[11px] text-z-brass">
-              Ir a gestionar
+              Ir a importar
             </p>
           </div>
           <ChevronRight className="mt-0.5 size-4 shrink-0 text-z-brass/70" />
@@ -150,14 +134,6 @@ export function MobileAvatarMenu({ name, email }: MobileAvatarMenuProps) {
           >
             <Wallet className="size-3.5 shrink-0 text-muted-foreground" />
             Cuentas
-          </Link>
-          <Link
-            href="/import"
-            onClick={close}
-            className="flex items-center gap-2.5 px-3.5 py-2 text-sm text-foreground/80 transition-colors hover:bg-white/4 hover:text-foreground"
-          >
-            <Upload className="size-3.5 shrink-0 text-muted-foreground" />
-            Importar extracto
           </Link>
           <Link
             href="/settings"


### PR DESCRIPTION
- Avatar menu: replace Atención card with prominent Importar CTA card, remove attention badge
- FAB: add screenshot capture (opens camera/gallery → import page) and quick capture text (drawer with text parsing)
- Import page: upload-first mobile layout — compact intro + wizard visible immediately, hero content collapsed into expandable "Más info" section on mobile, desktop unchanged
- StepUpload: accept images (PNG/JPG/WEBP) in addition to PDFs, route to /api/parse-image for images
- Import wizard: support initialFile from FAB screenshot flow via module-level ref + search params

https://claude.ai/code/session_015obyFBugPGfjFLwR7Uqu8r