### PR TITLE
fix: tab bar + button opens action menu instead of going straight to manual form

### DIFF
--- a/webapp/src/app/(dashboard)/layout.tsx
+++ b/webapp/src/app/(dashboard)/layout.tsx
@@ -103,7 +103,7 @@ export default async function DashboardLayout({
             }}
           >
             <AppDataProvider data={appData}>
-              <MobileSheetProvider accounts={accounts} categories={categories}>
+              <MobileSheetProvider>
                 <main className="flex-1 overflow-x-hidden p-4 pb-20 lg:p-6 lg:pb-6">
                   {profile.demo_mode && <DemoBanner />}
                   <PageTransition>

--- a/webapp/src/app/(dashboard)/layout.tsx
+++ b/webapp/src/app/(dashboard)/layout.tsx
@@ -14,6 +14,7 @@ import { getTagGroups } from "@/actions/tags";
 import { AppDataProvider } from "@/components/providers/app-data-provider";
 import { MobileTabBar } from "@/components/mobile/v2/mobile-tab-bar";
 import { MobileShellProvider } from "@/components/mobile/v2/mobile-shell-provider";
+import { MobileSheetProvider } from "@/components/mobile/mobile-sheet-provider";
 import { PageTransition } from "@/components/ui/page-transition";
 import { KeyboardInsetProvider } from "@/hooks/use-keyboard-inset";
 import { DemoBanner } from "@/components/dashboard/demo-banner";
@@ -102,14 +103,16 @@ export default async function DashboardLayout({
             }}
           >
             <AppDataProvider data={appData}>
-              <main className="flex-1 overflow-x-hidden p-4 pb-20 lg:p-6 lg:pb-6">
-                {profile.demo_mode && <DemoBanner />}
-                <PageTransition>
-                  {children}
-                </PageTransition>
-              </main>
+              <MobileSheetProvider accounts={accounts} categories={categories}>
+                <main className="flex-1 overflow-x-hidden p-4 pb-20 lg:p-6 lg:pb-6">
+                  {profile.demo_mode && <DemoBanner />}
+                  <PageTransition>
+                    {children}
+                  </PageTransition>
+                </main>
 
-              <MobileTabBar accounts={accounts} categories={categories} />
+                <MobileTabBar />
+              </MobileSheetProvider>
             </AppDataProvider>
           </MobileShellProvider>
         </KeyboardInsetProvider>

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { Plus, ArrowUpRight, ArrowDownLeft, ArrowLeftRight, Mic, Camera, Sparkles } from "lucide-react";
+import { ArrowUpRight, ArrowDownLeft, ArrowLeftRight, Mic, Camera, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 
@@ -16,6 +16,8 @@ export interface ContextAction {
 }
 
 interface FabMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onAction: (action: FabAction) => void;
   contextActions?: ContextAction[];
 }
@@ -26,71 +28,24 @@ const SUB_ACTIONS: ContextAction[] = [
   { id: "transfer", label: "Transferencia", icon: ArrowLeftRight, bg: "bg-z-sage-dark" },
 ];
 
