### PR TITLE
feat: multi-currency aggregation in dashboard metrics

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -47,10 +47,9 @@
 - **Context:** Spec: `docs/superpowers/specs/2026-04-13-income-aware-runway.md`
 
 ### Multi-currency aggregation in dashboard metrics
-- **Priority:** Medium
-- **What:** Dashboard hero, burn rate, and runway currently filter obligations/balances to `baseCurrency` only. Users with accounts in multiple currencies (e.g., USD savings + COP recurring) see incomplete totals. Should convert all currencies to base using `exchange_rate_cache` (frankfurter.app, cached 24h). Affects `getDashboardHeroData`, `getBurnRateCached`, and `RunwayMiniChart`.
-- **Context:** Pre-existing limitation (old code also filtered by currency). Not a regression from income-aware runway.
-- **Found:** Codex adversarial review, 2026-04-13
+- **Priority:** Done (this branch)
+- **What:** Dashboard hero, burn rate, runway, and net worth now aggregate all currencies by converting to base via `getRatesForCurrencies()`. Accounts/obligations with unavailable rates are excluded (not mixed raw). UI shows "tasa del día" hint when conversions are included.
+- **Known limitation:** Net worth history steps backward using single-currency cashflow, so the foreign portion floats as a constant — acceptable approximation for now.
 
 ### Tag system broader reach
 - **Priority:** Medium

--- a/webapp/src/actions/burn-rate.ts
+++ b/webapp/src/actions/burn-rate.ts
@@ -113,17 +113,19 @@ async function getBurnRateCached(
   };
 
   const obligationMarkers: ObligationMarker[] = (pendingOccurrences ?? [])
-    .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate)
+    .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
+      && (o.currency_code === baseCurrency || rates.has(o.currency_code as CurrencyCode)))
     .map((o) => ({
       date: o.occurrence_date,
       name: o.merchant_name ?? o.description ?? "Recurrente",
       amount: toBase(o.expected_amount, o.currency_code),
     }));
 
-  // Compute disponible using window-scoped pending occurrences (all currencies, converted)
+  // Compute disponible using window-scoped pending occurrences (convertible currencies only)
   const windowOutflows = (pendingOccurrences ?? [])
     .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
-      && o.account_type !== "CREDIT_CARD");
+      && o.account_type !== "CREDIT_CARD"
+      && (o.currency_code === baseCurrency || rates.has(o.currency_code as CurrencyCode)));
   const totalPending = windowOutflows.reduce((sum, o) => sum + toBase(o.expected_amount, o.currency_code), 0);
 
   // Include all liquid accounts with convertible currencies
