### PR TITLE
feat: recurring manager mobile redesign + ONCE frequency

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -65,6 +65,12 @@
 - **What:** The plan tab checklist has two disconnected interaction patterns: (1) tap row → inline payment form with flat buttons, (2) tap ⋮ → bottom Sheet with chip-style admin actions. They look like different apps. Unify into a single cohesive pattern — either improve inline to match chip style with small confirmation Sheet, or merge both into one bottom drawer per-item.
 - **Found:** Visual testing, 2026-04-14
 
+### Debt payment category — distinguish CREDIT_CARD vs LOAN
+- **Priority:** Medium
+- **What:** All debt payments auto-assign `CATEGORY_OBLIGACIONES` (parent). Should distinguish: CREDIT_CARD → "Pago tarjeta" subcategory, LOAN → "Cuota crédito" subcategory. Three changes needed: (1) add seed subcategories for "Pago tarjeta" and "Cuota crédito" under Obligaciones if they don't exist, (2) allow category picker in RecurringForm for debt accounts (pre-select correct subcategory based on `account_type`), (3) update `recordRecurringOccurrencePayment` to use template's `category_id` instead of hardcoded `DEBT_PAYMENT_CATEGORY_ID`.
+- **Context:** Currently `category_id` is forced to `null` on template create (lines 277/351 in recurring-templates.ts), and payment recording hardcodes `DEBT_PAYMENT_CATEGORY_ID` (line 650). User already has manual subcategories mapped correctly.
+- **Found:** User feedback, 2026-04-14
+
 ### Audit effectiveDirection usage across app
 - **Priority:** Low
 - **What:** The recurring manager introduced `effectiveDirection()` (INFLOW to debt account = expense, not income). Audit the whole app for places that classify by raw `template.direction` without checking account type — dashboards, budget calculations, income metrics, etc.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -43,10 +43,16 @@
 - **What:** MoreVertical (⋮) button on each occurrence row opens bottom Sheet with Edit, Pause/Activate, Delete. Reuses RecurringFormDialog and RecurringImpactDialog from desktop.
 - **Remaining:** Edit dialog opens behind the action sheet (nested Radix portal). Needs to close Sheet first, then open Dialog sequentially. Full recurring form also needs mobile redesign.
 
-### Recurring form mobile redesign
+### Manual transaction-to-recurring matching
 - **Priority:** Medium
-- **What:** RecurringFormDialog was designed for desktop. On mobile it opens as a Dialog over the action Sheet, causing layering issues. Needs a mobile-native form — either a full-page drawer or a dedicated route.
-- **Found:** Visual testing, 2026-04-13
+- **What:** Allow users to manually link any transaction (manual, email, OCR, PDF import) to a pending recurring occurrence. Use case: nómina arrives via email notification, user wants to link it to the mapped recurring income template before importing the statement.
+- **Context:** Currently auto-linking works via `findMatchingOccurrence()` (date ±3 days, amount ±1%, account match). Manual override needed when auto-match fails or user wants to link proactively.
+- **Found:** User feedback, 2026-04-14
+
+### Audit effectiveDirection usage across app
+- **Priority:** Low
+- **What:** The recurring manager introduced `effectiveDirection()` (INFLOW to debt account = expense, not income). Audit the whole app for places that classify by raw `template.direction` without checking account type — dashboards, budget calculations, income metrics, etc.
+- **Found:** Bug fix during recurring manager development, 2026-04-14
 
 
 ### Income-aware runway & daily budget

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,6 +55,11 @@
 - **Context:** `getTemplateStats()` in `actions/template-stats.ts` only queries `recurring_occurrences`. New templates have no occurrences yet even if the user has been paying for months.
 - **Found:** User feedback, 2026-04-14
 
+### Plan page mobile — grid navigation instead of list
+- **Priority:** Medium
+- **What:** The "Ir a" section on the plan page mobile view shows Presupuesto, Periodo, Recurrentes, Deseos as a vertical list of link cards. Replace with a 2x2 grid of buttons for better visual density and scannability.
+- **Found:** User feedback, 2026-04-14
+
 ### Recurring checklist — unify inline expand + action drawer
 - **Priority:** Medium
 - **What:** The plan tab checklist has two disconnected interaction patterns: (1) tap row → inline payment form with flat buttons, (2) tap ⋮ → bottom Sheet with chip-style admin actions. They look like different apps. Unify into a single cohesive pattern — either improve inline to match chip style with small confirmation Sheet, or merge both into one bottom drawer per-item.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,6 +55,11 @@
 - **Context:** `getTemplateStats()` in `actions/template-stats.ts` only queries `recurring_occurrences`. New templates have no occurrences yet even if the user has been paying for months.
 - **Found:** User feedback, 2026-04-14
 
+### Recurring checklist — unify inline expand + action drawer
+- **Priority:** Medium
+- **What:** The plan tab checklist has two disconnected interaction patterns: (1) tap row → inline payment form with flat buttons, (2) tap ⋮ → bottom Sheet with chip-style admin actions. They look like different apps. Unify into a single cohesive pattern — either improve inline to match chip style with small confirmation Sheet, or merge both into one bottom drawer per-item.
+- **Found:** Visual testing, 2026-04-14
+
 ### Audit effectiveDirection usage across app
 - **Priority:** Low
 - **What:** The recurring manager introduced `effectiveDirection()` (INFLOW to debt account = expense, not income). Audit the whole app for places that classify by raw `template.direction` without checking account type — dashboards, budget calculations, income metrics, etc.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -49,6 +49,12 @@
 - **Context:** Currently auto-linking works via `findMatchingOccurrence()` (date ±3 days, amount ±1%, account match). Manual override needed when auto-match fails or user wants to link proactively.
 - **Found:** User feedback, 2026-04-14
 
+### Recurring stats — historical backfill
+- **Priority:** Medium
+- **What:** Template stats (YTD, streak, annual estimate) are empty for newly created templates. Options: (1) backfill from `statement_snapshots` minimum payments or balance changes, (2) when creating a recurring template, auto-create historical occurrences as "paid" based on matching past transactions, (3) use snapshot history alongside occurrence history for the metrics.
+- **Context:** `getTemplateStats()` in `actions/template-stats.ts` only queries `recurring_occurrences`. New templates have no occurrences yet even if the user has been paying for months.
+- **Found:** User feedback, 2026-04-14
+
 ### Audit effectiveDirection usage across app
 - **Priority:** Low
 - **What:** The recurring manager introduced `effectiveDirection()` (INFLOW to debt account = expense, not income). Audit the whole app for places that classify by raw `template.direction` without checking account type — dashboards, budget calculations, income metrics, etc.

