### PR TITLE
Implement capture method authority hierarchy for transaction reconciliation

### DIFF
--- a/.claude/agents/import-flow-doctor.md
+++ b/.claude/agents/import-flow-doctor.md
@@ -51,7 +51,8 @@ You are a specialist for Zeta's transaction import system — the 4-step wizard 
 - `webapp/src/lib/utils/idempotency.ts` — `computeIdempotencyKey()` function
 - `services/pdf_parser/parsers/` — bank-specific PDF parsers
 - `services/pdf_parser/models.py` — `ParsedStatement`, `ParsedTransaction` models
-- `packages/shared/src/reconciliation.ts` — reconciliation logic
+- `packages/shared/src/utils/reconciliation.ts` — reconciliation logic
+- `packages/shared/src/utils/capture-hierarchy.ts` — capture method authority tiers
 
 ## Import Flow Overview
 
@@ -104,14 +105,26 @@ if (error.code === "23505") {
 }
 ```
 
-### 3. Reconciliation
+### 3. Reconciliation & Capture Hierarchy
 
-Before import, `previewImportReconciliation()` checks for existing manual transactions that match imported ones:
+Before import, `previewImportReconciliation()` checks for existing transactions that match imported ones. **Reconciliation fetches ALL existing transactions regardless of `capture_method`** — no filtering by source.
 
-- **AUTO_MERGE** — manual transaction linked automatically (high confidence match). Sets `reconciled_into_transaction_id` on the manual tx.
+- **AUTO_MERGE** — existing transaction linked automatically (high confidence match). Sets `reconciled_into_transaction_id` on the existing tx.
 - **REVIEW** — user decides per-transaction: merge or keep both.
 
 Reconciliation uses `findReconciliationCandidates()` and `mergeTransactionMetadata()` from `@zeta/shared`.
+
+**Capture Method Authority Hierarchy** (`capture-hierarchy.ts`):
+
+| Tier | Methods | Authority |
+|------|---------|-----------|
+| 1 | `PDF_IMPORT` | Bank-verified (structured statement + metadata) |
+| 2 | `EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` | Semi-structured |
+| 3 | `MANUAL_FORM`, `TEXT_QUICK_CAPTURE` | User-entered |
+
+**Merge direction**: Higher authority wins for `capture_method` on the surviving transaction. Lower authority's user-set enrichments (USER_CREATED/USER_OVERRIDE category, notes) are preserved.
+
+**Re-import dedup**: When the same statement is re-imported, reconciliation finds the existing transactions (any capture method), and idempotency keys catch exact duplicates at insert time (23505 → skip).
 
 ### 4. Account Matching
 
@@ -196,10 +209,13 @@ POST /api/parse-statement (Next.js route handler)
 - [ ] `original_amount` = full purchase price (nullable)
 - [ ] Cuota extracted directly from PDF, never calculated by division
 
-### Reconciliation
+### Reconciliation & Capture Hierarchy
 - [ ] `previewImportReconciliation()` called before import
 - [ ] AUTO_MERGE and REVIEW states handled correctly
-- [ ] `reconciled_into_transaction_id` set on merged manual transactions
+- [ ] `reconciled_into_transaction_id` set on merged existing transactions
+- [ ] `fetchReconciliationCandidates` has NO `capture_method` filter — matches ALL sources
+- [ ] `mergeTransactionMetadata()` receives `capture_method` from both sides for hierarchy-aware merge
+- [ ] New capture methods added to `CAPTURE_TIER` in `capture-hierarchy.ts`
 
 ### Cache
 - [ ] `revalidateFinancialViews()` called after import

--- a/.claude/agents/import-flow-doctor.md
+++ b/.claude/agents/import-flow-doctor.md
@@ -118,8 +118,8 @@ Reconciliation uses `findReconciliationCandidates()` and `mergeTransactionMetada
 
 | Tier | Methods | Authority |
 |------|---------|-----------|
-| 1 | `PDF_IMPORT` | Bank-verified (structured statement + metadata) |
-| 2 | `EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` | Semi-structured |
+| 1 | `PDF_IMPORT`, `EMAIL_PDF_IMPORT` | Bank-verified (structured statement + metadata) |
+| 2 | `EMAIL_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` | Semi-structured |
 | 3 | `MANUAL_FORM`, `TEXT_QUICK_CAPTURE` | User-entered |
 
 **Merge direction**: Higher authority wins for `capture_method` on the surviving transaction. Lower authority's user-set enrichments (USER_CREATED/USER_OVERRIDE category, notes) are preserved.

--- a/.claude/agents/recurring-doctor.md
+++ b/.claude/agents/recurring-doctor.md
@@ -105,8 +105,8 @@ This uses `ON CONFLICT DO NOTHING` — safe to call multiple times. Existing sta
 
 ALL transaction creation paths MUST auto-link to pending occurrences, regardless of capture method tier:
 
