### PR TITLE
feat: income occurrence UX + tech debt sweep

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -25,9 +25,9 @@
 - **Context:** Shipped card hero, flip-to-graph, transaction-based balance history, transfer dialog, quick actions. Deferred items noted by perf-auditor and design reviews.
 
 ### Income occurrence UX — different actions from expenses
-- **Priority:** Medium
-- **What:** Income occurrences show "Confirmar pago" / "Ya pagué" — should say "Confirmar ingreso" / "Ya recibí". Actions, labels, and possibly the color accent should be contextual based on `direction` (INFLOW vs OUTFLOW). Also needs a "skip" or "delete" option for occurrences the user wants to clear without marking as received.
-- **Found:** Visual testing, 2026-04-13
+- **Priority:** Done (this branch)
+- **What:** Direction-aware labels: "Confirmar ingreso" / "Ya recibí" for INFLOW, "Confirmar pago" / "Ya pagué" for OUTFLOW. Covers confirm inline, timeline, toasts, and attention fallback labels.
+- **Remaining:** Skip/delete option for clearing occurrences without marking received — deferred.
 
 ### Template active state — query-side filtering
 - **Priority:** Done (implemented in this branch)
@@ -81,17 +81,16 @@
 ## Tech Debt
 
 ### Defense-in-depth gaps
-- **`getCategoriesByRhythm`** (`categories.ts`) — transactions query missing `.eq("user_id", user.id)`. Relies solely on RLS.
-- **`bulkTagTransactions`** (`tags.ts`) — upserts into `transaction_tags` without verifying transaction ownership. RLS covers it but violates defense-in-depth convention.
-- **Found:** Server action reviewer, 2026-04-13
+- **Priority:** Done (this branch)
+- **What:** Added `.eq("user_id")` to `getCategoriesByRhythm` transactions query. Added ownership verification to `bulkTagTransactions`.
 
 ### Missing revalidation
-- **`createDestinatario` with `link_matching_transactions`** (`destinatarios.ts`) — manually lists 5 tags instead of calling `revalidateFinancialViews()`. Misses `"transactions"`, `"accounts"`, `"debt"`, `"recurring"`, `"occurrences"`.
-- **Found:** Server action reviewer, 2026-04-13
+- **Priority:** Done (this branch)
+- **What:** `createDestinatario` with `link_matching_transactions` now calls `revalidateFinancialViews()`.
 
 ### Uncached server action
-- **`getTagsForEntity`** (`tags.ts`) — called on every tag picker open with no `"use cache"`. Uses React `cache()` which only deduplicates within a single server render, not across client-side calls. 3 sequential DB queries each time.
-- **Found:** Efficiency review, 2026-04-13
+- **Priority:** Done (this branch)
+- **What:** `getTagsForEntity` extracted to `"use cache"` inner with `cacheTag("tags")` + `cacheLife("zeta")`.
 
 ### `transaction_tags` table missing columns
 - **What:** No `created_at` or `user_id` columns. Recents query works around this by joining through `transactions`. Adding these columns would:

