### PR TITLE
feat: undo completed occurrences + mobile recurring UI polish

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -29,6 +29,10 @@
 - **What:** Direction-aware labels: "Confirmar ingreso" / "Ya recibí" for INFLOW, "Confirmar pago" / "Ya pagué" for OUTFLOW. Covers confirm inline, timeline, toasts, and attention fallback labels.
 - **Remaining:** Skip/delete option for clearing occurrences without marking received — deferred.
 
+### Undo completed occurrences
+- **Priority:** Done (this branch)
+- **What:** Revert paid/skipped occurrences back to pending. For paid: deletes transactions via `recurrence_group_id`, reverses balance deltas. For skipped: resets status. "Deshacer" button on each completed item.
+
 ### Template active state — query-side filtering
 - **Priority:** Done (implemented in this branch)
 - **What:** Paused template occurrences are filtered at query time via `is_active` check in `getPendingOccurrencesCached` and `getNextIncomeOccurrenceCached`. No destructive status changes — occurrences stay `pending`, just invisible when template is paused. Reactivating brings them back automatically.
@@ -37,6 +41,12 @@
 ### Mobile recurring admin actions
 - **Priority:** Done (this branch)
 - **What:** MoreVertical (⋮) button on each occurrence row opens bottom Sheet with Edit, Pause/Activate, Delete. Reuses RecurringFormDialog and RecurringImpactDialog from desktop.
+- **Remaining:** Edit dialog opens behind the action sheet (nested Radix portal). Needs to close Sheet first, then open Dialog sequentially. Full recurring form also needs mobile redesign.
+
+### Recurring form mobile redesign
+- **Priority:** Medium
+- **What:** RecurringFormDialog was designed for desktop. On mobile it opens as a Dialog over the action Sheet, causing layering issues. Needs a mobile-native form — either a full-page drawer or a dedicated route.
+- **Found:** Visual testing, 2026-04-13
 
 
 ### Income-aware runway & daily budget

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,9 @@ Spawn these specialized agents for domain-specific review and diagnosis. Each ha
 - **No hardcoded styles**: Prefer existing utility patterns and component props from established components.
 - **Reuse existing components**: Check `webapp/src/components/ui/` (41 stories) before building new cards, badges, stat displays, or layout patterns.
 - **Button variants**: Only `BRASS_BUTTON_CLASS`, `GHOST_BUTTON_CLASS`, `BRASS_GHOST_BUTTON_CLASS` from `@/lib/constants/styles.ts`.
+- **Mobile bottom sheets/drawers**: Always add `MOBILE_TAB_BAR_CLEARANCE_CLASS` from `@/lib/constants/styles.ts` to `SheetContent` bottom padding. Without it, sheet content is hidden behind the tab bar.
+- **Date parsing**: Never use `new Date("YYYY-MM-DD")` — it parses as midnight UTC (wrong day in Colombia UTC-5). Pass ISO date strings directly to `formatDate()` (uses `parseISO`), or append `T12:00:00` if `Date` object is needed.
+- **Debt account direction**: INFLOW to CREDIT_CARD/LOAN accounts is a payment, not income. Use `isDebtAccountType()` from `@/lib/utils/account-balance` or `item.isDebtPayment` to distinguish. Never treat raw `direction === "INFLOW"` as income without checking account type.
 - Spawn `zetas-front-guy` after any TSX/CSS change. Spawn `frontend-auditor` for comprehensive reviews.
 
 ## Supabase

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -8,7 +8,7 @@ import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
-import { isDebtAccountType } from "@/lib/utils/account-balance";
+import { isDebtAccountType, reverseAccountBalanceDelta } from "@/lib/utils/account-balance";
 import {
   generateOccurrenceRowsBatch,
 } from "@/lib/utils/occurrence-generator";
@@ -389,6 +389,97 @@ export async function skipOccurrence(occurrenceId: string): Promise<ActionResult
 
   revalidateFinancialViews();
   revalidateTag("occurrences", "zeta");
