### PR TITLE
refactor: consolidate occurrence queries into single cached source

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -42,10 +42,9 @@
 
 
 ### Income-aware runway & daily budget
-- **Priority:** High
-- **What:** Dashboard "gasto diario" and runway metrics should factor in upcoming recurring income. Two options: (A) count until end of month but add next income to available balance, or (B) count until next income date instead of end of month. Currently both metrics assume no more money coming in — overly pessimistic when income is configured.
-- **Context:** Recurring income is now first-class. These metrics should reflect it. Affects mobile dashboard hero and gasto diario calculation.
-- **Found:** Visual testing, 2026-04-13
+- **Priority:** Done (shipped in PR #134)
+- **What:** Dashboard hero and runway use pay-cycle budgeting (now → next income date). Obligations scoped to window. Burn-rate chart shows single segment with obligation markers.
+- **Context:** Spec: `docs/superpowers/specs/2026-04-13-income-aware-runway.md`
 
 ### Multi-currency aggregation in dashboard metrics
 - **Priority:** Medium

--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -7,6 +7,7 @@ import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { toColombiaDateString } from "@/lib/utils/date";
 import { getPendingOccurrencesCached } from "@/actions/occurrences";
+import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -60,14 +61,16 @@ async function getAttentionItemsCached(
 ): Promise<AttentionItems> {
   "use cache";
   cacheTag("attention");
+  cacheTag("occurrences");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
   const today = new Date();
   const todayStr = toColombiaDateString(today);
   const in7DaysStr = toColombiaDateString(addDays(today, 7));
+  const rangeEnd = toColombiaDateString(addDays(today, PAY_CYCLE_LOOKAHEAD_DAYS));
 
-  const [remindersRes, emailsRes, pendingOccurrences] = await Promise.all([
+  const [remindersRes, emailsRes, allOccurrences] = await Promise.all([
     // 1. Overdue reminders
     supabase
       .from("financial_reminders")
@@ -87,9 +90,15 @@ async function getAttentionItemsCached(
       .order("created_at", { ascending: false })
       .limit(5),
 
-    // 3. Pending recurring occurrences (next 7 days) — shared cached source
-    getPendingOccurrencesCached(userId, todayStr, in7DaysStr, accessToken),
+    // 3. Pending recurring occurrences — canonical 45-day range aligns cache key
+    //    with dashboard queries, avoiding a redundant DB hit on cold loads.
+    getPendingOccurrencesCached(userId, todayStr, rangeEnd, accessToken),
   ]);
+
+  // Filter to 7-day window for attention display
+  const pendingOccurrences = allOccurrences.filter(
+    (o) => o.occurrence_date <= in7DaysStr,
+  );
 
   // ── Map overdue reminders ──────────────────────────────────────────────────
 

--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -62,6 +62,7 @@ async function getAttentionItemsCached(
   "use cache";
   cacheTag("attention");
   cacheTag("occurrences");
+  cacheTag("recurring");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);

--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -5,7 +5,8 @@ import { cacheTag, cacheLife } from "next/cache";
 import { addDays } from "date-fns";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
-import { toISODateString } from "@/lib/utils/date";
+import { toColombiaDateString } from "@/lib/utils/date";
+import { getPendingOccurrencesCached } from "@/actions/occurrences";
 
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -63,10 +64,10 @@ async function getAttentionItemsCached(
 
   const supabase = createCachedClient(accessToken);
   const today = new Date();
-  const todayStr = toISODateString(today);
-  const in7Days = addDays(today, 7);
+  const todayStr = toColombiaDateString(today);
+  const in7DaysStr = toColombiaDateString(addDays(today, 7));
 
-  const [remindersRes, emailsRes, occurrencesRes] = await Promise.all([
+  const [remindersRes, emailsRes, pendingOccurrences] = await Promise.all([
     // 1. Overdue reminders
     supabase
       .from("financial_reminders")
@@ -86,27 +87,8 @@ async function getAttentionItemsCached(
       .order("created_at", { ascending: false })
       .limit(5),
 
-    // 3. Pending recurring occurrences (next 7 days, already materialized)
-    supabase
-      .from("recurring_occurrences")
-      .select(`
-        id,
-        template_id,
-        occurrence_date,
-        expected_amount,
-        template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
-          merchant_name,
-          description,
-          direction,
-          is_active
-        )
-      `)
-      .eq("user_id", userId)
-      .eq("status", "pending")
-      .gte("occurrence_date", todayStr)
-      .lte("occurrence_date", toISODateString(in7Days))
-      .order("occurrence_date")
-      .limit(10),
+    // 3. Pending recurring occurrences (next 7 days) — shared cached source
+    getPendingOccurrencesCached(userId, todayStr, in7DaysStr, accessToken),
   ]);
 
   // ── Map overdue reminders ──────────────────────────────────────────────────
@@ -139,21 +121,18 @@ async function getAttentionItemsCached(
     }
   );
 
-  // ── Map upcoming payments from materialized occurrences ───────────────────
+  // ── Map upcoming payments from shared cached occurrences ──────────────────
 
-  const upcomingPayments: AttentionUpcomingPayment[] = (occurrencesRes.data ?? [])
-    .filter((o) => (o.template as { is_active?: boolean } | null)?.is_active !== false)
-    .map((o) => {
-    const tmpl = o.template as { merchant_name: string | null; description: string | null; direction: string };
-    return {
+  const upcomingPayments: AttentionUpcomingPayment[] = pendingOccurrences
+    .slice(0, 5)
+    .map((o) => ({
       templateId: o.template_id,
-      name: tmpl.merchant_name ?? tmpl.description ?? "Pago recurrente",
+      name: o.merchant_name ?? o.description ?? "Pago recurrente",
       amount: o.expected_amount,
       next_date: o.occurrence_date,
-      direction: tmpl.direction as "INFLOW" | "OUTFLOW",
+      direction: o.direction,
       occurrenceDate: o.occurrence_date,
-    };
-  }).slice(0, 5);
+    }));
 
   return { overdueReminders, upcomingPayments, pendingEmails };
 }

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -404,25 +404,37 @@ export async function findMatchingOccurrence(
   amount: number,
   direction: "INFLOW" | "OUTFLOW",
 ): Promise<string | null> {
-  const { user, accessToken } = await getAuthenticatedClient();
-  if (!user || !accessToken) return null;
+  // Direct query — not cached. This runs on mutation paths (tx creation)
+  // where fresh data is required to avoid double-linking in batch imports.
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return null;
 
-  // Look within ±3 days of the transaction date to account for payment timing
   const baseDateObj = new Date(`${transactionDate}T12:00:00`);
   const rangeStart = toColombiaDateString(addDays(baseDateObj, -3));
   const rangeEnd = toColombiaDateString(addDays(baseDateObj, 3));
 
-  const occurrences = await getPendingOccurrencesCached(user.id, rangeStart, rangeEnd, accessToken);
+  const { data, error } = await supabase
+    .from("recurring_occurrences")
+    .select(
+      `id, expected_amount,
+       template:recurring_transaction_templates!recurring_occurrences_template_id_fkey!inner(
+         account_id, direction, is_active
+       )`
+    )
+    .eq("user_id", user.id)
+    .eq("status", "pending")
+    .eq("template.account_id", accountId)
+    .eq("template.direction", direction)
+    .eq("template.is_active", true)
+    .gte("occurrence_date", rangeStart)
+    .lte("occurrence_date", rangeEnd);
 
-  // Match by account, direction, and amount (1% tolerance)
+  if (error || !data) return null;
+
   const tolerance = amount * 0.01;
-  const match = occurrences.find(
-    (o) =>
-      o.account_id === accountId &&
-      o.direction === direction &&
-      Math.abs(o.expected_amount - amount) <= tolerance,
+  const match = data.find(
+    (row) => Math.abs(row.expected_amount - amount) <= tolerance,
   );
-
   return match?.id ?? null;
 }
 

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -184,63 +184,30 @@ export async function getNextIncomeOccurrenceCached(
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const supabase = createCachedClient(accessToken);
+  const rangeEnd = toColombiaDateString(addDays(new Date(todayStr + "T12:00:00"), PAY_CYCLE_LOOKAHEAD_DAYS));
+  const occurrences = await getPendingOccurrencesCached(userId, todayStr, rangeEnd, accessToken);
 
-  const { data, error } = await supabase
-    .from("recurring_occurrences")
-    .select(`
-      occurrence_date,
-      expected_amount,
-      recurring_transaction_templates!recurring_occurrences_template_id_fkey!inner (
-        merchant_name,
-        description,
-        direction,
-        currency_code,
-        is_active,
-        accounts!recurring_transaction_templates_account_id_fkey (
-          account_type
-        )
-      )
-    `)
-    .eq("user_id", userId)
-    .eq("status", "pending")
-    .gte("occurrence_date", todayStr)
-    .order("occurrence_date", { ascending: true })
-    .limit(500);
+  const match = occurrences.find(
+    (o) =>
+      o.direction === "INFLOW" &&
+      o.currency_code === currency &&
+      !isDebtAccountType(o.account_type),
+  );
+  if (!match) return null;
 
-  if (error || !data || data.length === 0) return null;
+  const occDate = new Date(match.occurrence_date + "T12:00:00");
+  const today = new Date(todayStr + "T12:00:00");
+  const daysUntil = Math.max(
+    1,
+    Math.ceil((occDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
+  );
 
-  for (const row of data) {
-    const tpl = row.recurring_transaction_templates as {
-      merchant_name: string | null;
-      description: string | null;
-      direction: string;
-      currency_code: string;
-      is_active: boolean;
-      accounts: { account_type: string } | null;
-    };
-    if (!tpl.is_active) continue;
-    if (tpl.direction !== "INFLOW") continue;
-    if (tpl.currency_code !== currency) continue;
-    const acctType = tpl.accounts?.account_type;
-    if (acctType && isDebtAccountType(acctType)) continue;
-
-    const occDate = new Date(row.occurrence_date + "T12:00:00");
-    const today = new Date(todayStr + "T12:00:00");
-    const daysUntil = Math.max(
-      1,
-      Math.ceil((occDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
-    );
-
-    return {
-      date: row.occurrence_date,
-      amount: row.expected_amount,
-      name: tpl.merchant_name ?? tpl.description ?? "Ingreso",
-      daysUntil,
-    };
-  }
-
-  return null;
+  return {
+    date: match.occurrence_date,
+    amount: match.expected_amount,
+    name: match.merchant_name ?? match.description ?? "Ingreso",
+    daysUntil,
+  };
 }
 
 export async function getNextIncomeOccurrence(
@@ -437,42 +404,26 @@ export async function findMatchingOccurrence(
   amount: number,
   direction: "INFLOW" | "OUTFLOW",
 ): Promise<string | null> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return null;
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return null;
 
   // Look within ±3 days of the transaction date to account for payment timing
   const baseDateObj = new Date(`${transactionDate}T12:00:00`);
-  const windowStart = addDays(baseDateObj, -3).toISOString().split("T")[0];
-  const windowEnd = addDays(baseDateObj, 3).toISOString().split("T")[0];
+  const rangeStart = toColombiaDateString(addDays(baseDateObj, -3));
+  const rangeEnd = toColombiaDateString(addDays(baseDateObj, 3));
 
-  const { data, error } = await supabase
-    .from("recurring_occurrences")
-    .select(
-      `id, expected_amount,
-       template:recurring_transaction_templates!recurring_occurrences_template_id_fkey!inner(
-         account_id, direction, is_active
-       )`
-    )
-    .eq("user_id", user.id)
-    .eq("status", "pending")
-    .eq("template.account_id", accountId)
-    .eq("template.direction", direction)
-    .gte("occurrence_date", windowStart)
-    .lte("occurrence_date", windowEnd);
+  const occurrences = await getPendingOccurrencesCached(user.id, rangeStart, rangeEnd, accessToken);
 
-  if (error || !data) return null;
-
-  // Match by amount (1% tolerance), skip paused templates
+  // Match by account, direction, and amount (1% tolerance)
   const tolerance = amount * 0.01;
-  for (const row of data) {
-    const tmpl = row.template as { account_id: string; direction: string; is_active: boolean };
-    if (!tmpl.is_active) continue;
-    if (Math.abs(row.expected_amount - amount) <= tolerance) {
-      return row.id;
-    }
-  }
+  const match = occurrences.find(
+    (o) =>
+      o.account_id === accountId &&
+      o.direction === direction &&
+      Math.abs(o.expected_amount - amount) <= tolerance,
+  );
 
-  return null;
+  return match?.id ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`getNextIncomeOccurrenceCached`** and **`attention-items`** now call `getPendingOccurrencesCached` instead of standalone Supabase queries — `is_active` filter, FK hints, and select fragment maintained in one place
- **`findMatchingOccurrence`** stays as a direct (uncached) query since it runs on mutation paths (batch import, FAB, email) where fresh data is required
- Attention-items uses canonical 45-day range (aligns cache key with dashboard, avoids redundant DB hit on cold loads) and filters to 7 days in JS
- Added `"occurrences"` cacheTag to `getAttentionItemsCached` outer boundary for independent revalidation

## Review agent findings addressed

- **Perf auditor**: fixed cache key fragmentation (45-day canonical range), kept `findMatchingOccurrence` off cache path
- **Cache doctor**: added missing `"occurrences"` tag on attention-items outer boundary, reverted mutation-path function to direct query
- **Server action reviewer**: auth, defense-in-depth, return types all verified correct

## Test plan

- [ ] Dashboard loads correctly — hero, burn-rate, attention items all show occurrence data
- [ ] Creating a transaction auto-links to matching pending occurrence
- [ ] Batch PDF import doesn't double-link occurrences on same date
- [ ] Pausing a recurring template hides its occurrences everywhere (single filter point)
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)