### PR TITLE
feat: mobile recurring admin + import auto-tagging + debt label fix

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,10 +35,8 @@
 - **Found:** Visual testing, 2026-04-13
 
 ### Mobile recurring admin actions
-- **Priority:** Medium
-- **What:** Add pause/delete/edit actions for recurring templates on mobile. Currently mobile view (`MobileRecurrentesView`) only supports pay/skip — no way to manage templates without switching to desktop.
-- **Options:** Long-press action sheet on each item, or a "manage" link navigating to a detail view with admin actions.
-- **Found:** Visual testing, 2026-04-13
+- **Priority:** Done (this branch)
+- **What:** MoreVertical (⋮) button on each occurrence row opens bottom Sheet with Edit, Pause/Activate, Delete. Reuses RecurringFormDialog and RecurringImpactDialog from desktop.
 
 
 ### Income-aware runway & daily budget
@@ -52,9 +50,9 @@
 - **Known limitation:** Net worth history steps backward using single-currency cashflow, so the foreign portion floats as a constant — acceptable approximation for now.
 
 ### Tag system broader reach
-- **Priority:** Medium
-- **What:** Tags during destinatario rule imports, nómina variants
-- **Context:** Tags exist but are only usable from transaction detail and categorization inbox. Should be available during import flow and when creating recurring templates.
+- **Priority:** Partial (this branch)
+- **What:** Auto-tag from destinatario during import — transactions inherit their matched destinatario's tags. Reconciliation merges also preserve existing tags. Batched for performance.
+- **Remaining:** Tags on recurring templates (needs `recurring_template_tags` migration + form changes + occurrence-to-tx tag copy). Nómina tag variants.
 
 ### Categorization view enhancements
 - **Priority:** Medium