-/**
- * Tracks virtual keyboard height via visualViewport API.
- * Uses transform (GPU-composited) to move the FAB without layout thrashing.
- * Resets synchronously on focusout so the FAB never stays floating.
- */
-function useFabKeyboardOffset(ref: React.RefObject<HTMLButtonElement | null>) {
-  useEffect(() => {
-    const el = ref.current;
-    if (!el || typeof window === "undefined" || !window.visualViewport) return;
 
-    const vv = window.visualViewport;
-
-    function getOffset() {
-      return Math.max(0, window.innerHeight - vv!.height - vv!.offsetTop);
-    }
-
-    let rafId = 0;
-    function sync() {
-      cancelAnimationFrame(rafId);
-      rafId = requestAnimationFrame(() => {
-        el!.style.transform = `translate(-50%, -${getOffset()}px)`;
-      });
-    }
-
-    // Reset immediately when any input loses focus (keyboard closing)
-    function onFocusOut() {
-      cancelAnimationFrame(rafId);
-      el!.style.transform = "translate(-50%, 0px)";
-    }
-
-    sync();
-    vv.addEventListener("resize", sync);
-    vv.addEventListener("scroll", sync);
-    document.addEventListener("focusout", onFocusOut);
-
-    return () => {
-      cancelAnimationFrame(rafId);
-      vv.removeEventListener("resize", sync);
-      vv.removeEventListener("scroll", sync);
-      document.removeEventListener("focusout", onFocusOut);
-    };
-  }, [ref]);
-}
-
-export function FabMenu({ onAction, contextActions }: FabMenuProps) {
-  const [open, setOpen] = useState(false);
+export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMenuProps) {
   const pathname = usePathname();
-  const fabRef = useRef<HTMLButtonElement>(null);
-
-  useFabKeyboardOffset(fabRef);
 
   // Close on route change
-  useEffect(() => setOpen(false), [pathname]);
+  useEffect(() => onOpenChange(false), [pathname, onOpenChange]);
 
   const handleAction = useCallback(
     (action: FabAction) => {
-      setOpen(false);
+      onOpenChange(false);
       onAction(action);
     },
-    [onAction],
+    [onAction, onOpenChange],
   );
 
   return (
     <div className="lg:hidden">
-      <Drawer open={open} onOpenChange={setOpen}>
+      <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerContent>
           <DrawerTitle className="sr-only">Acciones</DrawerTitle>
           <div className="px-4 pb-4">
@@ -218,20 +173,6 @@ export function FabMenu({ onAction, contextActions }: FabMenuProps) {
           </div>
         </DrawerContent>
       </Drawer>
-
-      {/* Main FAB — floats above keyboard via GPU transform, snaps back on close */}
-      {!open && (
-        <button
-          ref={fabRef}
-          type="button"
-          onClick={() => setOpen(true)}
-          className="fixed bottom-5 left-1/2 z-50 flex size-14 -translate-x-1/2 items-center justify-center rounded-full bg-z-white text-z-ink shadow-lg will-change-transform mb-[env(safe-area-inset-bottom)]"
-          aria-label="Abrir menu de acciones"
-          data-testid="fab-button"
-        >
-          <Plus className="size-7" strokeWidth={2.5} />
-        </button>
-      )}
     </div>
   );
 }

--- a/webapp/src/components/mobile/mobile-sheet-provider.tsx
+++ b/webapp/src/components/mobile/mobile-sheet-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useMemo, useCallback, useRef } from "react";
+import dynamic from "next/dynamic";
 import { usePathname, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarPlus, Landmark } from "lucide-react";
@@ -10,17 +11,30 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
+import { useAccounts, useCategories } from "@/components/providers/app-data-provider";
 import { FabMenu, type FabAction, type ContextAction } from "./fab-menu";
