### PR TITLE
fix: update account balance from imported transactions when no statement metadata exists

### DIFF
--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -25,6 +25,7 @@ import type {
 } from "@/types/import";
 import { trackProductEvent } from "@/actions/product-events";
 import { linkTransactionToOccurrence } from "@/actions/occurrences";
+import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 
 type DebtKind = "credit_card" | "loan";
 type CurrencyCode = Database["public"]["Enums"]["currency_code"];
@@ -810,6 +811,7 @@ export async function importTransactions(
   let manualMerged = 0;
   let leftAsSeparate = 0;
   const details: string[] = [];
+  const importedTxs: TransactionToImport[] = [];
 
   for (const [txIndex, tx] of transactions.entries()) {
     // Use original_amount (full purchase price) for idempotency when available,
@@ -863,6 +865,7 @@ export async function importTransactions(
     }
 
     imported++;
+    importedTxs.push(tx);
 
     await linkTransactionToOccurrence(
       tx.account_id, tx.transaction_date,
@@ -974,6 +977,57 @@ export async function importTransactions(
     statementMeta: normalizedStatementMeta,
     details,
   });
+
+  // For accounts that didn't get an authoritative balance from statement metadata
+  // (e.g. screenshot imports with no credit_card_metadata/summary), apply per-tx
+  // balance deltas — same logic as manual transaction creation.
+  if (importedTxs.length > 0) {
+    const accountsWithMetaBalance = new Set<string>();
+    for (const meta of normalizedStatementMeta ?? []) {
+      if (meta.creditCardMetadata || meta.loanMetadata || meta.summary?.final_balance != null) {
+        accountsWithMetaBalance.add(meta.accountId);
+      }
+    }
+
+    // Group imported txs by account, only for accounts without authoritative metadata
+    const txsByAccount = new Map<string, TransactionToImport[]>();
+    for (const tx of importedTxs) {
+      if (accountsWithMetaBalance.has(tx.account_id)) continue;
+      const list = txsByAccount.get(tx.account_id) ?? [];
+      list.push(tx);
+      txsByAccount.set(tx.account_id, list);
+    }
+
+    if (txsByAccount.size > 0) {
+      const accountIds = [...txsByAccount.keys()];
+      const { data: balanceAccounts } = await supabase
+        .from("accounts")
+        .select("id, account_type, current_balance")
+        .eq("user_id", user.id)
+        .in("id", accountIds);
+
+      for (const account of balanceAccounts ?? []) {
+        const txs = txsByAccount.get(account.id);
+        if (!txs) continue;
+
+        let balance = Number(account.current_balance ?? 0);
+        for (const tx of txs) {
+          balance = applyAccountBalanceDelta({
+            currentBalance: balance,
+            accountType: account.account_type,
+            direction: tx.direction,
+            amount: tx.amount,
+          });
+        }
+
+        await supabase
+          .from("accounts")
+          .update({ current_balance: balance })
+          .eq("user_id", user.id)
+          .eq("id", account.id);
+      }
+    }
+  }
 
   revalidateFinancialViews();
   revalidateTag("snapshots", "zeta");

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -811,7 +811,7 @@ export async function importTransactions(
   let manualMerged = 0;
   let leftAsSeparate = 0;
   const details: string[] = [];
-  const importedTxs: TransactionToImport[] = [];
+  const balanceDeltaTxs: TransactionToImport[] = [];
 
   for (const [txIndex, tx] of transactions.entries()) {
     // Use original_amount (full purchase price) for idempotency when available,
@@ -875,8 +875,7 @@ export async function importTransactions(
       ? decisionMap.get(tx.import_key)
       : decisionMap.get(buildDecisionKey(-1, txIndex));
     if (!decision || decision.decision === "KEEP_BOTH") {
-      // Not reconciled — this tx introduces a new balance delta
-      importedTxs.push(tx);
+      balanceDeltaTxs.push(tx);
       leftAsSeparate++;
       continue;
     }
@@ -897,14 +896,13 @@ export async function importTransactions(
     }
 
     if (!manualTx) {
-      // Candidate gone — treat as unmatched, balance delta applies
-      importedTxs.push(tx);
+      balanceDeltaTxs.push(tx);
       leftAsSeparate++;
       continue;
     }
 
     // Reconciled (AUTO_MERGE / MERGE): manual tx already applied its balance
-    // delta when it was created, so do NOT add to importedTxs to avoid double-counting.
+    // delta when it was created, so do NOT add to balanceDeltaTxs to avoid double-counting.
     const merged = mergeTransactionMetadata(manualTx as ReconciliationCandidate, {
       category_id: insertedTx.category_id,
       notes: insertedTx.notes,
@@ -983,10 +981,8 @@ export async function importTransactions(
     details,
   });
 
-  // For accounts that didn't get an authoritative balance from statement metadata
-  // (e.g. screenshot imports with no credit_card_metadata/summary), apply per-tx
-  // balance deltas — same logic as manual transaction creation.
-  if (importedTxs.length > 0) {
+  // Screenshot imports lack statement metadata — fall back to per-tx balance deltas.
+  if (balanceDeltaTxs.length > 0) {
     const accountsWithMetaBalance = new Set<string>();
     for (const meta of normalizedStatementMeta ?? []) {
       if (meta.creditCardMetadata || meta.loanMetadata || meta.summary?.final_balance != null) {
@@ -994,9 +990,8 @@ export async function importTransactions(
       }
     }
 
-    // Group imported txs by account, only for accounts without authoritative metadata
     const txsByAccount = new Map<string, TransactionToImport[]>();
-    for (const tx of importedTxs) {
+    for (const tx of balanceDeltaTxs) {
       if (accountsWithMetaBalance.has(tx.account_id)) continue;
       const list = txsByAccount.get(tx.account_id) ?? [];
       list.push(tx);
@@ -1029,7 +1024,6 @@ export async function importTransactions(
           });
         }
 
-        // Patch currency_balances JSONB to stay consistent with scalar current_balance
         const existingBalances =
           account.currency_balances &&
           typeof account.currency_balances === "object" &&

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -865,7 +865,6 @@ export async function importTransactions(
     }
 
     imported++;
-    importedTxs.push(tx);
 
     await linkTransactionToOccurrence(
       tx.account_id, tx.transaction_date,
@@ -876,6 +875,8 @@ export async function importTransactions(
       ? decisionMap.get(tx.import_key)
       : decisionMap.get(buildDecisionKey(-1, txIndex));
     if (!decision || decision.decision === "KEEP_BOTH") {
+      // Not reconciled — this tx introduces a new balance delta
+      importedTxs.push(tx);
       leftAsSeparate++;
       continue;
     }
@@ -896,10 +897,14 @@ export async function importTransactions(
     }
 
     if (!manualTx) {
+      // Candidate gone — treat as unmatched, balance delta applies
+      importedTxs.push(tx);
       leftAsSeparate++;
       continue;
     }
 
+    // Reconciled (AUTO_MERGE / MERGE): manual tx already applied its balance
+    // delta when it was created, so do NOT add to importedTxs to avoid double-counting.
     const merged = mergeTransactionMetadata(manualTx as ReconciliationCandidate, {
       category_id: insertedTx.category_id,
       notes: insertedTx.notes,
@@ -1000,11 +1005,15 @@ export async function importTransactions(
 
     if (txsByAccount.size > 0) {
       const accountIds = [...txsByAccount.keys()];
-      const { data: balanceAccounts } = await supabase
+      const { data: balanceAccounts, error: balanceError } = await supabase
         .from("accounts")
-        .select("id, account_type, current_balance")
+        .select("id, account_type, current_balance, currency_code, currency_balances")
         .eq("user_id", user.id)
         .in("id", accountIds);
+
+      if (balanceError) {
+        console.error("Failed to fetch accounts for balance delta:", balanceError.message);
+      }
 
       for (const account of balanceAccounts ?? []) {
         const txs = txsByAccount.get(account.id);
@@ -1020,11 +1029,31 @@ export async function importTransactions(
           });
         }
 
-        await supabase
+        // Patch currency_balances JSONB to stay consistent with scalar current_balance
+        const existingBalances =
+          account.currency_balances &&
+          typeof account.currency_balances === "object" &&
+          !Array.isArray(account.currency_balances)
+            ? (account.currency_balances as Record<string, Record<string, number | null>>)
+            : {};
+        const currencyKey = account.currency_code ?? txs[0].currency_code;
+        existingBalances[currencyKey] = {
+          ...existingBalances[currencyKey],
+          current_balance: balance,
+        };
+
+        const { error: updateError } = await supabase
           .from("accounts")
-          .update({ current_balance: balance })
+          .update({
+            current_balance: balance,
+            currency_balances: existingBalances,
+          })
           .eq("user_id", user.id)
           .eq("id", account.id);
+
+        if (updateError) {
+          console.error("Failed to update balance for account", account.id, updateError.message);
+        }
       }
     }
   }


### PR DESCRIPTION
Screenshot imports (unlike PDF statements) don't include credit card metadata
(total_payment_due, credit_limit, etc.), so the balance was never updated.
Now falls back to applying per-transaction balance deltas — same logic as
manual transaction creation — for accounts without authoritative metadata.

https://claude.ai/code/session_01Q4CE9P5waWoUejDbjsXGwi