### PR TITLE
feat: recurring impact preview + recurring income

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,85 @@
+# Zeta Backlog
+
+> Persistent backlog shared across sessions. Update this file whenever a task is discovered but not tackled in the current session. Remove items when they ship (merged to main).
+
+## How to use
+
+- **Before starting work**: scan this file for items that overlap with your task — fix them together.
+- **After finishing work**: if review agents or testing surfaced new issues you didn't fix, add them here.
+- **After merging a PR**: remove the items it resolved.
+
+---
+
+## In Review
+
+| PR | Description | Branch |
+|---|---|---|
+| #130 | Inline drawer pickers + picker improvements | `feat/inline-drawer-pickers` |
+| — | Recurring impact preview + recurring income | `feat/recurring-impact-income` |
+
+## Features
+
+### Tag system broader reach
+- **Priority:** Medium
+- **What:** Tags during destinatario rule imports, nómina variants
+- **Context:** Tags exist but are only usable from transaction detail and categorization inbox. Should be available during import flow and when creating recurring templates.
+
+### Categorization view enhancements
+- **Priority:** Medium
+- **What:** Show similar transactions when categorizing, more action options in the categorization inbox
+- **Context:** Currently only shows category suggestion + accept/change. Could show "5 more like this" to encourage bulk categorization.
+
+### Smart insights
+- **Priority:** Low (large scope)
+- **What:** Cross-month account movement tracking, debt payment impact analysis
+- **Context:** Dashboard answers "Am I on track?" but doesn't yet show trends or explain why things changed.
+
+### Desktop transaction table expansion
+- **Priority:** Medium
+- **What:** Same action chip pattern (destinatario, tag, edit) for desktop table rows. Migrate desktop consumers from old pickers (`destinatario-picker.tsx`, `tag-picker.tsx`) to zone pickers, then delete old files.
+- **Context:** PR #130 only covers mobile. Desktop table still uses inline category popover only.
+- **Blocked by:** PR #130 merge
+
+### Mobile v2 redesign — Phase 3
+- **Priority:** Low (deferred)
+- **What:** Full root redesign with zone-based layouts, custom heroes, Zeta-branded visualizations
+- **Memory:** `project_mobile_v2_redesign.md`
+
+## Tech Debt
+
+### Defense-in-depth gaps
+- **`getCategoriesByRhythm`** (`categories.ts`) — transactions query missing `.eq("user_id", user.id)`. Relies solely on RLS.
+- **`bulkTagTransactions`** (`tags.ts`) — upserts into `transaction_tags` without verifying transaction ownership. RLS covers it but violates defense-in-depth convention.
+- **Found:** Server action reviewer, 2026-04-13
+
+### Missing revalidation
+- **`createDestinatario` with `link_matching_transactions`** (`destinatarios.ts`) — manually lists 5 tags instead of calling `revalidateFinancialViews()`. Misses `"transactions"`, `"accounts"`, `"debt"`, `"recurring"`, `"occurrences"`.
+- **Found:** Server action reviewer, 2026-04-13
+
+### Uncached server action
+- **`getTagsForEntity`** (`tags.ts`) — called on every tag picker open with no `"use cache"`. Uses React `cache()` which only deduplicates within a single server render, not across client-side calls. 3 sequential DB queries each time.
+- **Found:** Efficiency review, 2026-04-13
+
+### `transaction_tags` table missing columns
+- **What:** No `created_at` or `user_id` columns. Recents query works around this by joining through `transactions`. Adding these columns would:
+  - Enable proper recency ordering (currently orders by transaction_date as proxy)
+  - Improve RLS performance (current policy uses EXISTS subquery per row)
+  - Allow direct defense-in-depth filtering
+- **Migration needed:** `ALTER TABLE` + backfill + index + RLS policy update. Spawn `supabase-migrator`.
+- **Found:** Server action reviewer + perf auditor, 2026-04-13
+
+### Shared PickerShell component
+- **What:** Popover/dialog/drawer branching is duplicated across 3 zone pickers (~40 lines each, ~120 total). A shared `PickerShell` accepting `{ open, onOpenChange, trigger, title, icon, body, variant }` would eliminate the duplication.
+- **When:** Extract when a 4th picker is added or when touching all 3 pickers.
+- **Found:** Code reuse review, 2026-04-13
+
+### `categories.ts` cached functions use `createAdminClient()`
+- **What:** 5 cached functions use `createAdminClient()` instead of `createCachedClient(accessToken)`. Categories table is not encrypted so it works, but deviates from established pattern and bypasses RLS entirely.
+- **Found:** Server action reviewer, 2026-04-13
+
+## Open PRs (stale)
+
+| PR | Description | Status |
+|---|---|---|
+| #98 | Demo mode with mock accounts | Open since 2026-04-08 |
+| #84 | Design review system in production | Open since 2026-04-06 |