--- a/webapp/src/actions/burn-rate.ts
+++ b/webapp/src/actions/burn-rate.ts
@@ -9,6 +9,7 @@ import type { CurrencyCode } from "@/types/domain";
 import { getNextIncomeOccurrenceCached, getPendingOccurrencesCached } from "@/actions/occurrences";
 import { getRatesForCurrencies } from "@/actions/exchange-rate";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 
 export interface BurnRateDataPoint {
   date: string;       // "YYYY-MM-DD"
@@ -115,7 +116,7 @@ async function getBurnRateCached(
   // Debt INFLOW (payment into loan/credit card) is an effective outflow for the user
   const isEffectiveOutflow = (o: { direction: string; account_type: string }) =>
     o.direction === "OUTFLOW" ||
-    (o.direction === "INFLOW" && (o.account_type === "CREDIT_CARD" || o.account_type === "LOAN"));
+    (o.direction === "INFLOW" && isDebtAccountType(o.account_type));
 
   const obligationMarkers: ObligationMarker[] = (pendingOccurrences ?? [])
     .filter((o) => isEffectiveOutflow(o) && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate

--- a/webapp/src/actions/burn-rate.ts
+++ b/webapp/src/actions/burn-rate.ts
@@ -112,8 +112,13 @@ async function getBurnRateCached(
     return rate ? amount * rate : 0; // skip if no rate
   };
 
+  // Debt INFLOW (payment into loan/credit card) is an effective outflow for the user
+  const isEffectiveOutflow = (o: { direction: string; account_type: string }) =>
+    o.direction === "OUTFLOW" ||
+    (o.direction === "INFLOW" && (o.account_type === "CREDIT_CARD" || o.account_type === "LOAN"));
+
   const obligationMarkers: ObligationMarker[] = (pendingOccurrences ?? [])
-    .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
+    .filter((o) => isEffectiveOutflow(o) && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
       && (o.currency_code === baseCurrency || rates.has(o.currency_code as CurrencyCode)))
     .map((o) => ({
       date: o.occurrence_date,
@@ -122,8 +127,9 @@ async function getBurnRateCached(
     }));
 
   // Compute disponible using window-scoped pending occurrences (convertible currencies only)
+  // Exclude credit card obligations from disponible (they don't reduce liquid balance)
   const windowOutflows = (pendingOccurrences ?? [])
-    .filter((o) => o.direction === "OUTFLOW" && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
+    .filter((o) => isEffectiveOutflow(o) && o.occurrence_date >= todayStr && o.occurrence_date <= windowEndDate
       && o.account_type !== "CREDIT_CARD"
       && (o.currency_code === baseCurrency || rates.has(o.currency_code as CurrencyCode)));
   const totalPending = windowOutflows.reduce((sum, o) => sum + toBase(o.expected_amount, o.currency_code), 0);

--- a/webapp/src/actions/charts.ts
+++ b/webapp/src/actions/charts.ts
@@ -846,8 +846,13 @@ export async function getDashboardHeroData(
       && (o.currency_code === baseCurrency || rates.has(o.currency_code as CurrencyCode))
   );
 
+  // Debt INFLOW (payment into loan/credit card) is an effective outflow for the user
+  const isEffectiveOutflow = (o: { direction: string; account_type: string }) =>
+    o.direction === "OUTFLOW" ||
+    (o.direction === "INFLOW" && (o.account_type === "CREDIT_CARD" || o.account_type === "LOAN"));
+
   const recurringObligations: PendingObligation[] = windowOccurrences
-    .filter((o) => o.direction === "OUTFLOW")
+    .filter((o) => isEffectiveOutflow(o))
     .map((o) => ({
       id: o.id,
       name: o.merchant_name ?? o.description ?? "Recurrente",
@@ -856,8 +861,9 @@ export async function getDashboardHeroData(
       due_date: o.occurrence_date,
     }));
 
+  // Exclude credit card obligations from disponible (they don't reduce liquid balance)
   const windowObligationsTotal = windowOccurrences
-    .filter((o) => o.direction === "OUTFLOW" && o.account_type !== "CREDIT_CARD")
+    .filter((o) => isEffectiveOutflow(o) && o.account_type !== "CREDIT_CARD")
     .reduce((sum, o) => sum + toBase(o.expected_amount, o.currency_code as CurrencyCode), 0);
 
   // 4. Pending INFLOW occurrences within window (expected income, NOT added to availableToSpend)

--- a/webapp/src/actions/charts.ts
+++ b/webapp/src/actions/charts.ts
@@ -8,6 +8,7 @@ import { toColombiaDateString, getColombiaDayOfMonth } from "@/lib/utils/date";
 import { getAccounts } from "@/actions/accounts";
 import { getPendingOccurrencesCached, getNextIncomeOccurrenceCached } from "@/actions/occurrences";
 import { getRatesForCurrencies } from "@/actions/exchange-rate";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 import { getFreshnessLevel } from "@/lib/utils/dashboard";
 import { getIsDemoFilter, getDemoAccountIds } from "@/lib/demo-filter";
@@ -849,7 +850,7 @@ export async function getDashboardHeroData(
   // Debt INFLOW (payment into loan/credit card) is an effective outflow for the user
   const isEffectiveOutflow = (o: { direction: string; account_type: string }) =>
     o.direction === "OUTFLOW" ||
-    (o.direction === "INFLOW" && (o.account_type === "CREDIT_CARD" || o.account_type === "LOAN"));
+    (o.direction === "INFLOW" && isDebtAccountType(o.account_type));
 
   const recurringObligations: PendingObligation[] = windowOccurrences
     .filter((o) => isEffectiveOutflow(o))

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -820,6 +820,23 @@ export async function importTransactions(
     }
   }
 
+  // Pre-fetch tags for reconciliation candidates (avoid N+1 inside loop)
+  const candidateIds = reconciliationDecisions
+    .filter((d) => d.decision !== "KEEP_BOTH")
+    .map((d) => d.candidateTransactionId);
+  const existingTagMap = new Map<string, string[]>();
+  if (candidateIds.length > 0) {
+    const { data: candidateTags } = await supabase
+      .from("transaction_tags")
+      .select("transaction_id, tag_id")
+      .in("transaction_id", candidateIds);
+    for (const ct of candidateTags ?? []) {
+      const existing = existingTagMap.get(ct.transaction_id) ?? [];
+      existing.push(ct.tag_id);
+      existingTagMap.set(ct.transaction_id, existing);
+    }
+  }
+
   let imported = 0;
   let skipped = 0;
   let errors = 0;
@@ -954,14 +971,11 @@ export async function importTransactions(
       .eq("user_id", user.id)
       .eq("id", existingTx.id);
 
-    // Accumulate existing transaction's tags for the surviving (imported) transaction
-    const { data: existingTags } = await supabase
-      .from("transaction_tags")
-      .select("tag_id")
-      .eq("transaction_id", existingTx.id);
+    // Copy existing transaction's tags to surviving (imported) transaction (pre-fetched)
+    const existingTags = existingTagMap.get(existingTx.id);
     if (existingTags) {
-      for (const t of existingTags) {
-        pendingTagInserts.push({ transaction_id: insertedTx.id, tag_id: t.tag_id });
+      for (const tag_id of existingTags) {
+        pendingTagInserts.push({ transaction_id: insertedTx.id, tag_id });
       }
     }
 

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -803,6 +803,23 @@ export async function importTransactions(
     ])
   );
 
+  // Pre-fetch destinatario → tag mappings to auto-tag imported transactions
+  const destIds = [...new Set(
+    transactions.filter((tx) => tx.destinatario_id).map((tx) => tx.destinatario_id!)
+  )];
+  const destTagMap = new Map<string, string[]>();
+  if (destIds.length > 0) {
+    const { data: destTags } = await supabase
+      .from("destinatario_tags")
+      .select("destinatario_id, tag_id")
+      .in("destinatario_id", destIds);
+    for (const dt of destTags ?? []) {
+      const existing = destTagMap.get(dt.destinatario_id) ?? [];
+      existing.push(dt.tag_id);
+      destTagMap.set(dt.destinatario_id, existing);
+    }
+  }
+
   let imported = 0;
   let skipped = 0;
   let errors = 0;
@@ -811,6 +828,7 @@ export async function importTransactions(
   let leftAsSeparate = 0;
   const details: string[] = [];
   const balanceDeltaTxs: TransactionToImport[] = [];
+  const pendingTagInserts: { transaction_id: string; tag_id: string }[] = [];
 
   for (const [txIndex, tx] of transactions.entries()) {
     // Use original_amount (full purchase price) for idempotency when available,
@@ -864,6 +882,14 @@ export async function importTransactions(
     }
 
     imported++;
+
+    // Accumulate auto-tags from destinatario (batched after loop)
+    const tagIds = tx.destinatario_id ? destTagMap.get(tx.destinatario_id) : undefined;
+    if (tagIds) {
+      for (const tag_id of tagIds) {
+        pendingTagInserts.push({ transaction_id: insertedTx.id, tag_id });
+      }
+    }
 
     await linkTransactionToOccurrence(
       tx.account_id, tx.transaction_date,
@@ -927,6 +953,17 @@ export async function importTransactions(
       })
       .eq("user_id", user.id)
       .eq("id", existingTx.id);
+
+    // Accumulate existing transaction's tags for the surviving (imported) transaction
+    const { data: existingTags } = await supabase
+      .from("transaction_tags")
+      .select("tag_id")
+      .eq("transaction_id", existingTx.id);
+    if (existingTags) {
+      for (const t of existingTags) {
+        pendingTagInserts.push({ transaction_id: insertedTx.id, tag_id: t.tag_id });
+      }
+    }
 
     if (decision.decision === "AUTO_MERGE") autoMerged++;
     else manualMerged++;
@@ -1053,9 +1090,17 @@ export async function importTransactions(
     }
   }
 
+  // Batch-insert all accumulated transaction tags
+  if (pendingTagInserts.length > 0) {
+    await supabase
+      .from("transaction_tags")
+      .upsert(pendingTagInserts, { onConflict: "transaction_id,tag_id", ignoreDuplicates: true });
+  }
+
   revalidateFinancialViews();
   revalidateTag("snapshots", "zeta");
   revalidateTag("impact", "zeta");
+  revalidateTag("tags", "zeta");
 
   await trackProductEvent({
     event_name: "import_completed",

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -1106,9 +1106,13 @@ export async function importTransactions(
 
   // Batch-insert all accumulated transaction tags
   if (pendingTagInserts.length > 0) {
-    await supabase
+    const { error: tagError } = await supabase
       .from("transaction_tags")
       .upsert(pendingTagInserts, { onConflict: "transaction_id,tag_id", ignoreDuplicates: true });
+    if (tagError) {
+      console.error("Failed to auto-tag imported transactions:", tagError.message);
+      details.push(`Auto-etiquetado parcial: ${tagError.message}`);
+    }
   }
 
   revalidateFinancialViews();

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -328,16 +328,20 @@ function TemplateActionSheet({
     });
   };
 
-  const handlePauseConfirm = async () => {
+  const handlePauseConfirm = () => {
     if (!template) return;
-    await toggleRecurringTemplate(template.id, false);
-    onClose();
+    startTransition(async () => {
+      await toggleRecurringTemplate(template.id, false);
+      onClose();
+    });
   };
 
-  const handleDeleteConfirm = async () => {
+  const handleDeleteConfirm = () => {
     if (!template) return;
-    await deleteRecurringTemplate(template.id);
-    onClose();
+    startTransition(async () => {
+      await deleteRecurringTemplate(template.id);
+      onClose();
+    });
   };
 
   return (
@@ -357,7 +361,8 @@ function TemplateActionSheet({
               trigger={
                 <button
                   type="button"
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5"
+                  disabled={isPending}
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5 disabled:opacity-50"
                 >
                   <Pencil className="size-4 text-muted-foreground" />
                   <span className="text-sm">Editar</span>
@@ -406,7 +411,8 @@ function TemplateActionSheet({
               trigger={
                 <button
                   type="button"
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left text-z-debt active:bg-white/5"
+                  disabled={isPending}
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left text-z-debt active:bg-white/5 disabled:opacity-50"
                 >
                   <Trash2 className="size-4" />
                   <span className="text-sm">Eliminar</span>

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { Check, ChevronLeft, ChevronRight, Tag } from "lucide-react";
+import { useState, useMemo, useTransition } from "react";
+import { Check, ChevronLeft, ChevronRight, MoreVertical, Pause, Pencil, Play, Tag, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
-import { PANEL_INSET_CLASS, HERO_CARD_GRADIENT_CLASS } from "@/lib/constants/styles";
+import { PANEL_INSET_CLASS, HERO_CARD_GRADIENT_CLASS, MOBILE_ACTION_BUTTON_CLASS, MOBILE_EYEBROW_CLASS } from "@/lib/constants/styles";
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
 import { RecurringConfirmInline } from "@/components/recurring/recurring-confirm-inline";
-import type { CurrencyCode, RecurringTemplateWithRelations, Account } from "@/types/domain";
+import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
+import { RecurringImpactDialog } from "@/components/recurring/recurring-impact-dialog";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { useCategories } from "@/components/providers/app-data-provider";
+import {
+  deleteRecurringTemplate,
+  toggleRecurringTemplate,
+} from "@/actions/recurring-templates";
+import type { CategoryWithChildren, CurrencyCode, RecurringTemplateWithRelations, Account } from "@/types/domain";
 
 /* ------------------------------------------------------------------ */
 /*  Props                                                              */
@@ -59,6 +67,13 @@ export function MobileRecurrentesView({
 }: MobileRecurrentesViewProps) {
   const hook = useRecurringMonth(templates, accounts);
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [actionItem, setActionItem] = useState<OccurrenceItem | null>(null);
+  const categories = useCategories();
+
+  const templateMap = useMemo(
+    () => new Map(templates.map((t) => [t.id, t])),
+    [templates]
+  );
 
   const sourceAccounts = useMemo(
     () => accounts
@@ -91,7 +106,7 @@ export function MobileRecurrentesView({
           <button
             type="button"
             onClick={hook.goPrevMonth}
-            className="flex size-7 items-center justify-center rounded-full border border-white/10 text-muted-foreground active:bg-white/5"
+            className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5"
           >
             <ChevronLeft className="size-3.5" />
           </button>
@@ -101,7 +116,7 @@ export function MobileRecurrentesView({
           <button
             type="button"
             onClick={hook.goNextMonth}
-            className="flex size-7 items-center justify-center rounded-full border border-white/10 text-muted-foreground active:bg-white/5"
+            className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5"
           >
             <ChevronRight className="size-3.5" />
           </button>
@@ -110,13 +125,13 @@ export function MobileRecurrentesView({
         {/* Summary chips */}
         <div className="mt-3 flex gap-3 text-center">
           <div className="flex-1">
-            <p className="text-[10px] text-amber-400">Pendientes</p>
-            <p className="text-lg font-semibold text-amber-400">{hook.pending.length}</p>
+            <p className="text-[10px] text-z-alert">Pendientes</p>
+            <p className="text-lg font-semibold text-z-alert">{hook.pending.length}</p>
           </div>
           <div className="h-8 w-px bg-white/6 self-center" />
           <div className="flex-1">
-            <p className="text-[10px] text-emerald-400">Completados</p>
-            <p className="text-lg font-semibold text-emerald-400">{hook.completed.length}</p>
+            <p className="text-[10px] text-z-income">Completados</p>
+            <p className="text-lg font-semibold text-z-income">{hook.completed.length}</p>
           </div>
         </div>
       </div>
@@ -131,7 +146,7 @@ export function MobileRecurrentesView({
       {/* Pending payments grouped by date */}
       {hook.isHydrated && sortedDates.length > 0 && (
         <div className="space-y-2">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          <p className={MOBILE_EYEBROW_CLASS}>
             Pendientes
           </p>
           {sortedDates.map((date) => {
@@ -159,41 +174,62 @@ export function MobileRecurrentesView({
 
                     return (
                       <div key={item.key}>
-                        {/* Payment row */}
-                        <button
-                          type="button"
-                          onClick={() => setExpandedKey(isExpanded ? null : item.key)}
+                        {/* Payment row — split into tap area + action button */}
+                        <div
                           className={cn(
-                            "flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors active:bg-white/[0.03]",
+                            "flex w-full items-center gap-2.5 px-3 py-2.5",
                             isBusy && "opacity-50 pointer-events-none"
                           )}
                         >
-                          {/* Category dot */}
-                          <span
-                            className="flex size-7 shrink-0 items-center justify-center rounded-lg"
-                            style={{ backgroundColor: item.categoryColor + "20" }}
+                          {/* Tap area for expand/collapse */}
+                          <button
+                            type="button"
+                            onClick={() => setExpandedKey(isExpanded ? null : item.key)}
+                            className="flex flex-1 items-center gap-2.5 text-left transition-colors active:bg-white/[0.03]"
                           >
-                            <Tag className="size-3" style={{ color: item.categoryColor }} />
-                          </span>
+                            {/* Category dot */}
+                            <span
+                              className="flex size-7 shrink-0 items-center justify-center rounded-lg"
+                              style={{ backgroundColor: item.categoryColor + "20" }}
+                            >
+                              <Tag className="size-3" style={{ color: item.categoryColor }} />
+                            </span>
 
-                          {/* Merchant + account */}
-                          <div className="min-w-0 flex-1">
-                            <p className="truncate text-xs font-medium">{item.merchant}</p>
-                            <p className="text-[10px] text-muted-foreground">
-                              {item.accountName}
-                            </p>
-                          </div>
+                            {/* Merchant + account */}
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate text-xs font-medium">{item.merchant}</p>
+                              <p className="text-[10px] text-muted-foreground">
+                                {item.accountName}
+                              </p>
+                            </div>
 
-                          {/* Amount */}
-                          <span className="shrink-0 text-xs font-semibold tabular-nums">
-                            {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
-                          </span>
+                            {/* Amount */}
+                            <span className="shrink-0 text-xs font-semibold tabular-nums">
+                              {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
+                            </span>
+                          </button>
 
                           {/* Action hint */}
-                          <span className="shrink-0 rounded-md bg-z-brass/10 px-2 py-0.5 text-[10px] text-z-brass">
+                          <button
+                            type="button"
+                            onClick={() => setExpandedKey(isExpanded ? null : item.key)}
+                            className={cn("shrink-0", MOBILE_ACTION_BUTTON_CLASS)}
+                          >
                             {isExpanded ? "Cerrar" : "Pagar"}
-                          </span>
-                        </button>
+                          </button>
+
+                          {/* Admin actions */}
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setActionItem(item);
+                            }}
+                            className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground active:bg-white/10"
+                          >
+                            <MoreVertical className="size-3.5" />
+                          </button>
+                        </div>
 
                         {/* Inline confirm panel */}
                         {isExpanded && (
@@ -238,8 +274,8 @@ export function MobileRecurrentesView({
       {/* No pending state */}
       {hook.isHydrated && sortedDates.length === 0 && hook.completed.length > 0 && (
         <div className={cn(PANEL_INSET_CLASS, "py-6 text-center")}>
-          <Check className="mx-auto size-6 text-emerald-400" />
-          <p className="mt-2 text-xs font-medium text-emerald-400">Todo al día</p>
+          <Check className="mx-auto size-6 text-z-income" />
+          <p className="mt-2 text-xs font-medium text-z-income">Todo al día</p>
           <p className="mt-0.5 text-[10px] text-muted-foreground">
             {hook.completed.length} pago{hook.completed.length !== 1 ? "s" : ""} completado{hook.completed.length !== 1 ? "s" : ""}
           </p>
@@ -250,7 +286,137 @@ export function MobileRecurrentesView({
       {hook.isHydrated && hook.completed.length > 0 && (
         <CompletedSection completed={hook.completed} />
       )}
+
+      {/* Admin action sheet */}
+      <TemplateActionSheet
+        item={actionItem}
+        template={actionItem ? templateMap.get(actionItem.templateId) ?? null : null}
+        accounts={accounts}
+        categories={categories}
+        onClose={() => setActionItem(null)}
+      />
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Template Action Sheet                                              */
+/* ------------------------------------------------------------------ */
+
+function TemplateActionSheet({
+  item,
+  template,
+  accounts,
+  categories,
+  onClose,
+}: {
+  item: OccurrenceItem | null;
+  template: RecurringTemplateWithRelations | null;
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  onClose: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const open = !!item && !!template;
+
+  const handleActivate = () => {
+    if (!template) return;
+    startTransition(async () => {
+      await toggleRecurringTemplate(template.id, true);
+      onClose();
+    });
+  };
+
+  const handlePauseConfirm = async () => {
+    if (!template) return;
+    await toggleRecurringTemplate(template.id, false);
+    onClose();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!template) return;
+    await deleteRecurringTemplate(template.id);
+    onClose();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      <SheetContent side="bottom" className="rounded-t-2xl pb-8">
+        <SheetHeader>
+          <SheetTitle className="text-left">{template?.merchant_name}</SheetTitle>
+        </SheetHeader>
+
+        {template && (
+          <div className="mt-4 space-y-1">
+            {/* Edit */}
+            <RecurringFormDialog
+              template={template ?? undefined}
+              accounts={accounts}
+              categories={categories}
+              trigger={
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5"
+                >
+                  <Pencil className="size-4 text-muted-foreground" />
+                  <span className="text-sm">Editar</span>
+                </button>
+              }
+            />
+
+            {/* Pause / Activate */}
+            {template.is_active ? (
+              <RecurringImpactDialog
+                templateId={template.id}
+                templateName={template.merchant_name ?? "Recurrente"}
+                currencyCode={(template.currency_code ?? "COP") as CurrencyCode}
+                action="pause"
+                onConfirm={handlePauseConfirm}
+                trigger={
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5"
+                    disabled={isPending}
+                  >
+                    <Pause className="size-4 text-muted-foreground" />
+                    <span className="text-sm">Pausar</span>
+                  </button>
+                }
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={handleActivate}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5"
+                disabled={isPending}
+              >
+                <Play className="size-4 text-muted-foreground" />
+                <span className="text-sm">{isPending ? "Activando..." : "Activar"}</span>
+              </button>
+            )}
+
+            {/* Delete */}
+            <RecurringImpactDialog
+              templateId={template.id}
+              templateName={template.merchant_name ?? "Recurrente"}
+              currencyCode={(template.currency_code ?? "COP") as CurrencyCode}
+              action="delete"
+              onConfirm={handleDeleteConfirm}
+              trigger={
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left text-z-debt active:bg-white/5"
+                >
+                  <Trash2 className="size-4" />
+                  <span className="text-sm">Eliminar</span>
+                </button>
+              }
+            />
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
   );
 }
 
@@ -279,7 +445,7 @@ function CompletedSection({
         <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
           {completed.map((item) => (
             <div key={item.key} className="flex items-center gap-2.5 px-3 py-2.5 opacity-60">
-              <Check className="size-4 shrink-0 text-emerald-400" />
+              <Check className="size-4 shrink-0 text-z-income" />
               <div className="min-w-0 flex-1">
                 <p className="truncate text-xs">{item.merchant}</p>
                 <p className="text-[10px] text-muted-foreground">{formatDate(item.date, "dd MMM")}</p>

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -294,6 +294,7 @@ export function MobileRecurrentesView({
         accounts={accounts}
         categories={categories}
         onClose={() => setActionItem(null)}
+        onMutate={hook.refreshOccurrences}
       />
     </div>
   );
@@ -309,12 +310,14 @@ function TemplateActionSheet({
   accounts,
   categories,
   onClose,
+  onMutate,
 }: {
   item: OccurrenceItem | null;
   template: RecurringTemplateWithRelations | null;
   accounts: Account[];
   categories: CategoryWithChildren[];
   onClose: () => void;
+  onMutate: () => Promise<void>;
 }) {
   const [isPending, startTransition] = useTransition();
 
@@ -324,6 +327,7 @@ function TemplateActionSheet({
     if (!template) return;
     startTransition(async () => {
       await toggleRecurringTemplate(template.id, true);
+      await onMutate();
       onClose();
     });
   };
@@ -332,6 +336,7 @@ function TemplateActionSheet({
     if (!template) return;
     startTransition(async () => {
       await toggleRecurringTemplate(template.id, false);
+      await onMutate();
       onClose();
     });
   };
@@ -340,6 +345,7 @@ function TemplateActionSheet({
     if (!template) return;
     startTransition(async () => {
       await deleteRecurringTemplate(template.id);
+      await onMutate();
       onClose();
     });
   };

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -86,7 +86,7 @@ export function PlanExpandableChips({
                   </p>
                   <p className={cn("text-[10px]", c.textMuted)}>{c.label}</p>
                   <p className="text-[9px] text-muted-foreground">
-                    {next.template.description} · {formatDate(new Date(next.next_date), "dd MMM")}
+                    {next.template.description} · {formatDate(next.next_date, "dd MMM")}
                   </p>
                 </>
               ) : (
@@ -116,7 +116,7 @@ export function PlanExpandableChips({
                     <div>
                       <p className="text-xs font-medium">{item.template.description}</p>
                       <p className="text-[10px] text-muted-foreground">
-                        {formatDate(new Date(item.next_date), "dd MMM yyyy")}
+                        {formatDate(item.next_date, "dd MMM yyyy")}
                         {item.template.account && ` · ${item.template.account.name}`}
                       </p>
                     </div>

--- a/webapp/src/components/recurring/recurring-confirm-inline.tsx
+++ b/webapp/src/components/recurring/recurring-confirm-inline.tsx
@@ -44,7 +44,7 @@ export function RecurringConfirmInline({
   isPending,
   sourceAccounts,
 }: RecurringConfirmInlineProps) {
-  const isIncome = item.direction === "INFLOW";
+  const isIncome = item.direction === "INFLOW" && !item.isDebtPayment;
   const [amount, setAmount] = useState<string>(String(item.plannedAmount));
   const [paymentDate, setPaymentDate] = useState<string>(
     format(new Date(), "yyyy-MM-dd")

--- a/webapp/src/components/recurring/recurring-payment-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-payment-timeline.tsx
@@ -189,7 +189,7 @@ export function PaymentTimeline({
 
                       {/* Confirm indicator */}
                       <span className="shrink-0 text-xs text-muted-foreground">
-                        {isExpanded ? "Cerrar" : item.direction === "INFLOW" ? "Confirmar ingreso ▸" : "Confirmar ▸"}
+                        {isExpanded ? "Cerrar" : (item.direction === "INFLOW" && !item.isDebtPayment) ? "Confirmar ingreso ▸" : "Confirmar ▸"}
                       </span>
                     </div>
 

--- a/webapp/src/components/recurring/upcoming-recurring-card.tsx
+++ b/webapp/src/components/recurring/upcoming-recurring-card.tsx
@@ -33,16 +33,20 @@ export function UpcomingRecurringCard({
           </p>
         ) : (
           <div className="space-y-3">
-            {upcoming.slice(0, 5).map((item, i) => (
+            {upcoming.slice(0, 5).map((item, i) => {
+              const acctType = item.template.account?.account_type;
+              const isDebtPayment = acctType === "CREDIT_CARD" || acctType === "LOAN";
+              const isIncome = item.template.direction === "INFLOW" && !isDebtPayment;
+              return (
               <div
                 key={`${item.template.id}-${item.next_date}-${i}`}
                 className="flex items-center justify-between"
               >
                 <div className="flex items-center gap-3">
-                  {item.template.direction === "INFLOW" ? (
-                    <ArrowDownLeft className="h-4 w-4 text-green-500" />
+                  {isIncome ? (
+                    <ArrowDownLeft className="h-4 w-4 text-z-income" />
                   ) : (
-                    <ArrowUpRight className="h-4 w-4 text-orange-500" />
+                    <ArrowUpRight className="h-4 w-4 text-z-expense" />
                   )}
                   <div>
                     <p className="text-sm font-medium">
@@ -56,17 +60,18 @@ export function UpcomingRecurringCard({
                 </div>
                 <span
                   className={`text-sm font-medium ${
-                    item.template.direction === "INFLOW" ? "text-green-600" : ""
+                    isIncome ? "text-z-income" : ""
                   }`}
                 >
-                  {item.template.direction === "INFLOW" ? "+" : "-"}
+                  {isIncome ? "+" : "-"}
                   {formatCurrency(
                     item.template.amount,
                     item.template.currency_code as CurrencyCode
                   )}
                 </span>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </CardContent>

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -137,6 +137,12 @@ export function useRecurringMonth(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monthKey]);
 
+  /* ---- Manual refresh (for admin actions that change template state) ---- */
+  const refreshOccurrences = useCallback(async () => {
+    const result = await getOccurrencesForMonth(monthKey);
+    if (result.success) setOccurrences(result.data);
+  }, [monthKey]);
+
   /* ---- pending / completed splits ---- */
   const pending = useMemo(
     () =>
@@ -338,5 +344,6 @@ export function useRecurringMonth(
     // Helpers
     getDateStatus,
     totalPlanned,
+    refreshOccurrences,
   };
 }


### PR DESCRIPTION
## Summary
- **Mobile recurring admin actions**: MoreVertical (⋮) button on each pending occurrence row opens bottom Sheet with Edit, Pause/Activate, Delete — reuses desktop's RecurringFormDialog and RecurringImpactDialog
- **Import auto-tagging**: Imported transactions inherit their matched destinatario's tags automatically. Batched for performance. Reconciliation merges preserve existing tags.
- **Debt payment label fix**: Loan/credit card payments no longer show income labels ("Confirmar ingreso" / "Ya recibí") — now correctly show "Confirmar pago" / "Ya pagué"

## Test plan
- [ ] Mobile `/recurrentes` — tap ⋮ on a pending occurrence → Sheet opens with Edit, Pause, Delete
- [ ] Edit opens RecurringFormDialog, Pause/Delete show RecurringImpactDialog
- [ ] Import PDF with destinatario matches → verify transactions get destinatario's tags
- [ ] Re-import same PDF → 23505 skip, no duplicate tags
- [ ] Loan/credit card recurring: confirm inline shows "Confirmar pago" / "Ya pagué"
- [ ] Income recurring: confirm inline still shows "Confirmar ingreso" / "Ya recibí"
- [ ] Upcoming recurring card: debt payments show expense icon/sign, not income

🤖 Generated with [Claude Code](https://claude.com/claude-code)