@@ -163,17 +165,19 @@ export async function getBurnRate(
   try {
     const baseCurrency = (currency ?? "COP") as CurrencyCode;
 
-    // Fetch account currencies outside cache boundary (side-effecting rate lookups)
-    const { data: acctCurrencies } = await supabase
-      .from("accounts")
-      .select("currency_code")
-      .eq("user_id", user.id)
-      .eq("is_active", true)
-      .in("account_type", ["CHECKING", "SAVINGS"]);
+    // Fetch account + obligation currencies outside cache boundary (side-effecting rate lookups)
+    const [{ data: acctCurrencies }, { data: templateCurrencies }] = await Promise.all([
+      supabase.from("accounts").select("currency_code")
+        .eq("user_id", user.id).eq("is_active", true)
+        .in("account_type", ["CHECKING", "SAVINGS"]),
+      supabase.from("recurring_transaction_templates").select("currency_code")
+        .eq("user_id", user.id).eq("is_active", true),
+    ]);
 
-    const uniqueCurrencies = [...new Set(
-      (acctCurrencies ?? []).map((a) => a.currency_code)
-    )] as CurrencyCode[];
+    const uniqueCurrencies = [...new Set([
+      ...(acctCurrencies ?? []).map((a) => a.currency_code),
+      ...(templateCurrencies ?? []).map((t) => t.currency_code),
+    ])] as CurrencyCode[];
     const rates = uniqueCurrencies.some((c) => c !== baseCurrency)
       ? await getRatesForCurrencies(uniqueCurrencies, baseCurrency)
       : new Map<CurrencyCode, number>();

--- a/webapp/src/actions/burn-rate.ts
+++ b/webapp/src/actions/burn-rate.ts
@@ -7,6 +7,7 @@ import { createCachedClient } from "@/lib/supabase/cached";
 import { toColombiaDateString } from "@/lib/utils/date";
 import type { CurrencyCode } from "@/types/domain";
 import { getNextIncomeOccurrenceCached, getPendingOccurrencesCached } from "@/actions/occurrences";
+import { getRatesForCurrencies } from "@/actions/exchange-rate";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 
 export interface BurnRateDataPoint {
@@ -46,7 +47,8 @@ export interface BurnRateResponse {
 async function getBurnRateCached(
   accessToken: string,
   userId: string,
-  currency: string
+  currency: string,
+  ratesJson: string // serialized Map — "use cache" requires serializable params
 ): Promise<BurnRateResponse | null> {
   "use cache";
   cacheTag("dashboard:hero");
@@ -73,6 +75,9 @@ async function getBurnRateCached(
       .select("id, current_balance, currency_code, account_type")
       .eq("user_id", userId).eq("is_active", true)
       .in("account_type", ["CHECKING", "SAVINGS"]),
+    // TODO: transactions are base-currency-only while liquidBalance is multi-currency.
+    // This overestimates runway for users who also spend in foreign currencies.
+    // Per-transaction historical rate conversion would be needed for full accuracy.
     supabase.from("transactions")
       .select("id, amount, transaction_date, direction, is_recurring")
       .eq("user_id", userId).eq("direction", "OUTFLOW")
@@ -99,27 +104,32 @@ async function getBurnRateCached(
     windowEndDate = `${yearStr}-${monthStr}-${String(daysInMonth).padStart(2, "0")}`;
   }
 
+  // Deserialize pre-fetched exchange rates (fetched outside cache boundary)
+  const rates = new Map<CurrencyCode, number>(JSON.parse(ratesJson));
+  const toBase = (amount: number, currency: string) => {
+    if (currency === baseCurrency) return amount;
+    const rate = rates.get(currency as CurrencyCode);
+    return rate ? amount * rate : 0; // skip if no rate
+  };
+
   const obligationMarkers: ObligationMarker[] = (pendingOccurrences ?? [])
     .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate)
     .map((o) => ({
       date: o.occurrence_date,
       name: o.merchant_name ?? o.description ?? "Recurrente",
-      amount: o.expected_amount,
+      amount: toBase(o.expected_amount, o.currency_code),
     }));
 
-  // Compute disponible using window-scoped pending occurrences (same window as chart)
+  // Compute disponible using window-scoped pending occurrences (all currencies, converted)
   const windowOutflows = (pendingOccurrences ?? [])
     .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
-      && o.currency_code === baseCurrency && o.account_type !== "CREDIT_CARD");
-  const totalPending = windowOutflows.reduce((sum, o) => sum + o.expected_amount, 0);
+      && o.account_type !== "CREDIT_CARD");
+  const totalPending = windowOutflows.reduce((sum, o) => sum + toBase(o.expected_amount, o.currency_code), 0);
 
-  const liquidAccounts = accounts.filter(
-    (a) => a.currency_code === baseCurrency
-  );
-  const liquidBalance = liquidAccounts.reduce(
-    (sum, a) => sum + (a.current_balance ?? 0),
-    0
-  );
+  // Include all liquid accounts with convertible currencies
+  const liquidBalance = accounts
+    .filter((a) => a.currency_code === baseCurrency || rates.has(a.currency_code as CurrencyCode))
+    .reduce((sum, a) => sum + toBase(a.current_balance ?? 0, a.currency_code), 0);
   const disponible = liquidBalance - totalPending;
 
   // Split transactions into total vs discretionary using is_recurring flag
@@ -147,11 +157,31 @@ async function getBurnRateCached(
 export async function getBurnRate(
   currency?: string
 ): Promise<BurnRateResponse | null> {
-  const { user, accessToken } = await getAuthenticatedClient();
+  const { supabase, user, accessToken } = await getAuthenticatedClient();
   if (!user || !accessToken) return null;
 
   try {
-    return await getBurnRateCached(accessToken, user.id, currency ?? "COP");
+    const baseCurrency = (currency ?? "COP") as CurrencyCode;
+
+    // Fetch account currencies outside cache boundary (side-effecting rate lookups)
+    const { data: acctCurrencies } = await supabase
+      .from("accounts")
+      .select("currency_code")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .in("account_type", ["CHECKING", "SAVINGS"]);
+
+    const uniqueCurrencies = [...new Set(
+      (acctCurrencies ?? []).map((a) => a.currency_code)
+    )] as CurrencyCode[];
+    const rates = uniqueCurrencies.some((c) => c !== baseCurrency)
+      ? await getRatesForCurrencies(uniqueCurrencies, baseCurrency)
+      : new Map<CurrencyCode, number>();
+
+    return await getBurnRateCached(
+      accessToken, user.id, currency ?? "COP",
+      JSON.stringify([...rates.entries()])
+    );
   } catch (error) {
     console.error("Error loading burn rate:", error);
     return null;

--- a/webapp/src/actions/charts.ts
+++ b/webapp/src/actions/charts.ts
@@ -7,6 +7,7 @@ import { addDays } from "date-fns";
 import { toColombiaDateString, getColombiaDayOfMonth } from "@/lib/utils/date";
 import { getAccounts } from "@/actions/accounts";
 import { getPendingOccurrencesCached, getNextIncomeOccurrenceCached } from "@/actions/occurrences";
+import { getRatesForCurrencies } from "@/actions/exchange-rate";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 import { getFreshnessLevel } from "@/lib/utils/dashboard";
 import { getIsDemoFilter, getDemoAccountIds } from "@/lib/demo-filter";
@@ -621,15 +622,31 @@ export async function getNetWorthHistory(month?: string, currency?: CurrencyCode
   // If no accounts, return early
   if (!accounts || accounts.length === 0) return [];
 
-  const currencyAccounts = accounts.filter((a) => a.currency_code === baseCurrency);
+  // Convert all accounts to base currency
+  const otherCurrencies = [...new Set(
+    accounts.map((a) => a.currency_code).filter((c) => c !== baseCurrency)
+  )] as CurrencyCode[];
+  const nwRates = otherCurrencies.length > 0
+    ? await getRatesForCurrencies(otherCurrencies, baseCurrency)
+    : new Map<CurrencyCode, number>();
+  const toBase = (amount: number, currency: string) => {
+    if (currency === baseCurrency) return amount;
+    const rate = nwRates.get(currency as CurrencyCode);
+    return rate ? amount * rate : 0; // skip if no rate
+  };
+  const nwConvertible = (a: { currency_code: string }) =>
+    a.currency_code === baseCurrency || nwRates.has(a.currency_code as CurrencyCode);
 
-  const totalAssets = currencyAccounts
-    .filter((a) => a.account_type !== "CREDIT_CARD" && a.account_type !== "LOAN")
-    .reduce((sum, a) => sum + a.current_balance, 0);
+  const totalAssets = accounts
+    .filter((a) => a.account_type !== "CREDIT_CARD" && a.account_type !== "LOAN" && nwConvertible(a))
+    .reduce((sum, a) => sum + toBase(a.current_balance, a.currency_code as CurrencyCode), 0);
 
-  const totalLiabilities = currencyAccounts
-    .filter((a) => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN")
-    .reduce((sum, a) => sum + computeDebtBalance(a as Parameters<typeof computeDebtBalance>[0]), 0);
+  const totalLiabilities = accounts
+    .filter((a) => (a.account_type === "CREDIT_CARD" || a.account_type === "LOAN") && nwConvertible(a))
+    .reduce((sum, a) => sum + toBase(
+      computeDebtBalance(a as Parameters<typeof computeDebtBalance>[0]),
+      a.currency_code as CurrencyCode
+    ), 0);
 
   const currentNetWorth = totalAssets - totalLiabilities;
 
@@ -700,6 +717,8 @@ export interface DashboardHeroData {
   oldestUpdate: string | null;
   currency: string;
   hasOtherCurrencies: boolean;
+  includesConvertedAmounts: boolean;
+  hasUnconvertibleCurrencies: boolean;
   // Pay-cycle fields
   nextIncomeDate: string | null;
   nextIncomeAmount: number;
@@ -728,6 +747,8 @@ export async function getDashboardHeroData(
       oldestUpdate: null,
       currency: "COP",
       hasOtherCurrencies: false,
+      includesConvertedAmounts: false,
+      hasUnconvertibleCurrencies: false,
       nextIncomeDate: null,
       nextIncomeAmount: 0,
       nextIncomeName: null,
@@ -752,29 +773,46 @@ export async function getDashboardHeroData(
     getPendingOccurrencesCached(user.id, colombiaToday, rangeEnd, accessToken).catch(() => [] as never[]),
   ]);
 
-  // 1. Process accounts
+  // 1. Process accounts (all currencies, converted to base)
   const dashboardAccounts = accountsResult.success
     ? accountsResult.data.map((a) => ({
         id: a.id,
         name: a.name,
         account_type: a.account_type,
         current_balance: a.current_balance,
-        currency_code: a.currency_code,
+        currency_code: a.currency_code as CurrencyCode,
         updated_at: a.updated_at,
       }))
     : [];
 
-  const currencyAccounts = dashboardAccounts.filter((a) => a.currency_code === baseCurrency);
-  const liquidAccounts = currencyAccounts.filter(
-    (account) => account.account_type !== "CREDIT_CARD" && account.account_type !== "LOAN"
+  const otherCurrencies = [...new Set(
+    dashboardAccounts.map((a) => a.currency_code).filter((c) => c !== baseCurrency)
+  )] as CurrencyCode[];
+  const rates = otherCurrencies.length > 0
+    ? await getRatesForCurrencies(otherCurrencies, baseCurrency)
+    : new Map<CurrencyCode, number>();
+  const toBase = (amount: number, currency: CurrencyCode) => {
+    if (currency === baseCurrency) return amount;
+    const rate = rates.get(currency);
+    return rate ? amount * rate : 0; // skip if no rate — never mix raw foreign amounts
+  };
+
+  // Filter out accounts with unconvertible currencies
+  const convertible = (a: { currency_code: CurrencyCode }) =>
+    a.currency_code === baseCurrency || rates.has(a.currency_code);
+
+  const liquidAccounts = dashboardAccounts.filter(
+    (account) => account.account_type !== "CREDIT_CARD" && account.account_type !== "LOAN" && convertible(account)
   );
-  const creditCardAccounts = currencyAccounts.filter(
-    (account) => account.account_type === "CREDIT_CARD"
+  const creditCardAccounts = dashboardAccounts.filter(
+    (account) => account.account_type === "CREDIT_CARD" && convertible(account)
   );
   const trackedFreshnessAccounts = [...liquidAccounts, ...creditCardAccounts];
-  const hasOtherCurrencies = dashboardAccounts.some((a) => a.currency_code !== baseCurrency);
+  const hasOtherCurrencies = otherCurrencies.length > 0;
+  const includesConvertedAmounts = hasOtherCurrencies && rates.size > 0;
+  const hasUnconvertibleCurrencies = hasOtherCurrencies && rates.size < otherCurrencies.length;
   const totalLiquid = liquidAccounts.reduce(
-    (sum, account) => sum + (account.current_balance ?? 0),
+    (sum, account) => sum + toBase(account.current_balance ?? 0, account.currency_code),
     0
   );
 
@@ -801,9 +839,9 @@ export async function getDashboardHeroData(
     windowEndDate = `${yearStr}-${monthStr}-${String(daysInMonth).padStart(2, "0")}`;
   }
 
-  // Filter cached occurrences to pay-cycle window + base currency
+  // Filter cached occurrences to pay-cycle window (all currencies, converted to base)
   const windowOccurrences = pendingOccurrences.filter(
-    (o) => o.occurrence_date >= colombiaToday && o.occurrence_date <= windowEndDate && o.currency_code === baseCurrency
+    (o) => o.occurrence_date >= colombiaToday && o.occurrence_date <= windowEndDate
   );
 
   const recurringObligations: PendingObligation[] = windowOccurrences
@@ -811,19 +849,21 @@ export async function getDashboardHeroData(
     .map((o) => ({
       id: o.id,
       name: o.merchant_name ?? o.description ?? "Recurrente",
-      amount: o.expected_amount,
+      amount: toBase(o.expected_amount, o.currency_code as CurrencyCode),
       currency_code: o.currency_code,
       due_date: o.occurrence_date,
     }));
 
   const windowObligationsTotal = windowOccurrences
     .filter((o) => o.direction === "OUTFLOW" && o.account_type !== "CREDIT_CARD")
-    .reduce((sum, o) => sum + o.expected_amount, 0);
+    .reduce((sum, o) => sum + toBase(o.expected_amount, o.currency_code as CurrencyCode), 0);
 
   // 4. Pending INFLOW occurrences within window (expected income, NOT added to availableToSpend)
   const pendingInflowOccurrences = windowOccurrences
     .filter((o) => o.direction === "INFLOW" && o.account_type !== "CREDIT_CARD" && o.account_type !== "LOAN");
-  const pendingIncome = pendingInflowOccurrences.reduce((sum, o) => sum + o.expected_amount, 0);
+  const pendingIncome = pendingInflowOccurrences.reduce(
+    (sum, o) => sum + toBase(o.expected_amount, o.currency_code as CurrencyCode), 0
+  );
   const pendingIncomeCount = pendingInflowOccurrences.length;
 
   // 5. Sort by due date
@@ -845,6 +885,8 @@ export async function getDashboardHeroData(
     oldestUpdate,
     currency: baseCurrency,
     hasOtherCurrencies,
+    includesConvertedAmounts,
+    hasUnconvertibleCurrencies,
     nextIncomeDate: nextIncome?.date ?? null,
     nextIncomeAmount: nextIncome?.amount ?? 0,
     nextIncomeName: nextIncome?.name ?? null,

--- a/webapp/src/actions/charts.ts
+++ b/webapp/src/actions/charts.ts
@@ -639,7 +639,7 @@ export async function getNetWorthHistory(month?: string, currency?: CurrencyCode
 
   const totalAssets = accounts
     .filter((a) => a.account_type !== "CREDIT_CARD" && a.account_type !== "LOAN" && nwConvertible(a))
-    .reduce((sum, a) => sum + toBase(a.current_balance, a.currency_code as CurrencyCode), 0);
+    .reduce((sum, a) => sum + toBase(a.current_balance ?? 0, a.currency_code as CurrencyCode), 0);
 
   const totalLiabilities = accounts
     .filter((a) => (a.account_type === "CREDIT_CARD" || a.account_type === "LOAN") && nwConvertible(a))
@@ -785,9 +785,10 @@ export async function getDashboardHeroData(
       }))
     : [];
 
-  const otherCurrencies = [...new Set(
-    dashboardAccounts.map((a) => a.currency_code).filter((c) => c !== baseCurrency)
-  )] as CurrencyCode[];
+  const otherCurrencies = [...new Set([
+    ...dashboardAccounts.map((a) => a.currency_code),
+    ...(pendingOccurrences ?? []).map((o) => o.currency_code as CurrencyCode),
+  ].filter((c) => c !== baseCurrency))] as CurrencyCode[];
   const rates = otherCurrencies.length > 0
     ? await getRatesForCurrencies(otherCurrencies, baseCurrency)
     : new Map<CurrencyCode, number>();
@@ -839,9 +840,10 @@ export async function getDashboardHeroData(
     windowEndDate = `${yearStr}-${monthStr}-${String(daysInMonth).padStart(2, "0")}`;
   }
 
-  // Filter cached occurrences to pay-cycle window (all currencies, converted to base)
+  // Filter cached occurrences to pay-cycle window (convertible currencies only)
   const windowOccurrences = pendingOccurrences.filter(
     (o) => o.occurrence_date >= colombiaToday && o.occurrence_date <= windowEndDate
+      && (o.currency_code === baseCurrency || rates.has(o.currency_code as CurrencyCode))
   );
 
   const recurringObligations: PendingObligation[] = windowOccurrences

--- a/webapp/src/actions/exchange-rate.ts
+++ b/webapp/src/actions/exchange-rate.ts
@@ -74,6 +74,31 @@ export async function getExchangeRate(
   }
 }
 
+/**
+ * Fetch exchange rates for multiple currencies → base in parallel.
+ * Returns a map: map.get("USD") = how many baseCurrency units per 1 USD.
+ * Missing or failed rates are omitted from the map.
+ */
+export async function getRatesForCurrencies(
+  currencies: CurrencyCode[],
+  baseCurrency: CurrencyCode
+): Promise<Map<CurrencyCode, number>> {
+  const unique = [...new Set(currencies.filter((c) => c !== baseCurrency))];
+  const rates = new Map<CurrencyCode, number>();
+
+  if (unique.length === 0) return rates;
+
+  const results = await Promise.all(
+    unique.map((c) => getExchangeRate(c, baseCurrency).then((r) => [c, r] as const))
+  );
+
+  for (const [currency, result] of results) {
+    if (result?.rate) rates.set(currency, result.rate);
+  }
+
+  return rates;
+}
+
 function formatCached(cached: ExchangeRateCacheRow, pair: string): ExchangeRateResult {
   const rate = Number(cached.rate);
   const avg30d = cached.avg_30d ? Number(cached.avg_30d) : null;

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -135,6 +135,7 @@ async function getTagsForEntityCached(
   "use cache";
   cacheTag("tags");
   cacheTag("transactions");
+  cacheTag("destinatarios");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
@@ -479,17 +480,20 @@ export async function bulkTagTransactions(
     .single();
   if (!tag) return { success: false, error: "Etiqueta no encontrada" };
 
+  // Deduplicate to avoid false count mismatch
+  const uniqueIds = [...new Set(transactionIds)];
+
   // Defense-in-depth: verify all transactions belong to user
   const { count } = await supabase
     .from("transactions")
     .select("id", { count: "exact", head: true })
     .eq("user_id", user.id)
-    .in("id", transactionIds);
-  if (count !== transactionIds.length) {
+    .in("id", uniqueIds);
+  if (count !== uniqueIds.length) {
     return { success: false, error: "Transacciones no encontradas" };
   }
 
-  const rows = transactionIds.map((id) => ({ transaction_id: id, tag_id: tagId }));
+  const rows = uniqueIds.map((id) => ({ transaction_id: id, tag_id: tagId }));
 
   const { error } = await supabase
     .from("transaction_tags")
@@ -500,5 +504,5 @@ export async function bulkTagTransactions(
   revalidateTag("tags", "zeta");
   revalidateTag("categorize", "zeta");
   revalidateTag("transactions", "zeta");
-  return { success: true, data: { tagged: transactionIds.length } };
+  return { success: true, data: { tagged: uniqueIds.length } };
 }

--- a/webapp/src/components/dashboard/dashboard-hero.tsx
+++ b/webapp/src/components/dashboard/dashboard-hero.tsx
@@ -25,7 +25,7 @@ interface DashboardHeroProps {
 }
 
 export function DashboardHero({ data, allocationData, debtFreeBanner }: DashboardHeroProps) {
-  const { totalLiquid, totalPending, availableToSpend, pendingIncome, pendingIncomeCount, freshness, pendingObligations, currency, hasOtherCurrencies, nextIncomeDate, nextIncomeAmount, nextIncomeName, incomeConfigured } = data;
+  const { totalLiquid, totalPending, availableToSpend, pendingIncome, pendingIncomeCount, freshness, pendingObligations, currency, includesConvertedAmounts, hasUnconvertibleCurrencies, nextIncomeDate, nextIncomeAmount, nextIncomeName, incomeConfigured } = data;
   const f = freshnessMap[freshness];
   const code = currency as CurrencyCode;
   const hasPendingObligations = pendingObligations.length > 0;
@@ -99,9 +99,14 @@ export function DashboardHero({ data, allocationData, debtFreeBanner }: Dashboar
             <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
               {guidanceCopy}
             </p>
-            {hasOtherCurrencies && (
-              <p className="text-xs text-muted-foreground">
-                Tienes cuentas en otras monedas no incluidas en estos totales.
+            {includesConvertedAmounts && (
+              <p className="text-xs text-z-sage-dark">
+                Incluye montos convertidos de otras monedas (tasa del día).
+              </p>
+            )}
+            {hasUnconvertibleCurrencies && (
+              <p className="text-xs text-z-alert">
+                Algunas cuentas en monedas sin tasa disponible no se incluyen.
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Dashboard hero, burn rate, runway, and net worth now aggregate **all currencies** by converting to base via `getRatesForCurrencies()` (parallel batch fetching from exchange rate cache)
- Accounts/obligations with unavailable rates are **excluded** (never mixed raw — avoids $100 USD showing as 100 COP)
- UI shows "tasa del día" hint when conversions are present, warning when rates unavailable
- Addresses PR #136 Gemini review: deduplicate IDs in `bulkTagTransactions`, add `cacheTag("destinatarios")`

### Architecture decisions
- Rate fetching hoisted **outside** `"use cache"` boundary in `getBurnRateCached` (rates passed as serialized param) — no side effects in cached functions
- Transaction-level charts (category spending, daily spending, cashflow) stay single-currency filtered — mixing currencies in spending charts is meaningless without per-transaction historical rates
- `getNextIncomeOccurrenceCached` stays base-currency-filtered — foreign income doesn't determine when COP obligations are due

### Known limitations
- Net worth history: foreign portion floats as constant through historical months (cashflow is single-currency)
- Burn rate: `dailyAverage` is base-currency spending while balance is multi-currency (overestimates runway for cross-currency spenders). Documented with TODO.

## Test plan
- [ ] User with only COP accounts: no change in behavior, no conversion hints shown
- [ ] User with COP + USD accounts: hero shows converted total, "tasa del día" hint visible
- [ ] User with COP + exotic currency (no cached rate): account excluded, warning shown
- [ ] Burn rate chart: liquid balance includes all currencies, spending line stays COP
- [ ] Net worth chart: includes all account balances converted to base

🤖 Generated with [Claude Code](https://claude.com/claude-code)