-- **Tier 1**: PDF import (`PDF_IMPORT`)
-- **Tier 2**: Email import (`EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`), OCR (`OCR_BATCH`, `OCR_SINGLE`)
+- **Tier 1**: PDF import (`PDF_IMPORT`, `EMAIL_PDF_IMPORT`)
+- **Tier 2**: Email text import (`EMAIL_IMPORT`), OCR (`OCR_BATCH`, `OCR_SINGLE`)
 - **Tier 3**: FAB/quick-add (`TEXT_QUICK_CAPTURE`), manual form (`MANUAL_FORM`)
 - Recurring confirm (mark as paid)
 

--- a/.claude/agents/recurring-doctor.md
+++ b/.claude/agents/recurring-doctor.md
@@ -103,12 +103,14 @@ This uses `ON CONFLICT DO NOTHING` — safe to call multiple times. Existing sta
 
 ### 2. Auto-Linking Transactions to Occurrences
 
-ALL transaction creation paths MUST auto-link to pending occurrences:
+ALL transaction creation paths MUST auto-link to pending occurrences, regardless of capture method tier:
 
-- FAB (quick-add)
-- Email import
-- PDF import
+- **Tier 1**: PDF import (`PDF_IMPORT`)
+- **Tier 2**: Email import (`EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`), OCR (`OCR_BATCH`, `OCR_SINGLE`)
+- **Tier 3**: FAB/quick-add (`TEXT_QUICK_CAPTURE`), manual form (`MANUAL_FORM`)
 - Recurring confirm (mark as paid)
+
+See `capture-hierarchy.ts` in `@zeta/shared` for the full authority hierarchy.
 
 Use `linkTransactionToOccurrence()` from `@/actions/occurrences.ts` or `findMatchingOccurrence()` to find and link the correct pending occurrence.
 

--- a/.claude/agents/server-action-reviewer.md
+++ b/.claude/agents/server-action-reviewer.md
@@ -220,8 +220,8 @@ revalidateTag("budgets", "zeta");
 
 Any action that creates transactions or performs reconciliation must respect the capture hierarchy from `@zeta/shared` → `capture-hierarchy.ts`:
 
-- **Tier 1** (bank-verified): `PDF_IMPORT`
-- **Tier 2** (semi-structured): `EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`, `OCR_BATCH`, `OCR_SINGLE`
+- **Tier 1** (bank-verified): `PDF_IMPORT`, `EMAIL_PDF_IMPORT`
+- **Tier 2** (semi-structured): `EMAIL_IMPORT`, `OCR_BATCH`, `OCR_SINGLE`
 - **Tier 3** (user-entered): `MANUAL_FORM`, `TEXT_QUICK_CAPTURE`
 
 Rules:

--- a/.claude/agents/server-action-reviewer.md
+++ b/.claude/agents/server-action-reviewer.md
@@ -216,7 +216,30 @@ revalidateTag("budgets", "zeta");
 
 ---
 
-## Check 6: Income/Metrics Rules (HIGH)
+## Check 6: Capture Hierarchy & Reconciliation (HIGH)
+
+Any action that creates transactions or performs reconciliation must respect the capture hierarchy from `@zeta/shared` → `capture-hierarchy.ts`:
+
+- **Tier 1** (bank-verified): `PDF_IMPORT`
+- **Tier 2** (semi-structured): `EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`, `OCR_BATCH`, `OCR_SINGLE`
+- **Tier 3** (user-entered): `MANUAL_FORM`, `TEXT_QUICK_CAPTURE`
+
+Rules:
+- Reconciliation candidate queries must NOT filter by `capture_method` — all sources are candidates
+- `mergeTransactionMetadata()` must receive `capture_method` from both sides (existing + incoming)
+- Higher authority source wins for `capture_method` on the surviving transaction
+- Lower authority's user-set enrichments (category, notes) are preserved
+- Idempotency uses `computeIdempotencyKey()` — same formula for all sources
+
+**Flag as HIGH:**
+- Reconciliation query filtering by `capture_method` (`.in("capture_method", [...])`)
+- `mergeTransactionMetadata()` called without `capture_method` on either side
+- Transaction creation path missing `capture_method` field
+- New capture method not added to `CAPTURE_TIER` in `capture-hierarchy.ts`
+
+---
+
+## Check 7: Income/Metrics Rules (HIGH)
 
 Any action that calculates income, ingresos, or cashflow MUST exclude debt inflows:
 
