### PR TITLE
fix: FAB menu closing + voice capture input bar visibility

### DIFF
--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Drawer as DrawerPrimitive } from "vaul";
 import { Plus, Mic, Sparkles, Image } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
-import { Drawer, DrawerPortal, DrawerOverlay, DrawerTitle } from "@/components/ui/drawer";
+import { Drawer, DrawerPortal, DrawerTitle } from "@/components/ui/drawer";
 
 export type FabAction = "voice" | "screenshot" | "quick-capture" | "new-recurring" | "new-account";
 
@@ -27,6 +27,7 @@ interface FabMenuProps {
 export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMenuProps) {
   const pathname = usePathname();
   const router = useRouter();
+  const closedViaBackRef = useRef(false);
 
   // Close on route change
   useEffect(() => onOpenChange(false), [pathname, onOpenChange]);
@@ -39,6 +40,27 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       return () => { document.body.style.overflow = prev; };
     }
   }, [open]);
+
+  // Back button closes the menu instead of navigating away
+  useEffect(() => {
+    if (!open) return;
+    closedViaBackRef.current = false;
+    history.pushState({ fabMenu: true }, "");
+
+    function handlePopState() {
+      closedViaBackRef.current = true;
+      onOpenChange(false);
+    }
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+      // If closed by non-back means (overlay tap, FAB toggle, swipe), pop the dummy entry
+      if (!closedViaBackRef.current) {
+        history.back();
+      }
+    };
+  }, [open, onOpenChange]);
 
   // Prefetch the transaction page when the drawer opens
   useEffect(() => {
@@ -62,11 +84,18 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
 
   return (
     <div className="lg:hidden">
+      {/* Custom backdrop — rendered outside vaul so pointer-events are never suppressed */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 transition-opacity"
+          onClick={() => onOpenChange(false)}
+          aria-hidden="true"
+        />
+      )}
+
       {/* modal={false} keeps the tab-bar FAB button interactive so it can toggle close */}
       <Drawer open={open} onOpenChange={onOpenChange} modal={false}>
         <DrawerPortal>
-          {/* Render overlay manually so we can attach onClick (vaul disables it when modal=false) */}
-          <DrawerOverlay onClick={() => onOpenChange(false)} />
           <DrawerPrimitive.Content
             data-slot="drawer-content"
             className="bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[85dvh] flex-col rounded-t-2xl border-t"

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -57,6 +57,7 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       window.removeEventListener("popstate", handlePopState);
       // If closed by non-back means (overlay tap, FAB toggle, swipe), pop the dummy entry
       if (!closedViaBackRef.current) {
+        closedViaBackRef.current = true; // prevent double-fire if late popstate leaks
         history.back();
       }
     };

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -58,7 +58,9 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       // If closed by non-back means (overlay tap, FAB toggle, swipe), pop the dummy entry
       if (!closedViaBackRef.current) {
         closedViaBackRef.current = true; // prevent double-fire if late popstate leaks
-        history.back();
+        if (history.state?.fabMenu) {
+          history.back();
+        }
       }
     };
   }, [open, onOpenChange]);
@@ -88,7 +90,7 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
       {/* Custom backdrop — rendered outside vaul so pointer-events are never suppressed */}
       {open && (
         <div
-          className="fixed inset-0 z-50 bg-black/50 transition-opacity"
+          className="fixed inset-0 z-50 bg-black/50"
           onClick={() => onOpenChange(false)}
           aria-hidden="true"
         />

--- a/webapp/src/components/mobile/mobile-sheet-provider.tsx
+++ b/webapp/src/components/mobile/mobile-sheet-provider.tsx
@@ -148,7 +148,7 @@ export function MobileSheetProvider({ children }: MobileSheetProviderProps) {
             <DrawerTitle>{activeAction ? getSheetTitle(activeAction) : ""}</DrawerTitle>
           </DrawerHeader>
 
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[calc(var(--z-mobile-tab-bar-h)_+_1rem_+_env(safe-area-inset-bottom))]">
             {activeAction === "voice" && (
               <VoiceCaptureSheet
                 accounts={accounts}

--- a/webapp/src/components/mobile/voice-capture-sheet.tsx
+++ b/webapp/src/components/mobile/voice-capture-sheet.tsx
@@ -287,7 +287,7 @@ export function VoiceCaptureSheet({
   // ── Render ──
 
   return (
-    <div className="flex flex-col" style={{ height: "min(60dvh, 28rem)" }}>
+    <div className="flex flex-col">
       {/* Account chip — tappable */}
       {selectedAccountId && !showAccountPicker && (
         <button
@@ -335,7 +335,7 @@ export function VoiceCaptureSheet({
       {/* Chat messages */}
       {!showAccountPicker && (
         <>
-          <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain pb-3">
+          <div ref={scrollRef} className="space-y-3 overflow-y-auto overscroll-contain pb-3" style={{ maxHeight: "min(45dvh, 22rem)" }}>
             {messages.map((msg, i) => {
               if (msg.role === "user") {
                 return (

--- a/webapp/src/components/mobile/voice-capture-sheet.tsx
+++ b/webapp/src/components/mobile/voice-capture-sheet.tsx
@@ -88,7 +88,8 @@ export function VoiceCaptureSheet({
   // Scroll to bottom on new messages (deferred to avoid forced reflow mid-render)
   useEffect(() => {
     const id = requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+      const el = scrollRef.current;
+      if (el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
     });
     return () => cancelAnimationFrame(id);
   }, [messages]);

--- a/webapp/src/components/mobile/voice-capture-sheet.tsx
+++ b/webapp/src/components/mobile/voice-capture-sheet.tsx
@@ -85,9 +85,12 @@ export function VoiceCaptureSheet({
   const [submitting, setSubmitting] = useState(false);
   const [textInput, setTextInput] = useState("");
 
-  // Scroll to bottom on new messages
+  // Scroll to bottom on new messages (deferred to avoid forced reflow mid-render)
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    const id = requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    });
+    return () => cancelAnimationFrame(id);
   }, [messages]);
 
   // ── Account selection ──
@@ -335,7 +338,7 @@ export function VoiceCaptureSheet({
       {/* Chat messages */}
       {!showAccountPicker && (
         <>
-          <div ref={scrollRef} className="space-y-3 overflow-y-auto overscroll-contain pb-3" style={{ maxHeight: "min(45dvh, 22rem)" }}>
+          <div ref={scrollRef} className="max-h-[min(45dvh,22rem)] space-y-3 overflow-y-auto overscroll-contain pb-3">
             {messages.map((msg, i) => {
               if (msg.role === "user") {
                 return (


### PR DESCRIPTION
- Replace vaul DrawerOverlay with custom backdrop div — vaul suppresses
  pointer-events on overlay when modal=false, so tap-to-dismiss never fired
- Add history.pushState/popstate handler so Android back button closes the
  FAB menu instead of navigating away
- Voice capture: remove fixed height container, constrain only the messages
  area (maxHeight) so the text input + mic button are always visible
- Add tab-bar clearance padding to the action sheet wrapper so drawer
  content doesn't hide behind the z-[9999] tab bar

https://claude.ai/code/session_016kUebXzhFtnggV1edAizPZ