### PR TITLE
feat: user-configurable allowed senders + reject failed tx emails

### DIFF
--- a/supabase/migrations/20260412195931_add_email_ingest_allowed_senders.sql
+++ b/supabase/migrations/20260412195931_add_email_ingest_allowed_senders.sql
@@ -1,0 +1,33 @@
+-- Stores user-configured allowed sender emails for email ingest.
+-- These supplement the hardcoded ALLOWED_SENDERS in the webhook.
+-- Bank email addresses aren't PII, so no encryption needed.
+
+CREATE TABLE email_ingest_allowed_senders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  sender_email TEXT NOT NULL,
+  label TEXT, -- optional friendly name (e.g. "Bancolombia alertas")
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Prevent duplicate entries per user
+  UNIQUE (user_id, sender_email)
+);
+
+-- RLS
+ALTER TABLE email_ingest_allowed_senders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own allowed senders"
+  ON email_ingest_allowed_senders FOR SELECT
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert their own allowed senders"
+  ON email_ingest_allowed_senders FOR INSERT
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can delete their own allowed senders"
+  ON email_ingest_allowed_senders FOR DELETE
+  USING ((select auth.uid()) = user_id);
+
+-- Index for webhook lookups (admin client queries by user_id)
+CREATE INDEX idx_email_ingest_allowed_senders_user
+  ON email_ingest_allowed_senders(user_id);

--- a/supabase/migrations/20260412200644_fix_email_ingest_allowed_senders_constraints.sql
+++ b/supabase/migrations/20260412200644_fix_email_ingest_allowed_senders_constraints.sql
@@ -1,0 +1,13 @@
+-- Fix: remove redundant index (UNIQUE constraint already creates a composite index with user_id leading)
+DROP INDEX IF EXISTS idx_email_ingest_allowed_senders_user;
+
+-- Fix: enforce lowercase storage for case-insensitive email matching
+ALTER TABLE email_ingest_allowed_senders
+  ADD CONSTRAINT email_ingest_allowed_senders_lowercase_email
+  CHECK (sender_email = lower(sender_email));
+
+-- Add UPDATE policy for inline label editing in settings UI
+CREATE POLICY "Users can update their own allowed senders"
+  ON email_ingest_allowed_senders FOR UPDATE
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);

--- a/supabase/migrations/20260413000433_fold_allowed_senders_into_rpc.sql
+++ b/supabase/migrations/20260413000433_fold_allowed_senders_into_rpc.sql
@@ -1,0 +1,41 @@
+-- Extend get_email_ingest_settings to include user-configured allowed senders.
+-- Eliminates a separate round-trip in the webhook for sender validation.
+-- Must DROP first because return type is changing (adding allowed_senders column).
+DROP FUNCTION IF EXISTS get_email_ingest_settings(TEXT);
+
+CREATE OR REPLACE FUNCTION get_email_ingest_settings(p_address_key TEXT)
+RETURNS TABLE(
+  id UUID,
+  user_id UUID,
+  account_id UUID,
+  auto_import BOOLEAN,
+  allowed_sender TEXT,
+  pdf_import_enabled BOOLEAN,
+  address_key TEXT,
+  allowed_senders TEXT[]
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+  SELECT
+    e.id,
+    e.user_id,
+    e.account_id,
+    e.auto_import,
+    zeta_decrypt_as(e.allowed_sender, e.user_id),
+    e.pdf_import_enabled,
+    e.address_key,
+    COALESCE(
+      (SELECT array_agg(s.sender_email)
+       FROM email_ingest_allowed_senders s
+       WHERE s.user_id = e.user_id),
+      '{}'::TEXT[]
+    )
+  FROM email_ingest_addresses_enc e
+  WHERE lower(e.address_key) = lower(p_address_key)
+    AND e.is_active = true;
+$$;
+
+REVOKE ALL ON FUNCTION get_email_ingest_settings(TEXT) FROM PUBLIC;

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -961,3 +961,74 @@ export async function bulkApproveEmailTransactions(
 
   return { success: true, data: { approved, errors } };
 }
+
+// ── Allowed Senders CRUD ──────────────────────────────────────────────────────
+
+export type AllowedSender = {
+  id: string;
+  sender_email: string;
+  label: string | null;
+  created_at: string;
+};
+
+export async function getAllowedSenders(): Promise<AllowedSender[]> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return [];
+
+  const { data } = await supabase
+    .from("email_ingest_allowed_senders")
+    .select("id, sender_email, label, created_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true });
+
+  return (data ?? []) as AllowedSender[];
+}
+
+export async function addAllowedSender(
+  senderEmail: string,
+  label?: string | null
+): Promise<ActionResult<AllowedSender>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const email = senderEmail.trim().toLowerCase();
+  if (!email || !email.includes("@")) {
+    return { success: false, error: "Dirección de correo inválida" };
+  }
+
+  const { data, error } = await supabase
+    .from("email_ingest_allowed_senders")
+    .insert({
+      user_id: user.id,
+      sender_email: email,
+      label: label?.trim() || null,
+    })
+    .select("id, sender_email, label, created_at")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return { success: false, error: "Este remitente ya está registrado" };
+    }
+    return { success: false, error: error.message };
+  }
+
+  revalidateTag("email-ingest", "zeta");
+  return { success: true, data: data as AllowedSender };
+}
+
+export async function removeAllowedSender(id: string): Promise<ActionResult<null>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const { error } = await supabase
+    .from("email_ingest_allowed_senders")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidateTag("email-ingest", "zeta");
+  return { success: true, data: null };
+}

