### PR TITLE
fix: stale UI after inline mutations + missing cache revalidation

### DIFF
--- a/webapp/src/actions/categories.ts
+++ b/webapp/src/actions/categories.ts
@@ -550,11 +550,8 @@ export async function deleteCategory(id: string): Promise<ActionResult> {
 
   if (error) return { success: false, error: error.message };
 
+  revalidateFinancialViews();
   revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }
 
@@ -649,7 +646,6 @@ export async function reassignAndDeleteCategory(
 
   revalidateFinancialViews();
   revalidateTag("categories", "zeta");
-  revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/categories.ts
+++ b/webapp/src/actions/categories.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { categorySchema } from "@/lib/validators/category";
@@ -590,6 +591,7 @@ export async function updateCategoryOrder(
   revalidateTag("budgets", "zeta");
   revalidateTag("dashboard:charts", "zeta");
   revalidateTag("dashboard:budgets", "zeta");
+  revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }
 
@@ -645,10 +647,8 @@ export async function reassignAndDeleteCategory(
 
   if (deleteError) return { success: false, error: deleteError.message };
 
+  revalidateFinancialViews();
   revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
   revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -586,7 +586,6 @@ export async function mergeDestinatarios(
 
   revalidateFinancialViews();
   revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -518,6 +518,7 @@ export async function patchDestinatario(
   if (error) return { success: false, error: error.message };
 
   revalidateTag("destinatarios", "zeta");
+  revalidateTag("attention", "zeta");
   return { success: true, data: null };
 }
 
@@ -583,7 +584,9 @@ export async function mergeDestinatarios(
 
   if (deleteError) return { success: false, error: deleteError.message };
 
+  revalidateFinancialViews();
   revalidateTag("destinatarios", "zeta");
+  revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }
 
@@ -665,6 +668,7 @@ export async function removeDestinatarioRule(
   if (error) return { success: false, error: error.message };
 
   revalidateTag("destinatarios", "zeta");
+  revalidateTag("attention", "zeta");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -359,7 +359,10 @@ export async function addTagToEntity(
   }
 
   revalidateTag("tags", "zeta");
-  if (entityType === "transaction") revalidateTag("categorize", "zeta");
+  if (entityType === "transaction") {
+    revalidateTag("categorize", "zeta");
+    revalidateTag("transactions", "zeta");
+  }
   if (entityType === "destinatario") revalidateTag("destinatarios", "zeta");
   if (entityType === "category") revalidateTag("categories", "zeta");
   return { success: true, data: null };
@@ -389,7 +392,10 @@ export async function removeTagFromEntity(
   if (error) return { success: false, error: error.message };
 
   revalidateTag("tags", "zeta");
-  if (entityType === "transaction") revalidateTag("categorize", "zeta");
+  if (entityType === "transaction") {
+    revalidateTag("categorize", "zeta");
+    revalidateTag("transactions", "zeta");
+  }
   if (entityType === "destinatario") revalidateTag("destinatarios", "zeta");
   if (entityType === "category") revalidateTag("categories", "zeta");
   return { success: true, data: null };
@@ -412,5 +418,6 @@ export async function bulkTagTransactions(
 
   revalidateTag("tags", "zeta");
   revalidateTag("categorize", "zeta");
+  revalidateTag("transactions", "zeta");
   return { success: true, data: { tagged: transactionIds.length } };
 }

--- a/webapp/src/components/budget/category-manage-list.tsx
+++ b/webapp/src/components/budget/category-manage-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,19 +22,17 @@ export function CategoryManageList({ categories }: CategoryManageListProps) {
   const [localCategories, setLocalCategories] = useState(categories);
   const [addingToParent, setAddingToParent] = useState<string | null>(null);
   const [newSubName, setNewSubName] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSaving, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setLocalCategories(categories);
   }, [categories]);
 
-  async function handleAddSubcategory(parentId: string) {
+  function handleAddSubcategory(parentId: string) {
     if (!newSubName.trim()) return;
-    setIsSaving(true);
     setError(null);
-
-    try {
+    startTransition(async () => {
       const parent = localCategories.find((c) => c.id === parentId);
       const formData = new FormData();
       formData.append("name", newSubName.trim());
@@ -60,28 +58,30 @@ export function CategoryManageList({ categories }: CategoryManageListProps) {
       } else {
         setError(result.error ?? "Error al crear subcategoría");
       }
-    } finally {
-      setIsSaving(false);
-    }
+    });
   }
 
-  async function handleDeleteSubcategory(id: string) {
+  function handleDeleteSubcategory(id: string) {
     setLocalCategories(prev => prev.filter(c => c.id !== id));
-    const result = await deleteCategory(id);
-    if (!result.success) {
-      setLocalCategories(categories);
-      toast.error("Error al eliminar");
-    }
+    startTransition(async () => {
+      const result = await deleteCategory(id);
+      if (!result.success) {
+        setLocalCategories(categories);
+        toast.error("Error al eliminar");
+      }
+    });
   }
 
-  async function handleToggleActive(id: string, currentlyActive: boolean) {
+  function handleToggleActive(id: string, currentlyActive: boolean) {
     setLocalCategories(prev => prev.map(c =>
       c.id === id ? { ...c, is_active: !currentlyActive } : c
     ));
-    const result = await toggleCategoryActive(id, !currentlyActive);
-    if (!result.success) {
-      setLocalCategories(categories);
-    }
+    startTransition(async () => {
+      const result = await toggleCategoryActive(id, !currentlyActive);
+      if (!result.success) {
+        setLocalCategories(categories);
+      }
+    });
   }
 
   return (

--- a/webapp/src/components/budget/category-manage-list.tsx
+++ b/webapp/src/components/budget/category-manage-list.tsx
@@ -62,7 +62,13 @@ export function CategoryManageList({ categories }: CategoryManageListProps) {
   }
 
   function handleDeleteSubcategory(id: string) {
-    setLocalCategories(prev => prev.filter(c => c.id !== id));
+    setLocalCategories(prev => prev
+      .filter(c => c.id !== id)
+      .map(parent => ({
+        ...parent,
+        children: parent.children.filter(child => child.id !== id),
+      }))
+    );
     startTransition(async () => {
       const result = await deleteCategory(id);
       if (!result.success) {
@@ -74,7 +80,14 @@ export function CategoryManageList({ categories }: CategoryManageListProps) {
 
   function handleToggleActive(id: string, currentlyActive: boolean) {
     setLocalCategories(prev => prev.map(c =>
-      c.id === id ? { ...c, is_active: !currentlyActive } : c
+      c.id === id
+        ? { ...c, is_active: !currentlyActive }
+        : {
+            ...c,
+            children: c.children.map(child =>
+              child.id === id ? { ...child, is_active: !currentlyActive } : child
+            ),
+          }
     ));
     startTransition(async () => {
       const result = await toggleCategoryActive(id, !currentlyActive);

--- a/webapp/src/components/categories/category-zone-manager.tsx
+++ b/webapp/src/components/categories/category-zone-manager.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback, useEffect, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { Plus, Eye, EyeOff, Trash2, GripVertical, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -478,13 +477,11 @@ function NewZoneTile({ onCreated }: { onCreated: () => void }) {
 // ─── CategoryZoneManager (main) ──────────────────────────────────────────────
 
 export function CategoryZoneManager({ categories }: CategoryZoneManagerProps) {
-  const router = useRouter();
   const [editingZoneId, setEditingZoneId] = useState<string | null>(null);
 
   const handleSaved = useCallback(() => {
     setEditingZoneId(null);
-    router.refresh();
-  }, [router]);
+  }, []);
 
   const handleCancelEdit = useCallback(() => {
     setEditingZoneId(null);

--- a/webapp/src/components/tags/tag-manager.tsx
+++ b/webapp/src/components/tags/tag-manager.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { Plus, Trash2 } from "lucide-react";
 import { createTagGroup, deleteTagGroup, createTag, deleteTag } from "@/actions/tags";
 import { TagChip } from "./tag-chip";
@@ -19,7 +18,6 @@ interface TagManagerProps {
 }
 
 export function TagManager({ tagGroups }: TagManagerProps) {
-  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [newGroupName, setNewGroupName] = useState("");
   const [newTagInputs, setNewTagInputs] = useState<Record<string, string>>({});
@@ -34,14 +32,12 @@ export function TagManager({ tagGroups }: TagManagerProps) {
     startTransition(async () => {
       await createTagGroup(fd);
       setNewGroupName("");
-      router.refresh();
     });
   }
 
   function handleDeleteGroup(id: string) {
     startTransition(async () => {
       await deleteTagGroup(id);
-      router.refresh();
     });
   }
 
@@ -55,14 +51,12 @@ export function TagManager({ tagGroups }: TagManagerProps) {
     startTransition(async () => {
       await createTag(fd);
       setNewTagInputs((prev) => ({ ...prev, [key]: "" }));
-      router.refresh();
     });
   }
 
   function handleDeleteTag(id: string) {
     startTransition(async () => {
       await deleteTag(id);
-      router.refresh();
     });
   }
 

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -27,4 +27,5 @@ export function revalidateFinancialViews() {
   revalidateTag("budgets", "zeta");
   revalidateTag("attention", "zeta");
   revalidateTag("occurrences", "zeta");
+  revalidateTag("recurring", "zeta");
 }


### PR DESCRIPTION
## Summary
- **Bug #3 fix**: Category manage list mutations (create/delete/toggle subcategories) were not wrapped in `startTransition` — Server Components never re-rendered after Data Cache invalidation, so new items wouldn't appear without page reload
- **Bug #7 fix**: Added `"recurring"` tag to `revalidateFinancialViews()` — occurrence mutations (`markOccurrencePaid`, `skipOccurrence`) now properly bust recurring template caches, fixing stale dashboard after recurring payments
- **7 additional revalidation gaps** fixed across categories, tags, and destinatarios actions (missing `revalidateFinancialViews()`, `"transactions"`, or `"attention"` tags)
- **Cleanup**: Removed redundant `router.refresh()` calls in `tag-manager.tsx` and `category-zone-manager.tsx` — `startTransition` already triggers Server Component re-render

## Test plan
- [ ] Navigate to budget categories management → add a subcategory → verify it appears immediately without reload
- [ ] Delete a subcategory → verify it disappears immediately
- [ ] Toggle category visibility → verify badge updates immediately
- [ ] Create/delete tags in settings → verify list updates without reload
- [ ] Mark a recurring payment as paid → navigate to dashboard → verify hero metrics reflect the payment
- [ ] Assign a tag to a transaction → verify transaction list shows updated tag
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)