--- a/docs/superpowers/plans/2026-04-14-recurring-manager-mobile.md
+++ b/docs/superpowers/plans/2026-04-14-recurring-manager-mobile.md
@@ -1,0 +1,1533 @@
+# Recurring Manager Mobile Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat occurrence checklist at `/recurrentes` with a full recurring template manager featuring a timeline UI, segmented gastos/ingresos tabs, inline expand with lazy stats, one-time payments (`ONCE` frequency), and full-page create/edit routes.
+
+**Architecture:** New top-level `/recurrentes` route replaces the current redirect. Page is a server component that fetches templates + occurrences, renders `MobileRecurringManager` client component. Timeline groups templates by next occurrence date within the selected month. Expanded view lazy-loads stats via `getTemplateStats()` server action. Create/edit use dedicated page routes reusing `RecurringForm`.
+
+**Tech Stack:** Next.js 15 App Router, Tailwind v4, shadcn/ui, Supabase, `@zeta/shared` recurrence utils
+
+**Spec:** `docs/superpowers/specs/2026-04-14-recurring-manager-mobile-redesign.md`
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `supabase/migrations/YYYYMMDD_add_once_frequency.sql` | Add `ONCE` to `recurrence_frequency` enum |
+| `webapp/src/app/(dashboard)/recurrentes/page.tsx` | Server component entry — replaces redirect, fetches data |
+| `webapp/src/app/(dashboard)/recurrentes/loading.tsx` | Loading skeleton |
+| `webapp/src/app/(dashboard)/recurrentes/new/page.tsx` | Create template — full page with `RecurringForm` |
+| `webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx` | Edit template — full page with `RecurringForm` |
+| `webapp/src/components/recurring/mobile-recurring-manager.tsx` | Main client component — hero, tabs, timeline |
+| `webapp/src/components/recurring/recurring-hero-compact.tsx` | Proportion bar hero |
+| `webapp/src/components/recurring/recurring-timeline.tsx` | Timeline with date groups, dots, template cards |
+| `webapp/src/components/recurring/recurring-template-card.tsx` | Collapsed + expanded card (inline on timeline) |
+| `webapp/src/actions/template-stats.ts` | `getTemplateStats()` server action |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `packages/shared/src/utils/recurrence.ts` | Add `ONCE` to `advanceByFrequency()` + `frequencyLabel()` |
+| `webapp/src/lib/validators/recurring-template.ts` | Add `ONCE` to frequency enum |
+| `webapp/src/components/recurring/recurring-form.tsx` | Add "Una vez" option, hide end_date when ONCE |
+| `webapp/src/components/recurring/recurring-impact-dialog.tsx` | Add optional `open`/`onOpenChange` controlled mode |
+| `webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx` | Change mobile view to link to `/recurrentes` instead of embedding `MobileRecurrentesView` |
+| `webapp/src/types/database.ts` | Regenerated after migration (add `ONCE` to enum) |
+
+### Untouched (still used)
+| File | Why |
+|------|-----|
+| `recurring-form-dialog.tsx` | Desktop still uses Dialog wrapper |
+| `mobile-recurrentes-view.tsx` | Kept for reference, eventually removed once new page is stable |
+| `recurring-list.tsx` | Desktop list view, unchanged |
+| `use-recurring-month.ts` | Reused for occurrence data in timeline |
+
+---
+
+## Task 1: Database Migration — Add `ONCE` Frequency
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDD_add_once_frequency.sql`
+
+- [ ] **Step 1: Create migration file**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta && npx supabase migration new add_once_frequency
+```
+
+- [ ] **Step 2: Write migration SQL**
+
+Write to the created migration file:
+
+```sql
+-- Add ONCE frequency for one-time planned payments
+ALTER TYPE recurrence_frequency ADD VALUE IF NOT EXISTS 'ONCE';
+```
+
+- [ ] **Step 3: Push migration**
+
+```bash
+npx supabase db push
+```
+
+Expected: Migration applied successfully.
+
+- [ ] **Step 4: Regenerate TypeScript types**
+
+```bash
+cd webapp && npx supabase gen types --lang=typescript --project-id tgkhaxipfgskxydotdtu > src/types/database.ts
+```
+
+Verify `ONCE` appears in the enum array (search for `recurrence_frequency`). Check that `export type Json =` header is intact (first line).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/ webapp/src/types/database.ts
+git commit -m "feat: add ONCE frequency to recurrence_frequency enum"
+```
+
+---
+
+## Task 2: Shared Package — `ONCE` Frequency Support
+
+**Files:**
+- Modify: `packages/shared/src/utils/recurrence.ts`
+
+- [ ] **Step 1: Add `ONCE` to `advanceByFrequency()`**
+
+In `packages/shared/src/utils/recurrence.ts`, add a case to the switch statement (around line 7-20):
+
+```typescript
+case "ONCE":
+  return date; // no advancement — single occurrence at start_date
+```
+
+- [ ] **Step 2: Add `ONCE` to `frequencyLabel()`**
+
+In the same file (around line 88-97), add:
+
+```typescript
+case "ONCE":
+  return "Una vez";
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+Expected: Clean build. The shared package compiles through webapp's Turbopack.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/shared/src/utils/recurrence.ts
+git commit -m "feat: add ONCE frequency to shared recurrence utils"
+```
+
+---
+
+## Task 3: Validator + Form — `ONCE` Support
+
+**Files:**
+- Modify: `webapp/src/lib/validators/recurring-template.ts`
+- Modify: `webapp/src/components/recurring/recurring-form.tsx`
+
+- [ ] **Step 1: Add `ONCE` to validator schema**
+
+In `webapp/src/lib/validators/recurring-template.ts` (line 13), add `"ONCE"` to the frequency enum array:
+
+```typescript
+frequency: z.enum(["WEEKLY", "BIWEEKLY", "MONTHLY", "QUARTERLY", "ANNUAL", "ONCE"]),
+```
+
+- [ ] **Step 2: Add `ONCE` to form frequency options**
+
+In `webapp/src/components/recurring/recurring-form.tsx`, update `FREQUENCY_OPTIONS` (lines 25-31):
+
+```typescript
+const FREQUENCY_OPTIONS = [
+  { value: "ONCE", label: "Una vez" },
+  { value: "WEEKLY", label: "Semanal" },
+  { value: "BIWEEKLY", label: "Quincenal" },
+  { value: "MONTHLY", label: "Mensual" },
+  { value: "QUARTERLY", label: "Trimestral" },
+  { value: "ANNUAL", label: "Anual" },
+] as const;
+```
+
+- [ ] **Step 3: Hide end_date when ONCE is selected**
+
+In `RecurringForm`, add state tracking for frequency and conditionally hide end_date. After the existing state declarations (~line 61-78), add:
+
+```typescript
+const [frequency, setFrequency] = useState<string>(
+  template?.frequency ?? "MONTHLY"
+);
+```
+
+Update the frequency `<Select>` to use controlled state:
+
+```typescript
+<Select
+  name="frequency"
+  value={frequency}
+  onValueChange={setFrequency}
+>
+```
+
+Wrap the end_date field (around lines 293-302) in a conditional:
+
+```typescript
+{frequency !== "ONCE" && (
+  <div className="space-y-2">
+    <Label htmlFor="end_date">Fecha fin (opcional)</Label>
+    <DatePicker ... />
+  </div>
+)}
+```
+
+When ONCE, change the grid from 2-col to 1-col for start_date:
+
+```typescript
+<div className={cn("grid gap-4", frequency === "ONCE" ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2")}>
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/lib/validators/recurring-template.ts webapp/src/components/recurring/recurring-form.tsx
+git commit -m "feat: add ONCE frequency option to recurring form and validator"
+```
+
+---
+
+## Task 4: Template Stats Server Action
+
+**Files:**
+- Create: `webapp/src/actions/template-stats.ts`
+
+- [ ] **Step 1: Create the server action**
+
+```typescript
+"use server";
+
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { startOfYear } from "date-fns";
+import type { ActionResult } from "@/types/actions";
+
+export interface TemplateStats {
+  ytdTotal: number;
+  annualEstimate: number;
+  streak: number;
+  isConsistent: boolean;
+  impactPercent: number | null;
+  marginAfter: number | null;
+}
+
+const FREQUENCY_MULTIPLIER: Record<string, number> = {
+  WEEKLY: 52,
+  BIWEEKLY: 26,
+  MONTHLY: 12,
+  QUARTERLY: 4,
+  ANNUAL: 1,
+  ONCE: 1,
+};
+
+export async function getTemplateStats(
+  templateId: string
+): Promise<ActionResult<TemplateStats>> {
+  const { supabase, user } = await getAuthenticatedClient();
+
+  // Fetch template
+  const { data: template, error: tErr } = await supabase
+    .from("recurring_transaction_templates")
+    .select("id, amount, frequency, direction, account_id")
+    .eq("id", templateId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (tErr || !template) {
+    return { success: false, error: "Plantilla no encontrada" };
+  }
+
+  // Fetch paid occurrences this year
+  const yearStart = startOfYear(new Date()).toISOString().split("T")[0];
+  const { data: paidOccurrences } = await supabase
+    .from("recurring_occurrences")
+    .select("occurrence_date, expected_amount, paid_at")
+    .eq("template_id", templateId)
+    .eq("user_id", user.id)
+    .eq("status", "paid")
+    .gte("occurrence_date", yearStart)
+    .order("occurrence_date", { ascending: false });
+
+  const paid = paidOccurrences ?? [];
+  const ytdTotal = paid.reduce(
+    (sum, o) => sum + Number(o.expected_amount),
+    0
+  );
+
+  const multiplier = FREQUENCY_MULTIPLIER[template.frequency] ?? 12;
+  const annualEstimate =
+    template.frequency === "ONCE"
+      ? Number(template.amount)
+      : Number(template.amount) * multiplier;
+
+  // Streak: consecutive months with a payment (count backwards from most recent)
+  let streak = 0;
+  if (paid.length > 0) {
+    streak = 1;
+    for (let i = 1; i < paid.length; i++) {
+      const prev = new Date(paid[i - 1].occurrence_date);
+      const curr = new Date(paid[i].occurrence_date);
+      const monthDiff =
+        (prev.getFullYear() - curr.getFullYear()) * 12 +
+        prev.getMonth() -
+        curr.getMonth();
+      if (monthDiff <= 2) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Consistency: all paid amounts are within 5% of template amount
+  const templateAmount = Number(template.amount);
+  const isConsistent =
+    paid.length >= 2 &&
+    paid.every(
+      (o) => Math.abs(Number(o.expected_amount) - templateAmount) / templateAmount < 0.05
+    );
+
+  // Impact (for ONCE only)
+  let impactPercent: number | null = null;
+  let marginAfter: number | null = null;
+
+  if (template.frequency === "ONCE") {
+    // Get monthly income from recurring income templates
+    const { data: incomeTemplates } = await supabase
+      .from("recurring_transaction_templates")
+      .select("amount, frequency")
+      .eq("user_id", user.id)
+      .eq("direction", "INFLOW")
+      .eq("is_active", true);
+
+    const monthlyIncome = (incomeTemplates ?? []).reduce((sum, t) => {
+      const m = FREQUENCY_MULTIPLIER[t.frequency] ?? 12;
+      return sum + (Number(t.amount) * m) / 12;
+    }, 0);
+
+    if (monthlyIncome > 0) {
+      impactPercent = (Number(template.amount) / monthlyIncome) * 100;
+    }
+
+    // Get monthly expense total
+    const { data: expenseTemplates } = await supabase
+      .from("recurring_transaction_templates")
+      .select("amount, frequency")
+      .eq("user_id", user.id)
+      .eq("direction", "OUTFLOW")
+      .eq("is_active", true)
+      .neq("id", templateId);
+
+    const monthlyExpenses = (expenseTemplates ?? []).reduce((sum, t) => {
+      const m = FREQUENCY_MULTIPLIER[t.frequency] ?? 12;
+      return sum + (Number(t.amount) * m) / 12;
+    }, 0);
+
+    marginAfter = monthlyIncome - monthlyExpenses - Number(template.amount);
+  }
+
+  return {
+    success: true,
+    data: {
+      ytdTotal,
+      annualEstimate,
+      streak,
+      isConsistent,
+      impactPercent,
+      marginAfter,
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/actions/template-stats.ts
+git commit -m "feat: add getTemplateStats server action for recurring manager"
+```
+
+---
+
+## Task 5: RecurringImpactDialog — Controlled Mode
+
+**Files:**
+- Modify: `webapp/src/components/recurring/recurring-impact-dialog.tsx`
+
+- [ ] **Step 1: Add controlled mode props**
+
+Update the interface (around line 24-31):
+
+```typescript
+interface RecurringImpactDialogProps {
+  templateId: string;
+  templateName: string;
+  currencyCode: CurrencyCode;
+  action: "delete" | "pause";
+  onConfirm: () => void | Promise<void>;
+  trigger?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+- [ ] **Step 2: Implement controlled/uncontrolled pattern**
+
+Replace the internal state (line 41) with:
+
+```typescript
+const [internalOpen, setInternalOpen] = useState(false);
+const open = controlledOpen ?? internalOpen;
+const setOpen = controlledOnOpenChange ?? setInternalOpen;
+```
+
+Update destructured props to include new names:
+
+```typescript
+export function RecurringImpactDialog({
+  templateId,
+  templateName,
+  currencyCode,
+  action,
+  onConfirm,
+  trigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: RecurringImpactDialogProps) {
+```
+
+- [ ] **Step 3: Conditionally render trigger**
+
+Replace the AlertDialog JSX (line 77-78) to conditionally render the trigger:
+
+```typescript
+<AlertDialog open={open} onOpenChange={setOpen}>
+  {trigger && <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>}
+  <AlertDialogContent>
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+Desktop `RecurringList` still passes `trigger` — verify no regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webapp/src/components/recurring/recurring-impact-dialog.tsx
+git commit -m "feat: add controlled mode to RecurringImpactDialog"
+```
+
+---
+
+## Task 6: Recurring Hero Compact Component
+
+**Files:**
+- Create: `webapp/src/components/recurring/recurring-hero-compact.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```typescript
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+
+interface RecurringHeroCompactProps {
+  totalExpenses: number;
+  totalIncome: number;
+  currency: CurrencyCode;
+  monthLabel: string;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  canGoNext: boolean;
+}
+
+export function RecurringHeroCompact({
+  totalExpenses,
+  totalIncome,
+  currency,
+  monthLabel,
+  onPrevMonth,
+  onNextMonth,
+  canGoNext,
+}: RecurringHeroCompactProps) {
+  const net = totalIncome - totalExpenses;
+  const isPositive = net >= 0;
+  const total = totalExpenses + totalIncome;
+  const expensePercent = total > 0 ? (totalExpenses / total) * 100 : 50;
+
+  return (
+    <div className="space-y-3">
+      {/* Month navigation */}
+      <div className="flex items-center justify-center gap-4">
+        <button
+          type="button"
+          onClick={onPrevMonth}
+          className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5"
+        >
+          <ChevronLeft className="size-3.5" />
+        </button>
+        <span className="text-xs font-medium capitalize text-muted-foreground">
+          {monthLabel}
+        </span>
+        <button
+          type="button"
+          onClick={onNextMonth}
+          disabled={!canGoNext}
+          className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5 disabled:opacity-30"
+        >
+          <ChevronRight className="size-3.5" />
+        </button>
+      </div>
+
+      {/* Compact hero card */}
+      <div className="rounded-2xl border border-white/6 bg-gradient-to-br from-z-brass/[0.06] to-transparent p-3.5">
+        {/* Proportion bar */}
+        <div className="mb-3 flex h-1.5 overflow-hidden rounded-full">
+          <div
+            className="rounded-l-full bg-gradient-to-r from-z-debt to-z-alert"
+            style={{ width: `${expensePercent}%` }}
+          />
+          <div
+            className="rounded-r-full bg-gradient-to-r from-z-income to-emerald-500"
+            style={{ width: `${100 - expensePercent}%` }}
+          />
+        </div>
+
+        {/* Three numbers */}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          <div>
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-z-debt">
+              Gastos
+            </p>
+            <p className="text-base font-bold tabular-nums">
+              {formatCurrency(totalExpenses, currency)}
+            </p>
+          </div>
+          <div className="text-center px-2">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              Neto
+            </p>
+            <p
+              className={cn(
+                "text-xl font-extrabold tabular-nums",
+                isPositive ? "text-z-income" : "text-z-debt"
+              )}
+            >
+              {isPositive ? "+" : ""}
+              {formatCurrency(Math.abs(net), currency)}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-z-income">
+              Ingresos
+            </p>
+            <p className="text-base font-bold tabular-nums">
+              {formatCurrency(totalIncome, currency)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/recurring/recurring-hero-compact.tsx
+git commit -m "feat: add RecurringHeroCompact component"
+```
+
+---
+
+## Task 7: Recurring Template Card Component
+
+**Files:**
+- Create: `webapp/src/components/recurring/recurring-template-card.tsx`
+
+- [ ] **Step 1: Create collapsed + expanded card component**
+
+```typescript
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Pencil, Pause, Trash2, Check, MoreVertical } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { getTemplateStats, type TemplateStats } from "@/actions/template-stats";
+import { MOBILE_ACTION_BUTTON_CLASS } from "@/lib/constants/styles";
+import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+
+type OccurrenceStatus = "paid" | "pending" | "skipped" | null;
+
+interface RecurringTemplateCardProps {
+  template: RecurringTemplateWithRelations;
+  currency: CurrencyCode;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onPauseRequest: (template: RecurringTemplateWithRelations) => void;
+  onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
+  occurrenceStatus: OccurrenceStatus;
+}
+
+const FREQUENCY_MULTIPLIER: Record<string, number> = {
+  WEEKLY: 52, BIWEEKLY: 26, MONTHLY: 12, QUARTERLY: 4, ANNUAL: 1, ONCE: 1,
+};
+
+function yearlyEstimate(amount: number, frequency: string): number {
+  return frequency === "ONCE" ? amount : amount * (FREQUENCY_MULTIPLIER[frequency] ?? 12);
+}
+
+function frequencyShortLabel(f: string): string {
+  const labels: Record<string, string> = {
+    ONCE: "Una vez", WEEKLY: "Semanal", BIWEEKLY: "Quincenal",
+    MONTHLY: "Mensual", QUARTERLY: "Trimestral", ANNUAL: "Anual",
+  };
+  return labels[f] ?? f;
+}
+
+export function RecurringTemplateCard({
+  template,
+  currency,
+  isExpanded,
+  onToggleExpand,
+  onPauseRequest,
+  onDeleteRequest,
+  occurrenceStatus,
+}: RecurringTemplateCardProps) {
+  const router = useRouter();
+  const [stats, setStats] = useState<TemplateStats | null>(null);
+  const [loadingStats, setLoadingStats] = useState(false);
+  const amount = Number(template.amount);
+  const isOnce = template.frequency === "ONCE";
+
+  function handleExpand() {
+    onToggleExpand();
+    if (!isExpanded && !stats) {
+      setLoadingStats(true);
+      getTemplateStats(template.id).then((result) => {
+        if (result.success) setStats(result.data);
+        setLoadingStats(false);
+      });
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/6 bg-white/[0.03] overflow-hidden transition-all",
+        isExpanded && "border-z-brass/20"
+      )}
+    >
+      {/* Collapsed row */}
+      <button
+        type="button"
+        onClick={handleExpand}
+        className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left active:bg-white/[0.02]"
+      >
+        {/* Category dot */}
+        {template.category && (
+          <span
+            className="flex size-7 shrink-0 items-center justify-center rounded-lg text-xs"
+            style={{ backgroundColor: template.category.color + "20", color: template.category.color }}
+          >
+            {template.category.icon ?? "•"}
+          </span>
+        )}
+
+        {/* Info */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-xs font-semibold">{template.merchant_name}</p>
+            {isOnce && (
+              <span className="shrink-0 rounded bg-purple-500/20 px-1.5 py-px text-[8px] font-semibold text-purple-400">
+                UNA VEZ
+              </span>
+            )}
+            {occurrenceStatus === "paid" && (
+              <Check className="size-3 shrink-0 text-z-income" />
+            )}
+          </div>
+          <p className="text-[10px] text-muted-foreground">
+            {template.account.name} · {frequencyShortLabel(template.frequency)}
+          </p>
+        </div>
+
+        {/* Amount + yearly */}
+        <div className="shrink-0 text-right">
+          <p className="text-xs font-bold tabular-nums">
+            {formatCurrency(amount, currency)}
+          </p>
+          {!isOnce && (
+            <p className="text-[9px] text-muted-foreground tabular-nums">
+              {formatCurrency(yearlyEstimate(amount, template.frequency), currency)}/año
+            </p>
+          )}
+        </div>
+      </button>
+
+      {/* Expanded section */}
+      {isExpanded && (
+        <div className="border-t border-white/5 px-3 py-3 space-y-3">
+          {/* Stats chips */}
+          <div className="grid grid-cols-3 gap-1">
+            {loadingStats ? (
+              <>
+                <div className="h-12 animate-pulse rounded-lg bg-white/4" />
+                <div className="h-12 animate-pulse rounded-lg bg-white/4" />
+                <div className="h-12 animate-pulse rounded-lg bg-white/4" />
+              </>
+            ) : stats ? (
+              isOnce ? (
+                <>
+                  <StatChip label="% ingreso" value={stats.impactPercent != null ? `${stats.impactPercent.toFixed(1)}%` : "—"} />
+                  <StatChip label="Margen después" value={stats.marginAfter != null ? formatCurrency(stats.marginAfter, currency) : "—"} />
+                  <StatChip label="Estado" value={occurrenceStatus === "paid" ? "Pagado ✓" : "Pendiente"} />
+                </>
+              ) : (
+                <>
+                  <StatChip label="Este año" value={formatCurrency(stats.ytdTotal, currency)} />
+                  <StatChip label="Anual est." value={formatCurrency(stats.annualEstimate, currency)} />
+                  <StatChip
+                    label="Racha"
+                    value={`${stats.streak} mes${stats.streak !== 1 ? "es" : ""}`}
+                    note={stats.isConsistent ? "Consistente ✓" : undefined}
+                  />
+                </>
+              )
+            ) : null}
+          </div>
+
+          {/* Action buttons */}
+          <div className={cn("grid gap-1.5", isOnce ? "grid-cols-3" : template.direction === "INFLOW" ? "grid-cols-2" : "grid-cols-3")}>
+            <ActionButton
+              label="Editar"
+              icon={<Pencil className="size-3.5" />}
+              className="bg-z-brass/10 border-z-brass/20 text-z-brass"
+              onClick={() => router.push(`/recurrentes/${template.id}/edit`)}
+            />
+            {template.direction === "OUTFLOW" && !isOnce && (
+              <ActionButton
+                label="Pausar"
+                icon={<Pause className="size-3.5" />}
+                className="bg-z-alert/8 border-z-alert/15 text-z-alert"
+                onClick={() => onPauseRequest(template)}
+              />
+            )}
+            {isOnce && occurrenceStatus !== "paid" && (
+              <ActionButton
+                label="Pagado"
+                icon={<Check className="size-3.5" />}
+                className="bg-z-income/10 border-z-income/20 text-z-income"
+                onClick={() => {/* TODO: mark paid flow — will use existing confirmPayment */}}
+              />
+            )}
+            <ActionButton
+              label="Eliminar"
+              icon={<Trash2 className="size-3.5" />}
+              className="bg-z-debt/8 border-z-debt/15 text-z-debt"
+              onClick={() => onDeleteRequest(template)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatChip({ label, value, note }: { label: string; value: string; note?: string }) {
+  return (
+    <div className="rounded-lg bg-white/[0.03] px-2 py-2 text-center">
+      <p className="text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-sm font-bold tabular-nums">{value}</p>
+      {note && <p className="text-[8px] text-z-income">{note}</p>}
+    </div>
+  );
+}
+
+function ActionButton({
+  label, icon, className, onClick,
+}: {
+  label: string; icon: React.ReactNode; className: string; onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn("flex items-center justify-center gap-1.5 rounded-lg border py-2.5 text-[11px] font-semibold active:opacity-70", className)}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/recurring/recurring-template-card.tsx
+git commit -m "feat: add RecurringTemplateCard with expanded stats and actions"
+```
+
+---
+
+## Task 8: Recurring Timeline Component
+
+**Files:**
+- Create: `webapp/src/components/recurring/recurring-timeline.tsx`
+
+- [ ] **Step 1: Create timeline component**
+
+```typescript
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { formatDate } from "@/lib/utils/date";
+import { RecurringTemplateCard } from "./recurring-template-card";
+import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+
+type DateStatus = "past" | "today" | "future";
+type OccurrenceStatusMap = Map<string, "paid" | "pending" | "skipped">;
+
+interface RecurringTimelineProps {
+  templates: RecurringTemplateWithRelations[];
+  currency: CurrencyCode;
+  direction: "OUTFLOW" | "INFLOW";
+  occurrencesByDate: Map<string, { templateId: string; date: string }[]>;
+  occurrenceStatuses: OccurrenceStatusMap;
+  expandedId: string | null;
+  onToggleExpand: (templateId: string) => void;
+  onPauseRequest: (template: RecurringTemplateWithRelations) => void;
+  onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
+  getDateStatus: (date: string) => DateStatus;
+}
+
+const STATUS_ORDER: Record<DateStatus, number> = { past: 0, today: 1, future: 2 };
+
+function dotStyle(status: DateStatus) {
+  switch (status) {
+    case "past":
+      return "bg-z-debt shadow-[0_0_8px_rgba(239,68,68,0.4)]";
+    case "today":
+      return "bg-z-alert shadow-[0_0_8px_rgba(245,158,11,0.4)]";
+    case "future":
+      return "border-2 border-white/15 bg-transparent";
+  }
+}
+
+function dateColor(status: DateStatus) {
+  switch (status) {
+    case "past": return "text-z-debt";
+    case "today": return "text-z-alert";
+    case "future": return "text-muted-foreground";
+  }
+}
+
+function lineColor(direction: "OUTFLOW" | "INFLOW") {
+  return direction === "OUTFLOW"
+    ? "from-z-brass/40 to-z-brass/10"
+    : "from-z-income/40 to-z-income/10";
+}
+
+export function RecurringTimeline({
+  templates,
+  currency,
+  direction,
+  occurrencesByDate,
+  occurrenceStatuses,
+  expandedId,
+  onToggleExpand,
+  onPauseRequest,
+  onDeleteRequest,
+  getDateStatus,
+}: RecurringTimelineProps) {
+  const templateMap = useMemo(
+    () => new Map(templates.map((t) => [t.id, t])),
+    [templates]
+  );
+
+  const activeTemplates = templates.filter((t) => t.direction === direction && t.is_active);
+  const pausedTemplates = templates.filter((t) => t.direction === direction && !t.is_active);
+
+  // Build date groups from occurrences
+  const sortedDates = useMemo(() => {
+    const dates = Array.from(occurrencesByDate.keys())
+      .filter((date) => {
+        const items = occurrencesByDate.get(date)!;
+        return items.some((item) => {
+          const tmpl = templateMap.get(item.templateId);
+          return tmpl && tmpl.direction === direction && tmpl.is_active;
+        });
+      })
+      .map((date) => ({ date, order: STATUS_ORDER[getDateStatus(date)] }))
+      .sort((a, b) => a.order - b.order || a.date.localeCompare(b.date));
+    return dates.map((d) => d.date);
+  }, [occurrencesByDate, templateMap, direction, getDateStatus]);
+
+  return (
+    <div className="relative pl-6">
+      {/* Vertical line */}
+      <div className={cn("absolute left-[7px] top-0 bottom-0 w-0.5 bg-gradient-to-b", lineColor(direction))} />
+
+      {/* Date groups */}
+      {sortedDates.map((date) => {
+        const status = getDateStatus(date);
+        const items = occurrencesByDate.get(date)!.filter((item) => {
+          const tmpl = templateMap.get(item.templateId);
+          return tmpl && tmpl.direction === direction && tmpl.is_active;
+        });
+
+        return (
+          <div key={date} className="relative mb-5">
+            {/* Dot */}
+            <div
+              className={cn(
+                "absolute -left-6 top-0.5 size-3 rounded-full",
+                dotStyle(status)
+              )}
+            />
+            {/* Date label */}
+            <p className={cn("mb-2 text-[10px] font-semibold uppercase tracking-[0.1em]", dateColor(status))}>
+              {status === "today" && "Hoy — "}
+              {status === "past" && "Vencido — "}
+              {formatDate(date, "EEEE d MMM")}
+            </p>
+
+            {/* Template cards */}
+            <div className="space-y-2">
+              {items.map((item) => {
+                const tmpl = templateMap.get(item.templateId);
+                if (!tmpl) return null;
+                const occKey = `${item.templateId}:${item.date}`;
+                return (
+                  <RecurringTemplateCard
+                    key={occKey}
+                    template={tmpl}
+                    currency={currency}
+                    isExpanded={expandedId === tmpl.id}
+                    onToggleExpand={() => onToggleExpand(tmpl.id)}
+                    onPauseRequest={onPauseRequest}
+                    onDeleteRequest={onDeleteRequest}
+                    occurrenceStatus={occurrenceStatuses.get(occKey) ?? null}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Paused templates */}
+      {pausedTemplates.length > 0 && (
+        <div className="relative mb-5 mt-6">
+          <div className="absolute -left-6 top-0.5 size-3 rounded-full border-2 border-dashed border-white/15" />
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">
+            Pausados
+          </p>
+          <div className="space-y-2">
+            {pausedTemplates.map((tmpl) => (
+              <div
+                key={tmpl.id}
+                className="rounded-xl border border-dashed border-white/8 bg-white/[0.02] px-3 py-2.5 opacity-45"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-xs font-semibold">{tmpl.merchant_name}</p>
+                    <p className="text-[10px] text-muted-foreground">Pausado</p>
+                  </div>
+                  <p className="text-xs font-bold tabular-nums line-through opacity-50">
+                    {formatCurrency(Number(tmpl.amount), currency)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {sortedDates.length === 0 && pausedTemplates.length === 0 && (
+        <div className="py-8 text-center text-xs text-muted-foreground">
+          No hay {direction === "OUTFLOW" ? "gastos" : "ingresos"} recurrentes
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/recurring/recurring-timeline.tsx
+git commit -m "feat: add RecurringTimeline component with date-grouped status dots"
+```
+
+---
+
+## Task 9: Mobile Recurring Manager (Main Client Component)
+
+**Files:**
+- Create: `webapp/src/components/recurring/mobile-recurring-manager.tsx`
+
+- [ ] **Step 1: Create the main orchestrating component**
+
+This component composes hero + segmented control + timeline, manages expanded state, and handles the sequential overlay pattern for pause/delete.
+
+```typescript
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { useRecurringMonth } from "./use-recurring-month";
+import { RecurringHeroCompact } from "./recurring-hero-compact";
+import { RecurringTimeline } from "./recurring-timeline";
+import { RecurringImpactDialog } from "./recurring-impact-dialog";
+import {
+  deleteRecurringTemplate,
+  toggleRecurringTemplate,
+} from "@/actions/recurring-templates";
+import type { Account, CategoryWithChildren, CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+
+type TabDirection = "OUTFLOW" | "INFLOW";
+
+interface MobileRecurringManagerProps {
+  templates: RecurringTemplateWithRelations[];
+  accounts: Account[];
+  currency: CurrencyCode;
+}
+
+export function MobileRecurringManager({
+  templates,
+  accounts,
+  currency,
+}: MobileRecurringManagerProps) {
+  const hook = useRecurringMonth(templates, accounts);
+  const [activeTab, setActiveTab] = useState<TabDirection>("OUTFLOW");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Sequential overlay state for pause/delete
+  const [impactAction, setImpactAction] = useState<{
+    template: RecurringTemplateWithRelations;
+    action: "pause" | "delete";
+  } | null>(null);
+
+  // Compute totals
+  const totalExpenses = useMemo(
+    () => templates
+      .filter((t) => t.direction === "OUTFLOW" && t.is_active)
+      .reduce((sum, t) => sum + Number(t.amount), 0),
+    [templates]
+  );
+
+  const totalIncome = useMemo(
+    () => templates
+      .filter((t) => t.direction === "INFLOW" && t.is_active)
+      .reduce((sum, t) => sum + Number(t.amount), 0),
+    [templates]
+  );
+
+  // Build occurrence data maps for timeline
+  const { occurrencesByDate, occurrenceStatuses } = useMemo(() => {
+    const byDate = new Map<string, { templateId: string; date: string }[]>();
+    const statuses = new Map<string, "paid" | "pending" | "skipped">();
+
+    for (const item of [...hook.pending, ...hook.completed]) {
+      const key = item.date;
+      if (!byDate.has(key)) byDate.set(key, []);
+      byDate.get(key)!.push({ templateId: item.templateId, date: item.date });
+      statuses.set(`${item.templateId}:${item.date}`, item.occurrenceId ? (hook.completed.some((c) => c.key === item.key) ? "paid" : "pending") : "pending");
+    }
+
+    return { occurrencesByDate: byDate, occurrenceStatuses: statuses };
+  }, [hook.pending, hook.completed]);
+
+  const handlePauseRequest = (template: RecurringTemplateWithRelations) => {
+    setImpactAction({ template, action: "pause" });
+  };
+
+  const handleDeleteRequest = (template: RecurringTemplateWithRelations) => {
+    setImpactAction({ template, action: "delete" });
+  };
+
+  const handleImpactConfirm = async () => {
+    if (!impactAction) return;
+    const { template, action } = impactAction;
+    if (action === "pause") {
+      await toggleRecurringTemplate(template.id, false);
+    } else {
+      await deleteRecurringTemplate(template.id);
+    }
+    await hook.refreshOccurrences();
+    setImpactAction(null);
+  };
+
+  return (
+    <div className={cn("space-y-4", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
+      {/* Hero */}
+      <RecurringHeroCompact
+        totalExpenses={totalExpenses}
+        totalIncome={totalIncome}
+        currency={currency}
+        monthLabel={hook.monthLabel}
+        onPrevMonth={hook.goPrevMonth}
+        onNextMonth={hook.goNextMonth}
+        canGoNext={true}
+      />
+
+      {/* Segmented control */}
+      <div className="flex rounded-xl border border-white/6 bg-white/[0.03] p-1">
+        <button
+          type="button"
+          onClick={() => setActiveTab("OUTFLOW")}
+          className={cn(
+            "flex-1 rounded-lg py-2 text-center text-[11px] font-semibold transition-colors",
+            activeTab === "OUTFLOW"
+              ? "bg-z-brass/15 border border-z-brass/30 text-z-brass"
+              : "text-muted-foreground"
+          )}
+        >
+          Gastos
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("INFLOW")}
+          className={cn(
+            "flex-1 rounded-lg py-2 text-center text-[11px] font-semibold transition-colors",
+            activeTab === "INFLOW"
+              ? "bg-z-income/12 border border-z-income/25 text-z-income"
+              : "text-muted-foreground"
+          )}
+        >
+          Ingresos
+        </button>
+      </div>
+
+      {/* Loading */}
+      {!hook.isHydrated && (
+        <div className="py-8 text-center text-sm text-muted-foreground animate-pulse">
+          Cargando recurrentes...
+        </div>
+      )}
+
+      {/* Timeline */}
+      {hook.isHydrated && (
+        <RecurringTimeline
+          templates={templates}
+          currency={currency}
+          direction={activeTab}
+          occurrencesByDate={occurrencesByDate}
+          occurrenceStatuses={occurrenceStatuses}
+          expandedId={expandedId}
+          onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
+          onPauseRequest={handlePauseRequest}
+          onDeleteRequest={handleDeleteRequest}
+          getDateStatus={hook.getDateStatus}
+        />
+      )}
+
+      {/* Create button */}
+      <div className="flex justify-center pb-4">
+        <Link
+          href={`/recurrentes/new?direction=${activeTab}`}
+          className={cn(
+            "flex items-center gap-2 rounded-full border px-6 py-2.5 text-xs font-semibold",
+            activeTab === "OUTFLOW"
+              ? "border-z-brass/30 text-z-brass"
+              : "border-z-income/30 text-z-income"
+          )}
+        >
+          <Plus className="size-3.5" />
+          {activeTab === "OUTFLOW" ? "Nuevo gasto recurrente" : "Nuevo ingreso"}
+        </Link>
+      </div>
+
+      {/* Impact dialog (controlled, outside any Sheet) */}
+      {impactAction && (
+        <RecurringImpactDialog
+          templateId={impactAction.template.id}
+          templateName={impactAction.template.merchant_name ?? "Recurrente"}
+          currencyCode={(impactAction.template.currency_code ?? "COP") as CurrencyCode}
+          action={impactAction.action}
+          onConfirm={handleImpactConfirm}
+          open={!!impactAction}
+          onOpenChange={(open) => {
+            if (!open) setImpactAction(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/recurring/mobile-recurring-manager.tsx
+git commit -m "feat: add MobileRecurringManager with timeline, tabs, and sequential overlay"
+```
+
+---
+
+## Task 10: Route Pages — `/recurrentes`, `/recurrentes/new`, `/recurrentes/[id]/edit`
+
+**Files:**
+- Modify: `webapp/src/app/(dashboard)/recurrentes/page.tsx` (replace redirect)
+- Create: `webapp/src/app/(dashboard)/recurrentes/loading.tsx`
+- Create: `webapp/src/app/(dashboard)/recurrentes/new/page.tsx`
+- Create: `webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx`
+
+- [ ] **Step 1: Replace redirect with manager page**
+
+Overwrite `webapp/src/app/(dashboard)/recurrentes/page.tsx`:
+
+```typescript
+import { Suspense } from "react";
+import { MobileHeader } from "@/components/mobile/mobile-header";
+import { MobileRecurringManager } from "@/components/recurring/mobile-recurring-manager";
+import { getRecurringTemplates, getRecurringSummary } from "@/actions/recurring-templates";
+import { ensureCurrentOccurrences } from "@/actions/occurrences";
+import { getAccounts } from "@/actions/accounts";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+import type { CurrencyCode } from "@/types/domain";
+
+export default async function RecurrentesPage() {
+  await ensureCurrentOccurrences();
+
+  const [templates, accounts, summary] = await Promise.all([
+    getRecurringTemplates(),
+    getAccounts(),
+    getRecurringSummary(),
+  ]);
+
+  const currency: CurrencyCode = "COP";
+
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
+      <MobileRecurringManager
+        templates={templates}
+        accounts={accounts}
+        currency={currency}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create loading skeleton**
+
+Write `webapp/src/app/(dashboard)/recurrentes/loading.tsx`:
+
+```typescript
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+
+export default function RecurrentesLoading() {
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <div className="space-y-4 p-4">
+        <div className="h-24 animate-pulse rounded-2xl bg-white/4" />
+        <div className="h-10 animate-pulse rounded-xl bg-white/4" />
+        <div className="space-y-3">
+          <div className="h-16 animate-pulse rounded-xl bg-white/4" />
+          <div className="h-16 animate-pulse rounded-xl bg-white/4" />
+          <div className="h-16 animate-pulse rounded-xl bg-white/4" />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create new template page**
+
+Write `webapp/src/app/(dashboard)/recurrentes/new/page.tsx`:
+
+```typescript
+import { MobileHeader } from "@/components/mobile/mobile-header";
+import { RecurringForm } from "@/components/recurring/recurring-form";
+import { getAccounts } from "@/actions/accounts";
+import { getCategories } from "@/actions/categories";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+import { redirect } from "next/navigation";
+
+export default async function NewRecurrentePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ direction?: string }>;
+}) {
+  const params = await searchParams;
+  const [accounts, categories] = await Promise.all([
+    getAccounts(),
+    getCategories(),
+  ]);
+
+  async function handleSuccess() {
+    "use server";
+    redirect("/recurrentes");
+  }
+
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <MobileHeader variant="sub" title="Nueva recurrente" backHref="/recurrentes" />
+      <div className="px-4 pb-20">
+        <RecurringForm
+          accounts={accounts}
+          categories={categories}
+          defaultDirection={params.direction === "INFLOW" ? "INFLOW" : "OUTFLOW"}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+Note: `RecurringForm` needs a `defaultDirection` prop added (small mod in Task 3 or inline here). If the form already uses `template?.direction ?? "OUTFLOW"` as default, passing direction via search param and pre-selecting in the form works.
+
+- [ ] **Step 4: Create edit template page**
+
+Write `webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx`:
+
+```typescript
+import { notFound, redirect } from "next/navigation";
+import { MobileHeader } from "@/components/mobile/mobile-header";
+import { RecurringForm } from "@/components/recurring/recurring-form";
+import { getRecurringTemplate } from "@/actions/recurring-templates";
+import { getAccounts } from "@/actions/accounts";
+import { getCategories } from "@/actions/categories";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+
+export default async function EditRecurrentePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [template, accounts, categories] = await Promise.all([
+    getRecurringTemplate(id),
+    getAccounts(),
+    getCategories(),
+  ]);
+
+  if (!template) notFound();
+
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <MobileHeader
+        variant="sub"
+        title={`Editar ${template.merchant_name}`}
+        backHref="/recurrentes"
+      />
+      <div className="px-4 pb-20">
+        <RecurringForm
+          template={template}
+          accounts={accounts}
+          categories={categories}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webapp/src/app/\(dashboard\)/recurrentes/
+git commit -m "feat: add /recurrentes route pages (manager, new, edit)"
+```
+
+---
+
+## Task 11: Update Plan Page — Link to `/recurrentes`
+
+**Files:**
+- Modify: `webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx`
+
+- [ ] **Step 1: Replace mobile view with redirect link**
+
+The mobile section of `plan-tab-recurrentes.tsx` (around line 38-52) currently renders `<MobileRecurrentesView>`. Replace the mobile block to redirect to `/recurrentes`:
+
+In the server component, add a redirect for mobile. Since this is a server component rendered inside the Plan page tabs, the simplest approach is to keep the desktop view but change the mobile `<div className="lg:hidden">` block to show a link card:
+
+```typescript
+<div className="lg:hidden">
+  <Link
+    href="/recurrentes"
+    className="flex items-center justify-between rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3"
+  >
+    <div>
+      <p className="text-sm font-semibold">Administrar recurrentes</p>
+      <p className="text-xs text-muted-foreground">
+        {summary.activeCount} activos · {formatCurrency(summary.totalMonthlyExpenses + summary.totalMonthlyIncome, currency)}/mes
+      </p>
+    </div>
+    <ChevronRight className="size-4 text-muted-foreground" />
+  </Link>
+</div>
+```
+
+Add `Link` from `next/link` and `ChevronRight` from `lucide-react` to imports.
+
+- [ ] **Step 2: Build check**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+git commit -m "feat: plan page mobile recurrentes links to /recurrentes manager"
+```
+
+---
+
+## Task 12: Visual Testing + Polish
+
+- [ ] **Step 1: Start dev server and test mobile viewport**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm dev
+```
+
+Open `http://localhost:3000/recurrentes` at 390×844 viewport (iPhone 14 Pro).
+
+- [ ] **Step 2: Test golden path**
+
+1. Verify hero shows correct totals and proportion bar
+2. Verify segmented control switches between Gastos/Ingresos
+3. Verify timeline shows templates grouped by date with correct status dots
+4. Tap a template card → expanded view with skeleton → stats load
+5. Tap Edit → navigates to `/recurrentes/[id]/edit` with form pre-filled
+6. Save edit → redirects back to `/recurrentes`
+7. Tap Pause on expanded card → AlertDialog appears (no layering bug)
+8. Confirm Pause → template moves to Paused section
+9. Tap Delete → AlertDialog with impact → confirm → template removed
+10. Tap "+ Nuevo gasto recurrente" → navigates to `/recurrentes/new`
+11. Fill form → save → redirects back to `/recurrentes`
+
+- [ ] **Step 3: Test edge cases**
+
+1. Navigate from Plan → "Administrar recurrentes" → `/recurrentes` → back → Plan
+2. `/recurrentes/new` → back → `/recurrentes`
+3. Empty state: no templates → shows "No hay gastos recurrentes"
+4. Only paused templates → shows Paused section only
+5. Desktop viewport → Plan page still shows desktop `RecurringList` (no regression)
+
+- [ ] **Step 4: Fix any styling issues found**
+
+- [ ] **Step 5: Final build gate**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+```
+
+- [ ] **Step 6: Commit any polish fixes**
+
+```bash
+git add -A
+git commit -m "fix: recurring manager visual polish and edge case fixes"
+```
+
+---
+
+## Task 13: Agent Review Gates
+
+Run all four review agents before declaring done.
+
+- [ ] **Step 1: `recurring-doctor`** — verify occurrence lifecycle, `ONCE` frequency handling, `ensureCurrentOccurrences` called on new page
+
+- [ ] **Step 2: `zetas-front-guy`** — audit all new TSX files for token compliance, design system patterns
+
+- [ ] **Step 3: `server-action-reviewer`** — review `getTemplateStats` action for auth, defense-in-depth, error handling
+
+- [ ] **Step 4: `cache-doctor`** — verify new page route caching, `revalidateTag` paths after mutations
+
+- [ ] **Step 5: Fix any issues found by agents**
+
+- [ ] **Step 6: Final build gate + commit**
+
+```bash
+cd /Users/cristian/Documents/developing/current-projects/zeta/webapp && pnpm build
+git add -A
+git commit -m "fix: address review agent findings"
+```

--- a/docs/superpowers/specs/2026-04-14-recurring-manager-mobile-redesign.md
+++ b/docs/superpowers/specs/2026-04-14-recurring-manager-mobile-redesign.md
@@ -1,0 +1,150 @@
+# Recurring Manager — Mobile Redesign
+
+**Date:** 2026-04-14
+**Status:** Draft
+**Scope:** New top-level `/recurrentes` route — complete redesign from payment checklist to recurring template manager (mobile)
+
+## Problem
+
+The mobile recurring page is a flat list of pending/completed occurrences. It answers "what's due this month?" but doesn't let users manage their recurring obligations: no visible create button, no template overview, no financial context (yearly cost, history), and a critical layering bug where edit/pause/delete dialogs render behind the action sheet (z-50 behind z-[10000]).
+
+## Design Decisions
+
+All decisions validated through visual companion mockups during brainstorming.
+
+### Routing
+
+Recurring becomes a **top-level route**: `/recurrentes`, `/recurrentes/new`, `/recurrentes/[id]/edit`.
+
+The Plan page's "Recurrentes" card becomes a navigation link to `/recurrentes` (same pattern as Plan → Accounts, Plan → Deudas).
+
+**Back button behavior:** `router.back()` everywhere. Natural browser history handles the chain:
+- Plan → `/recurrentes` → back → Plan
+- `/recurrentes` → `/recurrentes/new` → back → `/recurrentes`
+- `/recurrentes` → `/recurrentes/[id]/edit` → back → `/recurrentes`
+- Deep-linked `/recurrentes` with no history → fallback to `/plan`
+
+### Page Structure (top to bottom)
+
+1. **Header** — "Recurrentes" + back arrow (`router.back()`) + profile avatar (existing pattern)
+2. **Compact Hero** — proportion bar (red-to-green) showing gastos vs ingresos ratio. Three numbers: gastos total | net balance | ingresos total. Green net = positive, red = negative.
+3. **Month navigation** — chevrons + month label (existing pattern, reused)
+4. **Segmented control** — "Gastos" / "Ingresos" tabs. Tap or swipe to switch. Active tab shows accent color (brass for gastos, green for ingresos).
+5. **Timeline** — vertical timeline grouped by date, one tab visible at a time
+6. **Create button** — "+ Nuevo gasto recurrente" or "+ Nuevo ingreso" (contextual to active tab). Navigates to `/recurrentes/new`.
+
+### Timeline Design
+
+- Vertical line on the left with status-colored dots at each date group
+- **Status dots:**
+  - Filled red + glow → overdue (past due date, not paid)
+  - Filled amber + glow → due today
+  - Hollow gray → future
+  - Filled green → paid/received
+  - Dashed hollow → paused templates section
+- **Template cards** at each date: name, account info, amount, frequency label, yearly cost estimate
+- **Light status hint** — small indicator on each card showing if this month's occurrence is paid/pending. Read-only context, no confirm/skip actions (those stay on the Plan page).
+- **One-time payments** distinguished by: square dot (not circle), dashed border, "UNA VEZ" badge
+- **Paused templates** collected at timeline bottom: dashed border, dimmed opacity, "Pausado desde [date]"
+- Templates sorted: active by next date ascending, paused at bottom
+
+### Expanded View (tap a template card)
+
+Expands inline on the timeline. Only one expanded at a time.
+
+**Instant (no fetch):**
+- Header: name, account, amount (larger), frequency
+- Action buttons: Edit / Pause / Delete (expense), Edit / Delete (income), Edit / Mark Paid / Delete (one-time)
+
+**Lazy loaded (skeleton → data):**
+- Stats chips (fixed height, no layout shift): year-to-date total, annual estimate, payment streak
+- Stats fetched via server action on expand
+
+**Varies by type:**
+| Type | Stats | Actions |
+|------|-------|---------|
+| Recurring expense | YTD, annual est., streak | Edit, Pause, Delete |
+| Recurring income | YTD, annual est., streak + "Consistente ✓" if stable | Edit, Delete |
+| One-time payment | % of monthly income, remaining margin after payment | Edit, Mark Paid, Delete |
+
+**Graph (6-month bar chart) deferred** — can be added later as enhancement inside expanded view.
+
+### Create & Edit Flow
+
+Both use **full page routes**:
+- Create: `/recurrentes/new` — reuses `RecurringForm` component
+- Edit: `/recurrentes/[id]/edit` — same `RecurringForm` with template data pre-filled
+
+Avoids all z-index layering issues. Consistent pattern. Most space for the 8-field form.
+
+### Dialog Layering Fix (Pause/Delete)
+
+Current bug: `TemplateActionSheet` (Sheet z-[10000]) nests `RecurringImpactDialog` (AlertDialog z-50). Dialog renders behind sheet.
+
+Fix: sequential overlay pattern. When user taps Pause/Delete in the action sheet:
+1. Close the Sheet
+2. Wait for close animation (350ms)
+3. Open `RecurringImpactDialog` as controlled AlertDialog (at page level, outside Sheet)
+
+For Edit: Sheet closes → navigate to `/recurrentes/[id]/edit`. No overlay needed.
+
+## Data Model Changes
+
+### New frequency value: `ONCE`
+
+Add `ONCE` to the `recurring_frequency` enum in Supabase. A template with `frequency = 'ONCE'` generates exactly one occurrence, then the template auto-deactivates (`is_active = false`) after the occurrence is paid/skipped.
+
+**Migration:** `ALTER TYPE recurring_frequency ADD VALUE 'ONCE';`
+
+**Occurrence generation:** `ensureCurrentOccurrences()` generates a single occurrence at `start_date` for `ONCE` templates. No recurrence calculation needed.
+
+**Form changes:** Add "Una vez" option to frequency select. When selected, hide end_date field (irrelevant).
+
+### Template stats server action
+
+New server action: `getTemplateStats(templateId)` → returns:
+```typescript
+{
+  ytdTotal: number;        // sum of paid occurrences this calendar year
+  annualEstimate: number;  // amount × frequency multiplier (or ytdTotal for ONCE)
+  streak: number;          // consecutive months with a paid occurrence
+  impactPercent?: number;  // for ONCE: amount / monthly income × 100
+  marginAfter?: number;    // for ONCE: monthly income - monthly expenses - amount
+}
+```
+
+Fetched on expand, not on page load.
+
+## Components
+
+### New
+- `MobileRecurringManager` — top-level page component. Contains hero, segmented control, timeline, expanded views.
+- `RecurringTimeline` — the timeline rendering (dots, date groups, template cards)
+- `RecurringTemplateCard` — collapsed and expanded states for a single template
+- `RecurringHeroCompact` — the proportion bar hero
+- `/recurrentes/page.tsx` — route entry point (server component, fetches data)
+- `/recurrentes/new/page.tsx` — create form page
+- `/recurrentes/[id]/edit/page.tsx` — edit form page
+
+### Reused
+- `RecurringForm` (`recurring-form.tsx`) — the form itself, used in create and edit pages
+- `RecurringImpactDialog` (`recurring-impact-dialog.tsx`) — extended with optional controlled mode
+- `useRecurringMonth` hook — existing occurrence data, adapted for timeline grouping
+- `MOBILE_TAB_BAR_CLEARANCE_CLASS`, `PANEL_INSET_CLASS`, `HERO_CARD_GRADIENT_CLASS` — existing style constants
+- `formatCurrency`, `formatDate` — existing utilities
+
+### Modified
+- `RecurringImpactDialog` — add optional `open`/`onOpenChange` props for controlled mode (backward-compatible)
+- `recurring_frequency` enum — add `ONCE` value
+- `ensureCurrentOccurrences()` — handle `ONCE` frequency
+- `RecurringForm` — add "Una vez" frequency option, conditional end_date visibility
+- Plan page "Recurrentes" card — change from tab switch to navigation link to `/recurrentes`
+
+## What's NOT in scope
+
+- 6-month payment history bar chart (deferred enhancement)
+- Calendar view overlay (future addition on top of timeline)
+- Desktop changes (desktop recurring list stays as-is)
+- Checklist/confirm payment flow (stays in monthly plan tab)
+- Tags on recurring templates (separate backlog item)
+- Swipe gesture for tab switching (tap first, swipe as enhancement)

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -787,6 +787,7 @@ export type Database = {
         | "MONTHLY"
         | "QUARTERLY"
         | "ANNUAL"
+        | "ONCE"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
     }
@@ -949,6 +950,7 @@ export const Constants = {
         "MONTHLY",
         "QUARTERLY",
         "ANNUAL",
+        "ONCE",
       ],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],

--- a/packages/shared/src/utils/recurrence.ts
+++ b/packages/shared/src/utils/recurrence.ts
@@ -16,6 +16,12 @@ function advanceByFrequency(date: Date, frequency: RecurrenceFrequency): Date {
       return addMonths(date, 3);
     case "ANNUAL":
       return addYears(date, 1);
+    case "ONCE":
+      return date; // no advancement — single occurrence at start_date
+    default: {
+      const _exhaustive: never = frequency;
+      return _exhaustive;
+    }
   }
 }
 
@@ -35,6 +41,13 @@ export function getNextOccurrence(
 
   // If end date has passed, no more occurrences
   if (end && isBefore(end, from)) return null;
+
+  // ONCE: single occurrence at start_date
+  if (frequency === "ONCE") {
+    if (end && isBefore(end, from)) return null;
+    if (isBefore(start, from)) return null;
+    return start.toISOString().split("T")[0];
+  }
 
   let current = start;
 
@@ -65,6 +78,16 @@ export function getOccurrencesBetween(
   const from = startOfDay(rangeStart);
   const to = startOfDay(rangeEnd);
 
+  // ONCE: single occurrence at start_date if within range
+  if (frequency === "ONCE") {
+    if (!isAfter(start, to) && !isBefore(start, from)) {
+      if (!end || !isAfter(start, end)) {
+        dates.push(start.toISOString().split("T")[0]);
+      }
+    }
+    return dates;
+  }
+
   let current = start;
 
   // Advance to first occurrence on or after rangeStart
@@ -87,6 +110,7 @@ export function getOccurrencesBetween(
  */
 export function frequencyLabel(frequency: RecurrenceFrequency): string {
   const labels: Record<RecurrenceFrequency, string> = {
+    ONCE: "Una vez",
     WEEKLY: "Semanal",
     BIWEEKLY: "Quincenal",
     MONTHLY: "Mensual",

--- a/supabase/migrations/20260414144717_add_once_frequency.sql
+++ b/supabase/migrations/20260414144717_add_once_frequency.sql
@@ -1,0 +1,2 @@
+-- Add ONCE frequency for one-time planned payments
+ALTER TYPE recurrence_frequency ADD VALUE IF NOT EXISTS 'ONCE';

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -355,12 +355,13 @@ async function deactivateOnceTemplateIfNeeded(
     .single();
 
   if (tmpl?.frequency === "ONCE") {
-    await supabase
+    const { error: deactivateErr } = await supabase
       .from("recurring_transaction_templates")
       .update({ is_active: false })
       .eq("id", templateId)
       .eq("user_id", userId);
 
+    if (deactivateErr) console.error("Failed to deactivate ONCE template:", deactivateErr.message);
     revalidateTag("recurring", "zeta");
   }
 }
@@ -558,11 +559,13 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
       .single();
 
     if (tmpl?.frequency === "ONCE" && !tmpl.is_active) {
-      await supabase
+      const { error: reactivateErr } = await supabase
         .from("recurring_transaction_templates")
         .update({ is_active: true })
         .eq("id", occurrence.template_id)
         .eq("user_id", user.id);
+
+      if (reactivateErr) console.error("Failed to reactivate ONCE template:", reactivateErr.message);
     }
   }
 

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -340,6 +340,32 @@ export async function getPendingOccurrences(
 }
 
 /**
+ * If the template has frequency ONCE, deactivate it after its occurrence is resolved.
+ */
+async function deactivateOnceTemplateIfNeeded(
+  supabase: Awaited<ReturnType<typeof getAuthenticatedClient>>["supabase"],
+  templateId: string,
+  userId: string,
+) {
+  const { data: tmpl } = await supabase
+    .from("recurring_transaction_templates")
+    .select("frequency")
+    .eq("id", templateId)
+    .eq("user_id", userId)
+    .single();
+
+  if (tmpl?.frequency === "ONCE") {
+    await supabase
+      .from("recurring_transaction_templates")
+      .update({ is_active: false })
+      .eq("id", templateId)
+      .eq("user_id", userId);
+
+    revalidateTag("recurring", "zeta");
+  }
+}
+
+/**
  * Mark an occurrence as paid and link it to the created transaction.
  * Only transitions from 'pending'.
  */
@@ -350,7 +376,7 @@ export async function markOccurrencePaid(
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
 
-  const { error } = await supabase
+  const { data: occurrence, error } = await supabase
     .from("recurring_occurrences")
     .update({
       status: "paid",
@@ -359,9 +385,16 @@ export async function markOccurrencePaid(
     })
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
-    .eq("status", "pending");
+    .eq("status", "pending")
+    .select("template_id")
+    .single();
 
   if (error) return { success: false, error: error.message };
+
+  // Auto-deactivate ONCE templates after their single occurrence is resolved
+  if (occurrence?.template_id) {
+    await deactivateOnceTemplateIfNeeded(supabase, occurrence.template_id, user.id);
+  }
 
   revalidateFinancialViews();
   revalidateTag("occurrences", "zeta");
@@ -376,7 +409,7 @@ export async function skipOccurrence(occurrenceId: string): Promise<ActionResult
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
 
-  const { error } = await supabase
+  const { data: occurrence, error } = await supabase
     .from("recurring_occurrences")
     .update({
       status: "skipped",
@@ -384,9 +417,16 @@ export async function skipOccurrence(occurrenceId: string): Promise<ActionResult
     })
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
-    .eq("status", "pending");
+    .eq("status", "pending")
+    .select("template_id")
+    .single();
 
   if (error) return { success: false, error: error.message };
+
+  // Auto-deactivate ONCE templates after their single occurrence is resolved
+  if (occurrence?.template_id) {
+    await deactivateOnceTemplateIfNeeded(supabase, occurrence.template_id, user.id);
+  }
 
   revalidateFinancialViews();
   revalidateTag("occurrences", "zeta");
@@ -507,6 +547,24 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
     .eq("user_id", user.id);
 
   if (updateError) return { success: false, error: updateError.message };
+
+  // Re-activate ONCE templates so the reverted occurrence becomes visible
+  if (occurrence.template_id) {
+    const { data: tmpl } = await supabase
+      .from("recurring_transaction_templates")
+      .select("frequency, is_active")
+      .eq("id", occurrence.template_id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (tmpl?.frequency === "ONCE" && !tmpl.is_active) {
+      await supabase
+        .from("recurring_transaction_templates")
+        .update({ is_active: true })
+        .eq("id", occurrence.template_id)
+        .eq("user_id", user.id);
+    }
+  }
 
   revalidateFinancialViews();
   revalidateTag("occurrences", "zeta");

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -342,28 +342,23 @@ export async function getPendingOccurrences(
 /**
  * If the template has frequency ONCE, deactivate it after its occurrence is resolved.
  */
-async function deactivateOnceTemplateIfNeeded(
+/**
+ * Deactivate a ONCE template after its occurrence is resolved.
+ * Accepts frequency directly to avoid an extra DB read.
+ */
+async function deactivateOnceTemplate(
   supabase: Awaited<ReturnType<typeof getAuthenticatedClient>>["supabase"],
   templateId: string,
   userId: string,
 ) {
-  const { data: tmpl } = await supabase
+  const { error: deactivateErr } = await supabase
     .from("recurring_transaction_templates")
-    .select("frequency")
+    .update({ is_active: false })
     .eq("id", templateId)
-    .eq("user_id", userId)
-    .single();
+    .eq("user_id", userId);
 
-  if (tmpl?.frequency === "ONCE") {
-    const { error: deactivateErr } = await supabase
-      .from("recurring_transaction_templates")
-      .update({ is_active: false })
-      .eq("id", templateId)
-      .eq("user_id", userId);
-
-    if (deactivateErr) console.error("Failed to deactivate ONCE template:", deactivateErr.message);
-    revalidateTag("recurring", "zeta");
-  }
+  if (deactivateErr) console.error("Failed to deactivate ONCE template:", deactivateErr.message);
+  revalidateTag("recurring", "zeta");
 }
 
 /**
@@ -387,14 +382,15 @@ export async function markOccurrencePaid(
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
     .eq("status", "pending")
-    .select("template_id")
+    .select("template_id, template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(frequency)")
     .single();
 
   if (error) return { success: false, error: error.message };
 
   // Auto-deactivate ONCE templates after their single occurrence is resolved
-  if (occurrence?.template_id) {
-    await deactivateOnceTemplateIfNeeded(supabase, occurrence.template_id, user.id);
+  const freq = (occurrence?.template as { frequency: string } | null)?.frequency;
+  if (freq === "ONCE" && occurrence?.template_id) {
+    await deactivateOnceTemplate(supabase, occurrence.template_id, user.id);
   }
 
   revalidateFinancialViews();
@@ -419,14 +415,15 @@ export async function skipOccurrence(occurrenceId: string): Promise<ActionResult
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
     .eq("status", "pending")
-    .select("template_id")
+    .select("template_id, template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(frequency)")
     .single();
 
   if (error) return { success: false, error: error.message };
 
   // Auto-deactivate ONCE templates after their single occurrence is resolved
-  if (occurrence?.template_id) {
-    await deactivateOnceTemplateIfNeeded(supabase, occurrence.template_id, user.id);
+  const freq = (occurrence?.template as { frequency: string } | null)?.frequency;
+  if (freq === "ONCE" && occurrence?.template_id) {
+    await deactivateOnceTemplate(supabase, occurrence.template_id, user.id);
   }
 
   revalidateFinancialViews();

--- a/webapp/src/actions/template-stats.ts
+++ b/webapp/src/actions/template-stats.ts
@@ -1,0 +1,142 @@
+"use server";
+
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { startOfYear } from "date-fns";
+import type { ActionResult } from "@/types/actions";
+
+export interface TemplateStats {
+  ytdTotal: number;
+  annualEstimate: number;
+  streak: number;
+  isConsistent: boolean;
+  impactPercent: number | null;
+  marginAfter: number | null;
+}
+
+const FREQUENCY_MULTIPLIER: Record<string, number> = {
+  WEEKLY: 52,
+  BIWEEKLY: 26,
+  MONTHLY: 12,
+  QUARTERLY: 4,
+  ANNUAL: 1,
+  ONCE: 1,
+};
+
+export async function getTemplateStats(
+  templateId: string
+): Promise<ActionResult<TemplateStats>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const { data: template, error: tErr } = await supabase
+    .from("recurring_transaction_templates")
+    .select("id, amount, frequency, direction, account_id")
+    .eq("id", templateId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (tErr || !template) {
+    return { success: false, error: "Plantilla no encontrada" };
+  }
+
+  // Paid occurrences this year
+  const yearStart = startOfYear(new Date()).toISOString().split("T")[0];
+  const { data: paidOccurrences } = await supabase
+    .from("recurring_occurrences")
+    .select("occurrence_date, expected_amount, paid_at")
+    .eq("template_id", templateId)
+    .eq("user_id", user.id)
+    .eq("status", "paid")
+    .gte("occurrence_date", yearStart)
+    .order("occurrence_date", { ascending: false });
+
+  const paid = paidOccurrences ?? [];
+  const ytdTotal = paid.reduce(
+    (sum, o) => sum + Number(o.expected_amount),
+    0
+  );
+
+  const multiplier = FREQUENCY_MULTIPLIER[template.frequency] ?? 12;
+  const annualEstimate =
+    template.frequency === "ONCE"
+      ? Number(template.amount)
+      : Number(template.amount) * multiplier;
+
+  // Streak: consecutive periods with a payment (count backwards)
+  let streak = 0;
+  if (paid.length > 0) {
+    streak = 1;
+    for (let i = 1; i < paid.length; i++) {
+      const prev = new Date(paid[i - 1].occurrence_date + "T12:00:00");
+      const curr = new Date(paid[i].occurrence_date + "T12:00:00");
+      const monthDiff =
+        (prev.getFullYear() - curr.getFullYear()) * 12 +
+        prev.getMonth() -
+        curr.getMonth();
+      if (monthDiff <= 2) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Consistency: all paid amounts within 5% of template amount
+  const templateAmount = Number(template.amount);
+  const isConsistent =
+    paid.length >= 2 &&
+    paid.every(
+      (o) =>
+        Math.abs(Number(o.expected_amount) - templateAmount) / templateAmount <
+        0.05
+    );
+
+  // Impact (ONCE only)
+  let impactPercent: number | null = null;
+  let marginAfter: number | null = null;
+
+  if (template.frequency === "ONCE") {
+    const { data: incomeTemplates } = await supabase
+      .from("recurring_transaction_templates")
+      .select("amount, frequency")
+      .eq("user_id", user.id)
+      .eq("direction", "INFLOW")
+      .eq("is_active", true);
+
+    const monthlyIncome = (incomeTemplates ?? []).reduce((sum, t) => {
+      const m = FREQUENCY_MULTIPLIER[t.frequency] ?? 12;
+      return sum + (Number(t.amount) * m) / 12;
+    }, 0);
+
+    if (monthlyIncome > 0) {
+      impactPercent = (Number(template.amount) / monthlyIncome) * 100;
+    }
+
+    const { data: expenseTemplates } = await supabase
+      .from("recurring_transaction_templates")
+      .select("amount, frequency")
+      .eq("user_id", user.id)
+      .eq("direction", "OUTFLOW")
+      .eq("is_active", true)
+      .neq("id", templateId);
+
+    const monthlyExpenses = (expenseTemplates ?? []).reduce((sum, t) => {
+      const m = FREQUENCY_MULTIPLIER[t.frequency] ?? 12;
+      return sum + (Number(t.amount) * m) / 12;
+    }, 0);
+
+    marginAfter = monthlyIncome - monthlyExpenses - Number(template.amount);
+  }
+
+  return {
+    success: true,
+    data: {
+      ytdTotal,
+      annualEstimate,
+      streak,
+      isConsistent,
+      impactPercent,
+      marginAfter,
+    },
+  };
+}

--- a/webapp/src/actions/template-stats.ts
+++ b/webapp/src/actions/template-stats.ts
@@ -1,6 +1,8 @@
 "use server";
 
+import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { startOfYear } from "date-fns";
 import type { ActionResult } from "@/types/actions";
 
@@ -22,21 +24,26 @@ const FREQUENCY_MULTIPLIER: Record<string, number> = {
   ONCE: 1,
 };
 
-export async function getTemplateStats(
-  templateId: string
-): Promise<ActionResult<TemplateStats>> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+async function getTemplateStatsCached(
+  userId: string,
+  templateId: string,
+  accessToken: string
+): Promise<TemplateStats> {
+  "use cache";
+  cacheTag("recurring");
+  cacheLife("zeta");
 
-  const { data: template, error: tErr } = await supabase
+  const supabase = createCachedClient(accessToken);
+
+  const { data: template } = await supabase
     .from("recurring_transaction_templates")
     .select("id, amount, frequency, direction, account_id")
     .eq("id", templateId)
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .single();
 
-  if (tErr || !template) {
-    return { success: false, error: "Plantilla no encontrada" };
+  if (!template) {
+    return { ytdTotal: 0, annualEstimate: 0, streak: 0, isConsistent: false, impactPercent: null, marginAfter: null };
   }
 
   // Paid occurrences this year
@@ -45,7 +52,7 @@ export async function getTemplateStats(
     .from("recurring_occurrences")
     .select("occurrence_date, expected_amount, paid_at")
     .eq("template_id", templateId)
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .eq("status", "paid")
     .gte("occurrence_date", yearStart)
     .order("occurrence_date", { ascending: false });
@@ -99,7 +106,7 @@ export async function getTemplateStats(
     const { data: incomeTemplates } = await supabase
       .from("recurring_transaction_templates")
       .select("amount, frequency")
-      .eq("user_id", user.id)
+      .eq("user_id", userId)
       .eq("direction", "INFLOW")
       .eq("is_active", true);
 
@@ -115,7 +122,7 @@ export async function getTemplateStats(
     const { data: expenseTemplates } = await supabase
       .from("recurring_transaction_templates")
       .select("amount, frequency")
-      .eq("user_id", user.id)
+      .eq("user_id", userId)
       .eq("direction", "OUTFLOW")
       .eq("is_active", true)
       .neq("id", templateId);
@@ -129,14 +136,24 @@ export async function getTemplateStats(
   }
 
   return {
-    success: true,
-    data: {
-      ytdTotal,
-      annualEstimate,
-      streak,
-      isConsistent,
-      impactPercent,
-      marginAfter,
-    },
+    ytdTotal,
+    annualEstimate,
+    streak,
+    isConsistent,
+    impactPercent,
+    marginAfter,
   };
+}
+
+export async function getTemplateStats(
+  templateId: string
+): Promise<ActionResult<TemplateStats>> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const data = await getTemplateStatsCached(user.id, templateId, accessToken);
+    return { success: true, data };
+  } catch {
+    return { success: false, error: "Error al cargar estadísticas" };
+  }
 }

--- a/webapp/src/actions/template-stats.ts
+++ b/webapp/src/actions/template-stats.ts
@@ -3,6 +3,7 @@
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { startOfYear } from "date-fns";
 import type { ActionResult } from "@/types/actions";
 
@@ -30,7 +31,7 @@ async function getTemplateStatsCached(
   accessToken: string
 ): Promise<TemplateStats> {
   "use cache";
-  cacheTag("recurring");
+  cacheTag("recurring", "occurrences");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
@@ -105,12 +106,16 @@ async function getTemplateStatsCached(
   if (template.frequency === "ONCE") {
     const { data: incomeTemplates } = await supabase
       .from("recurring_transaction_templates")
-      .select("amount, frequency")
+      .select("amount, frequency, account:accounts!recurring_transaction_templates_account_id_fkey(account_type)")
       .eq("user_id", userId)
       .eq("direction", "INFLOW")
       .eq("is_active", true);
 
-    const monthlyIncome = (incomeTemplates ?? []).reduce((sum, t) => {
+    // Filter out debt payments (INFLOW to CREDIT_CARD/LOAN = payment, not income)
+    const realIncome = (incomeTemplates ?? []).filter(
+      (t) => !isDebtAccountType((t.account as { account_type: string } | null)?.account_type ?? "")
+    );
+    const monthlyIncome = realIncome.reduce((sum, t) => {
       const m = FREQUENCY_MULTIPLIER[t.frequency] ?? 12;
       return sum + (Number(t.amount) * m) / 12;
     }, 0);

--- a/webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from "next/navigation";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
+import { RecurringForm } from "@/components/recurring/recurring-form";
+import { getRecurringTemplate } from "@/actions/recurring-templates";
+import { getAccounts } from "@/actions/accounts";
+import { getCategories } from "@/actions/categories";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+
+export default async function EditRecurrentePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [templateResult, accountsResult, categoriesResult] = await Promise.all([
+    getRecurringTemplate(id),
+    getAccounts(),
+    getCategories(),
+  ]);
+
+  if (!templateResult.success) notFound();
+
+  const template = templateResult.data;
+  const accounts = accountsResult.success ? accountsResult.data : [];
+  const categories = categoriesResult.success ? categoriesResult.data : [];
+
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <MobileHeader
+        variant="sub"
+        title={`Editar ${template.merchant_name}`}
+        backHref="/recurrentes"
+      />
+      <div className="px-4 pb-20">
+        <RecurringForm
+          template={template}
+          accounts={accounts}
+          categories={categories}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/app/(dashboard)/recurrentes/new/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/new/page.tsx
@@ -1,0 +1,27 @@
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
+import { RecurringForm } from "@/components/recurring/recurring-form";
+import { getAccounts } from "@/actions/accounts";
+import { getCategories } from "@/actions/categories";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+
+export default async function NewRecurrentePage() {
+  const [accountsResult, categoriesResult] = await Promise.all([
+    getAccounts(),
+    getCategories(),
+  ]);
+
+  const accounts = accountsResult.success ? accountsResult.data : [];
+  const categories = categoriesResult.success ? categoriesResult.data : [];
+
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <MobileHeader variant="sub" title="Nueva recurrente" backHref="/recurrentes" />
+      <div className="px-4 pb-20">
+        <RecurringForm
+          accounts={accounts}
+          categories={categories}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/app/(dashboard)/recurrentes/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/page.tsx
@@ -4,7 +4,7 @@ import { MobileRecurringManager } from "@/components/recurring/mobile-recurring-
 import { getRecurringTemplates } from "@/actions/recurring-templates";
 import { getAccounts } from "@/actions/accounts";
 import { getPreferredCurrency } from "@/actions/profile";
-import { ensureCurrentOccurrences } from "@/actions/occurrences";
+import { ensureCurrentOccurrences, getOccurrencesForMonth } from "@/actions/occurrences";
 import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -12,14 +12,16 @@ export default async function RecurrentesPage() {
   await connection();
   await ensureCurrentOccurrences();
 
-  const [templatesResult, accountsResult, currency] = await Promise.all([
+  const [templatesResult, accountsResult, currency, occurrencesResult] = await Promise.all([
     getRecurringTemplates(),
     getAccounts(),
     getPreferredCurrency(),
+    getOccurrencesForMonth(),
   ]);
 
   const templates = templatesResult.success ? templatesResult.data : [];
   const accounts = accountsResult.success ? accountsResult.data : [];
+  const initialOccurrences = occurrencesResult.success ? occurrencesResult.data : [];
 
   return (
     <div className={PAGE_STACK_CLASS}>
@@ -28,6 +30,7 @@ export default async function RecurrentesPage() {
         templates={templates}
         accounts={accounts}
         currency={currency as CurrencyCode}
+        initialOccurrences={initialOccurrences}
       />
     </div>
   );

--- a/webapp/src/app/(dashboard)/recurrentes/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/page.tsx
@@ -1,5 +1,34 @@
-import { redirect } from "next/navigation";
+import { connection } from "next/server";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
+import { MobileRecurringManager } from "@/components/recurring/mobile-recurring-manager";
+import { getRecurringTemplates } from "@/actions/recurring-templates";
+import { getAccounts } from "@/actions/accounts";
+import { getPreferredCurrency } from "@/actions/profile";
+import { ensureCurrentOccurrences } from "@/actions/occurrences";
+import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
+import type { CurrencyCode } from "@/types/domain";
 
-export default function RecurrentesPage() {
-  redirect("/plan?tab=recurrentes");
+export default async function RecurrentesPage() {
+  await connection();
+  await ensureCurrentOccurrences();
+
+  const [templatesResult, accountsResult, currency] = await Promise.all([
+    getRecurringTemplates(),
+    getAccounts(),
+    getPreferredCurrency(),
+  ]);
+
+  const templates = templatesResult.success ? templatesResult.data : [];
+  const accounts = accountsResult.success ? accountsResult.data : [];
+
+  return (
+    <div className={PAGE_STACK_CLASS}>
+      <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
+      <MobileRecurringManager
+        templates={templates}
+        accounts={accounts}
+        currency={currency as CurrencyCode}
+      />
+    </div>
+  );
 }

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -7,6 +7,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { PANEL_INSET_CLASS, HERO_CARD_GRADIENT_CLASS, MOBILE_ACTION_BUTTON_CLASS, MOBILE_EYEBROW_CLASS, MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
+import type { RecurringOccurrence } from "@/actions/occurrences";
 import { RecurringConfirmInline } from "@/components/recurring/recurring-confirm-inline";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringImpactDialog } from "@/components/recurring/recurring-impact-dialog";
@@ -29,6 +30,7 @@ interface MobileRecurrentesViewProps {
   templates: RecurringTemplateWithRelations[];
   accounts: Account[];
   currency: CurrencyCode;
+  initialOccurrences?: RecurringOccurrence[];
 }
 
 /* ------------------------------------------------------------------ */
@@ -67,8 +69,9 @@ export function MobileRecurrentesView({
   templates,
   accounts,
   currency,
+  initialOccurrences,
 }: MobileRecurrentesViewProps) {
-  const hook = useRecurringMonth(templates, accounts);
+  const hook = useRecurringMonth(templates, accounts, initialOccurrences);
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const [actionItem, setActionItem] = useState<OccurrenceItem | null>(null);
   const categories = useCategories();

--- a/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
@@ -6,6 +6,7 @@ import {
   getRecurringTemplates,
   getRecurringSummary,
 } from "@/actions/recurring-templates";
+import { getOccurrencesForMonth } from "@/actions/occurrences";
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
@@ -20,7 +21,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import type { CurrencyCode } from "@/types/domain";
 
 export async function PlanTabRecurrentes() {
-  const [templatesResult, accountsResult, categoriesResult, summary, currency, attentionSnapshot] =
+  const [templatesResult, accountsResult, categoriesResult, summary, currency, attentionSnapshot, occurrencesResult] =
     await Promise.all([
       getRecurringTemplates(),
       getAccounts(),
@@ -28,11 +29,13 @@ export async function PlanTabRecurrentes() {
       getRecurringSummary(),
       getPreferredCurrency(),
       getAttentionSnapshot(),
+      getOccurrencesForMonth(),
     ]);
 
   const templates = templatesResult.success ? templatesResult.data : [];
   const accounts = accountsResult.success ? accountsResult.data : [];
   const categories = categoriesResult.success ? categoriesResult.data : [];
+  const initialOccurrences = occurrencesResult.success ? occurrencesResult.data : undefined;
 
   return (
     <div className="space-y-6">
@@ -59,6 +62,7 @@ export async function PlanTabRecurrentes() {
           templates={templates}
           accounts={accounts}
           currency={currency as CurrencyCode}
+          initialOccurrences={initialOccurrences}
         />
       </div>
 

--- a/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
@@ -11,6 +11,8 @@ import { ChevronRight } from "lucide-react";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringList } from "@/components/recurring/recurring-list";
 import { RecurringTimelineView } from "@/components/recurring/recurring-timeline-view";
+import { MobileRecurrentesView } from "@/components/mobile/v2/plan/mobile-recurrentes-view";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { DesktopOnly } from "@/components/ui/responsive-render";
 import { SummaryCard } from "@/components/ui/summary-card";
 import { AttentionCard } from "@/components/ui/attention-card";
@@ -34,20 +36,30 @@ export async function PlanTabRecurrentes() {
 
   return (
     <div className="space-y-6">
-      {/* Mobile — link to dedicated manager */}
+      {/* Mobile — checklist + link to manager */}
       <div className="lg:hidden">
-        <Link
-          href="/recurrentes"
-          className="flex items-center justify-between rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3"
-        >
-          <div>
-            <p className="text-sm font-semibold">Administrar recurrentes</p>
-            <p className="text-xs text-muted-foreground">
-              {summary.activeCount} activos · {formatCurrency(summary.totalMonthlyExpenses + summary.totalMonthlyIncome, currency as CurrencyCode)}/mes
-            </p>
-          </div>
-          <ChevronRight className="size-4 text-muted-foreground" />
-        </Link>
+        <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
+        {/* Link to template manager */}
+        <div className="px-4 pb-3">
+          <Link
+            href="/recurrentes"
+            className="flex items-center justify-between rounded-xl border border-z-brass/20 bg-z-brass/5 px-4 py-2.5"
+          >
+            <div>
+              <p className="text-xs font-semibold text-z-brass">Administrar plantillas</p>
+              <p className="text-[10px] text-muted-foreground">
+                {summary.activeCount} activos · {formatCurrency(summary.totalMonthlyExpenses + summary.totalMonthlyIncome, currency as CurrencyCode)}/mes
+              </p>
+            </div>
+            <ChevronRight className="size-4 text-z-brass/60" />
+          </Link>
+        </div>
+        {/* Payment checklist */}
+        <MobileRecurrentesView
+          templates={templates}
+          accounts={accounts}
+          currency={currency as CurrencyCode}
+        />
       </div>
 
       {/* Desktop — only mounted on desktop viewports */}

--- a/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
@@ -6,11 +6,11 @@ import {
   getRecurringTemplates,
   getRecurringSummary,
 } from "@/actions/recurring-templates";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringList } from "@/components/recurring/recurring-list";
 import { RecurringTimelineView } from "@/components/recurring/recurring-timeline-view";
-import { MobileRecurrentesView } from "@/components/mobile/v2/plan/mobile-recurrentes-view";
-import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { DesktopOnly } from "@/components/ui/responsive-render";
 import { SummaryCard } from "@/components/ui/summary-card";
 import { AttentionCard } from "@/components/ui/attention-card";
@@ -34,14 +34,20 @@ export async function PlanTabRecurrentes() {
 
   return (
     <div className="space-y-6">
-      {/* Mobile view */}
+      {/* Mobile — link to dedicated manager */}
       <div className="lg:hidden">
-        <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
-        <MobileRecurrentesView
-          templates={templates}
-          accounts={accounts}
-          currency={currency as CurrencyCode}
-        />
+        <Link
+          href="/recurrentes"
+          className="flex items-center justify-between rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3"
+        >
+          <div>
+            <p className="text-sm font-semibold">Administrar recurrentes</p>
+            <p className="text-xs text-muted-foreground">
+              {summary.activeCount} activos · {formatCurrency(summary.totalMonthlyExpenses + summary.totalMonthlyIncome, currency as CurrencyCode)}/mes
+            </p>
+          </div>
+          <ChevronRight className="size-4 text-muted-foreground" />
+        </Link>
       </div>
 
       {/* Desktop — only mounted on desktop viewports */}

--- a/webapp/src/components/recurring/mobile-recurring-manager.tsx
+++ b/webapp/src/components/recurring/mobile-recurring-manager.tsx
@@ -73,6 +73,11 @@ export function MobileRecurringManager({
     setImpactAction({ template, action: "delete" });
   };
 
+  const handleResumeRequest = async (template: RecurringTemplateWithRelations) => {
+    await toggleRecurringTemplate(template.id, true);
+    await hook.refreshOccurrences();
+  };
+
   const handleImpactConfirm = async () => {
     if (!impactAction) return;
     const { template, action } = impactAction;
@@ -145,6 +150,7 @@ export function MobileRecurringManager({
           onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
           onPauseRequest={handlePauseRequest}
           onDeleteRequest={handleDeleteRequest}
+          onResumeRequest={handleResumeRequest}
           getDateStatus={hook.getDateStatus}
           getEffectiveDirection={effectiveDirection}
         />

--- a/webapp/src/components/recurring/mobile-recurring-manager.tsx
+++ b/webapp/src/components/recurring/mobile-recurring-manager.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { useRecurringMonth } from "./use-recurring-month";
 import { RecurringHeroCompact } from "./recurring-hero-compact";
 import { RecurringTimeline } from "./recurring-timeline";
@@ -16,6 +17,14 @@ import {
 import type { Account, CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
 
 type TabDirection = "OUTFLOW" | "INFLOW";
+
+/** INFLOW to debt accounts is a payment (expense), not income */
+function effectiveDirection(template: RecurringTemplateWithRelations): TabDirection {
+  if (template.direction === "INFLOW" && isDebtAccountType(template.account.account_type)) {
+    return "OUTFLOW";
+  }
+  return template.direction as TabDirection;
+}
 
 interface MobileRecurringManagerProps {
   templates: RecurringTemplateWithRelations[];
@@ -38,17 +47,17 @@ export function MobileRecurringManager({
     action: "pause" | "delete";
   } | null>(null);
 
-  // Compute totals per direction
+  // Compute totals per effective direction (debt payments = expense, not income)
   const totalExpenses = useMemo(
     () => templates
-      .filter((t) => t.direction === "OUTFLOW" && t.is_active)
+      .filter((t) => effectiveDirection(t) === "OUTFLOW" && t.is_active)
       .reduce((sum, t) => sum + Number(t.amount), 0),
     [templates]
   );
 
   const totalIncome = useMemo(
     () => templates
-      .filter((t) => t.direction === "INFLOW" && t.is_active)
+      .filter((t) => effectiveDirection(t) === "INFLOW" && t.is_active)
       .reduce((sum, t) => sum + Number(t.amount), 0),
     [templates]
   );
@@ -134,6 +143,7 @@ export function MobileRecurringManager({
           onPauseRequest={handlePauseRequest}
           onDeleteRequest={handleDeleteRequest}
           getDateStatus={hook.getDateStatus}
+          getEffectiveDirection={effectiveDirection}
         />
       )}
 

--- a/webapp/src/components/recurring/mobile-recurring-manager.tsx
+++ b/webapp/src/components/recurring/mobile-recurring-manager.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { useRecurringMonth } from "./use-recurring-month";
+import { RecurringHeroCompact } from "./recurring-hero-compact";
+import { RecurringTimeline } from "./recurring-timeline";
+import { RecurringImpactDialog } from "./recurring-impact-dialog";
+import {
+  deleteRecurringTemplate,
+  toggleRecurringTemplate,
+} from "@/actions/recurring-templates";
+import type { Account, CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+
+type TabDirection = "OUTFLOW" | "INFLOW";
+
+interface MobileRecurringManagerProps {
+  templates: RecurringTemplateWithRelations[];
+  accounts: Account[];
+  currency: CurrencyCode;
+}
+
+export function MobileRecurringManager({
+  templates,
+  accounts,
+  currency,
+}: MobileRecurringManagerProps) {
+  const hook = useRecurringMonth(templates, accounts);
+  const [activeTab, setActiveTab] = useState<TabDirection>("OUTFLOW");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Sequential overlay state for pause/delete
+  const [impactAction, setImpactAction] = useState<{
+    template: RecurringTemplateWithRelations;
+    action: "pause" | "delete";
+  } | null>(null);
+
+  // Compute totals per direction
+  const totalExpenses = useMemo(
+    () => templates
+      .filter((t) => t.direction === "OUTFLOW" && t.is_active)
+      .reduce((sum, t) => sum + Number(t.amount), 0),
+    [templates]
+  );
+
+  const totalIncome = useMemo(
+    () => templates
+      .filter((t) => t.direction === "INFLOW" && t.is_active)
+      .reduce((sum, t) => sum + Number(t.amount), 0),
+    [templates]
+  );
+
+  const handlePauseRequest = (template: RecurringTemplateWithRelations) => {
+    setImpactAction({ template, action: "pause" });
+  };
+
+  const handleDeleteRequest = (template: RecurringTemplateWithRelations) => {
+    setImpactAction({ template, action: "delete" });
+  };
+
+  const handleImpactConfirm = async () => {
+    if (!impactAction) return;
+    const { template, action } = impactAction;
+    if (action === "pause") {
+      await toggleRecurringTemplate(template.id, false);
+    } else {
+      await deleteRecurringTemplate(template.id);
+    }
+    await hook.refreshOccurrences();
+    setImpactAction(null);
+  };
+
+  return (
+    <div className={cn("space-y-4 px-4", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
+      {/* Hero */}
+      <RecurringHeroCompact
+        totalExpenses={totalExpenses}
+        totalIncome={totalIncome}
+        currency={currency}
+        monthLabel={hook.monthLabel}
+        onPrevMonth={hook.goPrevMonth}
+        onNextMonth={hook.goNextMonth}
+        canGoNext={true}
+      />
+
+      {/* Segmented control */}
+      <div className="flex rounded-xl border border-white/6 bg-white/[0.03] p-1">
+        <button
+          type="button"
+          onClick={() => { setActiveTab("OUTFLOW"); setExpandedId(null); }}
+          className={cn(
+            "flex-1 rounded-lg py-2 text-center text-[11px] font-semibold transition-colors",
+            activeTab === "OUTFLOW"
+              ? "border border-z-brass/30 bg-z-brass/15 text-z-brass"
+              : "text-muted-foreground"
+          )}
+        >
+          Gastos
+        </button>
+        <button
+          type="button"
+          onClick={() => { setActiveTab("INFLOW"); setExpandedId(null); }}
+          className={cn(
+            "flex-1 rounded-lg py-2 text-center text-[11px] font-semibold transition-colors",
+            activeTab === "INFLOW"
+              ? "border border-z-income/25 bg-z-income/12 text-z-income"
+              : "text-muted-foreground"
+          )}
+        >
+          Ingresos
+        </button>
+      </div>
+
+      {/* Loading */}
+      {!hook.isHydrated && (
+        <div className="animate-pulse py-8 text-center text-sm text-muted-foreground">
+          Cargando recurrentes...
+        </div>
+      )}
+
+      {/* Timeline */}
+      {hook.isHydrated && (
+        <RecurringTimeline
+          templates={templates}
+          currency={currency}
+          direction={activeTab}
+          pending={hook.pending}
+          completed={hook.completed}
+          expandedId={expandedId}
+          onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
+          onPauseRequest={handlePauseRequest}
+          onDeleteRequest={handleDeleteRequest}
+          getDateStatus={hook.getDateStatus}
+        />
+      )}
+
+      {/* Create button */}
+      <div className="flex justify-center pb-4">
+        <Link
+          href={`/recurrentes/new?direction=${activeTab}`}
+          className={cn(
+            "flex items-center gap-2 rounded-full border px-6 py-2.5 text-xs font-semibold active:opacity-70",
+            activeTab === "OUTFLOW"
+              ? "border-z-brass/30 text-z-brass"
+              : "border-z-income/30 text-z-income"
+          )}
+        >
+          <Plus className="size-3.5" />
+          {activeTab === "OUTFLOW" ? "Nuevo gasto recurrente" : "Nuevo ingreso"}
+        </Link>
+      </div>
+
+      {/* Impact dialog (controlled, outside any Sheet) */}
+      {impactAction && (
+        <RecurringImpactDialog
+          templateId={impactAction.template.id}
+          templateName={impactAction.template.merchant_name ?? "Recurrente"}
+          currencyCode={(impactAction.template.currency_code ?? "COP") as CurrencyCode}
+          action={impactAction.action}
+          onConfirm={handleImpactConfirm}
+          open={!!impactAction}
+          onOpenChange={(open) => {
+            if (!open) setImpactAction(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/recurring/mobile-recurring-manager.tsx
+++ b/webapp/src/components/recurring/mobile-recurring-manager.tsx
@@ -14,6 +14,7 @@ import {
   deleteRecurringTemplate,
   toggleRecurringTemplate,
 } from "@/actions/recurring-templates";
+import type { RecurringOccurrence } from "@/actions/occurrences";
 import type { Account, CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
 
 type TabDirection = "OUTFLOW" | "INFLOW";
@@ -30,14 +31,16 @@ interface MobileRecurringManagerProps {
   templates: RecurringTemplateWithRelations[];
   accounts: Account[];
   currency: CurrencyCode;
+  initialOccurrences?: RecurringOccurrence[];
 }
 
 export function MobileRecurringManager({
   templates,
   accounts,
   currency,
+  initialOccurrences,
 }: MobileRecurringManagerProps) {
-  const hook = useRecurringMonth(templates, accounts);
+  const hook = useRecurringMonth(templates, accounts, initialOccurrences);
   const [activeTab, setActiveTab] = useState<TabDirection>("OUTFLOW");
   const [expandedId, setExpandedId] = useState<string | null>(null);
 

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -23,6 +23,7 @@ import type { ActionResult } from "@/types/actions";
 import type { Account, CategoryWithChildren, RecurringTemplate, TransactionDirection } from "@/types/domain";
 
 const FREQUENCY_OPTIONS = [
+  { value: "ONCE", label: "Una vez" },
   { value: "WEEKLY", label: "Semanal" },
   { value: "BIWEEKLY", label: "Quincenal" },
   { value: "MONTHLY", label: "Mensual" },
@@ -72,6 +73,9 @@ export function RecurringForm({
   );
   const [categoryId, setCategoryId] = useState<string | null>(
     template?.category_id ?? null
+  );
+  const [frequency, setFrequency] = useState<string>(
+    template?.frequency ?? "MONTHLY"
   );
   const [transferSourceAccountId, setTransferSourceAccountId] = useState<string>(
     template?.transfer_source_account_id ?? ""
@@ -192,7 +196,8 @@ export function RecurringForm({
           <Label htmlFor="frequency">Frecuencia</Label>
           <Select
             name="frequency"
-            defaultValue={template?.frequency ?? "MONTHLY"}
+            value={frequency}
+            onValueChange={setFrequency}
           >
             <SelectTrigger>
               <SelectValue />
@@ -279,26 +284,28 @@ export function RecurringForm({
         value={selectedAccount?.currency_code ?? template?.currency_code ?? "COP"}
       />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className={`grid gap-4 ${frequency === "ONCE" ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2"}`}>
         <div className="space-y-2">
-          <Label htmlFor="start_date">Fecha de inicio</Label>
+          <Label htmlFor="start_date">{frequency === "ONCE" ? "Fecha de pago" : "Fecha de inicio"}</Label>
           <DatePicker
             value={startDate}
             onChange={(v) => setStartDate(v ?? defaultStartDate)}
             name="start_date"
-            placeholder="Fecha de inicio"
+            placeholder={frequency === "ONCE" ? "Fecha de pago" : "Fecha de inicio"}
           />
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="end_date">Fecha fin (opcional)</Label>
-          <DatePicker
-            value={endDate}
-            onChange={setEndDate}
-            name="end_date"
-            placeholder="Sin fecha fin"
-          />
-        </div>
+        {frequency !== "ONCE" && (
+          <div className="space-y-2">
+            <Label htmlFor="end_date">Fecha fin (opcional)</Label>
+            <DatePicker
+              value={endDate}
+              onChange={setEndDate}
+              name="end_date"
+              placeholder="Sin fecha fin"
+            />
+          </div>
+        )}
       </div>
 
       {isDebtAccount ? (

--- a/webapp/src/components/recurring/recurring-hero-compact.tsx
+++ b/webapp/src/components/recurring/recurring-hero-compact.tsx
@@ -62,7 +62,7 @@ export function RecurringHeroCompact({
             style={{ width: `${expensePercent}%` }}
           />
           <div
-            className="rounded-r-full bg-gradient-to-r from-z-income to-emerald-500"
+            className="rounded-r-full bg-gradient-to-r from-z-income to-z-income/70"
             style={{ width: `${100 - expensePercent}%` }}
           />
         </div>
@@ -70,7 +70,7 @@ export function RecurringHeroCompact({
         {/* Three numbers */}
         <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
           <div>
-            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-z-debt">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.18em] text-z-debt">
               Gastos
             </p>
             <p className="text-base font-bold tabular-nums">
@@ -78,7 +78,7 @@ export function RecurringHeroCompact({
             </p>
           </div>
           <div className="px-2 text-center">
-            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
               Neto
             </p>
             <p
@@ -92,7 +92,7 @@ export function RecurringHeroCompact({
             </p>
           </div>
           <div className="text-right">
-            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-z-income">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.18em] text-z-income">
               Ingresos
             </p>
             <p className="text-base font-bold tabular-nums">

--- a/webapp/src/components/recurring/recurring-hero-compact.tsx
+++ b/webapp/src/components/recurring/recurring-hero-compact.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { formatCurrency } from "@/lib/utils/currency";
+import { formatCurrencyCompact } from "@/lib/utils/currency";
 import type { CurrencyCode } from "@/types/domain";
 
 interface RecurringHeroCompactProps {
@@ -74,7 +74,7 @@ export function RecurringHeroCompact({
               Gastos
             </p>
             <p className="text-base font-bold tabular-nums">
-              {formatCurrency(totalExpenses, currency)}
+              {formatCurrencyCompact(totalExpenses, currency)}
             </p>
           </div>
           <div className="px-2 text-center">
@@ -88,7 +88,7 @@ export function RecurringHeroCompact({
               )}
             >
               {isPositive ? "+" : ""}
-              {formatCurrency(Math.abs(net), currency)}
+              {formatCurrencyCompact(Math.abs(net), currency)}
             </p>
           </div>
           <div className="text-right">
@@ -96,7 +96,7 @@ export function RecurringHeroCompact({
               Ingresos
             </p>
             <p className="text-base font-bold tabular-nums">
-              {formatCurrency(totalIncome, currency)}
+              {formatCurrencyCompact(totalIncome, currency)}
             </p>
           </div>
         </div>

--- a/webapp/src/components/recurring/recurring-hero-compact.tsx
+++ b/webapp/src/components/recurring/recurring-hero-compact.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+
+interface RecurringHeroCompactProps {
+  totalExpenses: number;
+  totalIncome: number;
+  currency: CurrencyCode;
+  monthLabel: string;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  canGoNext: boolean;
+}
+
+export function RecurringHeroCompact({
+  totalExpenses,
+  totalIncome,
+  currency,
+  monthLabel,
+  onPrevMonth,
+  onNextMonth,
+  canGoNext,
+}: RecurringHeroCompactProps) {
+  const net = totalIncome - totalExpenses;
+  const isPositive = net >= 0;
+  const total = totalExpenses + totalIncome;
+  const expensePercent = total > 0 ? (totalExpenses / total) * 100 : 50;
+
+  return (
+    <div className="space-y-3">
+      {/* Month navigation */}
+      <div className="flex items-center justify-center gap-4">
+        <button
+          type="button"
+          onClick={onPrevMonth}
+          className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5"
+        >
+          <ChevronLeft className="size-3.5" />
+        </button>
+        <span className="text-xs font-medium capitalize text-muted-foreground">
+          {monthLabel}
+        </span>
+        <button
+          type="button"
+          onClick={onNextMonth}
+          disabled={!canGoNext}
+          className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5 disabled:opacity-30"
+        >
+          <ChevronRight className="size-3.5" />
+        </button>
+      </div>
+
+      {/* Compact hero card */}
+      <div className="rounded-2xl border border-white/6 bg-gradient-to-br from-z-brass/[0.06] to-transparent p-3.5">
+        {/* Proportion bar */}
+        <div className="mb-3 flex h-1.5 overflow-hidden rounded-full">
+          <div
+            className="rounded-l-full bg-gradient-to-r from-z-debt to-z-alert"
+            style={{ width: `${expensePercent}%` }}
+          />
+          <div
+            className="rounded-r-full bg-gradient-to-r from-z-income to-emerald-500"
+            style={{ width: `${100 - expensePercent}%` }}
+          />
+        </div>
+
+        {/* Three numbers */}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          <div>
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-z-debt">
+              Gastos
+            </p>
+            <p className="text-base font-bold tabular-nums">
+              {formatCurrency(totalExpenses, currency)}
+            </p>
+          </div>
+          <div className="px-2 text-center">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              Neto
+            </p>
+            <p
+              className={cn(
+                "text-xl font-extrabold tabular-nums",
+                isPositive ? "text-z-income" : "text-z-debt"
+              )}
+            >
+              {isPositive ? "+" : ""}
+              {formatCurrency(Math.abs(net), currency)}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-z-income">
+              Ingresos
+            </p>
+            <p className="text-base font-bold tabular-nums">
+              {formatCurrency(totalIncome, currency)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/recurring/recurring-impact-dialog.tsx
+++ b/webapp/src/components/recurring/recurring-impact-dialog.tsx
@@ -27,7 +27,9 @@ interface RecurringImpactDialogProps {
   currencyCode: CurrencyCode;
   action: "delete" | "pause";
   onConfirm: () => void | Promise<void>;
-  trigger: React.ReactNode;
+  trigger?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function RecurringImpactDialog({
@@ -37,8 +39,12 @@ export function RecurringImpactDialog({
   action,
   onConfirm,
   trigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
 }: RecurringImpactDialogProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = controlledOnOpenChange ?? setInternalOpen;
   const [impact, setImpact] = useState<TemplateImpact | null>(null);
   const [loading, setLoading] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -75,7 +81,7 @@ export function RecurringImpactDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
-      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      {trigger && <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>}
       <AlertDialogContent>
         <AlertDialogHeader>
           <div className="flex items-center gap-3">

--- a/webapp/src/components/recurring/recurring-template-card.tsx
+++ b/webapp/src/components/recurring/recurring-template-card.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Pencil, Pause, Trash2, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { getTemplateStats, type TemplateStats } from "@/actions/template-stats";
+import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+
+type OccurrenceStatus = "paid" | "pending" | "skipped" | null;
+
+interface RecurringTemplateCardProps {
+  template: RecurringTemplateWithRelations;
+  currency: CurrencyCode;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onPauseRequest: (template: RecurringTemplateWithRelations) => void;
+  onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
+  occurrenceStatus: OccurrenceStatus;
+}
+
+const FREQUENCY_MULTIPLIER: Record<string, number> = {
+  WEEKLY: 52, BIWEEKLY: 26, MONTHLY: 12, QUARTERLY: 4, ANNUAL: 1, ONCE: 1,
+};
+
+function yearlyEstimate(amount: number, frequency: string): number {
+  return frequency === "ONCE" ? amount : amount * (FREQUENCY_MULTIPLIER[frequency] ?? 12);
+}
+
+function frequencyShortLabel(f: string): string {
+  const labels: Record<string, string> = {
+    ONCE: "Una vez", WEEKLY: "Semanal", BIWEEKLY: "Quincenal",
+    MONTHLY: "Mensual", QUARTERLY: "Trimestral", ANNUAL: "Anual",
+  };
+  return labels[f] ?? f;
+}
+
+export function RecurringTemplateCard({
+  template,
+  currency,
+  isExpanded,
+  onToggleExpand,
+  onPauseRequest,
+  onDeleteRequest,
+  occurrenceStatus,
+}: RecurringTemplateCardProps) {
+  const router = useRouter();
+  const [stats, setStats] = useState<TemplateStats | null>(null);
+  const [loadingStats, setLoadingStats] = useState(false);
+  const amount = Number(template.amount);
+  const isOnce = template.frequency === "ONCE";
+
+  function handleExpand() {
+    onToggleExpand();
+    if (!isExpanded && !stats) {
+      setLoadingStats(true);
+      getTemplateStats(template.id).then((result) => {
+        if (result.success) setStats(result.data);
+        setLoadingStats(false);
+      });
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-white/6 bg-white/[0.03] transition-all",
+        isExpanded && "border-z-brass/20"
+      )}
+    >
+      {/* Collapsed row */}
+      <button
+        type="button"
+        onClick={handleExpand}
+        className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left active:bg-white/[0.02]"
+      >
+        {/* Category dot */}
+        {template.category && (
+          <span
+            className="flex size-7 shrink-0 items-center justify-center rounded-lg text-xs"
+            style={{ backgroundColor: template.category.color + "20", color: template.category.color }}
+          >
+            {template.category.icon ?? "•"}
+          </span>
+        )}
+
+        {/* Info */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-xs font-semibold">{template.merchant_name}</p>
+            {isOnce && (
+              <span className="shrink-0 rounded bg-purple-500/20 px-1.5 py-px text-[8px] font-semibold text-purple-400">
+                UNA VEZ
+              </span>
+            )}
+            {occurrenceStatus === "paid" && (
+              <Check className="size-3 shrink-0 text-z-income" />
+            )}
+          </div>
+          <p className="text-[10px] text-muted-foreground">
+            {template.account.name} · {frequencyShortLabel(template.frequency)}
+          </p>
+        </div>
+
+        {/* Amount + yearly */}
+        <div className="shrink-0 text-right">
+          <p className="text-xs font-bold tabular-nums">
+            {formatCurrency(amount, currency)}
+          </p>
+          {!isOnce && (
+            <p className="text-[9px] tabular-nums text-muted-foreground">
+              {formatCurrency(yearlyEstimate(amount, template.frequency), currency)}/año
+            </p>
+          )}
+        </div>
+      </button>
+
+      {/* Expanded section */}
+      {isExpanded && (
+        <div className="space-y-3 border-t border-white/5 px-3 py-3">
+          {/* Stats chips */}
+          <div className="grid grid-cols-3 gap-1">
+            {loadingStats ? (
+              <>
+                <div className="h-12 animate-pulse rounded-lg bg-white/4" />
+                <div className="h-12 animate-pulse rounded-lg bg-white/4" />
+                <div className="h-12 animate-pulse rounded-lg bg-white/4" />
+              </>
+            ) : stats ? (
+              isOnce ? (
+                <>
+                  <StatChip label="% ingreso" value={stats.impactPercent != null ? `${stats.impactPercent.toFixed(1)}%` : "—"} />
+                  <StatChip label="Margen después" value={stats.marginAfter != null ? formatCurrency(stats.marginAfter, currency) : "—"} />
+                  <StatChip label="Estado" value={occurrenceStatus === "paid" ? "Pagado ✓" : "Pendiente"} />
+                </>
+              ) : (
+                <>
+                  <StatChip label="Este año" value={formatCurrency(stats.ytdTotal, currency)} />
+                  <StatChip label="Anual est." value={formatCurrency(stats.annualEstimate, currency)} />
+                  <StatChip
+                    label="Racha"
+                    value={`${stats.streak} mes${stats.streak !== 1 ? "es" : ""}`}
+                    note={stats.isConsistent ? "Consistente ✓" : undefined}
+                  />
+                </>
+              )
+            ) : null}
+          </div>
+
+          {/* Action buttons */}
+          <div className={cn(
+            "grid gap-1.5",
+            isOnce ? "grid-cols-2" : template.direction === "INFLOW" ? "grid-cols-2" : "grid-cols-3"
+          )}>
+            <ActionButton
+              label="Editar"
+              icon={<Pencil className="size-3.5" />}
+              className="bg-z-brass/10 border-z-brass/20 text-z-brass"
+              onClick={() => router.push(`/recurrentes/${template.id}/edit`)}
+            />
+            {template.direction === "OUTFLOW" && !isOnce && (
+              <ActionButton
+                label="Pausar"
+                icon={<Pause className="size-3.5" />}
+                className="bg-z-alert/8 border-z-alert/15 text-z-alert"
+                onClick={() => onPauseRequest(template)}
+              />
+            )}
+            <ActionButton
+              label="Eliminar"
+              icon={<Trash2 className="size-3.5" />}
+              className="bg-z-debt/8 border-z-debt/15 text-z-debt"
+              onClick={() => onDeleteRequest(template)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatChip({ label, value, note }: { label: string; value: string; note?: string }) {
+  return (
+    <div className="rounded-lg bg-white/[0.03] px-2 py-2 text-center">
+      <p className="text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-sm font-bold tabular-nums">{value}</p>
+      {note && <p className="text-[8px] text-z-income">{note}</p>}
+    </div>
+  );
+}
+
+function ActionButton({
+  label, icon, className, onClick,
+}: {
+  label: string; icon: React.ReactNode; className: string; onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      className={cn("flex items-center justify-center gap-1.5 rounded-lg border py-2.5 text-[11px] font-semibold active:opacity-70", className)}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/webapp/src/components/recurring/recurring-template-card.tsx
+++ b/webapp/src/components/recurring/recurring-template-card.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Pencil, Pause, Trash2, Check } from "lucide-react";
+import { Pencil, Pause, Trash2, Check, Tag } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import { CategoryIcon } from "@/components/categories/category-icon";
 import { getTemplateStats, type TemplateStats } from "@/actions/template-stats";
 import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
 
@@ -75,15 +76,20 @@ export function RecurringTemplateCard({
         onClick={handleExpand}
         className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left active:bg-white/[0.02]"
       >
-        {/* Category dot */}
-        {template.category && (
-          <span
-            className="flex size-7 shrink-0 items-center justify-center rounded-lg text-xs"
-            style={{ backgroundColor: template.category.color + "20", color: template.category.color }}
-          >
-            {template.category.icon ?? "•"}
-          </span>
-        )}
+        {/* Category icon */}
+        <span
+          className="flex size-7 shrink-0 items-center justify-center rounded-lg"
+          style={{
+            backgroundColor: (template.category?.color ?? "#888") + "20",
+            color: template.category?.color ?? "#888",
+          }}
+        >
+          {template.category?.icon ? (
+            <CategoryIcon icon={template.category.icon} className="size-3.5" />
+          ) : (
+            <Tag className="size-3.5" />
+          )}
+        </span>
 
         {/* Info */}
         <div className="min-w-0 flex-1">

--- a/webapp/src/components/recurring/recurring-template-card.tsx
+++ b/webapp/src/components/recurring/recurring-template-card.tsx
@@ -80,8 +80,8 @@ export function RecurringTemplateCard({
         <span
           className="flex size-7 shrink-0 items-center justify-center rounded-lg"
           style={{
-            backgroundColor: (template.category?.color ?? "#888") + "20",
-            color: template.category?.color ?? "#888",
+            backgroundColor: (template.category?.color ?? "hsl(var(--z-sage-dark))") + "20",
+            color: template.category?.color ?? "hsl(var(--z-sage-dark))",
           }}
         >
           {template.category?.icon ? (
@@ -96,7 +96,7 @@ export function RecurringTemplateCard({
           <div className="flex items-center gap-1.5">
             <p className="truncate text-xs font-semibold">{template.merchant_name}</p>
             {isOnce && (
-              <span className="shrink-0 rounded bg-purple-500/20 px-1.5 py-px text-[8px] font-semibold text-purple-400">
+              <span className="shrink-0 rounded bg-z-brass/15 px-1.5 py-px text-[8px] font-semibold text-z-brass">
                 UNA VEZ
               </span>
             )}
@@ -124,7 +124,7 @@ export function RecurringTemplateCard({
 
       {/* Expanded section */}
       {isExpanded && (
-        <div className="space-y-3 border-t border-white/5 px-3 py-3">
+        <div className="space-y-3 border-t border-white/6 px-3 py-3">
           {/* Stats chips */}
           <div className="grid grid-cols-3 gap-1">
             {loadingStats ? (
@@ -189,7 +189,7 @@ export function RecurringTemplateCard({
 function StatChip({ label, value, note }: { label: string; value: string; note?: string }) {
   return (
     <div className="rounded-lg bg-white/[0.03] px-2 py-2 text-center">
-      <p className="text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">{label}</p>
+      <p className="text-[8px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
       <p className="mt-0.5 text-sm font-bold tabular-nums">{value}</p>
       {note && <p className="text-[8px] text-z-income">{note}</p>}
     </div>

--- a/webapp/src/components/recurring/recurring-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-timeline.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { formatDate } from "@/lib/utils/date";
+import { formatCurrency } from "@/lib/utils/currency";
+import { RecurringTemplateCard } from "./recurring-template-card";
+import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+import type { OccurrenceItem, DateStatus } from "./use-recurring-month";
+
+interface RecurringTimelineProps {
+  templates: RecurringTemplateWithRelations[];
+  currency: CurrencyCode;
+  direction: "OUTFLOW" | "INFLOW";
+  pending: OccurrenceItem[];
+  completed: OccurrenceItem[];
+  expandedId: string | null;
+  onToggleExpand: (templateId: string) => void;
+  onPauseRequest: (template: RecurringTemplateWithRelations) => void;
+  onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
+  getDateStatus: (date: string) => DateStatus;
+}
+
+const STATUS_ORDER: Record<DateStatus, number> = { past: 0, today: 1, future: 2 };
+
+function dotStyle(status: DateStatus) {
+  switch (status) {
+    case "past":
+      return "bg-z-debt shadow-[0_0_8px_rgba(239,68,68,0.4)]";
+    case "today":
+      return "bg-z-alert shadow-[0_0_8px_rgba(245,158,11,0.4)]";
+    case "future":
+      return "border-2 border-white/15 bg-transparent";
+  }
+}
+
+function dateColor(status: DateStatus) {
+  switch (status) {
+    case "past": return "text-z-debt";
+    case "today": return "text-z-alert";
+    case "future": return "text-muted-foreground";
+  }
+}
+
+function lineColor(direction: "OUTFLOW" | "INFLOW") {
+  return direction === "OUTFLOW"
+    ? "from-z-brass/40 to-z-brass/10"
+    : "from-z-income/40 to-z-income/10";
+}
+
+export function RecurringTimeline({
+  templates,
+  currency,
+  direction,
+  pending,
+  completed,
+  expandedId,
+  onToggleExpand,
+  onPauseRequest,
+  onDeleteRequest,
+  getDateStatus,
+}: RecurringTimelineProps) {
+  const templateMap = useMemo(
+    () => new Map(templates.map((t) => [t.id, t])),
+    [templates]
+  );
+
+  const pausedTemplates = templates.filter((t) => t.direction === direction && !t.is_active);
+
+  // Build date-grouped items from pending + completed, filtered by direction
+  const allItems = useMemo(() => [...pending, ...completed], [pending, completed]);
+
+  const dateGroups = useMemo(() => {
+    const groups = new Map<string, OccurrenceItem[]>();
+    for (const item of allItems) {
+      const tmpl = templateMap.get(item.templateId);
+      if (!tmpl || tmpl.direction !== direction || !tmpl.is_active) continue;
+      if (!groups.has(item.date)) groups.set(item.date, []);
+      groups.get(item.date)!.push(item);
+    }
+    return groups;
+  }, [allItems, templateMap, direction]);
+
+  const sortedDates = useMemo(
+    () => Array.from(dateGroups.keys())
+      .map((date) => ({ date, order: STATUS_ORDER[getDateStatus(date)] }))
+      .sort((a, b) => a.order - b.order || a.date.localeCompare(b.date))
+      .map((d) => d.date),
+    [dateGroups, getDateStatus]
+  );
+
+  // Build occurrence status map (templateId:date → paid/pending)
+  const occurrenceStatuses = useMemo(() => {
+    const completedKeys = new Set(completed.map((c) => c.key));
+    const statuses = new Map<string, "paid" | "pending" | "skipped">();
+    for (const item of allItems) {
+      statuses.set(`${item.templateId}:${item.date}`, completedKeys.has(item.key) ? "paid" : "pending");
+    }
+    return statuses;
+  }, [allItems, completed]);
+
+  return (
+    <div className="relative pl-6">
+      {/* Vertical line */}
+      <div className={cn("absolute bottom-0 left-[7px] top-0 w-0.5 bg-gradient-to-b", lineColor(direction))} />
+
+      {/* Date groups */}
+      {sortedDates.map((date) => {
+        const status = getDateStatus(date);
+        const items = dateGroups.get(date)!;
+
+        return (
+          <div key={date} className="relative mb-5">
+            {/* Dot */}
+            <div className={cn("absolute -left-6 top-0.5 size-3 rounded-full", dotStyle(status))} />
+            {/* Date label */}
+            <p className={cn("mb-2 text-[10px] font-semibold uppercase tracking-[0.1em]", dateColor(status))}>
+              {status === "today" && "Hoy — "}
+              {status === "past" && "Vencido — "}
+              {formatDate(date, "EEEE d MMM")}
+            </p>
+
+            {/* Template cards */}
+            <div className="space-y-2">
+              {items.map((item) => {
+                const tmpl = templateMap.get(item.templateId);
+                if (!tmpl) return null;
+                const occKey = `${item.templateId}:${item.date}`;
+                return (
+                  <RecurringTemplateCard
+                    key={occKey}
+                    template={tmpl}
+                    currency={currency}
+                    isExpanded={expandedId === tmpl.id}
+                    onToggleExpand={() => onToggleExpand(tmpl.id)}
+                    onPauseRequest={onPauseRequest}
+                    onDeleteRequest={onDeleteRequest}
+                    occurrenceStatus={occurrenceStatuses.get(occKey) ?? null}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Completed section — items already paid this month (green dots) */}
+      {completed.filter((c) => {
+        const tmpl = templateMap.get(c.templateId);
+        return tmpl && tmpl.direction === direction && tmpl.is_active && !dateGroups.has(c.date);
+      }).length > 0 && (
+        <div className="relative mb-5">
+          <div className="absolute -left-6 top-0.5 size-3 rounded-full bg-z-income shadow-[0_0_6px_rgba(74,222,128,0.3)]" />
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-z-income">
+            Completados
+          </p>
+          <div className="space-y-2">
+            {completed
+              .filter((c) => {
+                const tmpl = templateMap.get(c.templateId);
+                return tmpl && tmpl.direction === direction && tmpl.is_active && !dateGroups.has(c.date);
+              })
+              .map((item) => {
+                const tmpl = templateMap.get(item.templateId);
+                if (!tmpl) return null;
+                return (
+                  <RecurringTemplateCard
+                    key={`completed-${item.key}`}
+                    template={tmpl}
+                    currency={currency}
+                    isExpanded={expandedId === tmpl.id}
+                    onToggleExpand={() => onToggleExpand(tmpl.id)}
+                    onPauseRequest={onPauseRequest}
+                    onDeleteRequest={onDeleteRequest}
+                    occurrenceStatus="paid"
+                  />
+                );
+              })}
+          </div>
+        </div>
+      )}
+
+      {/* Paused templates */}
+      {pausedTemplates.length > 0 && (
+        <div className="relative mb-5 mt-6">
+          <div className="absolute -left-6 top-0.5 size-3 rounded-full border-2 border-dashed border-white/15" />
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">
+            Pausados
+          </p>
+          <div className="space-y-2">
+            {pausedTemplates.map((tmpl) => (
+              <div
+                key={tmpl.id}
+                className="rounded-xl border border-dashed border-white/8 bg-white/[0.02] px-3 py-2.5 opacity-45"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-xs font-semibold">{tmpl.merchant_name}</p>
+                    <p className="text-[10px] text-muted-foreground">Pausado</p>
+                  </div>
+                  <p className="text-xs font-bold tabular-nums opacity-50 line-through">
+                    {formatCurrency(Number(tmpl.amount), currency)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {sortedDates.length === 0 && pausedTemplates.length === 0 && (
+        <div className="py-8 text-center text-xs text-muted-foreground">
+          No hay {direction === "OUTFLOW" ? "gastos" : "ingresos"} recurrentes
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/recurring/recurring-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-timeline.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Pencil, Play, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDate } from "@/lib/utils/date";
 import { formatCurrency } from "@/lib/utils/currency";
@@ -18,6 +20,7 @@ interface RecurringTimelineProps {
   onToggleExpand: (templateId: string) => void;
   onPauseRequest: (template: RecurringTemplateWithRelations) => void;
   onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
+  onResumeRequest: (template: RecurringTemplateWithRelations) => void;
   getDateStatus: (date: string) => DateStatus;
   getEffectiveDirection: (template: RecurringTemplateWithRelations) => "OUTFLOW" | "INFLOW";
 }
@@ -73,6 +76,7 @@ export function RecurringTimeline({
   onToggleExpand,
   onPauseRequest,
   onDeleteRequest,
+  onResumeRequest,
   getDateStatus,
   getEffectiveDirection,
 }: RecurringTimelineProps) {
@@ -220,20 +224,15 @@ export function RecurringTimeline({
           </p>
           <div className="space-y-2">
             {pausedTemplates.map((tmpl) => (
-              <div
+              <PausedTemplateCard
                 key={tmpl.id}
-                className="rounded-xl border border-dashed border-white/8 bg-white/[0.02] px-3 py-2.5 opacity-45"
-              >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-xs font-semibold">{tmpl.merchant_name}</p>
-                    <p className="text-[10px] text-muted-foreground">Pausado</p>
-                  </div>
-                  <p className="text-xs font-bold tabular-nums opacity-50 line-through">
-                    {formatCurrency(Number(tmpl.amount), currency)}
-                  </p>
-                </div>
-              </div>
+                template={tmpl}
+                currency={currency}
+                isExpanded={expandedId === tmpl.id}
+                onToggleExpand={() => onToggleExpand(tmpl.id)}
+                onResumeRequest={onResumeRequest}
+                onDeleteRequest={onDeleteRequest}
+              />
             ))}
           </div>
         </div>
@@ -243,6 +242,79 @@ export function RecurringTimeline({
       {sortedDates.length === 0 && pausedTemplates.length === 0 && (
         <div className="py-8 text-center text-xs text-muted-foreground">
           No hay {direction === "OUTFLOW" ? "gastos" : "ingresos"} recurrentes
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Paused template card — expandable with Resume/Edit/Delete          */
+/* ------------------------------------------------------------------ */
+
+function PausedTemplateCard({
+  template,
+  currency,
+  isExpanded,
+  onToggleExpand,
+  onResumeRequest,
+  onDeleteRequest,
+}: {
+  template: RecurringTemplateWithRelations;
+  currency: CurrencyCode;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onResumeRequest: (template: RecurringTemplateWithRelations) => void;
+  onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
+}) {
+  const router = useRouter();
+
+  return (
+    <div className={cn(
+      "overflow-hidden rounded-xl border border-dashed border-white/8 bg-white/[0.02] transition-all",
+      isExpanded && "border-z-brass/20 border-solid opacity-100",
+      !isExpanded && "opacity-50"
+    )}>
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        className="flex w-full items-center justify-between px-3 py-2.5 text-left active:bg-white/[0.02]"
+      >
+        <div>
+          <p className="text-xs font-semibold">{template.merchant_name}</p>
+          <p className="text-[10px] text-muted-foreground">Pausado</p>
+        </div>
+        <p className="text-xs font-bold tabular-nums opacity-50 line-through">
+          {formatCurrency(Number(template.amount), currency)}
+        </p>
+      </button>
+
+      {isExpanded && (
+        <div className="grid grid-cols-3 gap-1.5 border-t border-white/5 px-3 py-3">
+          <button
+            type="button"
+            onClick={() => onResumeRequest(template)}
+            className="flex items-center justify-center gap-1.5 rounded-lg border border-z-income/20 bg-z-income/10 py-2.5 text-[11px] font-semibold text-z-income active:opacity-70"
+          >
+            <Play className="size-3.5" />
+            Activar
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push(`/recurrentes/${template.id}/edit`)}
+            className="flex items-center justify-center gap-1.5 rounded-lg border border-z-brass/20 bg-z-brass/10 py-2.5 text-[11px] font-semibold text-z-brass active:opacity-70"
+          >
+            <Pencil className="size-3.5" />
+            Editar
+          </button>
+          <button
+            type="button"
+            onClick={() => onDeleteRequest(template)}
+            className="flex items-center justify-center gap-1.5 rounded-lg border border-z-debt/15 bg-z-debt/8 py-2.5 text-[11px] font-semibold text-z-debt active:opacity-70"
+          >
+            <Trash2 className="size-3.5" />
+            Eliminar
+          </button>
         </div>
       )}
     </div>

--- a/webapp/src/components/recurring/recurring-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-timeline.tsx
@@ -19,6 +19,7 @@ interface RecurringTimelineProps {
   onPauseRequest: (template: RecurringTemplateWithRelations) => void;
   onDeleteRequest: (template: RecurringTemplateWithRelations) => void;
   getDateStatus: (date: string) => DateStatus;
+  getEffectiveDirection: (template: RecurringTemplateWithRelations) => "OUTFLOW" | "INFLOW";
 }
 
 const STATUS_ORDER: Record<DateStatus, number> = { past: 0, today: 1, future: 2 };
@@ -59,13 +60,14 @@ export function RecurringTimeline({
   onPauseRequest,
   onDeleteRequest,
   getDateStatus,
+  getEffectiveDirection,
 }: RecurringTimelineProps) {
   const templateMap = useMemo(
     () => new Map(templates.map((t) => [t.id, t])),
     [templates]
   );
 
-  const pausedTemplates = templates.filter((t) => t.direction === direction && !t.is_active);
+  const pausedTemplates = templates.filter((t) => getEffectiveDirection(t) === direction && !t.is_active);
 
   // Build date-grouped items from pending + completed, filtered by direction
   const allItems = useMemo(() => [...pending, ...completed], [pending, completed]);
@@ -74,7 +76,7 @@ export function RecurringTimeline({
     const groups = new Map<string, OccurrenceItem[]>();
     for (const item of allItems) {
       const tmpl = templateMap.get(item.templateId);
-      if (!tmpl || tmpl.direction !== direction || !tmpl.is_active) continue;
+      if (!tmpl || getEffectiveDirection(tmpl) !== direction || !tmpl.is_active) continue;
       if (!groups.has(item.date)) groups.set(item.date, []);
       groups.get(item.date)!.push(item);
     }
@@ -147,7 +149,7 @@ export function RecurringTimeline({
       {/* Completed section — items already paid this month (green dots) */}
       {completed.filter((c) => {
         const tmpl = templateMap.get(c.templateId);
-        return tmpl && tmpl.direction === direction && tmpl.is_active && !dateGroups.has(c.date);
+        return tmpl && getEffectiveDirection(tmpl) === direction && tmpl.is_active && !dateGroups.has(c.date);
       }).length > 0 && (
         <div className="relative mb-5">
           <div className="absolute -left-6 top-0.5 size-3 rounded-full bg-z-income shadow-[0_0_6px_rgba(74,222,128,0.3)]" />
@@ -158,7 +160,7 @@ export function RecurringTimeline({
             {completed
               .filter((c) => {
                 const tmpl = templateMap.get(c.templateId);
-                return tmpl && tmpl.direction === direction && tmpl.is_active && !dateGroups.has(c.date);
+                return tmpl && getEffectiveDirection(tmpl) === direction && tmpl.is_active && !dateGroups.has(c.date);
               })
               .map((item) => {
                 const tmpl = templateMap.get(item.templateId);

--- a/webapp/src/components/recurring/recurring-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-timeline.tsx
@@ -22,24 +22,38 @@ interface RecurringTimelineProps {
   getEffectiveDirection: (template: RecurringTemplateWithRelations) => "OUTFLOW" | "INFLOW";
 }
 
-const STATUS_ORDER: Record<DateStatus, number> = { past: 0, today: 1, future: 2 };
+type EffectiveStatus = "overdue" | "paid" | "today" | "future";
 
-function dotStyle(status: DateStatus) {
+const STATUS_ORDER: Record<EffectiveStatus, number> = { overdue: 0, today: 1, future: 2, paid: 3 };
+
+function dotStyle(status: EffectiveStatus) {
   switch (status) {
-    case "past":
+    case "overdue":
       return "bg-z-debt shadow-[0_0_8px_rgba(239,68,68,0.4)]";
     case "today":
       return "bg-z-alert shadow-[0_0_8px_rgba(245,158,11,0.4)]";
     case "future":
       return "border-2 border-white/15 bg-transparent";
+    case "paid":
+      return "bg-z-income shadow-[0_0_6px_rgba(74,222,128,0.3)]";
   }
 }
 
-function dateColor(status: DateStatus) {
+function dateColor(status: EffectiveStatus) {
   switch (status) {
-    case "past": return "text-z-debt";
+    case "overdue": return "text-z-debt";
     case "today": return "text-z-alert";
     case "future": return "text-muted-foreground";
+    case "paid": return "text-z-income";
+  }
+}
+
+function dateLabel(status: EffectiveStatus) {
+  switch (status) {
+    case "overdue": return "Vencido — ";
+    case "today": return "Hoy — ";
+    case "paid": return "";
+    case "future": return "";
   }
 }
 
@@ -83,23 +97,39 @@ export function RecurringTimeline({
     return groups;
   }, [allItems, templateMap, direction]);
 
-  const sortedDates = useMemo(
-    () => Array.from(dateGroups.keys())
-      .map((date) => ({ date, order: STATUS_ORDER[getDateStatus(date)] }))
-      .sort((a, b) => a.order - b.order || a.date.localeCompare(b.date))
-      .map((d) => d.date),
-    [dateGroups, getDateStatus]
-  );
-
   // Build occurrence status map (templateId:date → paid/pending)
+  const completedKeys = useMemo(() => new Set(completed.map((c) => c.key)), [completed]);
+
   const occurrenceStatuses = useMemo(() => {
-    const completedKeys = new Set(completed.map((c) => c.key));
     const statuses = new Map<string, "paid" | "pending" | "skipped">();
     for (const item of allItems) {
       statuses.set(`${item.templateId}:${item.date}`, completedKeys.has(item.key) ? "paid" : "pending");
     }
     return statuses;
-  }, [allItems, completed]);
+  }, [allItems, completedKeys]);
+
+  // Compute effective status per date group: combines date + payment status
+  const getGroupStatus = useMemo(() => {
+    return (date: string, items: OccurrenceItem[]): EffectiveStatus => {
+      const dateStatus = getDateStatus(date);
+      const allPaid = items.every((item) => completedKeys.has(item.key));
+      if (allPaid) return "paid";
+      if (dateStatus === "past") return "overdue";
+      if (dateStatus === "today") return "today";
+      return "future";
+    };
+  }, [getDateStatus, completedKeys]);
+
+  const sortedDates = useMemo(
+    () => Array.from(dateGroups.keys())
+      .map((date) => {
+        const items = dateGroups.get(date)!;
+        return { date, order: STATUS_ORDER[getGroupStatus(date, items)] };
+      })
+      .sort((a, b) => a.order - b.order || a.date.localeCompare(b.date))
+      .map((d) => d.date),
+    [dateGroups, getGroupStatus]
+  );
 
   return (
     <div className="relative pl-6">
@@ -108,8 +138,8 @@ export function RecurringTimeline({
 
       {/* Date groups */}
       {sortedDates.map((date) => {
-        const status = getDateStatus(date);
         const items = dateGroups.get(date)!;
+        const status = getGroupStatus(date, items);
 
         return (
           <div key={date} className="relative mb-5">
@@ -117,8 +147,7 @@ export function RecurringTimeline({
             <div className={cn("absolute -left-6 top-0.5 size-3 rounded-full", dotStyle(status))} />
             {/* Date label */}
             <p className={cn("mb-2 text-[10px] font-semibold uppercase tracking-[0.1em]", dateColor(status))}>
-              {status === "today" && "Hoy — "}
-              {status === "past" && "Vencido — "}
+              {dateLabel(status)}
               {formatDate(date, "EEEE d MMM")}
             </p>
 

--- a/webapp/src/components/recurring/recurring-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-timeline.tsx
@@ -36,7 +36,7 @@ function dotStyle(status: EffectiveStatus) {
     case "today":
       return "bg-z-alert shadow-[0_0_8px_rgba(245,158,11,0.4)]";
     case "future":
-      return "border-2 border-white/15 bg-transparent";
+      return "border-2 border-white/6 bg-transparent";
     case "paid":
       return "bg-z-income shadow-[0_0_6px_rgba(74,222,128,0.3)]";
   }
@@ -150,7 +150,7 @@ export function RecurringTimeline({
             {/* Dot */}
             <div className={cn("absolute -left-6 top-0.5 size-3 rounded-full", dotStyle(status))} />
             {/* Date label */}
-            <p className={cn("mb-2 text-[10px] font-semibold uppercase tracking-[0.1em]", dateColor(status))}>
+            <p className={cn("mb-2 text-[10px] font-semibold uppercase tracking-[0.18em]", dateColor(status))}>
               {dateLabel(status)}
               {formatDate(date, "EEEE d MMM")}
             </p>
@@ -186,7 +186,7 @@ export function RecurringTimeline({
       }).length > 0 && (
         <div className="relative mb-5">
           <div className="absolute -left-6 top-0.5 size-3 rounded-full bg-z-income shadow-[0_0_6px_rgba(74,222,128,0.3)]" />
-          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-z-income">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-income">
             Completados
           </p>
           <div className="space-y-2">
@@ -218,8 +218,8 @@ export function RecurringTimeline({
       {/* Paused templates */}
       {pausedTemplates.length > 0 && (
         <div className="relative mb-5 mt-6">
-          <div className="absolute -left-6 top-0.5 size-3 rounded-full border-2 border-dashed border-white/15" />
-          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">
+          <div className="absolute -left-6 top-0.5 size-3 rounded-full border-2 border-dashed border-white/6" />
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/50">
             Pausados
           </p>
           <div className="space-y-2">
@@ -271,7 +271,7 @@ function PausedTemplateCard({
 
   return (
     <div className={cn(
-      "overflow-hidden rounded-xl border border-dashed border-white/8 bg-white/[0.02] transition-all",
+      "overflow-hidden rounded-xl border border-dashed border-white/6 bg-white/[0.02] transition-all",
       isExpanded && "border-z-brass/20 border-solid opacity-100",
       !isExpanded && "opacity-50"
     )}>

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   addMonths,
@@ -86,7 +86,8 @@ function mapToOccurrenceItem(
 
 export function useRecurringMonth(
   _templates: RecurringTemplateWithRelations[], // kept for caller signature compat
-  accounts: Account[]
+  accounts: Account[],
+  initialOccurrences?: RecurringOccurrence[]
 ) {
   const router = useRouter();
 
@@ -109,11 +110,19 @@ export function useRecurringMonth(
   );
 
   /* ---- DB-backed occurrences state ---- */
-  const [occurrences, setOccurrences] = useState<RecurringOccurrence[]>([]);
-  const [isHydrated, setIsHydrated] = useState(false);
+  const [occurrences, setOccurrences] = useState<RecurringOccurrence[]>(initialOccurrences ?? []);
+  const [isHydrated, setIsHydrated] = useState(!!initialOccurrences);
 
   /* ---- Load occurrences from DB on mount and month change ---- */
+  const skipInitialFetch = useRef(!!initialOccurrences);
+
   useEffect(() => {
+    // Skip first fetch if server already provided data for current month
+    if (skipInitialFetch.current) {
+      skipInitialFetch.current = false;
+      return;
+    }
+
     setIsHydrated(false);
     let cancelled = false;
 

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -113,15 +113,19 @@ export function useRecurringMonth(
   const [occurrences, setOccurrences] = useState<RecurringOccurrence[]>(initialOccurrences ?? []);
   const [isHydrated, setIsHydrated] = useState(!!initialOccurrences);
 
-  /* ---- Load occurrences from DB on mount and month change ---- */
-  const skipInitialFetch = useRef(!!initialOccurrences);
+  /* ---- Track previous monthKey to detect actual changes ---- */
+  const prevMonthKey = useRef(monthKey);
+  const hadInitialData = useRef(!!initialOccurrences);
 
+  /* ---- Load occurrences from DB on month change ---- */
   useEffect(() => {
-    // Skip first fetch if server already provided data for current month
-    if (skipInitialFetch.current) {
-      skipInitialFetch.current = false;
-      return;
-    }
+    const monthChanged = prevMonthKey.current !== monthKey;
+    prevMonthKey.current = monthKey;
+
+    // On mount: skip if server provided initial data
+    if (!monthChanged && hadInitialData.current) return;
+    // After first real navigation, always fetch (even if returning to initial month)
+    if (monthChanged) hadInitialData.current = false;
 
     setIsHydrated(false);
     let cancelled = false;

--- a/webapp/src/lib/utils/currency.ts
+++ b/webapp/src/lib/utils/currency.ts
@@ -27,6 +27,31 @@ export function formatCurrency(
   }).format(amount);
 }
 
+/**
+ * Abbreviated currency format: $3.76M, $178K, $500.
+ * Uses K for thousands, M for millions. Keeps 1-2 significant digits after abbreviation.
+ */
+export function formatCurrencyCompact(
+  amount: number,
+  currencyCode: CurrencyCode = "COP"
+): string {
+  const config = CURRENCY_CONFIG[currencyCode];
+  const abs = Math.abs(amount);
+  const sign = amount < 0 ? "-" : "";
+
+  if (abs >= 1_000_000) {
+    const val = abs / 1_000_000;
+    const formatted = val >= 10 ? val.toFixed(1).replace(/\.0$/, "") : val.toFixed(2).replace(/0$/, "").replace(/\.$/, "");
+    return `${sign}${config.symbol} ${formatted}M`;
+  }
+  if (abs >= 1_000) {
+    const val = abs / 1_000;
+    const formatted = val >= 100 ? Math.round(val).toString() : val.toFixed(1).replace(/\.0$/, "");
+    return `${sign}${config.symbol} ${formatted}K`;
+  }
+  return formatCurrency(amount, currencyCode);
+}
+
 export function getCurrencySymbol(currencyCode: CurrencyCode): string {
   return CURRENCY_CONFIG[currencyCode].symbol;
 }

--- a/webapp/src/lib/utils/recurrence.ts
+++ b/webapp/src/lib/utils/recurrence.ts
@@ -1,4 +1,4 @@
-import { addDays, addWeeks, addMonths, addYears, parseISO, isBefore, isAfter, startOfDay } from "date-fns";
+import { addWeeks, addMonths, addYears, parseISO, isBefore, isAfter, startOfDay } from "date-fns";
 import type { RecurrenceFrequency } from "@/types/domain";
 
 /**
@@ -16,6 +16,8 @@ function advanceByFrequency(date: Date, frequency: RecurrenceFrequency): Date {
       return addMonths(date, 3);
     case "ANNUAL":
       return addYears(date, 1);
+    case "ONCE":
+      return date;
   }
 }
 
@@ -35,6 +37,12 @@ export function getNextOccurrence(
 
   // If end date has passed, no more occurrences
   if (end && isBefore(end, from)) return null;
+
+  // ONCE: single occurrence at start_date
+  if (frequency === "ONCE") {
+    if (isBefore(start, from)) return null;
+    return start.toISOString().split("T")[0];
+  }
 
   let current = start;
 
@@ -65,6 +73,16 @@ export function getOccurrencesBetween(
   const from = startOfDay(rangeStart);
   const to = startOfDay(rangeEnd);
 
+  // ONCE: single occurrence at start_date if within range
+  if (frequency === "ONCE") {
+    if (!isAfter(start, to) && !isBefore(start, from)) {
+      if (!end || !isAfter(start, end)) {
+        dates.push(start.toISOString().split("T")[0]);
+      }
+    }
+    return dates;
+  }
+
   let current = start;
 
   // Advance to first occurrence on or after rangeStart
@@ -87,6 +105,7 @@ export function getOccurrencesBetween(
  */
 export function frequencyLabel(frequency: RecurrenceFrequency): string {
   const labels: Record<RecurrenceFrequency, string> = {
+    ONCE: "Una vez",
     WEEKLY: "Semanal",
     BIWEEKLY: "Quincenal",
     MONTHLY: "Mensual",

--- a/webapp/src/lib/validators/recurring-template.ts
+++ b/webapp/src/lib/validators/recurring-template.ts
@@ -10,7 +10,7 @@ export const recurringTemplateSchema = z.object({
   amount: z.coerce.number().positive("El monto debe ser mayor a 0"),
   currency_code: z.enum(["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"]),
   direction: z.enum(["INFLOW", "OUTFLOW"]),
-  frequency: z.enum(["WEEKLY", "BIWEEKLY", "MONTHLY", "QUARTERLY", "ANNUAL"]),
+  frequency: z.enum(["ONCE", "WEEKLY", "BIWEEKLY", "MONTHLY", "QUARTERLY", "ANNUAL"]),
   merchant_name: z.string().min(1, "El nombre es requerido"),
   description: z.string().optional(),
   category_id: z.preprocess(

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -155,147 +155,6 @@ export type Database = {
           },
         ]
       }
-      accounts: {
-        Row: {
-          account_type: Database["public"]["Enums"]["account_type"]
-          available_balance: number | null
-          card_brand: string | null
-          color: string | null
-          connection_status: Database["public"]["Enums"]["connection_status"]
-          created_at: string
-          credit_limit: number | null
-          currency_balances: Json | null
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          current_balance: number
-          cutoff_day: number | null
-          debit_card_mask: string | null
-          display_order: number
-          expected_return_rate: number | null
-          icon: string | null
-          id: string
-          initial_investment: number | null
-          institution_name: string | null
-          interest_rate: number | null
-          is_active: boolean
-          is_demo: boolean
-          is_payroll_deducted: boolean
-          last_synced_at: string | null
-          loan_amount: number | null
-          loan_end_date: string | null
-          loan_start_date: string | null
-          mask: string | null
-          mask_hmac: string | null
-          maturity_date: string | null
-          monthly_payment: number | null
-          name: string
-          payment_day: number | null
-          pdf_password: string | null
-          provider: Database["public"]["Enums"]["data_provider"]
-          provider_account_id: string | null
-          provider_account_id_hmac: string | null
-          show_in_dashboard: boolean
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_type: Database["public"]["Enums"]["account_type"]
-          available_balance?: number | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?: Database["public"]["Enums"]["connection_status"]
-          created_at?: string
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          current_balance?: number
-          cutoff_day?: number | null
-          debit_card_mask?: string | null
-          display_order?: number
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string
-          initial_investment?: number | null
-          institution_name?: string | null
-          interest_rate?: number | null
-          is_active?: boolean
-          is_demo?: boolean
-          is_payroll_deducted?: boolean
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: string | null
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name: string
-          payment_day?: number | null
-          pdf_password?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_account_id?: string | null
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_type?: Database["public"]["Enums"]["account_type"]
-          available_balance?: number | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?: Database["public"]["Enums"]["connection_status"]
-          created_at?: string
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          current_balance?: number
-          cutoff_day?: number | null
-          debit_card_mask?: string | null
-          display_order?: number
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string
-          initial_investment?: number | null
-          institution_name?: string | null
-          interest_rate?: number | null
-          is_active?: boolean
-          is_demo?: boolean
-          is_payroll_deducted?: boolean
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: string | null
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name?: string
-          payment_day?: number | null
-          pdf_password?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_account_id?: string | null
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       admin_config: {
         Row: {
           id: string
@@ -435,7 +294,7 @@ export type Database = {
           last_used_at?: string | null
           revoked_at?: string | null
           token: string
-          token_hash?: string
+          token_hash: string
           user_id: string
         }
         Update: {
@@ -462,57 +321,6 @@ export type Database = {
             columns: ["default_account_id"]
             isOneToOne: false
             referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      capture_tokens: {
-        Row: {
-          created_at: string
-          default_account_id: string | null
-          id: string
-          label: string
-          last_used_at: string | null
-          revoked_at: string | null
-          token: string
-          token_hash: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          default_account_id?: string | null
-          id?: string
-          label: string
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token: string
-          token_hash?: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          default_account_id?: string | null
-          id?: string
-          label?: string
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token?: string
-          token_hash?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
             referencedColumns: ["id"]
           },
         ]
@@ -932,88 +740,6 @@ export type Database = {
           },
         ]
       }
-      destinatarios: {
-        Row: {
-          created_at: string
-          default_category_id: string | null
-          id: string
-          is_active: boolean
-          name: string
-          name_hmac: string | null
-          notes: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          default_category_id?: string | null
-          id?: string
-          is_active?: boolean
-          name: string
-          name_hmac?: string | null
-          notes?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          default_category_id?: string | null
-          id?: string
-          is_active?: boolean
-          name?: string
-          name_hmac?: string | null
-          notes?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "destinatarios_default_category_id_fkey"
-            columns: ["default_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      email_ingest_allowed_senders: {
-        Row: {
-          created_at: string
-          id: string
-          label: string | null
-          sender_email: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          label?: string | null
-          sender_email: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          label?: string | null
-          sender_email?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
       email_ingest_addresses_enc: {
         Row: {
           account_id: string | null
@@ -1085,76 +811,29 @@ export type Database = {
           },
         ]
       }
-      email_ingest_addresses: {
+      email_ingest_allowed_senders: {
         Row: {
-          account_id: string | null
-          address_key: string
-          allowed_sender: string | null
-          auto_import: boolean
           created_at: string
-          gmail_verification_at: string | null
-          gmail_verification_url: string | null
           id: string
-          is_active: boolean
-          pdf_import_enabled: boolean
+          label: string | null
+          sender_email: string
           user_id: string
         }
         Insert: {
-          account_id?: string | null
-          address_key: string
-          allowed_sender?: string | null
-          auto_import?: boolean
           created_at?: string
-          gmail_verification_at?: string | null
-          gmail_verification_url?: string | null
           id?: string
-          is_active?: boolean
-          pdf_import_enabled?: boolean
+          label?: string | null
+          sender_email: string
           user_id: string
         }
         Update: {
-          account_id?: string | null
-          address_key?: string
-          allowed_sender?: string | null
-          auto_import?: boolean
           created_at?: string
-          gmail_verification_at?: string | null
-          gmail_verification_url?: string | null
           id?: string
-          is_active?: boolean
-          pdf_import_enabled?: boolean
+          label?: string | null
+          sender_email?: string
           user_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
       email_ingest_logs: {
         Row: {
@@ -1719,63 +1398,6 @@ export type Database = {
           budget_mode: string | null
           created_at: string
           dashboard_config: Json | null
-          email: string
-          estimated_monthly_expenses: number | null
-          estimated_monthly_income: number | null
-          full_name: string | null
-          id: string
-          locale: string
-          monthly_salary: number | null
-          onboarding_completed: boolean
-          preferred_currency: Database["public"]["Enums"]["currency_code"]
-          timezone: string
-          updated_at: string
-        }
-        Insert: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string
-          dashboard_config?: Json | null
-          email: string
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: string | null
-          id: string
-          locale?: string
-          monthly_salary?: number | null
-          onboarding_completed?: boolean
-          preferred_currency?: Database["public"]["Enums"]["currency_code"]
-          timezone?: string
-          updated_at?: string
-        }
-        Update: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string
-          dashboard_config?: Json | null
-          email?: string
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: string | null
-          id?: string
-          locale?: string
-          monthly_salary?: number | null
-          onboarding_completed?: boolean
-          preferred_currency?: Database["public"]["Enums"]["currency_code"]
-          timezone?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      profiles: {
-        Row: {
-          app_purpose: string | null
-          avatar_url: string | null
-          budget_mode: string | null
-          created_at: string
-          dashboard_config: Json | null
           demo_mode: boolean
           email: string
           estimated_monthly_expenses: number | null
@@ -2010,119 +1632,6 @@ export type Database = {
           },
         ]
       }
-      recurring_transaction_templates: {
-        Row: {
-          account_id: string
-          amount: number
-          category_id: string | null
-          created_at: string
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          day_of_month: number | null
-          day_of_week: number | null
-          description: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          end_date: string | null
-          frequency: Database["public"]["Enums"]["recurrence_frequency"]
-          id: string
-          is_active: boolean
-          merchant_name: string | null
-          start_date: string
-          transfer_source_account_id: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id: string
-          amount: number
-          category_id?: string | null
-          created_at?: string
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          end_date?: string | null
-          frequency: Database["public"]["Enums"]["recurrence_frequency"]
-          id?: string
-          is_active?: boolean
-          merchant_name?: string | null
-          start_date: string
-          transfer_source_account_id?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string
-          amount?: number
-          category_id?: string | null
-          created_at?: string
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: string | null
-          direction?: Database["public"]["Enums"]["transaction_direction"]
-          end_date?: string | null
-          frequency?: Database["public"]["Enums"]["recurrence_frequency"]
-          id?: string
-          is_active?: boolean
-          merchant_name?: string | null
-          start_date?: string
-          transfer_source_account_id?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       statement_snapshots_enc: {
         Row: {
           account_id: string
@@ -2244,131 +1753,6 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      statement_snapshots: {
-        Row: {
-          account_id: string
-          available_credit: number | null
-          created_at: string
-          credit_limit: number | null
-          currency_code: string
-          final_balance: number | null
-          id: string
-          imported_count: number
-          initial_amount: number | null
-          installments_in_default: number | null
-          interest_charged: number | null
-          interest_rate: number | null
-          late_interest_rate: number | null
-          loan_number: string | null
-          minimum_payment: number | null
-          payment_due_date: string | null
-          period_from: string | null
-          period_to: string | null
-          previous_balance: number | null
-          purchases_and_charges: number | null
-          remaining_balance: number | null
-          skipped_count: number
-          source_filename: string | null
-          total_credits: number | null
-          total_debits: number | null
-          total_payment_due: number | null
-          transaction_count: number
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id: string
-          available_credit?: number | null
-          created_at?: string
-          credit_limit?: number | null
-          currency_code?: string
-          final_balance?: number | null
-          id?: string
-          imported_count?: number
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: string | null
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number
-          source_filename?: string | null
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string
-          available_credit?: number | null
-          created_at?: string
-          credit_limit?: number | null
-          currency_code?: string
-          final_balance?: number | null
-          id?: string
-          imported_count?: number
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: string | null
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number
-          source_filename?: string | null
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -2722,215 +2106,6 @@ export type Database = {
           },
         ]
       }
-      transactions: {
-        Row: {
-          account_id: string
-          amount: number
-          amount_in_base_currency: number | null
-          capture_input_text: string | null
-          capture_method: Database["public"]["Enums"]["transaction_capture_method"]
-          categorization_confidence: number | null
-          categorization_source: Database["public"]["Enums"]["categorization_source"]
-          category_id: string | null
-          clean_description: string | null
-          clean_description_hmac: string | null
-          created_at: string
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          destinatario_id: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          exchange_rate: number
-          id: string
-          idempotency_key: string
-          installment_current: number | null
-          installment_group_id: string | null
-          installment_total: number | null
-          is_excluded: boolean
-          is_recurring: boolean
-          is_subscription: boolean
-          merchant_category_code: string | null
-          merchant_logo_url: string | null
-          merchant_name: string | null
-          merchant_name_hmac: string | null
-          notes: string | null
-          original_amount: number | null
-          posting_date: string | null
-          provider: Database["public"]["Enums"]["data_provider"]
-          provider_transaction_id: string | null
-          raw_description: string | null
-          reconciled_into_transaction_id: string | null
-          reconciliation_score: number | null
-          recurrence_group_id: string | null
-          secondary_category_id: string | null
-          status: Database["public"]["Enums"]["transaction_status"]
-          tags: string[] | null
-          transaction_date: string
-          transfer_group_id: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id: string
-          amount: number
-          amount_in_base_currency?: number | null
-          capture_input_text?: string | null
-          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
-          categorization_confidence?: number | null
-          categorization_source?: Database["public"]["Enums"]["categorization_source"]
-          category_id?: string | null
-          clean_description?: string | null
-          clean_description_hmac?: string | null
-          created_at?: string
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          destinatario_id?: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          exchange_rate?: number
-          id?: string
-          idempotency_key: string
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean
-          is_recurring?: boolean
-          is_subscription?: boolean
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: string | null
-          merchant_name_hmac?: string | null
-          notes?: string | null
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_transaction_id?: string | null
-          raw_description?: string | null
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"]
-          tags?: string[] | null
-          transaction_date: string
-          transfer_group_id?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string
-          amount?: number
-          amount_in_base_currency?: number | null
-          capture_input_text?: string | null
-          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
-          categorization_confidence?: number | null
-          categorization_source?: Database["public"]["Enums"]["categorization_source"]
-          category_id?: string | null
-          clean_description?: string | null
-          clean_description_hmac?: string | null
-          created_at?: string
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          destinatario_id?: string | null
-          direction?: Database["public"]["Enums"]["transaction_direction"]
-          exchange_rate?: number
-          id?: string
-          idempotency_key?: string
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean
-          is_recurring?: boolean
-          is_subscription?: boolean
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: string | null
-          merchant_name_hmac?: string | null
-          notes?: string | null
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_transaction_id?: string | null
-          raw_description?: string | null
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"]
-          tags?: string[] | null
-          transaction_date?: string
-          transfer_group_id?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_secondary_category_id_fkey"
-            columns: ["secondary_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       unrecognized_emails: {
         Row: {
           created_at: string
@@ -3137,129 +2312,6 @@ export type Database = {
           },
         ]
       }
-      wishlist_items: {
-        Row: {
-          account_id: string | null
-          amount: number
-          bought_at: string | null
-          category_id: string | null
-          created_at: string
-          currency_code: string
-          desire_type: string | null
-          enriched: boolean
-          enriched_at: string | null
-          funding_type: string | null
-          id: string
-          image_url: string | null
-          installments: number | null
-          last_nudge_dismissed_at: string | null
-          last_score: number | null
-          last_scored_at: string | null
-          last_verdict: string | null
-          name: string
-          ready_at: string | null
-          status: string
-          transaction_id: string | null
-          updated_at: string
-          urgency: string | null
-          url: string | null
-          user_id: string
-          why: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount: number
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string
-          currency_code?: string
-          desire_type?: string | null
-          enriched?: boolean
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name: string
-          ready_at?: string | null
-          status?: string
-          transaction_id?: string | null
-          updated_at?: string
-          urgency?: string | null
-          url?: string | null
-          user_id: string
-          why?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string
-          currency_code?: string
-          desire_type?: string | null
-          enriched?: boolean
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name?: string
-          ready_at?: string | null
-          status?: string
-          transaction_id?: string | null
-          updated_at?: string
-          urgency?: string | null
-          url?: string | null
-          user_id?: string
-          why?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       wishlist_reflections: {
         Row: {
           days_since_purchase: number
@@ -3313,21 +2365,1020 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      accounts: {
+        Row: {
+          account_type: Database["public"]["Enums"]["account_type"] | null
+          available_balance: number | null
+          card_brand: string | null
+          color: string | null
+          connection_status:
+            | Database["public"]["Enums"]["connection_status"]
+            | null
+          created_at: string | null
+          credit_limit: number | null
+          currency_balances: Json | null
+          currency_code: Database["public"]["Enums"]["currency_code"] | null
+          current_balance: number | null
+          cutoff_day: number | null
+          debit_card_mask: string | null
+          display_order: number | null
+          expected_return_rate: number | null
+          icon: string | null
+          id: string | null
+          initial_investment: number | null
+          institution_name: string | null
+          interest_rate: number | null
+          is_active: boolean | null
+          is_demo: boolean | null
+          is_payroll_deducted: boolean | null
+          last_synced_at: string | null
+          loan_amount: number | null
+          loan_end_date: string | null
+          loan_start_date: string | null
+          mask: string | null
+          mask_hmac: string | null
+          maturity_date: string | null
+          monthly_payment: number | null
+          name: string | null
+          payment_day: number | null
+          pdf_password: string | null
+          provider: Database["public"]["Enums"]["data_provider"] | null
+          provider_account_id: string | null
+          provider_account_id_hmac: string | null
+          show_in_dashboard: boolean | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_type?: Database["public"]["Enums"]["account_type"] | null
+          available_balance?: number | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?:
+            | Database["public"]["Enums"]["connection_status"]
+            | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          current_balance?: number | null
+          cutoff_day?: number | null
+          debit_card_mask?: never
+          display_order?: number | null
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string | null
+          initial_investment?: number | null
+          institution_name?: never
+          interest_rate?: number | null
+          is_active?: boolean | null
+          is_demo?: boolean | null
+          is_payroll_deducted?: boolean | null
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: never
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: never
+          payment_day?: number | null
+          pdf_password?: never
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_account_id?: never
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_type?: Database["public"]["Enums"]["account_type"] | null
+          available_balance?: number | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?:
+            | Database["public"]["Enums"]["connection_status"]
+            | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          current_balance?: number | null
+          cutoff_day?: number | null
+          debit_card_mask?: never
+          display_order?: number | null
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string | null
+          initial_investment?: number | null
+          institution_name?: never
+          interest_rate?: number | null
+          is_active?: boolean | null
+          is_demo?: boolean | null
+          is_payroll_deducted?: boolean | null
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: never
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: never
+          payment_day?: number | null
+          pdf_password?: never
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_account_id?: never
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      capture_tokens: {
+        Row: {
+          created_at: string | null
+          default_account_id: string | null
+          id: string | null
+          label: string | null
+          last_used_at: string | null
+          revoked_at: string | null
+          token: string | null
+          token_hash: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          default_account_id?: string | null
+          id?: string | null
+          label?: never
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: never
+          token_hash?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          default_account_id?: string | null
+          id?: string | null
+          label?: never
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: never
+          token_hash?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      destinatarios: {
+        Row: {
+          created_at: string | null
+          default_category_id: string | null
+          id: string | null
+          is_active: boolean | null
+          name: string | null
+          name_hmac: string | null
+          notes: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          default_category_id?: string | null
+          id?: string | null
+          is_active?: boolean | null
+          name?: never
+          name_hmac?: string | null
+          notes?: never
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          default_category_id?: string | null
+          id?: string | null
+          is_active?: boolean | null
+          name?: never
+          name_hmac?: string | null
+          notes?: never
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "destinatarios_default_category_id_fkey"
+            columns: ["default_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      email_ingest_addresses: {
+        Row: {
+          account_id: string | null
+          address_key: string | null
+          allowed_sender: string | null
+          auto_import: boolean | null
+          created_at: string | null
+          gmail_verification_at: string | null
+          gmail_verification_url: string | null
+          id: string | null
+          is_active: boolean | null
+          pdf_import_enabled: boolean | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          address_key?: string | null
+          allowed_sender?: never
+          auto_import?: boolean | null
+          created_at?: string | null
+          gmail_verification_at?: string | null
+          gmail_verification_url?: never
+          id?: string | null
+          is_active?: boolean | null
+          pdf_import_enabled?: boolean | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          address_key?: string | null
+          allowed_sender?: never
+          auto_import?: boolean | null
+          created_at?: string | null
+          gmail_verification_at?: string | null
+          gmail_verification_url?: never
+          id?: string | null
+          is_active?: boolean | null
+          pdf_import_enabled?: boolean | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          app_purpose: string | null
+          avatar_url: string | null
+          budget_mode: string | null
+          created_at: string | null
+          dashboard_config: Json | null
+          demo_mode: boolean | null
+          email: string | null
+          estimated_monthly_expenses: number | null
+          estimated_monthly_income: number | null
+          full_name: string | null
+          id: string | null
+          locale: string | null
+          monthly_salary: number | null
+          onboarding_completed: boolean | null
+          preferred_currency:
+            | Database["public"]["Enums"]["currency_code"]
+            | null
+          timezone: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string | null
+          dashboard_config?: Json | null
+          demo_mode?: boolean | null
+          email?: never
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: never
+          id?: string | null
+          locale?: string | null
+          monthly_salary?: number | null
+          onboarding_completed?: boolean | null
+          preferred_currency?:
+            | Database["public"]["Enums"]["currency_code"]
+            | null
+          timezone?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string | null
+          dashboard_config?: Json | null
+          demo_mode?: boolean | null
+          email?: never
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: never
+          id?: string | null
+          locale?: string | null
+          monthly_salary?: number | null
+          onboarding_completed?: boolean | null
+          preferred_currency?:
+            | Database["public"]["Enums"]["currency_code"]
+            | null
+          timezone?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      recurring_transaction_templates: {
+        Row: {
+          account_id: string | null
+          amount: number | null
+          category_id: string | null
+          created_at: string | null
+          currency_code: Database["public"]["Enums"]["currency_code"] | null
+          day_of_month: number | null
+          day_of_week: number | null
+          description: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"] | null
+          end_date: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"] | null
+          id: string | null
+          is_active: boolean | null
+          merchant_name: string | null
+          start_date: string | null
+          transfer_source_account_id: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount?: number | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: never
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
+          id?: string | null
+          is_active?: boolean | null
+          merchant_name?: never
+          start_date?: string | null
+          transfer_source_account_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: never
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
+          id?: string | null
+          is_active?: boolean | null
+          merchant_name?: never
+          start_date?: string | null
+          transfer_source_account_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      statement_snapshots: {
+        Row: {
+          account_id: string | null
+          available_credit: number | null
+          created_at: string | null
+          credit_limit: number | null
+          currency_code: string | null
+          final_balance: number | null
+          id: string | null
+          imported_count: number | null
+          initial_amount: number | null
+          installments_in_default: number | null
+          interest_charged: number | null
+          interest_rate: number | null
+          late_interest_rate: number | null
+          loan_number: string | null
+          minimum_payment: number | null
+          payment_due_date: string | null
+          period_from: string | null
+          period_to: string | null
+          previous_balance: number | null
+          purchases_and_charges: number | null
+          remaining_balance: number | null
+          skipped_count: number | null
+          source_filename: string | null
+          total_credits: number | null
+          total_debits: number | null
+          total_payment_due: number | null
+          transaction_count: number | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          available_credit?: number | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_code?: string | null
+          final_balance?: number | null
+          id?: string | null
+          imported_count?: number | null
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: never
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number | null
+          source_filename?: never
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          available_credit?: number | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_code?: string | null
+          final_balance?: number | null
+          id?: string | null
+          imported_count?: number | null
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: never
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number | null
+          source_filename?: never
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      transactions: {
+        Row: {
+          account_id: string | null
+          amount: number | null
+          amount_in_base_currency: number | null
+          capture_input_text: string | null
+          capture_method:
+            | Database["public"]["Enums"]["transaction_capture_method"]
+            | null
+          categorization_confidence: number | null
+          categorization_source:
+            | Database["public"]["Enums"]["categorization_source"]
+            | null
+          category_id: string | null
+          clean_description: string | null
+          clean_description_hmac: string | null
+          created_at: string | null
+          currency_code: Database["public"]["Enums"]["currency_code"] | null
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"] | null
+          exchange_rate: number | null
+          id: string | null
+          idempotency_key: string | null
+          installment_current: number | null
+          installment_group_id: string | null
+          installment_total: number | null
+          is_excluded: boolean | null
+          is_recurring: boolean | null
+          is_subscription: boolean | null
+          merchant_category_code: string | null
+          merchant_logo_url: string | null
+          merchant_name: string | null
+          merchant_name_hmac: string | null
+          notes: string | null
+          original_amount: number | null
+          posting_date: string | null
+          provider: Database["public"]["Enums"]["data_provider"] | null
+          provider_transaction_id: string | null
+          raw_description: string | null
+          reconciled_into_transaction_id: string | null
+          reconciliation_score: number | null
+          recurrence_group_id: string | null
+          secondary_category_id: string | null
+          status: Database["public"]["Enums"]["transaction_status"] | null
+          tags: string[] | null
+          transaction_date: string | null
+          transfer_group_id: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount?: number | null
+          amount_in_base_currency?: number | null
+          capture_input_text?: never
+          capture_method?:
+            | Database["public"]["Enums"]["transaction_capture_method"]
+            | null
+          categorization_confidence?: number | null
+          categorization_source?:
+            | Database["public"]["Enums"]["categorization_source"]
+            | null
+          category_id?: string | null
+          clean_description?: never
+          clean_description_hmac?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          destinatario_id?: string | null
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          exchange_rate?: number | null
+          id?: string | null
+          idempotency_key?: string | null
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean | null
+          is_recurring?: boolean | null
+          is_subscription?: boolean | null
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: never
+          merchant_name_hmac?: string | null
+          notes?: never
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_transaction_id?: string | null
+          raw_description?: never
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"] | null
+          tags?: string[] | null
+          transaction_date?: string | null
+          transfer_group_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number | null
+          amount_in_base_currency?: number | null
+          capture_input_text?: never
+          capture_method?:
+            | Database["public"]["Enums"]["transaction_capture_method"]
+            | null
+          categorization_confidence?: number | null
+          categorization_source?:
+            | Database["public"]["Enums"]["categorization_source"]
+            | null
+          category_id?: string | null
+          clean_description?: never
+          clean_description_hmac?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          destinatario_id?: string | null
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          exchange_rate?: number | null
+          id?: string | null
+          idempotency_key?: string | null
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean | null
+          is_recurring?: boolean | null
+          is_subscription?: boolean | null
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: never
+          merchant_name_hmac?: string | null
+          notes?: never
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_transaction_id?: string | null
+          raw_description?: never
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"] | null
+          tags?: string[] | null
+          transaction_date?: string | null
+          transfer_group_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_secondary_category_id_fkey"
+            columns: ["secondary_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      wishlist_items: {
+        Row: {
+          account_id: string | null
+          amount: number | null
+          bought_at: string | null
+          category_id: string | null
+          created_at: string | null
+          currency_code: string | null
+          desire_type: string | null
+          enriched: boolean | null
+          enriched_at: string | null
+          funding_type: string | null
+          id: string | null
+          image_url: string | null
+          installments: number | null
+          last_nudge_dismissed_at: string | null
+          last_score: number | null
+          last_scored_at: string | null
+          last_verdict: string | null
+          name: string | null
+          ready_at: string | null
+          status: string | null
+          transaction_id: string | null
+          updated_at: string | null
+          urgency: string | null
+          url: string | null
+          user_id: string | null
+          why: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount?: number | null
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: string | null
+          desire_type?: string | null
+          enriched?: boolean | null
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string | null
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: never
+          ready_at?: string | null
+          status?: string | null
+          transaction_id?: string | null
+          updated_at?: string | null
+          urgency?: string | null
+          url?: never
+          user_id?: string | null
+          why?: never
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number | null
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: string | null
+          desire_type?: string | null
+          enriched?: boolean | null
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string | null
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: never
+          ready_at?: string | null
+          status?: string | null
+          transaction_id?: string | null
+          updated_at?: string | null
+          urgency?: string | null
+          url?: never
+          user_id?: string | null
+          why?: never
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Functions: {
       get_accounts_with_masks: {
         Args: { p_user_id: string }
         Returns: {
-          id: string
-          mask: string | null
-          debit_card_mask: string | null
-          pdf_password: string | null
           account_type: Database["public"]["Enums"]["account_type"]
           currency_code: Database["public"]["Enums"]["currency_code"]
           current_balance: number
+          debit_card_mask: string
+          id: string
           is_demo: boolean
+          mask: string
+          pdf_password: string
         }[]
+      }
+      get_email_ingest_settings: {
+        Args: { p_address_key: string }
+        Returns: {
+          account_id: string
+          address_key: string
+          allowed_sender: string
+          allowed_senders: string[]
+          auto_import: boolean
+          id: string
+          pdf_import_enabled: boolean
+          user_id: string
+        }[]
+      }
+      set_gmail_verification: {
+        Args: { p_ingest_id: string; p_url: string; p_user_id: string }
+        Returns: undefined
       }
       zeta_decrypt: { Args: { ciphertext: string }; Returns: string }
       zeta_decrypt_as: {
@@ -3378,6 +3429,7 @@ export type Database = {
         | "CSV_IMPORT"
         | "OCR"
         | "EMAIL"
+      occurrence_status: "pending" | "paid" | "skipped"
       planning_entry_status: "PLANNED" | "COMPLETED" | "SKIPPED"
       planning_entry_type: "INCOME" | "EXPENSE"
       planning_period_preset: "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "CUSTOM"
@@ -3387,6 +3439,7 @@ export type Database = {
         | "MONTHLY"
         | "QUARTERLY"
         | "ANNUAL"
+        | "ONCE"
       transaction_capture_method:
         | "MANUAL_FORM"
         | "TEXT_QUICK_CAPTURE"
@@ -3395,7 +3448,6 @@ export type Database = {
         | "OCR_SINGLE"
         | "EMAIL_IMPORT"
         | "EMAIL_PDF_IMPORT"
-      occurrence_status: "pending" | "paid" | "skipped"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
     }
@@ -3552,6 +3604,7 @@ export const Constants = {
         "OCR",
         "EMAIL",
       ],
+      occurrence_status: ["pending", "paid", "skipped"],
       planning_entry_status: ["PLANNED", "COMPLETED", "SKIPPED"],
       planning_entry_type: ["INCOME", "EXPENSE"],
       planning_period_preset: ["WEEKLY", "BIWEEKLY", "MONTHLY", "CUSTOM"],
@@ -3561,6 +3614,7 @@ export const Constants = {
         "MONTHLY",
         "QUARTERLY",
         "ANNUAL",
+        "ONCE",
       ],
       transaction_capture_method: [
         "MANUAL_FORM",
@@ -3571,7 +3625,6 @@ export const Constants = {
         "EMAIL_IMPORT",
         "EMAIL_PDF_IMPORT",
       ],
-      occurrence_status: ["pending", "paid", "skipped"],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],
     },

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -155,6 +155,147 @@ export type Database = {
           },
         ]
       }
+      accounts: {
+        Row: {
+          account_type: Database["public"]["Enums"]["account_type"]
+          available_balance: number | null
+          card_brand: string | null
+          color: string | null
+          connection_status: Database["public"]["Enums"]["connection_status"]
+          created_at: string
+          credit_limit: number | null
+          currency_balances: Json | null
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          current_balance: number
+          cutoff_day: number | null
+          debit_card_mask: string | null
+          display_order: number
+          expected_return_rate: number | null
+          icon: string | null
+          id: string
+          initial_investment: number | null
+          institution_name: string | null
+          interest_rate: number | null
+          is_active: boolean
+          is_demo: boolean
+          is_payroll_deducted: boolean
+          last_synced_at: string | null
+          loan_amount: number | null
+          loan_end_date: string | null
+          loan_start_date: string | null
+          mask: string | null
+          mask_hmac: string | null
+          maturity_date: string | null
+          monthly_payment: number | null
+          name: string
+          payment_day: number | null
+          pdf_password: string | null
+          provider: Database["public"]["Enums"]["data_provider"]
+          provider_account_id: string | null
+          provider_account_id_hmac: string | null
+          show_in_dashboard: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_type: Database["public"]["Enums"]["account_type"]
+          available_balance?: number | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?: Database["public"]["Enums"]["connection_status"]
+          created_at?: string
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          current_balance?: number
+          cutoff_day?: number | null
+          debit_card_mask?: string | null
+          display_order?: number
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string
+          initial_investment?: number | null
+          institution_name?: string | null
+          interest_rate?: number | null
+          is_active?: boolean
+          is_demo?: boolean
+          is_payroll_deducted?: boolean
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: string | null
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name: string
+          payment_day?: number | null
+          pdf_password?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_type?: Database["public"]["Enums"]["account_type"]
+          available_balance?: number | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?: Database["public"]["Enums"]["connection_status"]
+          created_at?: string
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          current_balance?: number
+          cutoff_day?: number | null
+          debit_card_mask?: string | null
+          display_order?: number
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string
+          initial_investment?: number | null
+          institution_name?: string | null
+          interest_rate?: number | null
+          is_active?: boolean
+          is_demo?: boolean
+          is_payroll_deducted?: boolean
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: string | null
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: string
+          payment_day?: number | null
+          pdf_password?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       admin_config: {
         Row: {
           id: string
@@ -294,7 +435,7 @@ export type Database = {
           last_used_at?: string | null
           revoked_at?: string | null
           token: string
-          token_hash: string
+          token_hash?: string
           user_id: string
         }
         Update: {
@@ -321,6 +462,57 @@ export type Database = {
             columns: ["default_account_id"]
             isOneToOne: false
             referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      capture_tokens: {
+        Row: {
+          created_at: string
+          default_account_id: string | null
+          id: string
+          label: string
+          last_used_at: string | null
+          revoked_at: string | null
+          token: string
+          token_hash: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_account_id?: string | null
+          id?: string
+          label: string
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token: string
+          token_hash?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_account_id?: string | null
+          id?: string
+          label?: string
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: string
+          token_hash?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
             referencedColumns: ["id"]
           },
         ]
@@ -740,6 +932,88 @@ export type Database = {
           },
         ]
       }
+      destinatarios: {
+        Row: {
+          created_at: string
+          default_category_id: string | null
+          id: string
+          is_active: boolean
+          name: string
+          name_hmac: string | null
+          notes: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_category_id?: string | null
+          id?: string
+          is_active?: boolean
+          name: string
+          name_hmac?: string | null
+          notes?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_category_id?: string | null
+          id?: string
+          is_active?: boolean
+          name?: string
+          name_hmac?: string | null
+          notes?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "destinatarios_default_category_id_fkey"
+            columns: ["default_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      email_ingest_allowed_senders: {
+        Row: {
+          created_at: string
+          id: string
+          label: string | null
+          sender_email: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          label?: string | null
+          sender_email: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          label?: string | null
+          sender_email?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       email_ingest_addresses_enc: {
         Row: {
           account_id: string | null
@@ -811,29 +1085,76 @@ export type Database = {
           },
         ]
       }
-      email_ingest_allowed_senders: {
+      email_ingest_addresses: {
         Row: {
+          account_id: string | null
+          address_key: string
+          allowed_sender: string | null
+          auto_import: boolean
           created_at: string
+          gmail_verification_at: string | null
+          gmail_verification_url: string | null
           id: string
-          label: string | null
-          sender_email: string
+          is_active: boolean
+          pdf_import_enabled: boolean
           user_id: string
         }
         Insert: {
+          account_id?: string | null
+          address_key: string
+          allowed_sender?: string | null
+          auto_import?: boolean
           created_at?: string
+          gmail_verification_at?: string | null
+          gmail_verification_url?: string | null
           id?: string
-          label?: string | null
-          sender_email: string
+          is_active?: boolean
+          pdf_import_enabled?: boolean
           user_id: string
         }
         Update: {
+          account_id?: string | null
+          address_key?: string
+          allowed_sender?: string | null
+          auto_import?: boolean
           created_at?: string
+          gmail_verification_at?: string | null
+          gmail_verification_url?: string | null
           id?: string
-          label?: string | null
-          sender_email?: string
+          is_active?: boolean
+          pdf_import_enabled?: boolean
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       email_ingest_logs: {
         Row: {
@@ -1398,6 +1719,63 @@ export type Database = {
           budget_mode: string | null
           created_at: string
           dashboard_config: Json | null
+          email: string
+          estimated_monthly_expenses: number | null
+          estimated_monthly_income: number | null
+          full_name: string | null
+          id: string
+          locale: string
+          monthly_salary: number | null
+          onboarding_completed: boolean
+          preferred_currency: Database["public"]["Enums"]["currency_code"]
+          timezone: string
+          updated_at: string
+        }
+        Insert: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string
+          dashboard_config?: Json | null
+          email: string
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: string | null
+          id: string
+          locale?: string
+          monthly_salary?: number | null
+          onboarding_completed?: boolean
+          preferred_currency?: Database["public"]["Enums"]["currency_code"]
+          timezone?: string
+          updated_at?: string
+        }
+        Update: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string
+          dashboard_config?: Json | null
+          email?: string
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: string | null
+          id?: string
+          locale?: string
+          monthly_salary?: number | null
+          onboarding_completed?: boolean
+          preferred_currency?: Database["public"]["Enums"]["currency_code"]
+          timezone?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          app_purpose: string | null
+          avatar_url: string | null
+          budget_mode: string | null
+          created_at: string
+          dashboard_config: Json | null
           demo_mode: boolean
           email: string
           estimated_monthly_expenses: number | null
@@ -1632,6 +2010,119 @@ export type Database = {
           },
         ]
       }
+      recurring_transaction_templates: {
+        Row: {
+          account_id: string
+          amount: number
+          category_id: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          day_of_month: number | null
+          day_of_week: number | null
+          description: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id: string
+          is_active: boolean
+          merchant_name: string | null
+          start_date: string
+          transfer_source_account_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date: string
+          transfer_source_account_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date?: string
+          transfer_source_account_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       statement_snapshots_enc: {
         Row: {
           account_id: string
@@ -1753,6 +2244,131 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      statement_snapshots: {
+        Row: {
+          account_id: string
+          available_credit: number | null
+          created_at: string
+          credit_limit: number | null
+          currency_code: string
+          final_balance: number | null
+          id: string
+          imported_count: number
+          initial_amount: number | null
+          installments_in_default: number | null
+          interest_charged: number | null
+          interest_rate: number | null
+          late_interest_rate: number | null
+          loan_number: string | null
+          minimum_payment: number | null
+          payment_due_date: string | null
+          period_from: string | null
+          period_to: string | null
+          previous_balance: number | null
+          purchases_and_charges: number | null
+          remaining_balance: number | null
+          skipped_count: number
+          source_filename: string | null
+          total_credits: number | null
+          total_debits: number | null
+          total_payment_due: number | null
+          transaction_count: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          available_credit?: number | null
+          created_at?: string
+          credit_limit?: number | null
+          currency_code?: string
+          final_balance?: number | null
+          id?: string
+          imported_count?: number
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: string | null
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number
+          source_filename?: string | null
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          available_credit?: number | null
+          created_at?: string
+          credit_limit?: number | null
+          currency_code?: string
+          final_balance?: number | null
+          id?: string
+          imported_count?: number
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: string | null
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number
+          source_filename?: string | null
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -2106,6 +2722,215 @@ export type Database = {
           },
         ]
       }
+      transactions: {
+        Row: {
+          account_id: string
+          amount: number
+          amount_in_base_currency: number | null
+          capture_input_text: string | null
+          capture_method: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence: number | null
+          categorization_source: Database["public"]["Enums"]["categorization_source"]
+          category_id: string | null
+          clean_description: string | null
+          clean_description_hmac: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate: number
+          id: string
+          idempotency_key: string
+          installment_current: number | null
+          installment_group_id: string | null
+          installment_total: number | null
+          is_excluded: boolean
+          is_recurring: boolean
+          is_subscription: boolean
+          merchant_category_code: string | null
+          merchant_logo_url: string | null
+          merchant_name: string | null
+          merchant_name_hmac: string | null
+          notes: string | null
+          original_amount: number | null
+          posting_date: string | null
+          provider: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id: string | null
+          raw_description: string | null
+          reconciled_into_transaction_id: string | null
+          reconciliation_score: number | null
+          recurrence_group_id: string | null
+          secondary_category_id: string | null
+          status: Database["public"]["Enums"]["transaction_status"]
+          tags: string[] | null
+          transaction_date: string
+          transfer_group_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          amount_in_base_currency?: number | null
+          capture_input_text?: string | null
+          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence?: number | null
+          categorization_source?: Database["public"]["Enums"]["categorization_source"]
+          category_id?: string | null
+          clean_description?: string | null
+          clean_description_hmac?: string | null
+          created_at?: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          destinatario_id?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate?: number
+          id?: string
+          idempotency_key: string
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean
+          is_recurring?: boolean
+          is_subscription?: boolean
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: string | null
+          merchant_name_hmac?: string | null
+          notes?: string | null
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id?: string | null
+          raw_description?: string | null
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"]
+          tags?: string[] | null
+          transaction_date: string
+          transfer_group_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          amount_in_base_currency?: number | null
+          capture_input_text?: string | null
+          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence?: number | null
+          categorization_source?: Database["public"]["Enums"]["categorization_source"]
+          category_id?: string | null
+          clean_description?: string | null
+          clean_description_hmac?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          destinatario_id?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate?: number
+          id?: string
+          idempotency_key?: string
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean
+          is_recurring?: boolean
+          is_subscription?: boolean
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: string | null
+          merchant_name_hmac?: string | null
+          notes?: string | null
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id?: string | null
+          raw_description?: string | null
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"]
+          tags?: string[] | null
+          transaction_date?: string
+          transfer_group_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_secondary_category_id_fkey"
+            columns: ["secondary_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       unrecognized_emails: {
         Row: {
           created_at: string
@@ -2312,6 +3137,129 @@ export type Database = {
           },
         ]
       }
+      wishlist_items: {
+        Row: {
+          account_id: string | null
+          amount: number
+          bought_at: string | null
+          category_id: string | null
+          created_at: string
+          currency_code: string
+          desire_type: string | null
+          enriched: boolean
+          enriched_at: string | null
+          funding_type: string | null
+          id: string
+          image_url: string | null
+          installments: number | null
+          last_nudge_dismissed_at: string | null
+          last_score: number | null
+          last_scored_at: string | null
+          last_verdict: string | null
+          name: string
+          ready_at: string | null
+          status: string
+          transaction_id: string | null
+          updated_at: string
+          urgency: string | null
+          url: string | null
+          user_id: string
+          why: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount: number
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string
+          currency_code?: string
+          desire_type?: string | null
+          enriched?: boolean
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name: string
+          ready_at?: string | null
+          status?: string
+          transaction_id?: string | null
+          updated_at?: string
+          urgency?: string | null
+          url?: string | null
+          user_id: string
+          why?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string
+          currency_code?: string
+          desire_type?: string | null
+          enriched?: boolean
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: string
+          ready_at?: string | null
+          status?: string
+          transaction_id?: string | null
+          updated_at?: string
+          urgency?: string | null
+          url?: string | null
+          user_id?: string
+          why?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       wishlist_reflections: {
         Row: {
           days_since_purchase: number
@@ -2365,1020 +3313,21 @@ export type Database = {
       }
     }
     Views: {
-      accounts: {
-        Row: {
-          account_type: Database["public"]["Enums"]["account_type"] | null
-          available_balance: number | null
-          card_brand: string | null
-          color: string | null
-          connection_status:
-            | Database["public"]["Enums"]["connection_status"]
-            | null
-          created_at: string | null
-          credit_limit: number | null
-          currency_balances: Json | null
-          currency_code: Database["public"]["Enums"]["currency_code"] | null
-          current_balance: number | null
-          cutoff_day: number | null
-          debit_card_mask: string | null
-          display_order: number | null
-          expected_return_rate: number | null
-          icon: string | null
-          id: string | null
-          initial_investment: number | null
-          institution_name: string | null
-          interest_rate: number | null
-          is_active: boolean | null
-          is_demo: boolean | null
-          is_payroll_deducted: boolean | null
-          last_synced_at: string | null
-          loan_amount: number | null
-          loan_end_date: string | null
-          loan_start_date: string | null
-          mask: string | null
-          mask_hmac: string | null
-          maturity_date: string | null
-          monthly_payment: number | null
-          name: string | null
-          payment_day: number | null
-          pdf_password: string | null
-          provider: Database["public"]["Enums"]["data_provider"] | null
-          provider_account_id: string | null
-          provider_account_id_hmac: string | null
-          show_in_dashboard: boolean | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_type?: Database["public"]["Enums"]["account_type"] | null
-          available_balance?: number | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?:
-            | Database["public"]["Enums"]["connection_status"]
-            | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          current_balance?: number | null
-          cutoff_day?: number | null
-          debit_card_mask?: never
-          display_order?: number | null
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string | null
-          initial_investment?: number | null
-          institution_name?: never
-          interest_rate?: number | null
-          is_active?: boolean | null
-          is_demo?: boolean | null
-          is_payroll_deducted?: boolean | null
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: never
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name?: never
-          payment_day?: number | null
-          pdf_password?: never
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_account_id?: never
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_type?: Database["public"]["Enums"]["account_type"] | null
-          available_balance?: number | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?:
-            | Database["public"]["Enums"]["connection_status"]
-            | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          current_balance?: number | null
-          cutoff_day?: number | null
-          debit_card_mask?: never
-          display_order?: number | null
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string | null
-          initial_investment?: number | null
-          institution_name?: never
-          interest_rate?: number | null
-          is_active?: boolean | null
-          is_demo?: boolean | null
-          is_payroll_deducted?: boolean | null
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: never
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name?: never
-          payment_day?: number | null
-          pdf_password?: never
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_account_id?: never
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      capture_tokens: {
-        Row: {
-          created_at: string | null
-          default_account_id: string | null
-          id: string | null
-          label: string | null
-          last_used_at: string | null
-          revoked_at: string | null
-          token: string | null
-          token_hash: string | null
-          user_id: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          default_account_id?: string | null
-          id?: string | null
-          label?: never
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token?: never
-          token_hash?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          default_account_id?: string | null
-          id?: string | null
-          label?: never
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token?: never
-          token_hash?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      destinatarios: {
-        Row: {
-          created_at: string | null
-          default_category_id: string | null
-          id: string | null
-          is_active: boolean | null
-          name: string | null
-          name_hmac: string | null
-          notes: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          default_category_id?: string | null
-          id?: string | null
-          is_active?: boolean | null
-          name?: never
-          name_hmac?: string | null
-          notes?: never
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          default_category_id?: string | null
-          id?: string | null
-          is_active?: boolean | null
-          name?: never
-          name_hmac?: string | null
-          notes?: never
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "destinatarios_default_category_id_fkey"
-            columns: ["default_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      email_ingest_addresses: {
-        Row: {
-          account_id: string | null
-          address_key: string | null
-          allowed_sender: string | null
-          auto_import: boolean | null
-          created_at: string | null
-          gmail_verification_at: string | null
-          gmail_verification_url: string | null
-          id: string | null
-          is_active: boolean | null
-          pdf_import_enabled: boolean | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          address_key?: string | null
-          allowed_sender?: never
-          auto_import?: boolean | null
-          created_at?: string | null
-          gmail_verification_at?: string | null
-          gmail_verification_url?: never
-          id?: string | null
-          is_active?: boolean | null
-          pdf_import_enabled?: boolean | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          address_key?: string | null
-          allowed_sender?: never
-          auto_import?: boolean | null
-          created_at?: string | null
-          gmail_verification_at?: string | null
-          gmail_verification_url?: never
-          id?: string | null
-          is_active?: boolean | null
-          pdf_import_enabled?: boolean | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      profiles: {
-        Row: {
-          app_purpose: string | null
-          avatar_url: string | null
-          budget_mode: string | null
-          created_at: string | null
-          dashboard_config: Json | null
-          demo_mode: boolean | null
-          email: string | null
-          estimated_monthly_expenses: number | null
-          estimated_monthly_income: number | null
-          full_name: string | null
-          id: string | null
-          locale: string | null
-          monthly_salary: number | null
-          onboarding_completed: boolean | null
-          preferred_currency:
-            | Database["public"]["Enums"]["currency_code"]
-            | null
-          timezone: string | null
-          updated_at: string | null
-        }
-        Insert: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string | null
-          dashboard_config?: Json | null
-          demo_mode?: boolean | null
-          email?: never
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: never
-          id?: string | null
-          locale?: string | null
-          monthly_salary?: number | null
-          onboarding_completed?: boolean | null
-          preferred_currency?:
-            | Database["public"]["Enums"]["currency_code"]
-            | null
-          timezone?: string | null
-          updated_at?: string | null
-        }
-        Update: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string | null
-          dashboard_config?: Json | null
-          demo_mode?: boolean | null
-          email?: never
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: never
-          id?: string | null
-          locale?: string | null
-          monthly_salary?: number | null
-          onboarding_completed?: boolean | null
-          preferred_currency?:
-            | Database["public"]["Enums"]["currency_code"]
-            | null
-          timezone?: string | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
-      recurring_transaction_templates: {
-        Row: {
-          account_id: string | null
-          amount: number | null
-          category_id: string | null
-          created_at: string | null
-          currency_code: Database["public"]["Enums"]["currency_code"] | null
-          day_of_month: number | null
-          day_of_week: number | null
-          description: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"] | null
-          end_date: string | null
-          frequency: Database["public"]["Enums"]["recurrence_frequency"] | null
-          id: string | null
-          is_active: boolean | null
-          merchant_name: string | null
-          start_date: string | null
-          transfer_source_account_id: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount?: number | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: never
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          end_date?: string | null
-          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
-          id?: string | null
-          is_active?: boolean | null
-          merchant_name?: never
-          start_date?: string | null
-          transfer_source_account_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: never
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          end_date?: string | null
-          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
-          id?: string | null
-          is_active?: boolean | null
-          merchant_name?: never
-          start_date?: string | null
-          transfer_source_account_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      statement_snapshots: {
-        Row: {
-          account_id: string | null
-          available_credit: number | null
-          created_at: string | null
-          credit_limit: number | null
-          currency_code: string | null
-          final_balance: number | null
-          id: string | null
-          imported_count: number | null
-          initial_amount: number | null
-          installments_in_default: number | null
-          interest_charged: number | null
-          interest_rate: number | null
-          late_interest_rate: number | null
-          loan_number: string | null
-          minimum_payment: number | null
-          payment_due_date: string | null
-          period_from: string | null
-          period_to: string | null
-          previous_balance: number | null
-          purchases_and_charges: number | null
-          remaining_balance: number | null
-          skipped_count: number | null
-          source_filename: string | null
-          total_credits: number | null
-          total_debits: number | null
-          total_payment_due: number | null
-          transaction_count: number | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          available_credit?: number | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_code?: string | null
-          final_balance?: number | null
-          id?: string | null
-          imported_count?: number | null
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: never
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number | null
-          source_filename?: never
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          available_credit?: number | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_code?: string | null
-          final_balance?: number | null
-          id?: string | null
-          imported_count?: number | null
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: never
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number | null
-          source_filename?: never
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      transactions: {
-        Row: {
-          account_id: string | null
-          amount: number | null
-          amount_in_base_currency: number | null
-          capture_input_text: string | null
-          capture_method:
-            | Database["public"]["Enums"]["transaction_capture_method"]
-            | null
-          categorization_confidence: number | null
-          categorization_source:
-            | Database["public"]["Enums"]["categorization_source"]
-            | null
-          category_id: string | null
-          clean_description: string | null
-          clean_description_hmac: string | null
-          created_at: string | null
-          currency_code: Database["public"]["Enums"]["currency_code"] | null
-          destinatario_id: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"] | null
-          exchange_rate: number | null
-          id: string | null
-          idempotency_key: string | null
-          installment_current: number | null
-          installment_group_id: string | null
-          installment_total: number | null
-          is_excluded: boolean | null
-          is_recurring: boolean | null
-          is_subscription: boolean | null
-          merchant_category_code: string | null
-          merchant_logo_url: string | null
-          merchant_name: string | null
-          merchant_name_hmac: string | null
-          notes: string | null
-          original_amount: number | null
-          posting_date: string | null
-          provider: Database["public"]["Enums"]["data_provider"] | null
-          provider_transaction_id: string | null
-          raw_description: string | null
-          reconciled_into_transaction_id: string | null
-          reconciliation_score: number | null
-          recurrence_group_id: string | null
-          secondary_category_id: string | null
-          status: Database["public"]["Enums"]["transaction_status"] | null
-          tags: string[] | null
-          transaction_date: string | null
-          transfer_group_id: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount?: number | null
-          amount_in_base_currency?: number | null
-          capture_input_text?: never
-          capture_method?:
-            | Database["public"]["Enums"]["transaction_capture_method"]
-            | null
-          categorization_confidence?: number | null
-          categorization_source?:
-            | Database["public"]["Enums"]["categorization_source"]
-            | null
-          category_id?: string | null
-          clean_description?: never
-          clean_description_hmac?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          destinatario_id?: string | null
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          exchange_rate?: number | null
-          id?: string | null
-          idempotency_key?: string | null
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean | null
-          is_recurring?: boolean | null
-          is_subscription?: boolean | null
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: never
-          merchant_name_hmac?: string | null
-          notes?: never
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_transaction_id?: string | null
-          raw_description?: never
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"] | null
-          tags?: string[] | null
-          transaction_date?: string | null
-          transfer_group_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number | null
-          amount_in_base_currency?: number | null
-          capture_input_text?: never
-          capture_method?:
-            | Database["public"]["Enums"]["transaction_capture_method"]
-            | null
-          categorization_confidence?: number | null
-          categorization_source?:
-            | Database["public"]["Enums"]["categorization_source"]
-            | null
-          category_id?: string | null
-          clean_description?: never
-          clean_description_hmac?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          destinatario_id?: string | null
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          exchange_rate?: number | null
-          id?: string | null
-          idempotency_key?: string | null
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean | null
-          is_recurring?: boolean | null
-          is_subscription?: boolean | null
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: never
-          merchant_name_hmac?: string | null
-          notes?: never
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_transaction_id?: string | null
-          raw_description?: never
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"] | null
-          tags?: string[] | null
-          transaction_date?: string | null
-          transfer_group_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_secondary_category_id_fkey"
-            columns: ["secondary_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      wishlist_items: {
-        Row: {
-          account_id: string | null
-          amount: number | null
-          bought_at: string | null
-          category_id: string | null
-          created_at: string | null
-          currency_code: string | null
-          desire_type: string | null
-          enriched: boolean | null
-          enriched_at: string | null
-          funding_type: string | null
-          id: string | null
-          image_url: string | null
-          installments: number | null
-          last_nudge_dismissed_at: string | null
-          last_score: number | null
-          last_scored_at: string | null
-          last_verdict: string | null
-          name: string | null
-          ready_at: string | null
-          status: string | null
-          transaction_id: string | null
-          updated_at: string | null
-          urgency: string | null
-          url: string | null
-          user_id: string | null
-          why: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount?: number | null
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: string | null
-          desire_type?: string | null
-          enriched?: boolean | null
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string | null
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name?: never
-          ready_at?: string | null
-          status?: string | null
-          transaction_id?: string | null
-          updated_at?: string | null
-          urgency?: string | null
-          url?: never
-          user_id?: string | null
-          why?: never
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number | null
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: string | null
-          desire_type?: string | null
-          enriched?: boolean | null
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string | null
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name?: never
-          ready_at?: string | null
-          status?: string | null
-          transaction_id?: string | null
-          updated_at?: string | null
-          urgency?: string | null
-          url?: never
-          user_id?: string | null
-          why?: never
-        }
-        Relationships: [
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+      [_ in never]: never
     }
     Functions: {
       get_accounts_with_masks: {
         Args: { p_user_id: string }
         Returns: {
+          id: string
+          mask: string | null
+          debit_card_mask: string | null
+          pdf_password: string | null
           account_type: Database["public"]["Enums"]["account_type"]
           currency_code: Database["public"]["Enums"]["currency_code"]
           current_balance: number
-          debit_card_mask: string
-          id: string
           is_demo: boolean
-          mask: string
-          pdf_password: string
         }[]
-      }
-      get_email_ingest_settings: {
-        Args: { p_address_key: string }
-        Returns: {
-          account_id: string
-          address_key: string
-          allowed_sender: string
-          allowed_senders: string[]
-          auto_import: boolean
-          id: string
-          pdf_import_enabled: boolean
-          user_id: string
-        }[]
-      }
-      set_gmail_verification: {
-        Args: { p_ingest_id: string; p_url: string; p_user_id: string }
-        Returns: undefined
       }
       zeta_decrypt: { Args: { ciphertext: string }; Returns: string }
       zeta_decrypt_as: {
@@ -3429,7 +3378,6 @@ export type Database = {
         | "CSV_IMPORT"
         | "OCR"
         | "EMAIL"
-      occurrence_status: "pending" | "paid" | "skipped"
       planning_entry_status: "PLANNED" | "COMPLETED" | "SKIPPED"
       planning_entry_type: "INCOME" | "EXPENSE"
       planning_period_preset: "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "CUSTOM"
@@ -3448,6 +3396,7 @@ export type Database = {
         | "OCR_SINGLE"
         | "EMAIL_IMPORT"
         | "EMAIL_PDF_IMPORT"
+      occurrence_status: "pending" | "paid" | "skipped"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
     }
@@ -3604,7 +3553,6 @@ export const Constants = {
         "OCR",
         "EMAIL",
       ],
-      occurrence_status: ["pending", "paid", "skipped"],
       planning_entry_status: ["PLANNED", "COMPLETED", "SKIPPED"],
       planning_entry_type: ["INCOME", "EXPENSE"],
       planning_period_preset: ["WEEKLY", "BIWEEKLY", "MONTHLY", "CUSTOM"],
@@ -3625,6 +3573,7 @@ export const Constants = {
         "EMAIL_IMPORT",
         "EMAIL_PDF_IMPORT",
       ],
+      occurrence_status: ["pending", "paid", "skipped"],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],
     },


### PR DESCRIPTION
## Summary

- **New `/recurrentes` route** — full recurring template manager replacing the old redirect. Timeline UI with date-grouped status dots, segmented Gastos/Ingresos tabs, compact proportion bar hero.
- **`ONCE` frequency** — one-time planned payments. DB enum + shared utils + form + auto-deactivation lifecycle (deactivate on paid/skipped, re-activate on revert).
- **Template expanded view** — inline expand with lazy-loaded stats (YTD, annual estimate, streak). Cached via `"use cache"` + `"recurring"` tag.
- **Full page routes** — `/recurrentes/new` and `/recurrentes/[id]/edit` for create/edit forms. No more dialog-over-sheet layering issues.
- **Paused templates** — now interactive with Activar/Editar/Eliminar actions.
- **Bug fixes** — debt payments classified correctly (INFLOW to CREDIT_CARD/LOAN = expense, not income), `CategoryIcon` renders Lucide components instead of raw text, timeline date status accounts for payment status (paid items show green, not red "Vencido").
- **Performance** — server-side occurrence data eliminates loading spinner, `formatCurrencyCompact` prevents hero overflow, `getTemplateStats` cached.
- **Plan tab** — keeps payment checklist + adds "Administrar plantillas" link to manager.

## Backlog items added
- Manual transaction-to-recurring matching
- `effectiveDirection` audit across app
- Recurring stats historical backfill (from snapshots/past transactions)
- Checklist inline/drawer visual unification
- Plan page mobile grid navigation
- Debt payment category distinction (CREDIT_CARD vs LOAN subcategories)

## Test plan
- [ ] `/recurrentes` — hero shows compact amounts, tabs switch Gastos/Ingresos
- [ ] Timeline — paid items show green dot, overdue shows red, future hollow
- [ ] Tap template card — expands with skeleton → stats + action buttons
- [ ] Edit → navigates to `/recurrentes/[id]/edit`, back returns
- [ ] "+ Nuevo" → navigates to `/recurrentes/new`
- [ ] Pause/Delete from expanded card — AlertDialog appears (no layering bug)
- [ ] Paused templates — tap to expand, Activar/Editar/Eliminar work
- [ ] Plan tab → "Administrar plantillas" link + checklist still shows
- [ ] Desktop — no regression on RecurringList
- [ ] ONCE frequency — create template, occurrence generated, auto-deactivates on paid

🤖 Generated with [Claude Code](https://claude.com/claude-code)