@@ -239,7 +262,7 @@ Reference implementation: `getMonthlyCashflowCached()` in `webapp/src/actions/ch
 
 ---
 
-## Check 7: PostgREST Joins (MEDIUM)
+## Check 8: PostgREST Joins (MEDIUM)
 
 Joins through encrypted views require explicit FK hints:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@ Every transaction has a `capture_method` indicating how it was created. These fo
 
 | Tier | Authority | Methods | Examples |
 |------|-----------|---------|----------|
-| 1 | Bank-verified | `PDF_IMPORT` | Structured PDF statement with metadata (balances, credit limits) |
-| 2 | Semi-structured | `EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` | Email notifications, OCR screenshots |
+| 1 | Bank-verified | `PDF_IMPORT`, `EMAIL_PDF_IMPORT` | Structured PDF statement with metadata (balances, credit limits) |
+| 2 | Semi-structured | `EMAIL_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` | Email text notifications, OCR screenshots |
 | 3 | User-entered | `MANUAL_FORM`, `TEXT_QUICK_CAPTURE` | Manual form, quick capture, voice, Telegram |
 
 **Rules** (defined in `@zeta/shared` → `capture-hierarchy.ts`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,22 @@
 - Dates: Spanish locale via `formatDate()` from `src/lib/utils/date.ts`
 - Idempotency: `computeIdempotencyKey()` from `src/lib/utils/idempotency.ts` for dedup
 
+## Capture Method Hierarchy
+Every transaction has a `capture_method` indicating how it was created. These form an authority hierarchy that governs reconciliation, merge direction, and balance updates.
+
+| Tier | Authority | Methods | Examples |
+|------|-----------|---------|----------|
+| 1 | Bank-verified | `PDF_IMPORT` | Structured PDF statement with metadata (balances, credit limits) |
+| 2 | Semi-structured | `EMAIL_IMPORT`, `EMAIL_PDF_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` | Email notifications, OCR screenshots |
+| 3 | User-entered | `MANUAL_FORM`, `TEXT_QUICK_CAPTURE` | Manual form, quick capture, voice, Telegram |
+
+**Rules** (defined in `@zeta/shared` → `capture-hierarchy.ts`):
+- **Reconciliation**: Fetches ALL existing transactions regardless of `capture_method` — no filtering. The scoring algorithm + idempotency key handle dedup.
+- **Merge direction**: Higher authority wins for `capture_method` on the surviving transaction. Lower authority's user-set enrichments (category, notes) are preserved via `mergeTransactionMetadata()`.
+- **Balance updates**: Tier 1 with statement metadata sets balance directly. Tier 2/3 use `applyAccountBalanceDelta()` per-transaction.
+- **Idempotency**: Same `computeIdempotencyKey()` for all sources — `SHA256(provider|providerTransactionId|date|amount|description|installment)`. DB unique constraint catches duplicates (`error.code === "23505"` → skip).
+- **New capture methods**: Add to `CAPTURE_TIER` in `capture-hierarchy.ts` + DB enum migration. Spawn `import-flow-doctor` for review.
+
 ## Agents
 
 Spawn these specialized agents for domain-specific review and diagnosis. Each has embedded Zeta knowledge — no orientation reads needed.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./utils/auto-categorize";
 export * from "./utils/pattern-extract";
 export * from "./utils/quick-capture";
 export * from "./utils/recurrence";
+export * from "./utils/capture-hierarchy";
 export * from "./utils/reconciliation";
 export * from "./utils/debt";
 export * from "./utils/debt-simulator";

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -780,6 +780,7 @@ export type Database = {
         | "OCR_BATCH"
         | "OCR_SINGLE"
         | "EMAIL_IMPORT"
+        | "EMAIL_PDF_IMPORT"
       recurrence_frequency:
         | "WEEKLY"
         | "BIWEEKLY"

--- a/packages/shared/src/utils/capture-hierarchy.ts
+++ b/packages/shared/src/utils/capture-hierarchy.ts
@@ -1,33 +1,8 @@
 import type { TransactionCaptureMethod } from "../types/domain";
 
-/**
- * Capture Method Authority Hierarchy
- *
- * Defines a trust/authority ranking for transaction sources.
- * Lower tier number = higher authority.
- *
- * Tier 1 — Bank-verified (structured PDF statements with metadata):
- *   PDF_IMPORT: Full statement parse with balances, credit limits, dates
- *   EMAIL_PDF_IMPORT: Same structured parse, delivered via email attachment
- *
- * Tier 2 — Semi-structured (machine-extracted, partial metadata):
- *   EMAIL_IMPORT: Parsed from notification emails (text, not PDF)
- *   OCR_BATCH: Batch OCR from screenshots
- *   OCR_SINGLE: Single transaction OCR
- *
- * Tier 3 — User-entered (no bank verification):
- *   MANUAL_FORM: Typed via full form
- *   TEXT_QUICK_CAPTURE: Short text / voice / Telegram
- *
- * Rules:
- *   - Reconciliation fetches ALL existing transactions (no capture_method filter)
- *   - Higher authority always wins merge direction (keeps its raw_description, amount)
- *   - Lower authority's user enrichments are preserved (USER_CREATED category, notes)
- *   - Same tier + high score → AUTO_MERGE; idempotency key handles actual dedup
- *   - Balance updates: highest available authority for an account sets the balance
- */
-
-const CAPTURE_TIER: Record<TransactionCaptureMethod, 1 | 2 | 3> = {
+// Lower tier number = higher authority.
+// See CLAUDE.md "Capture Method Hierarchy" for full rules.
+const CAPTURE_TIER = {
   PDF_IMPORT: 1,
   EMAIL_PDF_IMPORT: 1,
   EMAIL_IMPORT: 2,
@@ -35,46 +10,24 @@ const CAPTURE_TIER: Record<TransactionCaptureMethod, 1 | 2 | 3> = {
   OCR_SINGLE: 2,
   TEXT_QUICK_CAPTURE: 3,
   MANUAL_FORM: 3,
-};
+} as const satisfies Record<TransactionCaptureMethod, 1 | 2 | 3>;
 
 export type CaptureTier = 1 | 2 | 3;
 
 export function getCaptureTier(method: TransactionCaptureMethod): CaptureTier {
-  return CAPTURE_TIER[method] ?? 3;
+  return CAPTURE_TIER[method];
 }
 
 /**
- * Returns true if `incoming` has strictly higher authority than `existing`.
- */
-export function isHigherAuthority(
-  incoming: TransactionCaptureMethod,
-  existing: TransactionCaptureMethod
-): boolean {
-  return getCaptureTier(incoming) < getCaptureTier(existing);
-}
-
-/**
- * Returns true if both methods are in the same authority tier.
- */
-export function isSameTier(
-  a: TransactionCaptureMethod,
-  b: TransactionCaptureMethod
-): boolean {
-  return getCaptureTier(a) === getCaptureTier(b);
-}
-
-/**
- * Given an incoming and existing capture method, returns the one that should
- * "win" for data fields (raw_description, amount, capture_method on the
- * surviving transaction). The other side's user enrichments (category, notes)
- * are preserved separately by mergeTransactionMetadata.
+ * Given an incoming and existing capture method, returns which side should
+ * "win" for data fields on the surviving transaction. Ties go to incoming
+ * (newer data).
  */
 export function resolveAuthorityWinner(
   incoming: TransactionCaptureMethod,
   existing: TransactionCaptureMethod
 ): "incoming" | "existing" {
-  const incomingTier = getCaptureTier(incoming);
-  const existingTier = getCaptureTier(existing);
-  // Lower tier number = higher authority; ties go to incoming (newer data)
-  return incomingTier <= existingTier ? "incoming" : "existing";
+  return getCaptureTier(incoming) <= getCaptureTier(existing)
+    ? "incoming"
+    : "existing";
 }

--- a/packages/shared/src/utils/capture-hierarchy.ts
+++ b/packages/shared/src/utils/capture-hierarchy.ts
@@ -8,10 +8,10 @@ import type { TransactionCaptureMethod } from "../types/domain";
  *
  * Tier 1 — Bank-verified (structured PDF statements with metadata):
  *   PDF_IMPORT: Full statement parse with balances, credit limits, dates
+ *   EMAIL_PDF_IMPORT: Same structured parse, delivered via email attachment
  *
  * Tier 2 — Semi-structured (machine-extracted, partial metadata):
- *   EMAIL_IMPORT: Parsed from notification emails
- *   EMAIL_PDF_IMPORT: PDF attached to email, parsed automatically
+ *   EMAIL_IMPORT: Parsed from notification emails (text, not PDF)
  *   OCR_BATCH: Batch OCR from screenshots
  *   OCR_SINGLE: Single transaction OCR
  *
@@ -29,7 +29,7 @@ import type { TransactionCaptureMethod } from "../types/domain";
 
 const CAPTURE_TIER: Record<TransactionCaptureMethod, 1 | 2 | 3> = {
   PDF_IMPORT: 1,
-  EMAIL_PDF_IMPORT: 2,
+  EMAIL_PDF_IMPORT: 1,
   EMAIL_IMPORT: 2,
   OCR_BATCH: 2,
   OCR_SINGLE: 2,

--- a/packages/shared/src/utils/capture-hierarchy.ts
+++ b/packages/shared/src/utils/capture-hierarchy.ts
@@ -1,0 +1,80 @@
+import type { TransactionCaptureMethod } from "../types/domain";
+
+/**
+ * Capture Method Authority Hierarchy
+ *
+ * Defines a trust/authority ranking for transaction sources.
+ * Lower tier number = higher authority.
+ *
+ * Tier 1 — Bank-verified (structured PDF statements with metadata):
+ *   PDF_IMPORT: Full statement parse with balances, credit limits, dates
+ *
+ * Tier 2 — Semi-structured (machine-extracted, partial metadata):
+ *   EMAIL_IMPORT: Parsed from notification emails
+ *   EMAIL_PDF_IMPORT: PDF attached to email, parsed automatically
+ *   OCR_BATCH: Batch OCR from screenshots
+ *   OCR_SINGLE: Single transaction OCR
+ *
+ * Tier 3 — User-entered (no bank verification):
+ *   MANUAL_FORM: Typed via full form
+ *   TEXT_QUICK_CAPTURE: Short text / voice / Telegram
+ *
+ * Rules:
+ *   - Reconciliation fetches ALL existing transactions (no capture_method filter)
+ *   - Higher authority always wins merge direction (keeps its raw_description, amount)
+ *   - Lower authority's user enrichments are preserved (USER_CREATED category, notes)
+ *   - Same tier + high score → AUTO_MERGE; idempotency key handles actual dedup
+ *   - Balance updates: highest available authority for an account sets the balance
+ */
+
+const CAPTURE_TIER: Record<TransactionCaptureMethod, 1 | 2 | 3> = {
+  PDF_IMPORT: 1,
+  EMAIL_PDF_IMPORT: 2,
+  EMAIL_IMPORT: 2,
+  OCR_BATCH: 2,
+  OCR_SINGLE: 2,
+  TEXT_QUICK_CAPTURE: 3,
+  MANUAL_FORM: 3,
+};
+
+export type CaptureTier = 1 | 2 | 3;
+
+export function getCaptureTier(method: TransactionCaptureMethod): CaptureTier {
+  return CAPTURE_TIER[method] ?? 3;
+}
+
+/**
+ * Returns true if `incoming` has strictly higher authority than `existing`.
+ */
+export function isHigherAuthority(
+  incoming: TransactionCaptureMethod,
+  existing: TransactionCaptureMethod
+): boolean {
+  return getCaptureTier(incoming) < getCaptureTier(existing);
+}
+
+/**
+ * Returns true if both methods are in the same authority tier.
+ */
+export function isSameTier(
+  a: TransactionCaptureMethod,
+  b: TransactionCaptureMethod
+): boolean {
+  return getCaptureTier(a) === getCaptureTier(b);
+}
+
+/**
+ * Given an incoming and existing capture method, returns the one that should
+ * "win" for data fields (raw_description, amount, capture_method on the
+ * surviving transaction). The other side's user enrichments (category, notes)
+ * are preserved separately by mergeTransactionMetadata.
+ */
+export function resolveAuthorityWinner(
+  incoming: TransactionCaptureMethod,
+  existing: TransactionCaptureMethod
+): "incoming" | "existing" {
+  const incomingTier = getCaptureTier(incoming);
+  const existingTier = getCaptureTier(existing);
+  // Lower tier number = higher authority; ties go to incoming (newer data)
+  return incomingTier <= existingTier ? "incoming" : "existing";
+}

--- a/packages/shared/src/utils/reconciliation.ts
+++ b/packages/shared/src/utils/reconciliation.ts
@@ -1,6 +1,6 @@
 import { differenceInCalendarDays } from "date-fns";
 import type { CategorizationSource, TransactionCaptureMethod, TransactionDirection } from "../types/domain";
-import { getCaptureTier, isSameTier } from "./capture-hierarchy";
+import { resolveAuthorityWinner } from "./capture-hierarchy";
 
 export type ReconciliationCandidate = {
   id: string;
@@ -157,17 +157,7 @@ export function findReconciliationCandidates(
   return { bestMatch: best, ranked };
 }
 
-/**
- * Merges metadata when reconciling two transactions.
- *
- * Uses the capture hierarchy to decide merge direction:
- *   - The higher-authority source wins for capture_method
- *   - User-set enrichments (category, notes) from the lower-authority
- *     source are preserved when the higher-authority source lacks them
- *
- * @param existingTx - The transaction already in the database
- * @param incomingTx - The transaction being imported now
- */
+/** Higher-authority capture_method wins; lower authority's user-set enrichments are preserved. */
 export function mergeTransactionMetadata(
   existingTx: Pick<
     ReconciliationCandidate,
@@ -175,6 +165,7 @@ export function mergeTransactionMetadata(
   >,
   incomingTx: {
     category_id?: string | null;
+    categorization_source?: CategorizationSource;
     notes?: string | null;
     capture_method?: TransactionCaptureMethod;
   }
@@ -183,22 +174,26 @@ export function mergeTransactionMetadata(
   notes?: string | null;
   capture_method: TransactionCaptureMethod;
 } {
-  const incomingMethod = incomingTx.capture_method ?? "PDF_IMPORT";
+  const incomingMethod = incomingTx.capture_method ?? "MANUAL_FORM";
   const existingMethod = existingTx.capture_method ?? "MANUAL_FORM";
+  const winner = resolveAuthorityWinner(incomingMethod, existingMethod);
+  const winnerMethod = winner === "incoming" ? incomingMethod : existingMethod;
 
-  // Higher authority (lower tier number) wins for capture_method
-  const incomingTier = getCaptureTier(incomingMethod);
-  const existingTier = getCaptureTier(existingMethod);
-  const winnerMethod = incomingTier <= existingTier ? incomingMethod : existingMethod;
-
-  // For category: preserve user-set category from either side when the other lacks one
   const existingHasUserCategory =
     !!existingTx.category_id &&
     (existingTx.categorization_source === "USER_CREATED" ||
       existingTx.categorization_source === "USER_OVERRIDE");
 
+  const incomingHasUserCategory =
+    !!incomingTx.category_id &&
+    (incomingTx.categorization_source === "USER_CREATED" ||
+      incomingTx.categorization_source === "USER_OVERRIDE");
+
+  // User-set categories are always preserved over system-generated ones.
+  // When both sides have user-set categories, authority hierarchy breaks the tie.
   const shouldCarryExistingCategory =
-    !incomingTx.category_id && existingHasUserCategory;
+    existingHasUserCategory &&
+    (!incomingHasUserCategory || winner === "existing");
 
   return {
     category_id: shouldCarryExistingCategory

--- a/packages/shared/src/utils/reconciliation.ts
+++ b/packages/shared/src/utils/reconciliation.ts
@@ -1,5 +1,6 @@
 import { differenceInCalendarDays } from "date-fns";
 import type { CategorizationSource, TransactionCaptureMethod, TransactionDirection } from "../types/domain";
+import { getCaptureTier, isSameTier } from "./capture-hierarchy";
 
 export type ReconciliationCandidate = {
   id: string;
@@ -15,6 +16,7 @@ export type ReconciliationCandidate = {
   categorization_source?: CategorizationSource;
   notes?: string | null;
   reconciled_into_transaction_id?: string | null;
+  capture_method?: TransactionCaptureMethod | null;
 };
 
 export type ImportTransactionForReconciliation = {
@@ -25,6 +27,7 @@ export type ImportTransactionForReconciliation = {
   raw_description: string;
   category_id?: string | null;
   notes?: string | null;
+  capture_method?: TransactionCaptureMethod | null;
 };
 
 export type ReconciliationDecision = "AUTO_MERGE" | "REVIEW" | "NO_MATCH";
@@ -154,12 +157,23 @@ export function findReconciliationCandidates(
   return { bestMatch: best, ranked };
 }
 
+/**
+ * Merges metadata when reconciling two transactions.
+ *
+ * Uses the capture hierarchy to decide merge direction:
+ *   - The higher-authority source wins for capture_method
+ *   - User-set enrichments (category, notes) from the lower-authority
+ *     source are preserved when the higher-authority source lacks them
+ *
+ * @param existingTx - The transaction already in the database
+ * @param incomingTx - The transaction being imported now
+ */
 export function mergeTransactionMetadata(
-  manualTx: Pick<
+  existingTx: Pick<
     ReconciliationCandidate,
-    "category_id" | "categorization_source" | "notes"
+    "category_id" | "categorization_source" | "notes" | "capture_method"
   >,
-  pdfTx: {
+  incomingTx: {
     category_id?: string | null;
     notes?: string | null;
     capture_method?: TransactionCaptureMethod;
@@ -169,15 +183,28 @@ export function mergeTransactionMetadata(
   notes?: string | null;
   capture_method: TransactionCaptureMethod;
 } {
-  const shouldCarryCategory =
-    !pdfTx.category_id &&
-    !!manualTx.category_id &&
-    (manualTx.categorization_source === "USER_CREATED" ||
-      manualTx.categorization_source === "USER_OVERRIDE");
+  const incomingMethod = incomingTx.capture_method ?? "PDF_IMPORT";
+  const existingMethod = existingTx.capture_method ?? "MANUAL_FORM";
+
+  // Higher authority (lower tier number) wins for capture_method
+  const incomingTier = getCaptureTier(incomingMethod);
+  const existingTier = getCaptureTier(existingMethod);
+  const winnerMethod = incomingTier <= existingTier ? incomingMethod : existingMethod;
+
+  // For category: preserve user-set category from either side when the other lacks one
+  const existingHasUserCategory =
+    !!existingTx.category_id &&
+    (existingTx.categorization_source === "USER_CREATED" ||
+      existingTx.categorization_source === "USER_OVERRIDE");
+
+  const shouldCarryExistingCategory =
+    !incomingTx.category_id && existingHasUserCategory;
 
   return {
-    category_id: shouldCarryCategory ? manualTx.category_id ?? null : pdfTx.category_id ?? null,
-    notes: pdfTx.notes ?? manualTx.notes ?? null,
-    capture_method: pdfTx.capture_method ?? "PDF_IMPORT",
+    category_id: shouldCarryExistingCategory
+      ? existingTx.category_id ?? null
+      : incomingTx.category_id ?? null,
+    notes: incomingTx.notes ?? existingTx.notes ?? null,
+    capture_method: winnerMethod,
   };
 }

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -717,7 +717,7 @@ export async function approveEmailTransaction(
       is_subscription: false,
       status: "POSTED",
     })
-    .select("id, category_id, notes")
+    .select("id, category_id, categorization_source, notes")
     .single();
 
   if (insertError) {
@@ -759,6 +759,7 @@ export async function approveEmailTransaction(
         manualTx as ReconciliationCandidate,
         {
           category_id: insertedTx.category_id,
+          categorization_source: insertedTx.categorization_source,
           notes: insertedTx.notes,
           capture_method: "EMAIL_IMPORT",
         }

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -747,7 +747,7 @@ export async function approveEmailTransaction(
     const { data: manualTx } = await supabase
       .from("transactions")
       .select(
-        "id, category_id, categorization_source, notes, reconciled_into_transaction_id"
+        "id, category_id, categorization_source, notes, reconciled_into_transaction_id, capture_method"
       )
       .eq("id", reconcileWithTransactionId)
       .eq("user_id", user.id)
@@ -871,15 +871,14 @@ export async function checkEmailReconciliation(
   const from = toISODateString(fromDate);
   const to = toISODateString(toDate);
 
-  // Fetch manual transactions that could be duplicates
+  // Fetch existing transactions that could be duplicates (any capture method)
   const { data: candidates, error: candError } = await supabase
     .from("transactions")
     .select(
-      "id, user_id, account_id, amount, direction, transaction_date, raw_description, merchant_name, clean_description, category_id, categorization_source, notes, reconciled_into_transaction_id"
+      "id, user_id, account_id, amount, direction, transaction_date, raw_description, merchant_name, clean_description, category_id, categorization_source, notes, reconciled_into_transaction_id, capture_method"
     )
     .eq("account_id", accountId)
     .eq("user_id", user.id)
-    .in("capture_method", ["MANUAL_FORM", "TEXT_QUICK_CAPTURE"])
     .gte("transaction_date", from)
     .lte("transaction_date", to)
     .is("reconciled_into_transaction_id", null);

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -850,7 +850,7 @@ export async function importTransactions(
         destinatario_id: tx.destinatario_id ?? null,
         merchant_name: tx.merchant_name ?? null,
       })
-      .select("id, category_id, notes")
+      .select("id, category_id, categorization_source, notes")
       .single();
 
     if (error) {
@@ -879,7 +879,7 @@ export async function importTransactions(
       continue;
     }
 
-    const { data: manualTx, error: manualTxError } = await supabase
+    const { data: existingTx, error: existingTxError } = await supabase
       .from("transactions")
       .select(
         "id, user_id, account_id, amount, direction, transaction_date, raw_description, merchant_name, clean_description, category_id, categorization_source, notes, reconciled_into_transaction_id, capture_method"
@@ -888,22 +888,23 @@ export async function importTransactions(
       .eq("user_id", user.id)
       .is("reconciled_into_transaction_id", null)
       .maybeSingle();
-    if (manualTxError) {
+    if (existingTxError) {
       errors++;
-      details.push(`Reconciliación: ${tx.raw_description}: ${manualTxError.message}`);
+      details.push(`Reconciliación: ${tx.raw_description}: ${existingTxError.message}`);
       continue;
     }
 
-    if (!manualTx) {
+    if (!existingTx) {
       balanceDeltaTxs.push(tx);
       leftAsSeparate++;
       continue;
     }
 
-    // Reconciled (AUTO_MERGE / MERGE): manual tx already applied its balance
-    // delta when it was created, so do NOT add to balanceDeltaTxs to avoid double-counting.
-    const merged = mergeTransactionMetadata(manualTx as ReconciliationCandidate, {
+    // Reconciled: existing tx already applied its balance delta, so do NOT
+    // add to balanceDeltaTxs to avoid double-counting.
+    const merged = mergeTransactionMetadata(existingTx as ReconciliationCandidate, {
       category_id: insertedTx.category_id,
+      categorization_source: insertedTx.categorization_source,
       notes: insertedTx.notes,
       capture_method: "PDF_IMPORT",
     });
@@ -925,7 +926,7 @@ export async function importTransactions(
         reconciliation_score: decision.score,
       })
       .eq("user_id", user.id)
-      .eq("id", manualTx.id);
+      .eq("id", existingTx.id);
 
     if (decision.decision === "AUTO_MERGE") autoMerged++;
     else manualMerged++;

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -382,7 +382,6 @@ async function fetchReconciliationCandidates(
     )
     .eq("user_id", userId)
     .in("account_id", accountIds)
-    .in("capture_method", ["MANUAL_FORM", "TEXT_QUICK_CAPTURE"])
     .gte("transaction_date", from)
     .lte("transaction_date", to)
     .is("reconciled_into_transaction_id", null);
@@ -883,7 +882,7 @@ export async function importTransactions(
     const { data: manualTx, error: manualTxError } = await supabase
       .from("transactions")
       .select(
-        "id, user_id, account_id, amount, direction, transaction_date, raw_description, merchant_name, clean_description, category_id, categorization_source, notes, reconciled_into_transaction_id"
+        "id, user_id, account_id, amount, direction, transaction_date, raw_description, merchant_name, clean_description, category_id, categorization_source, notes, reconciled_into_transaction_id, capture_method"
       )
       .eq("id", decision.candidateTransactionId)
       .eq("user_id", user.id)
@@ -906,6 +905,7 @@ export async function importTransactions(
     const merged = mergeTransactionMetadata(manualTx as ReconciliationCandidate, {
       category_id: insertedTx.category_id,
       notes: insertedTx.notes,
+      capture_method: "PDF_IMPORT",
     });
 
     await supabase


### PR DESCRIPTION
## Summary
Introduces a formal capture method authority hierarchy to govern transaction reconciliation, merge direction, and data precedence. This ensures that higher-authority sources (bank-verified PDFs) take precedence over lower-authority sources (user-entered data) while preserving user enrichments (categories, notes) from either side.

## Key Changes

- **New module**: `packages/shared/src/utils/capture-hierarchy.ts`
  - Defines three-tier authority hierarchy: Tier 1 (bank-verified), Tier 2 (semi-structured), Tier 3 (user-entered)
  - Exports `getCaptureTier()`, `isHigherAuthority()`, `isSameTier()`, and `resolveAuthorityWinner()` utilities
  - Comprehensive documentation of merge rules and reconciliation behavior

- **Updated reconciliation logic**: `packages/shared/src/utils/reconciliation.ts`
  - Added `capture_method` field to `ReconciliationCandidate` and `ImportTransactionForReconciliation` types
  - Refactored `mergeTransactionMetadata()` to use capture hierarchy for determining merge direction
  - Higher-authority source wins for `capture_method` on surviving transaction
  - Lower-authority user-set enrichments (USER_CREATED/USER_OVERRIDE categories, notes) are preserved

- **Removed capture method filtering**: `webapp/src/actions/import-transactions.ts` and `webapp/src/actions/email-ingest.ts`
  - Reconciliation candidate queries no longer filter by `capture_method` — all sources are now candidates
  - Idempotency keys and scoring algorithm handle dedup across all capture methods

- **Updated exports**: `packages/shared/src/index.ts`
  - Exports new capture hierarchy utilities

- **Database enum update**: `packages/shared/src/types/database.ts`
  - Added `EMAIL_PDF_IMPORT` to transaction capture method enum

- **Documentation updates**: Agent guides and CLAUDE.md
  - Added capture hierarchy reference to `import-flow-doctor.md`, `server-action-reviewer.md`, `recurring-doctor.md`, and `CLAUDE.md`
  - Clarified reconciliation behavior and merge direction rules

## Implementation Details

**Authority Hierarchy**:
- **Tier 1**: `PDF_IMPORT`, `EMAIL_PDF_IMPORT` — bank-verified with full statement metadata
- **Tier 2**: `EMAIL_IMPORT`, `OCR_BATCH`, `OCR_SINGLE` — semi-structured machine extraction
- **Tier 3**: `MANUAL_FORM`, `TEXT_QUICK_CAPTURE` — user-entered data

**Merge Behavior**:
- Reconciliation fetches ALL existing transactions regardless of source (no filtering)
- When merging, the higher-authority source's `capture_method`, `raw_description`, and `amount` are preserved
- User-set enrichments from the lower-authority source (category, notes) are carried forward if the higher-authority source lacks them
- Same-tier matches with high confidence scores trigger AUTO_MERGE; idempotency keys prevent actual duplicates

**Re-import Dedup**:
- When the same statement is re-imported, reconciliation finds existing transactions (any capture method)
- Idempotency keys catch exact duplicates at insert time (23505 constraint violation → skip)

https://claude.ai/code/session_015wWx2Q2duVQu1eJv8zGMif