--- a/webapp/src/actions/charts.ts
+++ b/webapp/src/actions/charts.ts
@@ -685,6 +685,8 @@ export interface DashboardHeroData {
   pendingObligations: PendingObligation[];
   totalPending: number;
   availableToSpend: number;
+  pendingIncome: number;
+  pendingIncomeCount: number;
   monthlyIncome: number;
   monthlySpent: number;
   freshness: "fresh" | "stale" | "outdated";
@@ -704,6 +706,8 @@ export async function getDashboardHeroData(
       pendingObligations: [],
       totalPending: 0,
       availableToSpend: 0,
+      pendingIncome: 0,
+      pendingIncomeCount: 0,
       monthlyIncome: 0,
       monthlySpent: 0,
       freshness: "outdated",
@@ -771,6 +775,12 @@ export async function getDashboardHeroData(
     .filter((o) => o.direction === "OUTFLOW" && o.account_type !== "CREDIT_CARD")
     .reduce((sum, o) => sum + o.expected_amount, 0);
 
+  // 4. Pending INFLOW occurrences (expected income, NOT added to availableToSpend)
+  const pendingInflowOccurrences = pendingOccurrences
+    .filter((o) => o.direction === "INFLOW" && o.account_type !== "CREDIT_CARD" && o.account_type !== "LOAN");
+  const pendingIncome = pendingInflowOccurrences.reduce((sum, o) => sum + o.expected_amount, 0);
+  const pendingIncomeCount = pendingInflowOccurrences.length;
+
   // 5. Sort by due date
   const allObligations = recurringObligations
     .sort((a, b) => a.due_date.localeCompare(b.due_date));
@@ -782,6 +792,8 @@ export async function getDashboardHeroData(
     pendingObligations: allObligations,
     totalPending,
     availableToSpend,
+    pendingIncome,
+    pendingIncomeCount,
     monthlyIncome: monthMetrics.income,
     monthlySpent: monthMetrics.expenses,
     freshness,

--- a/webapp/src/actions/income.ts
+++ b/webapp/src/actions/income.ts
@@ -5,6 +5,8 @@ import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { toISODateString } from "@/lib/utils/date";
+import { toMonthlyAmount } from "@/lib/utils/recurring";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import type { CurrencyCode } from "@zeta/shared";
 
 export interface IncomeEstimate {
@@ -19,17 +21,6 @@ export interface IncomeEstimate {
     amount: number;
     date: string;
   }[];
-}
-
-function toMonthlyAmount(amount: number, frequency: string): number {
-  switch (frequency) {
-    case "WEEKLY": return amount * 4.33;
-    case "BIWEEKLY": return amount * 2.17;
-    case "MONTHLY": return amount;
-    case "QUARTERLY": return amount / 3;
-    case "ANNUAL": return amount / 12;
-    default: return amount;
-  }
 }
 
 // ─── Cached inner function ────────────────────────────────────────────────────
@@ -92,11 +83,10 @@ async function getEstimatedIncomeCached(
     .eq("direction", "INFLOW");
 
   if (inflowTemplates && inflowTemplates.length > 0) {
-    const DEBT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
     let recurringMonthlyIncome = 0;
     for (const t of inflowTemplates) {
       const acctType = (t.account as { account_type?: string } | null)?.account_type;
-      if (acctType && DEBT_TYPES.has(acctType)) continue; // debt inflows are NOT income
+      if (acctType && isDebtAccountType(acctType)) continue;
       recurringMonthlyIncome += toMonthlyAmount(t.amount, t.frequency);
     }
     if (recurringMonthlyIncome > 0) {

--- a/webapp/src/actions/income.ts
+++ b/webapp/src/actions/income.ts
@@ -12,13 +12,24 @@ export interface IncomeEstimate {
   currency: CurrencyCode;
   monthsOfData: number;
   totalIncome: number;
-  source: "profile" | "transactions"; // where the income figure came from
+  source: "profile" | "recurring" | "transactions";
   recentTransactions: {
     id: string;
     description: string;
     amount: number;
     date: string;
   }[];
+}
+
+function toMonthlyAmount(amount: number, frequency: string): number {
+  switch (frequency) {
+    case "WEEKLY": return amount * 4.33;
+    case "BIWEEKLY": return amount * 2.17;
+    case "MONTHLY": return amount;
+    case "QUARTERLY": return amount / 3;
+    case "ANNUAL": return amount / 12;
+    default: return amount;
+  }
 }
 
 // ─── Cached inner function ────────────────────────────────────────────────────
@@ -32,6 +43,7 @@ async function getEstimatedIncomeCached(
   "use cache";
   cacheTag("debt");
   cacheTag("profile");
+  cacheTag("recurring");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
@@ -69,6 +81,34 @@ async function getEstimatedIncomeCached(
       source: "profile" as const,
       recentTransactions: [],
     };
+  }
+
+  // Priority 3: Recurring INFLOW templates (active, non-debt accounts)
+  const { data: inflowTemplates } = await supabase
+    .from("recurring_transaction_templates")
+    .select("amount, frequency, account:accounts!recurring_transaction_templates_account_id_fkey(account_type)")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .eq("direction", "INFLOW");
+
+  if (inflowTemplates && inflowTemplates.length > 0) {
+    const DEBT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
+    let recurringMonthlyIncome = 0;
+    for (const t of inflowTemplates) {
+      const acctType = (t.account as { account_type?: string } | null)?.account_type;
+      if (acctType && DEBT_TYPES.has(acctType)) continue; // debt inflows are NOT income
+      recurringMonthlyIncome += toMonthlyAmount(t.amount, t.frequency);
+    }
+    if (recurringMonthlyIncome > 0) {
+      return {
+        monthlyAverage: recurringMonthlyIncome,
+        currency: baseCurrency,
+        monthsOfData: 0,
+        totalIncome: 0,
+        source: "recurring" as const,
+        recentTransactions: [],
+      };
+    }
   }
 
   const liquidAccountIds = liquidAccounts?.map((a) => a.id) ?? [];
@@ -132,14 +172,6 @@ async function getEstimatedIncomeCached(
 
 // ─── Public wrapper ───────────────────────────────────────────────────────────
 
-/**
- * Estimate monthly income from INFLOW transactions.
- * Queries all income transactions in the user's preferred currency,
- * groups by month, and returns the average.
- *
- * Excludes debt account inflows (credit card payments received, etc.)
- * by filtering to only checking/savings accounts.
- */
 export async function getEstimatedIncome(
   currency?: CurrencyCode,
   month?: string // "YYYY-MM" — if provided, return income for that specific month

--- a/webapp/src/actions/plan.ts
+++ b/webapp/src/actions/plan.ts
@@ -84,10 +84,14 @@ function buildHeroSummary({
     };
   }
 
+  const hasUpcomingIncome = heroData.pendingIncome > 0;
   return {
-    headline: "Tu plan está claro y bajo control",
-    guidance:
-      "El margen actual te permite decidir con calma. Usa esta vista para ajustar presupuesto y prioridades sin perder el hilo.",
+    headline: hasUpcomingIncome
+      ? "Tu plan está claro y hay ingresos en camino"
+      : "Tu plan está claro y bajo control",
+    guidance: hasUpcomingIncome
+      ? "El margen actual es estable y esperas ingresos próximos. Buen momento para revisar presupuesto y prioridades."
+      : "El margen actual te permite decidir con calma. Usa esta vista para ajustar presupuesto y prioridades sin perder el hilo.",
     recommendedAction: {
       href: "/categories",
       label: "Ver presupuesto",
@@ -139,15 +143,25 @@ export const getPlanPageData = cache(
       (a, b) => (b.interestRate ?? 0) - (a.interestRate ?? 0)
     )[0];
 
-    const dueSoon = upcomingRecurrences
+    const currencyFiltered = upcomingRecurrences
+      .filter((entry) => (entry.template.currency_code ?? baseCurrency) === baseCurrency);
+
+    const dueSoon = currencyFiltered
       .filter((entry) =>
         entry.template.direction === "OUTFLOW" ||
         entry.template.account.account_type === "CREDIT_CARD" ||
         entry.template.account.account_type === "LOAN"
       )
-      .filter((entry) => (entry.template.currency_code ?? baseCurrency) === baseCurrency)
       .slice(0, 6);
     const dueSoonTotal = dueSoon.reduce((sum, entry) => sum + entry.template.amount, 0);
+
+    const upcomingIncome = currencyFiltered
+      .filter((entry) =>
+        entry.template.direction === "INFLOW" &&
+        entry.template.account.account_type !== "CREDIT_CARD" &&
+        entry.template.account.account_type !== "LOAN"
+      )
+      .slice(0, 4);
 
     return {
       currency: baseCurrency,
@@ -176,6 +190,7 @@ export const getPlanPageData = cache(
       },
       recurring: {
         upcoming: dueSoon,
+        upcomingIncome,
         totalMonthlyExpenses: recurringSummary.totalMonthlyExpenses,
         totalMonthlyIncome: recurringSummary.totalMonthlyIncome,
         activeCount: recurringSummary.activeCount,

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -11,6 +11,7 @@ import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 import { ensureCurrentOccurrences } from "@/actions/occurrences";
 import {
   getOccurrencesBetween,
+  getNextOccurrence,
   DEBT_PAYMENT_CATEGORY_ID,
   TRANSFER_CATEGORY_ID,
 } from "@zeta/shared";
@@ -924,6 +925,97 @@ export async function getRecurringSummary(): Promise<{
   const { user, accessToken } = await getAuthenticatedClient();
   if (!user || !accessToken) return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
   return getRecurringSummaryCached(user.id, accessToken);
+}
+
+// ─── Impact preview ──────────────────────────────────────────────────────────
+
+export interface TemplateImpact {
+  pendingCount: number;
+  pendingTotal: number;
+  within14Days: { count: number; total: number };
+  planningEntriesCount: number;
+  nextOccurrenceDate: string | null;
+  monthlyAmount: number;
+  direction: "INFLOW" | "OUTFLOW";
+  templateName: string;
+}
+
+export async function getRecurringTemplateImpact(
+  templateId: string
+): Promise<ActionResult<TemplateImpact>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const idCheck = uuidStr("ID de plantilla inválido").safeParse(templateId);
+  if (!idCheck.success) return { success: false, error: idCheck.error.issues[0].message };
+
+  try {
+    const today = toISODateString(new Date());
+    const in14Days = toISODateString(addDays(new Date(), 14));
+
+    const [templateRes, occurrencesRes, planningRes] = await Promise.all([
+      supabase
+        .from("recurring_transaction_templates")
+        .select("id, merchant_name, description, amount, direction, frequency, start_date, end_date, account:accounts!recurring_transaction_templates_account_id_fkey(account_type)")
+        .eq("id", templateId)
+        .eq("user_id", user.id)
+        .single(),
+      supabase
+        .from("recurring_occurrences")
+        .select("id, occurrence_date, expected_amount")
+        .eq("template_id", templateId)
+        .eq("user_id", user.id)
+        .eq("status", "pending"),
+      supabase
+        .from("planning_entries")
+        .select("id")
+        .eq("recurring_template_id", templateId)
+        .eq("user_id", user.id),
+    ]);
+
+    if (templateRes.error || !templateRes.data) {
+      return { success: false, error: "No se encontró la plantilla." };
+    }
+
+    const template = templateRes.data;
+    const occurrences = occurrencesRes.data ?? [];
+    const planningEntries = planningRes.data ?? [];
+
+    const pendingCount = occurrences.length;
+    const pendingTotal = occurrences.reduce((sum, o) => sum + o.expected_amount, 0);
+
+    const near = occurrences.filter(
+      (o) => o.occurrence_date >= today && o.occurrence_date <= in14Days
+    );
+
+    // Resolve effective direction (debt accounts = INFLOW template but behaves as OUTFLOW obligation)
+    const accountType = (template.account as { account_type?: string } | null)?.account_type;
+    const isDebtPayment = !!accountType && DEBT_ACCOUNT_TYPES.has(accountType);
+    const effectiveDirection: "INFLOW" | "OUTFLOW" = isDebtPayment ? "OUTFLOW" : template.direction;
+
+    const nextDate = getNextOccurrence(
+      template.start_date,
+      template.frequency,
+      template.end_date
+    ) ?? null;
+
+    return {
+      success: true,
+      data: {
+        pendingCount,
+        pendingTotal,
+        within14Days: { count: near.length, total: near.reduce((s, o) => s + o.expected_amount, 0) },
+        planningEntriesCount: planningEntries.length,
+        nextOccurrenceDate: nextDate,
+        monthlyAmount: toMonthlyAmount(template.amount, template.frequency),
+        direction: effectiveDirection,
+        templateName: template.merchant_name ?? template.description ?? "Recurrente",
+      },
+    };
+  } catch (error) {
+    console.error("Error calculating template impact:", error);
+    return { success: false, error: "Error al calcular el impacto de la plantilla." };
+  }
 }
 
 function toMonthlyAmount(

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -8,6 +8,7 @@ import { createCachedClient } from "@/lib/supabase/cached";
 import { recurringTemplateSchema } from "@/lib/validators/recurring-template";
 import { computeIdempotencyKey } from "@/lib/utils/idempotency";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
+import { toMonthlyAmount } from "@/lib/utils/recurring";
 import { ensureCurrentOccurrences } from "@/actions/occurrences";
 import {
   getOccurrencesBetween,
@@ -1018,23 +1019,4 @@ export async function getRecurringTemplateImpact(
   }
 }
 
-function toMonthlyAmount(
-  amount: number,
-  frequency: string
-): number {
-  switch (frequency) {
-    case "WEEKLY":
-      return amount * 4.33;
-    case "BIWEEKLY":
-      return amount * 2.17;
-    case "MONTHLY":
-      return amount;
-    case "QUARTERLY":
-      return amount / 3;
-    case "ANNUAL":
-      return amount / 12;
-    default:
-      return amount;
-  }
-}
 

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -951,8 +951,9 @@ export async function getRecurringTemplateImpact(
   if (!idCheck.success) return { success: false, error: idCheck.error.issues[0].message };
 
   try {
-    const today = toISODateString(new Date());
-    const in14Days = toISODateString(addDays(new Date(), 14));
+    const now = new Date();
+    const today = toISODateString(now);
+    const in14Days = toISODateString(addDays(now, 14));
 
     const [templateRes, occurrencesRes, planningRes] = await Promise.all([
       supabase

--- a/webapp/src/components/dashboard/dashboard-hero.tsx
+++ b/webapp/src/components/dashboard/dashboard-hero.tsx
@@ -4,6 +4,7 @@ import { KPIWidget } from "@/components/ui/kpi-widget";
 import { Button } from "@/components/ui/button";
 import { StatusHeadline } from "./status-headline";
 import {
+  ArrowDownLeft,
   Banknote,
   CalendarClock,
   FileUp,
@@ -23,7 +24,7 @@ interface DashboardHeroProps {
 }
 
 export function DashboardHero({ data, allocationData, debtFreeBanner }: DashboardHeroProps) {
-  const { totalLiquid, totalPending, availableToSpend, freshness, pendingObligations, currency, hasOtherCurrencies } = data;
+  const { totalLiquid, totalPending, availableToSpend, pendingIncome, pendingIncomeCount, freshness, pendingObligations, currency, hasOtherCurrencies } = data;
   const f = freshnessMap[freshness];
   const code = currency as CurrencyCode;
   const hasPendingObligations = pendingObligations.length > 0;
@@ -123,7 +124,7 @@ export function DashboardHero({ data, allocationData, debtFreeBanner }: Dashboar
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className={`grid grid-cols-1 gap-3 ${pendingIncome > 0 ? "sm:grid-cols-2 lg:grid-cols-4" : "sm:grid-cols-3"}`}>
         <KPIWidget
           label="Saldo total"
           value={formatCurrency(totalLiquid, code)}
@@ -139,6 +140,16 @@ export function DashboardHero({ data, allocationData, debtFreeBanner }: Dashboar
           semanticColor="expense"
           className="bg-black/15 ring-1 ring-white/5"
         />
+        {pendingIncome > 0 && (
+          <KPIWidget
+            label="Ingresos esperados"
+            value={`+${formatCurrency(pendingIncome, code)}`}
+            trend={{ direction: "flat", text: `${pendingIncomeCount} ${pendingIncomeCount === 1 ? "pago" : "pagos"} próximos` }}
+            icon={<ArrowDownLeft className="size-4" />}
+            semanticColor="income"
+            className="bg-black/15 ring-1 ring-white/5"
+          />
+        )}
         <KPIWidget
           label="Libre"
           value={formatCurrency(availableToSpend, code)}

--- a/webapp/src/components/plan/plan-hero.tsx
+++ b/webapp/src/components/plan/plan-hero.tsx
@@ -104,7 +104,9 @@ export function PlanHero({
                 {incomeEstimate
                   ? incomeEstimate.source === "profile"
                     ? "Tomado de tu perfil"
-                    : `Estimado con ${incomeEstimate.monthsOfData} ${incomeEstimate.monthsOfData === 1 ? "mes" : "meses"} de movimientos`
+                    : incomeEstimate.source === "recurring"
+                      ? "Basado en tus ingresos recurrentes"
+                      : `Estimado con ${incomeEstimate.monthsOfData} ${incomeEstimate.monthsOfData === 1 ? "mes" : "meses"} de movimientos`
                   : "Configura o detecta ingresos para afinar el plan"}
               </span>
             }

--- a/webapp/src/components/plan/plan-recurring-section.tsx
+++ b/webapp/src/components/plan/plan-recurring-section.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, CalendarClock, Repeat2 } from "lucide-react";
+import { ArrowDownLeft, ArrowRight, CalendarClock, Repeat2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { formatCurrency } from "@/lib/utils/currency";
@@ -28,11 +28,17 @@ export function PlanRecurringSection({
         <CardTitle className="text-xl">Lo que ya viene en camino y no deberías olvidar</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className={`grid gap-3 ${recurring.totalMonthlyIncome > 0 ? "sm:grid-cols-2 lg:grid-cols-4" : "sm:grid-cols-3"}`}>
           <PlanStatCard
             label="Fijos mensuales"
             value={formatCurrency(recurring.totalMonthlyExpenses, currency)}
           />
+          {recurring.totalMonthlyIncome > 0 && (
+            <PlanStatCard
+              label="Ingresos recurrentes"
+              value={`+${formatCurrency(recurring.totalMonthlyIncome, currency)}`}
+            />
+          )}
           <PlanStatCard
             label="Próximos eventos"
             value={recurring.dueSoonCount}
@@ -74,6 +80,33 @@ export function PlanRecurringSection({
             </div>
           )}
         </div>
+
+        {recurring.upcomingIncome.length > 0 && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <ArrowDownLeft className="size-4 text-z-income" />
+              Ingresos esperados
+            </div>
+            <div className="space-y-2">
+              {recurring.upcomingIncome.map((entry) => (
+                <div
+                  key={`${entry.template.id}-${entry.next_date}`}
+                  className="flex items-center justify-between rounded-2xl border border-white/6 bg-z-income/5 px-4 py-3"
+                >
+                  <div className="space-y-1">
+                    <p className="font-medium">{entry.template.merchant_name ?? "Ingreso"}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatDate(entry.next_date, "dd MMM")} · {entry.template.account.name}
+                    </p>
+                  </div>
+                  <span className="text-sm font-semibold text-z-income">
+                    +{formatCurrency(entry.template.amount, currency)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="flex flex-wrap gap-3">
           <Button asChild className={BRASS_BUTTON_CLASS}>

--- a/webapp/src/components/recurring/recurring-impact-dialog.tsx
+++ b/webapp/src/components/recurring/recurring-impact-dialog.tsx
@@ -48,11 +48,14 @@ export function RecurringImpactDialog({
       setImpact(null);
       return;
     }
+    let stale = false;
     setLoading(true);
     getRecurringTemplateImpact(templateId).then((result) => {
+      if (stale) return;
       if (result.success) setImpact(result.data);
       setLoading(false);
     });
+    return () => { stale = true; };
   }, [open, templateId]);
 
   const isDelete = action === "delete";
@@ -60,6 +63,8 @@ export function RecurringImpactDialog({
   const title = isDelete
     ? `Eliminar "${templateName}"`
     : `Pausar "${templateName}"`;
+  const confirmLabel = isDelete ? "Eliminar definitivamente" : "Pausar plantilla";
+  const pendingLabel = isDelete ? "Eliminando..." : "Pausando...";
 
   function handleConfirm() {
     startTransition(() => {
@@ -111,13 +116,7 @@ export function RecurringImpactDialog({
             disabled={loading || isPending}
             className={BRASS_BUTTON_CLASS}
           >
-            {isPending
-              ? isDelete
-                ? "Eliminando..."
-                : "Pausando..."
-              : isDelete
-                ? "Eliminar definitivamente"
-                : "Pausar plantilla"}
+            {isPending ? pendingLabel : confirmLabel}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/webapp/src/components/recurring/recurring-impact-dialog.tsx
+++ b/webapp/src/components/recurring/recurring-impact-dialog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  getRecurringTemplateImpact,
+  type TemplateImpact,
+} from "@/actions/recurring-templates";
+import { formatCurrency } from "@/lib/utils/currency";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { AlertTriangle, Pause, Trash2 } from "lucide-react";
+import type { CurrencyCode } from "@/types/domain";
+
+interface RecurringImpactDialogProps {
+  templateId: string;
+  templateName: string;
+  currencyCode: CurrencyCode;
+  action: "delete" | "pause";
+  onConfirm: () => void;
+  trigger: React.ReactNode;
+}
+
+export function RecurringImpactDialog({
+  templateId,
+  templateName,
+  currencyCode,
+  action,
+  onConfirm,
+  trigger,
+}: RecurringImpactDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [impact, setImpact] = useState<TemplateImpact | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!open) {
+      setImpact(null);
+      return;
+    }
+    setLoading(true);
+    getRecurringTemplateImpact(templateId).then((result) => {
+      if (result.success) setImpact(result.data);
+      setLoading(false);
+    });
+  }, [open, templateId]);
+
+  const isDelete = action === "delete";
+  const Icon = isDelete ? Trash2 : Pause;
+  const title = isDelete
+    ? `Eliminar "${templateName}"`
+    : `Pausar "${templateName}"`;
+
+  function handleConfirm() {
+    startTransition(() => {
+      onConfirm();
+      setOpen(false);
+    });
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-full bg-z-debt/10">
+              <Icon className="size-5 text-z-debt" />
+            </div>
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+          </div>
+          <AlertDialogDescription className="sr-only">
+            Impacto de {isDelete ? "eliminar" : "pausar"} esta plantilla recurrente
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-4 py-2">
+          {loading ? (
+            <div className="space-y-3">
+              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+              <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+              <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+            </div>
+          ) : impact ? (
+            <ImpactSummary
+              impact={impact}
+              action={action}
+              currency={currencyCode}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No se pudo cargar el impacto.
+            </p>
+          )}
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={loading || isPending}
+            className={BRASS_BUTTON_CLASS}
+          >
+            {isPending
+              ? isDelete
+                ? "Eliminando..."
+                : "Pausando..."
+              : isDelete
+                ? "Eliminar definitivamente"
+                : "Pausar plantilla"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function ImpactSummary({
+  impact,
+  action,
+  currency,
+}: {
+  impact: TemplateImpact;
+  action: "delete" | "pause";
+  currency: CurrencyCode;
+}) {
+  const isDelete = action === "delete";
+  const isIncome = impact.direction === "INFLOW";
+  const items: string[] = [];
+
+  if (isDelete) {
+    if (impact.pendingCount > 0) {
+      items.push(
+        `Se eliminarán ${impact.pendingCount} ${impact.pendingCount === 1 ? "ocurrencia pendiente" : "ocurrencias pendientes"} por ${formatCurrency(impact.pendingTotal, currency)}.`
+      );
+    }
+    if (impact.within14Days.count > 0) {
+      items.push(
+        isIncome
+          ? `Esto reduce tus ingresos esperados en ${formatCurrency(impact.within14Days.total, currency)} en los próximos 14 días.`
+          : `Esto libera ${formatCurrency(impact.within14Days.total, currency)} de tu margen disponible (próximos 14 días).`
+      );
+    }
+    if (impact.planningEntriesCount > 0) {
+      items.push(
+        `${impact.planningEntriesCount} ${impact.planningEntriesCount === 1 ? "entrada" : "entradas"} del planificador quedarán sin plantilla asociada.`
+      );
+    }
+  } else {
+    // Pause
+    if (impact.pendingCount > 0) {
+      items.push(
+        `Las ${impact.pendingCount} ocurrencias pendientes seguirán activas, pero no se generarán nuevas.`
+      );
+    } else {
+      items.push("No hay ocurrencias pendientes. No se generarán nuevas al pausar.");
+    }
+  }
+
+  if (isIncome) {
+    items.push(
+      `Tu ingreso recurrente estimado baja en ${formatCurrency(impact.monthlyAmount, currency)}/mes.`
+    );
+  } else {
+    items.push(
+      `Tus obligaciones fijas bajan en ${formatCurrency(impact.monthlyAmount, currency)}/mes.`
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-2 rounded-lg border border-z-alert/20 bg-z-alert/5 p-3">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-z-alert" />
+        <div className="space-y-1 text-sm">
+          {items.map((item, i) => (
+            <p key={i}>{item}</p>
+          ))}
+        </div>
+      </div>
+      {isDelete && (
+        <p className="text-xs text-muted-foreground">
+          Esta acción no se puede deshacer. Las transacciones ya registradas no se eliminan.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/recurring/recurring-list.tsx
+++ b/webapp/src/components/recurring/recurring-list.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { RecurringFormDialog } from "./recurring-form-dialog";
+import { RecurringImpactDialog } from "./recurring-impact-dialog";
 import type {
   Account,
   CategoryWithChildren,
@@ -91,16 +92,18 @@ function RecurringCard({
     template.end_date
   );
 
-  const handleToggle = () => {
+  const handleActivate = () => {
     startTransition(() => {
-      toggleRecurringTemplate(template.id, !template.is_active);
+      toggleRecurringTemplate(template.id, true);
     });
   };
 
-  const handleDelete = () => {
-    startTransition(() => {
-      deleteRecurringTemplate(template.id);
-    });
+  const handlePauseConfirm = () => {
+    toggleRecurringTemplate(template.id, false);
+  };
+
+  const handleDeleteConfirm = () => {
+    deleteRecurringTemplate(template.id);
   };
 
   return (
@@ -109,12 +112,12 @@ function RecurringCard({
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
             {isIncome ? (
-              <div className="p-2 rounded-lg bg-green-500/10">
-                <ArrowDownLeft className="h-5 w-5 text-green-600" />
+              <div className="p-2 rounded-lg bg-z-income/10">
+                <ArrowDownLeft className="h-5 w-5 text-z-income" />
               </div>
             ) : (
-              <div className="p-2 rounded-lg bg-orange-500/10">
-                <ArrowUpRight className="h-5 w-5 text-orange-600" />
+              <div className="p-2 rounded-lg bg-z-expense/10">
+                <ArrowUpRight className="h-5 w-5 text-z-expense" />
               </div>
             )}
             <div>
@@ -143,26 +146,42 @@ function RecurringCard({
                   </DropdownMenuItem>
                 }
               />
-              <DropdownMenuItem onClick={handleToggle}>
-                {template.is_active ? (
-                  <>
-                    <Pause className="h-4 w-4 mr-2" />
-                    Pausar
-                  </>
-                ) : (
-                  <>
-                    <Play className="h-4 w-4 mr-2" />
-                    Activar
-                  </>
-                )}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={handleDelete}
-                className="text-destructive"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Eliminar
-              </DropdownMenuItem>
+              {template.is_active ? (
+                <RecurringImpactDialog
+                  templateId={template.id}
+                  templateName={template.merchant_name ?? "Recurrente"}
+                  currencyCode={(template.currency_code ?? "COP") as CurrencyCode}
+                  action="pause"
+                  onConfirm={handlePauseConfirm}
+                  trigger={
+                    <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                      <Pause className="h-4 w-4 mr-2" />
+                      Pausar
+                    </DropdownMenuItem>
+                  }
+                />
+              ) : (
+                <DropdownMenuItem onClick={handleActivate}>
+                  <Play className="h-4 w-4 mr-2" />
+                  Activar
+                </DropdownMenuItem>
+              )}
+              <RecurringImpactDialog
+                templateId={template.id}
+                templateName={template.merchant_name ?? "Recurrente"}
+                currencyCode={(template.currency_code ?? "COP") as CurrencyCode}
+                action="delete"
+                onConfirm={handleDeleteConfirm}
+                trigger={
+                  <DropdownMenuItem
+                    onSelect={(e) => e.preventDefault()}
+                    className="text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Eliminar
+                  </DropdownMenuItem>
+                }
+              />
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -170,7 +189,7 @@ function RecurringCard({
         <div className="mt-4 flex items-baseline justify-between">
           <span
             className={`text-xl font-bold ${
-              template.direction === "INFLOW" ? "text-green-600" : ""
+              template.direction === "INFLOW" ? "text-z-income" : ""
             }`}
           >
             {isIncome ? "+" : "-"}

--- a/webapp/src/lib/utils/recurring.ts
+++ b/webapp/src/lib/utils/recurring.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert a recurring amount to its monthly equivalent based on frequency.
+ */
+export function toMonthlyAmount(amount: number, frequency: string): number {
+  switch (frequency) {
+    case "WEEKLY": return amount * 4.33;
+    case "BIWEEKLY": return amount * 2.17;
+    case "MONTHLY": return amount;
+    case "QUARTERLY": return amount / 3;
+    case "ANNUAL": return amount / 12;
+    default: return amount;
+  }
+}

--- a/webapp/src/types/plan.ts
+++ b/webapp/src/types/plan.ts
@@ -42,6 +42,7 @@ export interface PlanDebtSummary {
 
 export interface PlanRecurringSummary {
   upcoming: UpcomingRecurrence[];
+  upcomingIncome: UpcomingRecurrence[];
   totalMonthlyExpenses: number;
   totalMonthlyIncome: number;
   activeCount: number;


### PR DESCRIPTION
## Summary
- **Impact preview dialog** before delete/pause — shows pending occurrences, margin delta, planning entry orphans, monthly amount change
- **Recurring income as first-class citizen** — INFLOW templates feed into income estimation, dashboard hero shows "Ingresos esperados" KPI, plan page shows upcoming income section + income-aware guidance
- **Design token fixes** — hardcoded green/orange colors replaced with `z-income`/`z-expense` tokens in recurring cards

## Key decisions
- No schema migration — existing amount override + ±3 day auto-link window handles date/amount variability
- Pending income shown as info only — NOT added to `availableToSpend` (money hasn't arrived)
- Income and obligations kept as separate arrays in plan page

## Files changed (10)
- 4 server actions: `recurring-templates.ts`, `income.ts`, `charts.ts`, `plan.ts`
- 1 new component: `recurring-impact-dialog.tsx`
- 4 modified components: `recurring-list.tsx`, `dashboard-hero.tsx`, `plan-hero.tsx`, `plan-recurring-section.tsx`
- 1 type: `plan.ts`

## Test plan
- [ ] Create INFLOW recurring template → verify it appears in plan page "Ingresos esperados" section
- [ ] Verify dashboard hero shows "Ingresos esperados" KPI when pending INFLOW occurrences exist
- [ ] Plan hero "Ingreso base" card shows "Basado en tus ingresos recurrentes" when no profile salary set
- [ ] Delete a recurring template → verify impact dialog shows pending count + margin delta
- [ ] Pause a recurring template → verify impact dialog shows different messaging
- [ ] Activate (resume) a paused template → verify it fires directly (no dialog)
- [ ] Confirm INFLOW occurrence with overridden amount → verify transaction created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)