+  return { success: true, data: undefined };
+}
+
+/**
+ * Revert a completed occurrence (paid or skipped) back to pending.
+ * For paid occurrences: deletes the created transaction(s) and reverses balance deltas.
+ * For skipped occurrences: simply resets status.
+ */
+export async function revertOccurrence(occurrenceId: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  // Fetch occurrence with its current state
+  const { data: occurrence, error: fetchError } = await supabase
+    .from("recurring_occurrences")
+    .select("id, status, transaction_id, template_id, occurrence_date")
+    .eq("id", occurrenceId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (fetchError || !occurrence) {
+    return { success: false, error: "Ocurrencia no encontrada" };
+  }
+
+  if (occurrence.status === "pending") {
+    return { success: false, error: "Esta ocurrencia ya está pendiente" };
+  }
+
+  // For paid occurrences: delete created transactions and reverse balances
+  if (occurrence.status === "paid" && occurrence.transaction_id) {
+    // Find all transactions in the same recurrence group (payment + transfer pair)
+    const { data: primaryTx } = await supabase
+      .from("transactions")
+      .select("recurrence_group_id")
+      .eq("id", occurrence.transaction_id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (primaryTx?.recurrence_group_id) {
+      // Get all transactions in the group to reverse balances
+      const { data: groupTxs } = await supabase
+        .from("transactions")
+        .select("id, amount, direction, account_id, accounts!account_id(account_type, current_balance)")
+        .eq("recurrence_group_id", primaryTx.recurrence_group_id)
+        .eq("user_id", user.id);
+
+      // Reverse balance deltas for each transaction
+      for (const tx of groupTxs ?? []) {
+        const account = tx.accounts as { account_type: string; current_balance: number } | null;
+        if (!account) continue;
+
+        const newBalance = reverseAccountBalanceDelta({
+          currentBalance: account.current_balance,
+          accountType: account.account_type,
+          direction: tx.direction as "INFLOW" | "OUTFLOW",
+          amount: tx.amount,
+        });
+
+        await supabase
+          .from("accounts")
+          .update({ current_balance: newBalance })
+          .eq("user_id", user.id)
+          .eq("id", tx.account_id);
+      }
+
+      // Delete all transactions in the recurrence group
+      await supabase
+        .from("transactions")
+        .delete()
+        .eq("recurrence_group_id", primaryTx.recurrence_group_id)
+        .eq("user_id", user.id);
+    }
+  }
+
+  // Reset occurrence to pending
+  const { error: updateError } = await supabase
+    .from("recurring_occurrences")
+    .update({
+      status: "pending" as const,
+      transaction_id: null,
+      paid_at: null,
+      skipped_at: null,
+    })
+    .eq("id", occurrenceId)
+    .eq("user_id", user.id);
+
+  if (updateError) return { success: false, error: updateError.message };
+
+  revalidateFinancialViews();
+  revalidateTag("occurrences", "zeta");
+  revalidateTag("recurring", "zeta");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -9,6 +9,7 @@ import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { isDebtAccountType, reverseAccountBalanceDelta } from "@/lib/utils/account-balance";
+import { UUID_RE } from "@/lib/validators/shared";
 import {
   generateOccurrenceRowsBatch,
 } from "@/lib/utils/occurrence-generator";
@@ -401,6 +402,10 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
 
+  if (!UUID_RE.test(occurrenceId)) {
+    return { success: false, error: "ID inválido" };
+  }
+
   // Fetch occurrence with its current state
   const { data: occurrence, error: fetchError } = await supabase
     .from("recurring_occurrences")
@@ -419,7 +424,7 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
 
   // For paid occurrences: delete created transactions and reverse balances
   if (occurrence.status === "paid" && occurrence.transaction_id) {
-    // Find all transactions in the same recurrence group (payment + transfer pair)
+    // Single query: get recurrence_group_id via FK join (avoids extra round trip)
     const { data: primaryTx } = await supabase
       .from("transactions")
       .select("recurrence_group_id")
@@ -428,38 +433,64 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
       .single();
 
     if (primaryTx?.recurrence_group_id) {
-      // Get all transactions in the group to reverse balances
+      // Get all transactions in the group
       const { data: groupTxs } = await supabase
         .from("transactions")
-        .select("id, amount, direction, account_id, accounts!account_id(account_type, current_balance)")
+        .select("id, amount, direction, account_id, accounts!transactions_account_id_fkey(account_type, current_balance)")
         .eq("recurrence_group_id", primaryTx.recurrence_group_id)
         .eq("user_id", user.id);
 
-      // Reverse balance deltas for each transaction
-      for (const tx of groupTxs ?? []) {
-        const account = tx.accounts as { account_type: string; current_balance: number } | null;
-        if (!account) continue;
+      const txIds = (groupTxs ?? []).map((tx) => tx.id);
 
-        const newBalance = reverseAccountBalanceDelta({
-          currentBalance: account.current_balance,
-          accountType: account.account_type,
-          direction: tx.direction as "INFLOW" | "OUTFLOW",
-          amount: tx.amount,
-        });
+      // Guard: block revert if any transaction was reconciled into by another
+      if (txIds.length > 0) {
+        const { count: reconciledRefs } = await supabase
+          .from("transactions")
+          .select("id", { count: "exact", head: true })
+          .in("reconciled_into_transaction_id", txIds)
+          .eq("user_id", user.id);
+        if (reconciledRefs && reconciledRefs > 0) {
+          return { success: false, error: "No se puede revertir: hay una transacción importada vinculada a este pago." };
+        }
+      }
 
-        await supabase
-          .from("accounts")
-          .update({ current_balance: newBalance })
-          .eq("user_id", user.id)
-          .eq("id", tx.account_id);
+      // Reverse balance deltas in parallel — safe because each tx in a
+      // recurrence group targets a different account (source ≠ destination)
+      const balanceResults = await Promise.all(
+        (groupTxs ?? []).map((tx) => {
+          const account = tx.accounts as { account_type: string; current_balance: number } | null;
+          if (!account) return Promise.resolve(null);
+
+          const newBalance = reverseAccountBalanceDelta({
+            currentBalance: account.current_balance,
+            accountType: account.account_type,
+            direction: tx.direction as "INFLOW" | "OUTFLOW",
+            amount: tx.amount,
+          });
+
+          return supabase
+            .from("accounts")
+            .update({ current_balance: newBalance })
+            .eq("user_id", user.id)
+            .eq("id", tx.account_id);
+        })
+      );
+
+      const balanceError = balanceResults.find((r) => r && "error" in r && r.error);
+      if (balanceError && "error" in balanceError && balanceError.error) {
+        return { success: false, error: `Error al revertir saldo: ${balanceError.error.message}` };
       }
 
       // Delete all transactions in the recurrence group
-      await supabase
+      const { error: deleteError } = await supabase
         .from("transactions")
         .delete()
         .eq("recurrence_group_id", primaryTx.recurrence_group_id)
         .eq("user_id", user.id);
+
+      if (deleteError) {
+        return { success: false, error: `Error al eliminar transacciones: ${deleteError.message}` };
+      }
     }
   }
 
@@ -467,7 +498,7 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
   const { error: updateError } = await supabase
     .from("recurring_occurrences")
     .update({
-      status: "pending" as const,
+      status: "pending",
       transaction_id: null,
       paid_at: null,
       skipped_at: null,

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -5,7 +5,7 @@ import { Check, ChevronLeft, ChevronRight, MoreVertical, Pause, Pencil, Play, Ta
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
-import { PANEL_INSET_CLASS, HERO_CARD_GRADIENT_CLASS, MOBILE_ACTION_BUTTON_CLASS, MOBILE_EYEBROW_CLASS } from "@/lib/constants/styles";
+import { PANEL_INSET_CLASS, HERO_CARD_GRADIENT_CLASS, MOBILE_ACTION_BUTTON_CLASS, MOBILE_EYEBROW_CLASS, MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
 import { RecurringConfirmInline } from "@/components/recurring/recurring-confirm-inline";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
@@ -16,6 +16,9 @@ import {
   deleteRecurringTemplate,
   toggleRecurringTemplate,
 } from "@/actions/recurring-templates";
+import { revertOccurrence } from "@/actions/occurrences";
+import { toast } from "sonner";
+import type { ActionResult } from "@/types/actions";
 import type { CategoryWithChildren, CurrencyCode, RecurringTemplateWithRelations, Account } from "@/types/domain";
 
 /* ------------------------------------------------------------------ */
@@ -174,10 +177,10 @@ export function MobileRecurrentesView({
 
                     return (
                       <div key={item.key}>
-                        {/* Payment row — split into tap area + action button */}
+                        {/* Payment row — tap to expand, ⋮ for admin */}
                         <div
                           className={cn(
-                            "flex w-full items-center gap-2.5 px-3 py-2.5",
+                            "flex w-full items-center gap-2 px-3 py-2.5",
                             isBusy && "opacity-50 pointer-events-none"
                           )}
                         >
@@ -185,11 +188,11 @@ export function MobileRecurrentesView({
                           <button
                             type="button"
                             onClick={() => setExpandedKey(isExpanded ? null : item.key)}
-                            className="flex flex-1 items-center gap-2.5 text-left transition-colors active:bg-white/[0.03]"
+                            className="flex min-w-0 flex-1 items-center gap-2 text-left active:bg-white/[0.03]"
                           >
                             {/* Category dot */}
                             <span
-                              className="flex size-7 shrink-0 items-center justify-center rounded-lg"
+                              className="flex size-6 shrink-0 items-center justify-center rounded-md"
                               style={{ backgroundColor: item.categoryColor + "20" }}
                             >
                               <Tag className="size-3" style={{ color: item.categoryColor }} />
@@ -198,16 +201,16 @@ export function MobileRecurrentesView({
                             {/* Merchant + account */}
                             <div className="min-w-0 flex-1">
                               <p className="truncate text-xs font-medium">{item.merchant}</p>
-                              <p className="text-[10px] text-muted-foreground">
+                              <p className="truncate text-[10px] text-muted-foreground">
                                 {item.accountName}
                               </p>
                             </div>
-
-                            {/* Amount */}
-                            <span className="shrink-0 text-xs font-semibold tabular-nums">
-                              {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
-                            </span>
                           </button>
+
+                          {/* Amount */}
+                          <span className="shrink-0 text-xs font-semibold tabular-nums">
+                            {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
+                          </span>
 
                           {/* Action hint */}
                           <button
@@ -284,7 +287,14 @@ export function MobileRecurrentesView({
 
       {/* Completed section */}
       {hook.isHydrated && hook.completed.length > 0 && (
-        <CompletedSection completed={hook.completed} />
+        <CompletedSection
+          completed={hook.completed}
+          onRevert={async (occurrenceId) => {
+            const result = await revertOccurrence(occurrenceId);
+            if (result.success) await hook.refreshOccurrences();
+            return result;
+          }}
+        />
       )}
 
       {/* Admin action sheet */}
@@ -352,13 +362,13 @@ function TemplateActionSheet({
 
   return (
     <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
-      <SheetContent side="bottom" className="rounded-t-2xl pb-8">
+      <SheetContent side="bottom" className={cn("rounded-t-2xl", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
         <SheetHeader>
           <SheetTitle className="text-left">{template?.merchant_name}</SheetTitle>
         </SheetHeader>
 
         {template && (
-          <div className="mt-4 space-y-1">
+          <div className="mt-3 grid grid-cols-3 gap-2">
             {/* Edit */}
             <RecurringFormDialog
               template={template ?? undefined}
@@ -368,10 +378,12 @@ function TemplateActionSheet({
                 <button
                   type="button"
                   disabled={isPending}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5 disabled:opacity-50"
+                  className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
                 >
-                  <Pencil className="size-4 text-muted-foreground" />
-                  <span className="text-sm">Editar</span>
+                  <span className="flex size-8 items-center justify-center rounded-full bg-z-brass/15">
+                    <Pencil className="size-4 text-z-brass" />
+                  </span>
+                  <span className="text-xs">Editar</span>
                 </button>
               }
             />
@@ -387,11 +399,13 @@ function TemplateActionSheet({
                 trigger={
                   <button
                     type="button"
-                    className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5"
                     disabled={isPending}
+                    className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
                   >
-                    <Pause className="size-4 text-muted-foreground" />
-                    <span className="text-sm">Pausar</span>
+                    <span className="flex size-8 items-center justify-center rounded-full bg-z-alert/15">
+                      <Pause className="size-4 text-z-alert" />
+                    </span>
+                    <span className="text-xs">Pausar</span>
                   </button>
                 }
               />
@@ -399,11 +413,13 @@ function TemplateActionSheet({
               <button
                 type="button"
                 onClick={handleActivate}
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left active:bg-white/5"
                 disabled={isPending}
+                className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
               >
-                <Play className="size-4 text-muted-foreground" />
-                <span className="text-sm">{isPending ? "Activando..." : "Activar"}</span>
+                <span className="flex size-8 items-center justify-center rounded-full bg-z-income/15">
+                  <Play className="size-4 text-z-income" />
+                </span>
+                <span className="text-xs">{isPending ? "..." : "Activar"}</span>
               </button>
             )}
 
@@ -418,10 +434,12 @@ function TemplateActionSheet({
                 <button
                   type="button"
                   disabled={isPending}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left text-z-debt active:bg-white/5 disabled:opacity-50"
+                  className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
                 >
-                  <Trash2 className="size-4" />
-                  <span className="text-sm">Eliminar</span>
+                  <span className="flex size-8 items-center justify-center rounded-full bg-z-debt/15">
+                    <Trash2 className="size-4 text-z-debt" />
+                  </span>
+                  <span className="text-xs text-z-debt">Eliminar</span>
                 </button>
               }
             />
@@ -438,35 +456,63 @@ function TemplateActionSheet({
 
 function CompletedSection({
   completed,
+  onRevert,
 }: {
   completed: OccurrenceItem[];
+  onRevert: (occurrenceId: string) => Promise<ActionResult>;
 }) {
   const [show, setShow] = useState(true);
+  const [revertingId, setRevertingId] = useState<string | null>(null);
+
+  async function handleRevert(item: OccurrenceItem) {
+    setRevertingId(item.occurrenceId);
+    const result = await onRevert(item.occurrenceId);
+    if (!result.success) {
+      toast.error(result.error ?? "Error al deshacer");
+    } else {
+      toast.success("Movido a pendientes");
+    }
+    setRevertingId(null);
+  }
 
   return (
     <div>
       <button
         type="button"
         onClick={() => setShow((prev) => !prev)}
-        className="flex w-full items-center justify-between py-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+        className={cn("flex w-full items-center justify-between py-2", MOBILE_EYEBROW_CLASS)}
       >
         <span>Completados ({completed.length})</span>
         <span>{show ? "Ocultar ↑" : "Ver ↓"}</span>
       </button>
       {show && (
         <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
-          {completed.map((item) => (
-            <div key={item.key} className="flex items-center gap-2.5 px-3 py-2.5 opacity-60">
-              <Check className="size-4 shrink-0 text-z-income" />
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-xs">{item.merchant}</p>
-                <p className="text-[10px] text-muted-foreground">{formatDate(item.date, "dd MMM")}</p>
+          {completed.map((item) => {
+            const isReverting = revertingId === item.occurrenceId;
+            return (
+              <div key={item.key} className={cn(
+                "flex items-center gap-2 px-3 py-2.5 opacity-60",
+                isReverting && "opacity-30 pointer-events-none"
+              )}>
+                <Check className="size-4 shrink-0 text-z-income" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs">{item.merchant}</p>
+                  <p className="text-[10px] text-muted-foreground">{formatDate(item.date, "dd MMM")}</p>
+                </div>
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRevert(item)}
+                  disabled={isReverting}
+                  className="shrink-0 rounded-md px-2 py-0.5 text-[10px] text-z-sage-dark active:bg-white/5"
+                >
+                  Deshacer
+                </button>
               </div>
-              <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
-              </span>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -163,7 +163,7 @@ export function MobileRecurrentesView({
               >
                 {/* Date header */}
                 <div className="px-3 py-1.5">
-                  <span className={cn("text-[10px] font-semibold uppercase tracking-wide", statusLabel(status))}>
+                  <span className={cn("text-[10px] font-semibold uppercase tracking-[0.18em]", statusLabel(status))}>
                     {status === "today" && "Hoy — "}
                     {formatDate(date, "EEEE d MMM")}
                   </span>
@@ -314,6 +314,9 @@ export function MobileRecurrentesView({
 /*  Template Action Sheet                                              */
 /* ------------------------------------------------------------------ */
 
+const SHEET_CHIP_CLASS =
+  "flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50";
+
 function TemplateActionSheet({
   item,
   template,
@@ -378,7 +381,7 @@ function TemplateActionSheet({
                 <button
                   type="button"
                   disabled={isPending}
-                  className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
+                  className={SHEET_CHIP_CLASS}
                 >
                   <span className="flex size-8 items-center justify-center rounded-full bg-z-brass/15">
                     <Pencil className="size-4 text-z-brass" />
@@ -400,7 +403,7 @@ function TemplateActionSheet({
                   <button
                     type="button"
                     disabled={isPending}
-                    className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
+                    className={SHEET_CHIP_CLASS}
                   >
                     <span className="flex size-8 items-center justify-center rounded-full bg-z-alert/15">
                       <Pause className="size-4 text-z-alert" />
@@ -414,7 +417,7 @@ function TemplateActionSheet({
                 type="button"
                 onClick={handleActivate}
                 disabled={isPending}
-                className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
+                className={SHEET_CHIP_CLASS}
               >
                 <span className="flex size-8 items-center justify-center rounded-full bg-z-income/15">
                   <Play className="size-4 text-z-income" />
@@ -434,7 +437,7 @@ function TemplateActionSheet({
                 <button
                   type="button"
                   disabled={isPending}
-                  className="flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50"
+                  className={SHEET_CHIP_CLASS}
                 >
                   <span className="flex size-8 items-center justify-center rounded-full bg-z-debt/15">
                     <Trash2 className="size-4 text-z-debt" />
@@ -466,13 +469,16 @@ function CompletedSection({
 
   async function handleRevert(item: OccurrenceItem) {
     setRevertingId(item.occurrenceId);
-    const result = await onRevert(item.occurrenceId);
-    if (!result.success) {
-      toast.error(result.error ?? "Error al deshacer");
-    } else {
-      toast.success("Movido a pendientes");
+    try {
+      const result = await onRevert(item.occurrenceId);
+      if (!result.success) {
+        toast.error(result.error ?? "Error al deshacer");
+      } else {
+        toast.success("Movido a pendientes");
+      }
+    } finally {
+      setRevertingId(null);
     }
-    setRevertingId(null);
   }
 
   return (
@@ -506,6 +512,7 @@ function CompletedSection({
                   type="button"
                   onClick={() => handleRevert(item)}
                   disabled={isReverting}
+                  aria-label={`Deshacer ${item.merchant}`}
                   className="shrink-0 rounded-md px-2 py-0.5 text-[10px] text-z-sage-dark active:bg-white/5"
                 >
                   Deshacer

--- a/webapp/src/components/ui/sheet.tsx
+++ b/webapp/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[10000] bg-black/50",
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[10000] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
## Summary
- **Undo completed occurrences**: `revertOccurrence()` server action reverts paid/skipped back to pending. Paid: deletes transactions via `recurrence_group_id`, reverses balance deltas. Skipped: resets status. "Deshacer" button on each completed row.
- **Sheet z-index fix**: Bumped Sheet overlay + content to `z-[10000]` so they render above the tab bar (`z-[9999]`)
- **Sheet bottom padding**: Uses `MOBILE_TAB_BAR_CLEARANCE_CLASS` — no more content hidden behind tab bar
- **Action sheet redesign**: 3-column chip grid matching FAB menu pattern (icon circles + labels)
- **Row responsiveness**: Tighter gaps, amount outside tap area, truncating merchant/account names
- **CLAUDE.md**: Added UI rules for mobile sheets, date parsing, debt direction semantics

## Test plan
- [ ] Completed occurrence → tap "Deshacer" on a skipped item → returns to pending
- [ ] Completed occurrence → tap "Deshacer" on a paid item → deletes transaction, reverses balance, returns to pending
- [ ] Action sheet renders above tab bar and FAB
- [ ] Action sheet chips (Editar/Pausar/Eliminar) are centered, not left-aligned
- [ ] Pending rows don't overflow on narrow screens
- [ ] Edit dialog still opens (known: layered behind sheet — backlogged for redesign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)