-import { MobileTransactionForm } from "./mobile-transaction-form";
-import { MobileQuickCaptureSheet } from "./mobile-quick-capture-sheet";
-import { RecurringForm } from "@/components/recurring/recurring-form";
-import { SpecializedAccountForm } from "@/components/accounts/specialized-account-form";
-import { VoiceCaptureSheet } from "./voice-capture-sheet";
-import type {
-  Account,
-  CategoryWithChildren,
-  TransactionDirection,
-} from "@/types/domain";
+import type { TransactionDirection } from "@/types/domain";
+
+const MobileTransactionForm = dynamic(
+  () => import("./mobile-transaction-form").then((m) => ({ default: m.MobileTransactionForm })),
+  { ssr: false },
+);
+const MobileQuickCaptureSheet = dynamic(
+  () => import("./mobile-quick-capture-sheet").then((m) => ({ default: m.MobileQuickCaptureSheet })),
+  { ssr: false },
+);
+const RecurringForm = dynamic(
+  () => import("@/components/recurring/recurring-form").then((m) => ({ default: m.RecurringForm })),
+  { ssr: false },
+);
+const SpecializedAccountForm = dynamic(
+  () => import("@/components/accounts/specialized-account-form").then((m) => ({ default: m.SpecializedAccountForm })),
+  { ssr: false },
+);
+const VoiceCaptureSheet = dynamic(
+  () => import("./voice-capture-sheet").then((m) => ({ default: m.VoiceCaptureSheet })),
+  { ssr: false },
+);
 
 // ── Context for opening the action menu from anywhere (e.g. tab bar) ────────
 const MobileActionContext = createContext<{ openActionMenu: () => void }>({
@@ -32,8 +46,6 @@ export function useMobileActionMenu() {
 }
 
 interface MobileSheetProviderProps {
-  accounts: Account[];
-  categories: CategoryWithChildren[];
   children: React.ReactNode;
 }
 
@@ -75,11 +87,9 @@ export function getPendingScreenshotFile(): File | null {
   return file;
 }
 
-export function MobileSheetProvider({
-  accounts,
-  categories,
-  children,
-}: MobileSheetProviderProps) {
+export function MobileSheetProvider({ children }: MobileSheetProviderProps) {
+  const accounts = useAccounts();
+  const categories = useCategories();
   const [fabOpen, setFabOpen] = useState(false);
   const [activeAction, setActiveAction] = useState<FabAction | null>(null);
   const pathname = usePathname();

--- a/webapp/src/components/mobile/mobile-sheet-provider.tsx
+++ b/webapp/src/components/mobile/mobile-sheet-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useRef } from "react";
+import { createContext, useContext, useState, useMemo, useCallback, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarPlus, Landmark } from "lucide-react";
@@ -21,6 +21,15 @@ import type {
   CategoryWithChildren,
   TransactionDirection,
 } from "@/types/domain";
+
+// ── Context for opening the action menu from anywhere (e.g. tab bar) ────────
+const MobileActionContext = createContext<{ openActionMenu: () => void }>({
+  openActionMenu: () => {},
+});
+
+export function useMobileActionMenu() {
+  return useContext(MobileActionContext);
+}
 
 interface MobileSheetProviderProps {
   accounts: Account[];
@@ -71,12 +80,16 @@ export function MobileSheetProvider({
   categories,
   children,
 }: MobileSheetProviderProps) {
+  const [fabOpen, setFabOpen] = useState(false);
   const [activeAction, setActiveAction] = useState<FabAction | null>(null);
   const pathname = usePathname();
   const router = useRouter();
   const screenshotInputRef = useRef<HTMLInputElement>(null);
 
   const contextActions = useMemo(() => getContextActions(pathname), [pathname]);
+
+  const openActionMenu = useCallback(() => setFabOpen(true), []);
+  const contextValue = useMemo(() => ({ openActionMenu }), [openActionMenu]);
 
   const handleSuccess = useCallback(() => {
     setActiveAction(null);
@@ -112,10 +125,10 @@ export function MobileSheetProvider({
   const drawerOpen = activeAction !== null && activeAction !== "screenshot";
 
   return (
-    <>
+    <MobileActionContext value={contextValue}>
       {children}
 
-      <FabMenu onAction={handleFabAction} contextActions={contextActions} />
+      <FabMenu open={fabOpen} onOpenChange={setFabOpen} onAction={handleFabAction} contextActions={contextActions} />
 
       {/* Hidden file input for screenshot capture */}
       <input
@@ -183,6 +196,6 @@ export function MobileSheetProvider({
           </div>
         </DrawerContent>
       </Drawer>
-    </>
+    </MobileActionContext>
   );
 }

--- a/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
+++ b/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useKeyboardInset } from "@/hooks/use-keyboard-inset";
 import { MOBILE_TABS, isMobileTabActive } from "@/lib/constants/mobile-nav";
 import { MOBILE_BG_CLASS } from "@/lib/constants/styles";
 import { useMobileActionMenu } from "@/components/mobile/mobile-sheet-provider";
@@ -38,6 +39,10 @@ function TabLinks({ tabs, pathname }: { tabs: typeof MOBILE_TABS; pathname: stri
 export function MobileTabBar() {
   const pathname = usePathname();
   const { openActionMenu } = useMobileActionMenu();
+  const keyboardInset = useKeyboardInset();
+
+  // Hide tab bar when virtual keyboard is open to avoid overlapping input
+  if (keyboardInset > 0) return null;
 
   return (
     <nav

--- a/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
+++ b/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
@@ -1,31 +1,16 @@
 "use client";
 
-import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import dynamic from "next/dynamic";
-import { Plus, X } from "lucide-react";
+import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useKeyboardInset } from "@/hooks/use-keyboard-inset";
 import { MOBILE_TABS, isMobileTabActive } from "@/lib/constants/mobile-nav";
 import { MOBILE_BG_CLASS } from "@/lib/constants/styles";
-import type { Account, CategoryWithChildren } from "@/types/domain";
-
-const MobileTransactionForm = dynamic(
-  () => import("@/components/mobile/mobile-transaction-form").then((m) => ({
-    default: m.MobileTransactionForm,
-  })),
-  { ssr: false, loading: () => null }
-);
+import { useMobileActionMenu } from "@/components/mobile/mobile-sheet-provider";
 
 const LEFT_TABS = MOBILE_TABS.slice(0, 2);
 const RIGHT_TABS = MOBILE_TABS.slice(2);
 const SAFE_AREA_BOTTOM_STYLE = { paddingBottom: "env(safe-area-inset-bottom)" } as const;
-
-interface MobileTabBarProps {
-  accounts: Account[];
-  categories: CategoryWithChildren[];
-}
 
 function TabLinks({ tabs, pathname }: { tabs: typeof MOBILE_TABS; pathname: string }) {
   return (
@@ -50,95 +35,36 @@ function TabLinks({ tabs, pathname }: { tabs: typeof MOBILE_TABS; pathname: stri
   );
 }
 
-export function MobileTabBar({ accounts, categories }: MobileTabBarProps) {
+export function MobileTabBar() {
   const pathname = usePathname();
-  const keyboardInset = useKeyboardInset();
-  const [formOpen, setFormOpen] = useState(false);
-
-  const keyboardOpen = keyboardInset > 0;
+  const { openActionMenu } = useMobileActionMenu();
 
   return (
-    <>
-      {!keyboardOpen && !formOpen && (
-        <nav
-          className="fixed bottom-0 left-0 right-0 z-[9999] lg:hidden"
-          style={SAFE_AREA_BOTTOM_STYLE}
-        >
-          <div
-            className={cn(
-              "flex items-center border-t border-white/6 backdrop-blur-md supports-[backdrop-filter]:bg-background/92",
-              MOBILE_BG_CLASS
-            )}
-          >
-            <TabLinks tabs={LEFT_TABS} pathname={pathname} />
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-[9999] lg:hidden"
+      style={SAFE_AREA_BOTTOM_STYLE}
+    >
+      <div
+        className={cn(
+          "flex items-center border-t border-white/6 backdrop-blur-md supports-[backdrop-filter]:bg-background/92",
+          MOBILE_BG_CLASS
+        )}
+      >
+        <TabLinks tabs={LEFT_TABS} pathname={pathname} />
 
-            <div className="relative flex shrink-0 items-center justify-center px-4 py-2">
-              <button
-                type="button"
-                onClick={() => setFormOpen(true)}
-                className="flex size-12 -mt-4 items-center justify-center rounded-full bg-z-brass text-z-ink shadow-[0_0_16px_rgba(184,148,79,0.4)] transition-transform active:scale-95"
-                aria-label="Registrar movimiento"
-              >
-                <Plus className="size-5 stroke-[2.5]" />
-              </button>
-            </div>
-
-            <TabLinks tabs={RIGHT_TABS} pathname={pathname} />
-          </div>
-        </nav>
-      )}
-
-      {keyboardOpen && !formOpen && (
-        <div
-          className="fixed bottom-0 left-0 right-0 z-[9999] flex items-center justify-center py-2 lg:hidden"
-          style={SAFE_AREA_BOTTOM_STYLE}
-        >
+        <div className="relative flex shrink-0 items-center justify-center px-4 py-2">
           <button
             type="button"
-            onClick={() => setFormOpen(true)}
-            className="flex size-11 items-center justify-center rounded-full bg-z-brass text-z-ink shadow-[0_0_16px_rgba(184,148,79,0.4)]"
-            aria-label="Registrar movimiento"
+            onClick={openActionMenu}
+            className="flex size-12 -mt-4 items-center justify-center rounded-full bg-z-brass text-z-ink shadow-[0_0_16px_rgba(184,148,79,0.4)] transition-transform active:scale-95"
+            aria-label="Abrir menu de acciones"
           >
-            <Plus className="size-4 stroke-[2.5]" />
+            <Plus className="size-5 stroke-[2.5]" />
           </button>
         </div>
-      )}
 
-      {formOpen && (
-        <div
-          className="fixed inset-0 z-50 flex flex-col bg-background lg:hidden"
-          style={{
-            paddingTop: "env(safe-area-inset-top)",
-            paddingBottom: keyboardOpen
-              ? `${keyboardInset}px`
-              : "env(safe-area-inset-bottom)",
-          }}
-        >
-          <div className="flex items-center border-b border-border/40 px-4 py-3">
-            <button
-              type="button"
-              onClick={() => setFormOpen(false)}
-              className="flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors active:bg-accent"
-              aria-label="Cerrar"
-            >
-              <X className="size-5" />
-            </button>
-            <h2 className="flex-1 text-center text-base font-semibold">
-              Registrar movimiento
-            </h2>
-            {/* Balances close button width for centered title */}
-            <div className="size-8" aria-hidden="true" />
-          </div>
-
-          <div className="flex-1 overflow-y-auto overscroll-contain px-4 py-4">
-            <MobileTransactionForm
-              accounts={accounts}
-              categories={categories}
-              onSuccess={() => setFormOpen(false)}
-            />
-          </div>
-        </div>
-      )}
-    </>
+        <TabLinks tabs={RIGHT_TABS} pathname={pathname} />
+      </div>
+    </nav>
   );
 }


### PR DESCRIPTION
The tab bar's center action button was bypassing the FAB action menu
and opening the full manual transaction form directly, making quick
capture, voice capture, and screenshot upload inaccessible.

Now the + button opens the action menu drawer (via MobileSheetProvider
context), giving access to all entry points: voice capture, screenshot,
quick capture, expense, income, transfer, and page-specific actions.

- FabMenu: controlled open/onOpenChange props, removed standalone button
- MobileSheetProvider: added MobileActionContext with useMobileActionMenu()
- MobileTabBar: simplified to pure navigation + action menu trigger
- Layout: wrapped content with MobileSheetProvider

https://claude.ai/code/session_01DyowKSgYr7wNepBoekPXSU