--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -137,7 +137,7 @@ async function getAttentionItemsCached(
     .slice(0, 5)
     .map((o) => ({
       templateId: o.template_id,
-      name: o.merchant_name ?? o.description ?? "Pago recurrente",
+      name: o.merchant_name ?? o.description ?? (o.direction === "INFLOW" ? "Ingreso recurrente" : "Pago recurrente"),
       amount: o.expected_amount,
       next_date: o.occurrence_date,
       direction: o.direction,

--- a/webapp/src/actions/categories.ts
+++ b/webapp/src/actions/categories.ts
@@ -743,6 +743,7 @@ export async function getCategoriesByRhythm(
       supabase
         .from("transactions")
         .select("amount, category_id")
+        .eq("user_id", user.id)
         .eq("direction", "OUTFLOW")
         .eq("is_excluded", false)
         .eq("currency_code", baseCurrency)

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -492,15 +492,10 @@ export async function createDestinatario(
       }
     }
 
-    revalidateTag("categorize", "zeta");
-    revalidateTag("dashboard:charts", "zeta");
-    revalidateTag("dashboard:budgets", "zeta");
-    revalidateTag("dashboard:cashflow", "zeta");
-    revalidateTag("dashboard:hero", "zeta");
+    revalidateFinancialViews();
   }
 
   revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
   return { success: true, data: { ...data, linked_count: linkedCount } };
 }
 

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -496,6 +496,7 @@ export async function createDestinatario(
   }
 
   revalidateTag("destinatarios", "zeta");
+  revalidateTag("attention", "zeta");
   return { success: true, data: { ...data, linked_count: linkedCount } };
 }
 

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -174,6 +174,7 @@ async function getTagsForEntityCached(
     .from("tags")
     .select("*")
     .in("id", tagIds)
+    .or(`user_id.eq.${userId},user_id.is.null`)
     .order("display_order");
 
   return tags ?? [];
@@ -468,6 +469,15 @@ export async function bulkTagTransactions(
 ): Promise<ActionResult<{ tagged: number }>> {
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
+
+  // Defense-in-depth: verify tag belongs to user (or is system tag)
+  const { data: tag } = await supabase
+    .from("tags")
+    .select("id")
+    .eq("id", tagId)
+    .or(`user_id.eq.${user.id},user_id.is.null`)
+    .single();
+  if (!tag) return { success: false, error: "Etiqueta no encontrada" };
 
   // Defense-in-depth: verify all transactions belong to user
   const { count } = await supabase

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -126,51 +126,67 @@ export const getTagGroups = cache(async (): Promise<ActionResult<TagGroupWithTag
   }
 });
 
-export const getTagsForEntity = cache(
-  async (entityType: TaggableEntity, entityId: string): Promise<Tag[]> => {
-    const { supabase, user } = await getAuthenticatedClient();
-    if (!user) return [];
+async function getTagsForEntityCached(
+  userId: string,
+  accessToken: string,
+  entityType: TaggableEntity,
+  entityId: string,
+): Promise<Tag[]> {
+  "use cache";
+  cacheTag("tags");
+  cacheLife("zeta");
 
-    // Ownership check — verify entity belongs to calling user
-    if (entityType === "transaction") {
-      const { data: tx } = await supabase
-        .from("transactions")
-        .select("id")
-        .eq("id", entityId)
-        .eq("user_id", user.id)
-        .single();
-      if (!tx) return [];
-    } else if (entityType === "destinatario") {
-      const { data: dest } = await supabase
-        .from("destinatarios")
-        .select("id")
-        .eq("id", entityId)
-        .eq("user_id", user.id)
-        .single();
-      if (!dest) return [];
-    }
-    // categories can be system-owned — skip ownership check
+  const supabase = createCachedClient(accessToken);
 
-    const tableName = `${entityType}_tags` as const;
-    const idColumn = `${entityType}_id` as const;
-
-    const { data } = await supabase
-      .from(tableName)
-      .select("tag_id")
-      .eq(idColumn, entityId);
-
-    if (!data || data.length === 0) return [];
-
-    const tagIds = data.map((r: { tag_id: string }) => r.tag_id);
-    const { data: tags } = await supabase
-      .from("tags")
-      .select("*")
-      .in("id", tagIds)
-      .order("display_order");
-
-    return tags ?? [];
+  // Ownership check — verify entity belongs to calling user
+  if (entityType === "transaction") {
+    const { data: tx } = await supabase
+      .from("transactions")
+      .select("id")
+      .eq("id", entityId)
+      .eq("user_id", userId)
+      .single();
+    if (!tx) return [];
+  } else if (entityType === "destinatario") {
+    const { data: dest } = await supabase
+      .from("destinatarios")
+      .select("id")
+      .eq("id", entityId)
+      .eq("user_id", userId)
+      .single();
+    if (!dest) return [];
   }
-);
+  // categories can be system-owned — skip ownership check
+
+  const tableName = `${entityType}_tags` as const;
+  const idColumn = `${entityType}_id` as const;
+
+  const { data } = await supabase
+    .from(tableName)
+    .select("tag_id")
+    .eq(idColumn, entityId);
+
+  if (!data || data.length === 0) return [];
+
+  const tagIds = data.map((r: { tag_id: string }) => r.tag_id);
+  const { data: tags } = await supabase
+    .from("tags")
+    .select("*")
+    .in("id", tagIds)
+    .order("display_order");
+
+  return tags ?? [];
+}
+
+export async function getTagsForEntity(
+  entityType: TaggableEntity,
+  entityId: string,
+): Promise<Tag[]> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
+
+  return getTagsForEntityCached(user.id, accessToken, entityType, entityId);
+}
 
 export const getAllTags = cache(async (): Promise<Tag[]> => {
   const { user, accessToken } = await getAuthenticatedClient();
@@ -451,6 +467,16 @@ export async function bulkTagTransactions(
 ): Promise<ActionResult<{ tagged: number }>> {
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
+
+  // Defense-in-depth: verify all transactions belong to user
+  const { count } = await supabase
+    .from("transactions")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .in("id", transactionIds);
+  if (count !== transactionIds.length) {
+    return { success: false, error: "Transacciones no encontradas" };
+  }
 
   const rows = transactionIds.map((id) => ({ transaction_id: id, tag_id: tagId }));
 

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -134,6 +134,7 @@ async function getTagsForEntityCached(
 ): Promise<Tag[]> {
   "use cache";
   cacheTag("tags");
+  cacheTag("transactions");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);

--- a/webapp/src/components/recurring/recurring-confirm-inline.tsx
+++ b/webapp/src/components/recurring/recurring-confirm-inline.tsx
@@ -44,6 +44,7 @@ export function RecurringConfirmInline({
   isPending,
   sourceAccounts,
 }: RecurringConfirmInlineProps) {
+  const isIncome = item.direction === "INFLOW";
   const [amount, setAmount] = useState<string>(String(item.plannedAmount));
   const [paymentDate, setPaymentDate] = useState<string>(
     format(new Date(), "yyyy-MM-dd")
@@ -76,25 +77,25 @@ export function RecurringConfirmInline({
           {/* Amount */}
           <div className="space-y-1">
             <label className="text-xs font-medium text-muted-foreground">
-              Monto pagado
+              {isIncome ? "Monto recibido" : "Monto pagado"}
             </label>
             <CurrencyInput
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               className="h-8 text-sm"
-              placeholder="Monto pagado"
+              placeholder={isIncome ? "Monto recibido" : "Monto pagado"}
             />
           </div>
 
           {/* Date */}
           <div className="space-y-1">
             <label className="text-xs font-medium text-muted-foreground">
-              Fecha de pago
+              {isIncome ? "Fecha de ingreso" : "Fecha de pago"}
             </label>
             <DatePicker
               value={paymentDate}
               onChange={(v) => setPaymentDate(v ?? format(new Date(), "yyyy-MM-dd"))}
-              placeholder="Fecha de pago"
+              placeholder={isIncome ? "Fecha de ingreso" : "Fecha de pago"}
               className="h-8 w-full"
             />
           </div>
@@ -124,7 +125,7 @@ export function RecurringConfirmInline({
         {/* Actions row */}
         <div className="flex gap-2">
           <Button type="submit" size="sm" disabled={isPending}>
-            {isPending ? "Registrando..." : "Confirmar pago"}
+            {isPending ? "Registrando..." : isIncome ? "Confirmar ingreso" : "Confirmar pago"}
           </Button>
           <Button
             type="button"
@@ -133,7 +134,7 @@ export function RecurringConfirmInline({
             onClick={onSkip}
             disabled={isPending}
           >
-            Ya pagué
+            {isIncome ? "Ya recibí" : "Ya pagué"}
           </Button>
           <Button
             type="button"

--- a/webapp/src/components/recurring/recurring-payment-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-payment-timeline.tsx
@@ -189,7 +189,7 @@ export function PaymentTimeline({
 
                       {/* Confirm indicator */}
                       <span className="shrink-0 text-xs text-muted-foreground">
-                        {isExpanded ? "Cerrar" : "Confirmar ▸"}
+                        {isExpanded ? "Cerrar" : item.direction === "INFLOW" ? "Confirmar ingreso ▸" : "Confirmar ▸"}
                       </span>
                     </div>
 

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -254,7 +254,9 @@ export function useRecurringMonth(
       if (created > 0) {
         const msg = item.isDebtPayment
           ? "Pago registrado como transferencia + abono a deuda"
-          : "Pago recurrente registrado";
+          : item.direction === "INFLOW"
+            ? "Ingreso recurrente registrado"
+            : "Pago recurrente registrado";
 
         toast.success(msg);
         router.refresh();


### PR DESCRIPTION
## Summary

- **Income occurrence UX**: Direction-aware labels — income occurrences show "Confirmar ingreso" / "Ya recibí" instead of "Confirmar pago" / "Ya pagué". Covers confirm inline, timeline, toasts, and attention fallback labels.
- **Defense-in-depth**: Added `.eq("user_id")` to `getCategoriesByRhythm` transactions query, ownership verification in `bulkTagTransactions` (both transactions and tag), `user_id` filter on tags query in `getTagsForEntityCached`
- **Missing revalidation**: `createDestinatario` with `link_matching_transactions` now calls `revalidateFinancialViews()` + restored `"attention"` tag on outer path
- **Cached `getTagsForEntity`**: Extracted `"use cache"` inner with `cacheTag("tags", "transactions")` + `cacheLife("zeta")` — eliminates 3 sequential DB queries per tag picker open on cache hits

## Review agent findings addressed

- **Server action reviewer**: tag ownership check in `bulkTagTransactions`, defense-in-depth on tags query, missing `"attention"` revalidation
- **Perf auditor**: added `"transactions"` cacheTag for entity deletion coherence, `count` query acceptable for ownership check

## Test plan

- [ ] Income occurrence: confirm/skip actions show direction-aware Spanish labels
- [ ] Tag picker: loads tags (cached on second open)
- [ ] Bulk tag: rejects tags from other users
- [ ] Create destinatario with link_matching: dashboard refreshes correctly
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)