### PR TITLE
fix: add bottom padding to FAB menu to avoid overlap with tab bar

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -139,6 +139,9 @@
   --z-space-2xl: 40px;
   --z-space-3xl: 64px;
 
+  /* Mobile layout */
+  --z-mobile-tab-bar-h: 3.5rem;  /* ≈56px — matches tab bar rendered height */
+
   /* shadcn/ui variable mapping — dark mode first */
   --radius: 0.75rem;
   --background: var(--z-ink);

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { ArrowUpRight, ArrowDownLeft, ArrowLeftRight, Mic, Camera, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 
 export type FabAction = "expense" | "income" | "transfer" | "voice" | "screenshot" | "quick-capture" | "new-recurring" | "new-account";
@@ -48,7 +49,7 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerContent>
           <DrawerTitle className="sr-only">Acciones</DrawerTitle>
-          <div className="px-4 pb-[calc(4rem_+_env(safe-area-inset-bottom))]">
+          <div className={cn("px-4", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
             {/* Voice capture — prominent */}
             <button
               type="button"

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -48,7 +48,7 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerContent>
           <DrawerTitle className="sr-only">Acciones</DrawerTitle>
-          <div className="px-4 pb-[calc(5rem_+_env(safe-area-inset-bottom))]">
+          <div className="px-4 pb-[calc(4rem_+_env(safe-area-inset-bottom))]">
             {/* Voice capture — prominent */}
             <button
               type="button"

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -48,7 +48,7 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerContent>
           <DrawerTitle className="sr-only">Acciones</DrawerTitle>
-          <div className="px-4 pb-4">
+          <div className="px-4 pb-[calc(5rem+env(safe-area-inset-bottom))]">
             {/* Voice capture — prominent */}
             <button
               type="button"

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -48,7 +48,7 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerContent>
           <DrawerTitle className="sr-only">Acciones</DrawerTitle>
-          <div className="px-4 pb-[calc(5rem+env(safe-area-inset-bottom))]">
+          <div className="px-4 pb-[calc(5rem_+_env(safe-area-inset-bottom))]">
             {/* Voice capture — prominent */}
             <button
               type="button"

--- a/webapp/src/lib/constants/styles.ts
+++ b/webapp/src/lib/constants/styles.ts
@@ -47,6 +47,13 @@ export const MOBILE_BG_CLASS = "bg-background";
 /** Mobile v2 eyebrow label */
 export const MOBILE_EYEBROW_CLASS = SECTION_EYEBROW_CLASS;
 
+/** Height of the mobile tab bar — mirrors --z-mobile-tab-bar-h in globals.css */
+export const MOBILE_TAB_BAR_HEIGHT = "3.5rem";
+
+/** Bottom padding that clears the mobile tab bar + safe area */
+export const MOBILE_TAB_BAR_CLEARANCE_CLASS =
+  "pb-[calc(var(--z-mobile-tab-bar-h)_+_env(safe-area-inset-bottom))]";
+
 /** Mobile v2 action button (brass ghost) */
 export const MOBILE_ACTION_BUTTON_CLASS =
   "rounded-lg border border-z-brass/20 bg-z-brass/8 px-2.5 py-1 text-[10px] font-semibold text-z-brass";


### PR DESCRIPTION
The drawer (z-50) sits below the mobile tab bar (z-[9999]), so the
bottom actions (Gasto, Ingreso, Transferencia) were hidden behind the
nav bar. Adds safe-area-aware padding to clear the tab bar.

https://claude.ai/code/session_01AGUj2xH9jKS6S2gvPqLPtB