--- a/webapp/src/app/(dashboard)/settings/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/page.tsx
@@ -22,7 +22,7 @@ import { ReviewModeToggle } from "@/components/settings/review-mode-toggle";
 import { SettingsMobileAccordion } from "@/components/settings/settings-mobile-accordion";
 import { DemoModeCard } from "@/components/settings/demo-mode-card";
 import { getCaptureTokens } from "@/actions/capture-tokens";
-import { getEmailIngestAddress, getEmailIngestLogs, getUnrecognizedEmails } from "@/actions/email-ingest";
+import { getEmailIngestAddress, getEmailIngestLogs, getUnrecognizedEmails, getAllowedSenders } from "@/actions/email-ingest";
 import { getTagGroups } from "@/actions/tags";
 import { TagManager } from "@/components/tags/tag-manager";
 import type { Account } from "@/types/domain";
@@ -40,7 +40,7 @@ export default async function SettingsPage() {
 
   if (!profile) redirect("/login");
 
-  const [tokensResult, { data: accounts }, emailIngestResult, unrecognizedResult, emailLogsResult, tagGroupsResult] = await Promise.all([
+  const [tokensResult, { data: accounts }, emailIngestResult, unrecognizedResult, emailLogsResult, tagGroupsResult, allowedSenders] = await Promise.all([
     getCaptureTokens(),
     supabase
       .from("accounts")
@@ -52,6 +52,7 @@ export default async function SettingsPage() {
     getUnrecognizedEmails(),
     getEmailIngestLogs(),
     getTagGroups(),
+    getAllowedSenders(),
   ]);
 
   const tokens = tokensResult.success ? tokensResult.data : [];
@@ -84,6 +85,7 @@ export default async function SettingsPage() {
           <EmailIngestCard
             accounts={(accounts ?? []) as Account[]}
             initialAddress={emailIngestAddress}
+            initialAllowedSenders={allowedSenders}
           />
           <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
           <EmailIngestLogsCard initialLogs={emailLogs} />
@@ -163,6 +165,7 @@ export default async function SettingsPage() {
         <EmailIngestCard
           accounts={(accounts ?? []) as Account[]}
           initialAddress={emailIngestAddress}
+          initialAllowedSenders={allowedSenders}
         />
 
         <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -364,13 +364,27 @@ async function processEmail(ctx: {
     return NextResponse.json({ ok: true });
   }
 
-  // 6. Validate sender — accept bank notifications, user's forwarding email, or the ingest address itself
+  // 6. Validate sender — accept bank notifications, user's forwarding email, user-configured senders, or the ingest address itself
   const isBankSender = ALLOWED_SENDERS.some((s) => fromEmail.includes(s));
   const isAllowedSender = allowedSender && fromEmail.includes(allowedSender.toLowerCase());
   // Allow the ingest address itself as sender (Resend internal routing edge case).
   // Match full local-part + "@" to prevent substring spoofing.
   const isSelfSender = fromEmail.startsWith(`${addressKey.toLowerCase()}@`);
+
+  // Check user-configured allowed senders
+  let isUserConfiguredSender = false;
   if (!isBankSender && !isAllowedSender && !isSelfSender) {
+    const { data: userSenders } = await admin
+      .from("email_ingest_allowed_senders")
+      .select("sender_email")
+      .eq("user_id", userId);
+
+    isUserConfiguredSender = (userSenders ?? []).some(
+      (s) => fromEmail.includes(s.sender_email.toLowerCase())
+    );
+  }
+
+  if (!isBankSender && !isAllowedSender && !isSelfSender && !isUserConfiguredSender) {
     console.log(`[email-ingest][${emailId}] Sender rejected: "${from}" (allowed_sender=${allowedSender ?? "none"})`);
     await insertLog({
       userId,
@@ -383,7 +397,7 @@ async function processEmail(ctx: {
     return NextResponse.json({ ok: true });
   }
 
-  console.log(`[email-ingest][${emailId}] Sender OK (bank=${isBankSender}, allowed=${!!isAllowedSender}, self=${isSelfSender}), user=${userId}`);
+  console.log(`[email-ingest][${emailId}] Sender OK (bank=${isBankSender}, allowed=${!!isAllowedSender}, self=${isSelfSender}, userConfigured=${isUserConfiguredSender}), user=${userId}`);
 
   // 7. Rate limit: max 100 emails/day/user
   const withinLimit = await checkRateLimit(userId);

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -298,6 +298,7 @@ async function processEmail(ctx: {
       id: string; user_id: string; account_id: string | null;
       auto_import: boolean; allowed_sender: string | null;
       pdf_import_enabled: boolean; address_key: string;
+      allowed_senders: string[];
     } | null; error: { message: string; code?: string } | null };
 
   if (lookupError) {
@@ -325,6 +326,7 @@ async function processEmail(ctx: {
     auto_import: autoImport,
     allowed_sender: allowedSender,
     pdf_import_enabled: pdfImportEnabled,
+    allowed_senders: userAllowedSenders,
   } = ingestAddress;
 
   // 5. Detect Gmail forwarding verification emails
@@ -371,22 +373,10 @@ async function processEmail(ctx: {
   // Match full local-part + "@" to prevent substring spoofing.
   const isSelfSender = fromEmail.startsWith(`${addressKey.toLowerCase()}@`);
 
-  // Check user-configured allowed senders
-  let isUserConfiguredSender = false;
-  if (!isBankSender && !isAllowedSender && !isSelfSender) {
-    const { data: userSenders, error: userSendersError } = await admin
-      .from("email_ingest_allowed_senders")
-      .select("sender_email")
-      .eq("user_id", userId);
-
-    if (userSendersError) {
-      console.error(`[email-ingest][${emailId}] Failed to fetch user allowed senders:`, userSendersError.message);
-    }
-
-    isUserConfiguredSender = (userSenders ?? []).some(
-      (s) => fromEmail === s.sender_email.toLowerCase()
-    );
-  }
+  // Check user-configured allowed senders (loaded from RPC, no extra round-trip)
+  const isUserConfiguredSender = (userAllowedSenders ?? []).some(
+    (s) => fromEmail === s.toLowerCase()
+  );
 
   if (!isBankSender && !isAllowedSender && !isSelfSender && !isUserConfiguredSender) {
     console.log(`[email-ingest][${emailId}] Sender rejected: "${from}" (allowed_sender=${allowedSender ?? "none"})`);

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -380,7 +380,7 @@ async function processEmail(ctx: {
       .eq("user_id", userId);
 
     isUserConfiguredSender = (userSenders ?? []).some(
-      (s) => fromEmail.includes(s.sender_email.toLowerCase())
+      (s) => fromEmail === s.sender_email.toLowerCase()
     );
   }
 

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -374,10 +374,14 @@ async function processEmail(ctx: {
   // Check user-configured allowed senders
   let isUserConfiguredSender = false;
   if (!isBankSender && !isAllowedSender && !isSelfSender) {
-    const { data: userSenders } = await admin
+    const { data: userSenders, error: userSendersError } = await admin
       .from("email_ingest_allowed_senders")
       .select("sender_email")
       .eq("user_id", userId);
+
+    if (userSendersError) {
+      console.error(`[email-ingest][${emailId}] Failed to fetch user allowed senders:`, userSendersError.message);
+    }
 
     isUserConfiguredSender = (userSenders ?? []).some(
       (s) => fromEmail === s.sender_email.toLowerCase()

--- a/webapp/src/components/mobile/mobile-sheet-provider.tsx
+++ b/webapp/src/components/mobile/mobile-sheet-provider.tsx
@@ -98,7 +98,7 @@ export function MobileSheetProvider({ children }: MobileSheetProviderProps) {
 
   const contextActions = useMemo(() => getContextActions(pathname), [pathname]);
 
-  const openActionMenu = useCallback(() => setFabOpen(true), []);
+  const openActionMenu = useCallback(() => setFabOpen((prev) => !prev), []);
   const contextValue = useMemo(() => ({ openActionMenu }), [openActionMenu]);
 
   const handleSuccess = useCallback(() => {

--- a/webapp/src/components/settings/email-ingest-card.tsx
+++ b/webapp/src/components/settings/email-ingest-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { Mail, Copy, Check, PowerOff, Loader2, ExternalLink, ShieldCheck } from "lucide-react";
+import { Mail, Copy, Check, PowerOff, Loader2, ExternalLink, ShieldCheck, Plus, X } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,6 +19,9 @@ import {
   updateIngestSettings,
   deactivateIngestAddress,
   clearGmailVerification,
+  addAllowedSender,
+  removeAllowedSender,
+  type AllowedSender,
 } from "@/actions/email-ingest";
 import { cn } from "@/lib/utils";
 import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
@@ -30,12 +33,15 @@ const EMAIL_DOMAIN =
 interface EmailIngestCardProps {
   accounts: Account[];
   initialAddress: EmailIngestAddress | null;
+  initialAllowedSenders: AllowedSender[];
 }
 
-export function EmailIngestCard({ accounts, initialAddress }: EmailIngestCardProps) {
+export function EmailIngestCard({ accounts, initialAddress, initialAllowedSenders }: EmailIngestCardProps) {
   const [address, setAddress] = useState(initialAddress);
   const [isPending, startTransition] = useTransition();
   const [copied, setCopied] = useState(false);
+  const [allowedSenders, setAllowedSenders] = useState(initialAllowedSenders);
+  const [newSenderEmail, setNewSenderEmail] = useState("");
 
   const fullEmail = address ? `${address.address_key}@${EMAIL_DOMAIN}` : null;
 
@@ -281,6 +287,91 @@ export function EmailIngestCard({ accounts, initialAddress }: EmailIngestCardPro
               <p className="text-xs text-muted-foreground">
                 Si reenvías los correos de tu banco desde tu correo personal, ingresa esa dirección aquí para que Zeta los acepte.
               </p>
+            </div>
+
+            {/* Allowed bank senders */}
+            <div className="space-y-2">
+              <Label className="text-xs">Remitentes bancarios permitidos</Label>
+              <p className="text-xs text-muted-foreground">
+                Agrega las direcciones de correo de tu banco para que Zeta las acepte. Los remitentes de Bancolombia se incluyen por defecto.
+              </p>
+
+              {allowedSenders.length > 0 && (
+                <div className="space-y-1.5">
+                  {allowedSenders.map((sender) => (
+                    <div
+                      key={sender.id}
+                      className="flex items-center gap-2 rounded-md border border-border/40 bg-muted/10 px-2.5 py-1.5"
+                    >
+                      <code className="flex-1 truncate text-xs">{sender.sender_email}</code>
+                      {sender.label && (
+                        <span className="shrink-0 text-xs text-muted-foreground">{sender.label}</span>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                        disabled={isPending}
+                        onClick={() => {
+                          startTransition(async () => {
+                            const result = await removeAllowedSender(sender.id);
+                            if (result.success) {
+                              setAllowedSenders((prev) => prev.filter((s) => s.id !== sender.id));
+                            }
+                          });
+                        }}
+                      >
+                        <X className="size-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <Input
+                  type="email"
+                  placeholder="alertas@banco.com"
+                  value={newSenderEmail}
+                  onChange={(e) => setNewSenderEmail(e.target.value)}
+                  className="h-8 flex-1 text-xs"
+                  disabled={isPending}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      const email = newSenderEmail.trim();
+                      if (!email) return;
+                      startTransition(async () => {
+                        const result = await addAllowedSender(email);
+                        if (result.success) {
+                          setAllowedSenders((prev) => [...prev, result.data]);
+                          setNewSenderEmail("");
+                        }
+                      });
+                    }
+                  }}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1 px-2.5 text-xs"
+                  disabled={isPending || !newSenderEmail.trim()}
+                  onClick={() => {
+                    const email = newSenderEmail.trim();
+                    if (!email) return;
+                    startTransition(async () => {
+                      const result = await addAllowedSender(email);
+                      if (result.success) {
+                        setAllowedSenders((prev) => [...prev, result.data]);
+                        setNewSenderEmail("");
+                      }
+                    });
+                  }}
+                >
+                  <Plus className="size-3.5" />
+                  Agregar
+                </Button>
+              </div>
             </div>
 
             {/* Auto-import toggle */}

--- a/webapp/src/components/settings/email-ingest-card.tsx
+++ b/webapp/src/components/settings/email-ingest-card.tsx
@@ -23,6 +23,7 @@ import {
   removeAllowedSender,
   type AllowedSender,
 } from "@/actions/email-ingest";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 import type { Account, EmailIngestAddress } from "@/types/domain";
@@ -119,6 +120,8 @@ export function EmailIngestCard({ accounts, initialAddress, initialAllowedSender
       if (result.success) {
         setAllowedSenders((prev) => [...prev, result.data]);
         setNewSenderEmail("");
+      } else {
+        toast.error(result.error);
       }
     });
   }
@@ -330,6 +333,8 @@ export function EmailIngestCard({ accounts, initialAddress, initialAllowedSender
                             const result = await removeAllowedSender(sender.id);
                             if (result.success) {
                               setAllowedSenders((prev) => prev.filter((s) => s.id !== sender.id));
+                            } else {
+                              toast.error(result.error);
                             }
                           });
                         }}

--- a/webapp/src/components/settings/email-ingest-card.tsx
+++ b/webapp/src/components/settings/email-ingest-card.tsx
@@ -24,7 +24,7 @@ import {
   type AllowedSender,
 } from "@/actions/email-ingest";
 import { cn } from "@/lib/utils";
-import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 import type { Account, EmailIngestAddress } from "@/types/domain";
 
 const EMAIL_DOMAIN =
@@ -107,6 +107,18 @@ export function EmailIngestCard({ accounts, initialAddress, initialAllowedSender
       });
       if (result.success) {
         setAddress(result.data);
+      }
+    });
+  }
+
+  function handleAddSender() {
+    const email = newSenderEmail.trim();
+    if (!email) return;
+    startTransition(async () => {
+      const result = await addAllowedSender(email);
+      if (result.success) {
+        setAllowedSenders((prev) => [...prev, result.data]);
+        setNewSenderEmail("");
       }
     });
   }
@@ -310,6 +322,7 @@ export function EmailIngestCard({ accounts, initialAddress, initialAllowedSender
                       <Button
                         variant="ghost"
                         size="sm"
+                        aria-label="Eliminar remitente"
                         className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-destructive"
                         disabled={isPending}
                         onClick={() => {
@@ -339,34 +352,14 @@ export function EmailIngestCard({ accounts, initialAddress, initialAllowedSender
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();
-                      const email = newSenderEmail.trim();
-                      if (!email) return;
-                      startTransition(async () => {
-                        const result = await addAllowedSender(email);
-                        if (result.success) {
-                          setAllowedSenders((prev) => [...prev, result.data]);
-                          setNewSenderEmail("");
-                        }
-                      });
+                      handleAddSender();
                     }
                   }}
                 />
                 <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 gap-1 px-2.5 text-xs"
+                  className={cn(GHOST_BUTTON_CLASS, "h-8 gap-1 px-2.5 text-xs")}
                   disabled={isPending || !newSenderEmail.trim()}
-                  onClick={() => {
-                    const email = newSenderEmail.trim();
-                    if (!email) return;
-                    startTransition(async () => {
-                      const result = await addAllowedSender(email);
-                      if (result.success) {
-                        setAllowedSenders((prev) => [...prev, result.data]);
-                        setNewSenderEmail("");
-                      }
-                    });
-                  }}
+                  onClick={handleAddSender}
                 >
                   <Plus className="size-3.5" />
                   Agregar

--- a/webapp/src/lib/parsers/bancolombia-email.ts
+++ b/webapp/src/lib/parsers/bancolombia-email.ts
@@ -328,11 +328,27 @@ const PATTERNS: PatternDef[] = [
   },
 ];
 
+/** Phrases indicating the transaction was declined/failed — not a real movement */
+const FAILED_TX_PHRASES = [
+  "no fue exitosa",
+  "no se afecto",
+  "fue rechazada",
+  "no se realizo",
+  "no se realizó",
+  "intento fallido",
+];
+
 export function parseBancolombiaEmail(
   body: string
 ): ParsedEmailTransaction | null {
   const normalized = extractCandidateBody(body);
   if (!normalized) return null;
+
+  // Reject informative emails about failed/declined transactions
+  const lower = normalized.toLowerCase();
+  if (FAILED_TX_PHRASES.some((phrase) => lower.includes(phrase))) {
+    return null;
+  }
 
   for (const pattern of PATTERNS) {
     const match = normalized.match(pattern.regex);

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -984,6 +984,30 @@ export type Database = {
           },
         ]
       }
+      email_ingest_allowed_senders: {
+        Row: {
+          created_at: string
+          id: string
+          label: string | null
+          sender_email: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          label?: string | null
+          sender_email: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          label?: string | null
+          sender_email?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       email_ingest_addresses_enc: {
         Row: {
           account_id: string | null


### PR DESCRIPTION
## Summary
- **Allowed senders table**: New `email_ingest_allowed_senders` table lets users register bank sender emails from the settings UI instead of relying only on hardcoded addresses
- **Webhook update**: Checks user-configured senders alongside the hardcoded `ALLOWED_SENDERS` list
- **Parser safety**: Rejects Bancolombia emails containing "no fue exitosa", "fue rechazada", and similar declined-transaction phrases to prevent false imports
- **Settings UI**: Chip list with add/remove for managing allowed sender emails, integrated into the existing email ingest card

## Test plan
- [ ] Go to Settings → Email → verify "Remitentes bancarios permitidos" section appears
- [ ] Add `alertasynotificaciones@bancolombia.com.co` as a sender — verify it appears in the list
- [ ] Try adding a duplicate — verify friendly error message
- [ ] Remove a sender — verify it disappears
- [ ] Verify emails from user-configured senders pass webhook validation
- [ ] Send a "no fue exitosa" Bancolombia email — verify it returns `null` (no transaction created)
- [ ] Verify existing Bancolombia email patterns still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)