### PR TITLE
fix: cache revalidation bugs + vincular a recurrente in movimientos

### DIFF
--- a/webapp/src/actions/email-pdf-ingest.ts
+++ b/webapp/src/actions/email-pdf-ingest.ts
@@ -2,6 +2,7 @@
 
 import { revalidateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { parsePdfBuffer } from "@/lib/email-ingest/pdf-handler";
 import { parseStatementFilename, matchAccountByLast4 } from "@/lib/email-ingest/statement-filename";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -199,6 +200,7 @@ export async function markEmailPdfStatementImported(
     await admin.storage.from("email-pdfs").remove([row.storage_path]);
   }
 
+  revalidateFinancialViews();
   revalidateTag("email-ingest", "zeta");
   return { success: true, data: null };
 }

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -212,7 +212,7 @@ export async function getNextIncomeOccurrenceCached(
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const rangeEnd = toColombiaDateString(addDays(parseISO(todayStr), PAY_CYCLE_LOOKAHEAD_DAYS));
+  const rangeEnd = toColombiaDateString(addDays(parseISO(todayStr + "T12:00:00"), PAY_CYCLE_LOOKAHEAD_DAYS));
   const occurrences = await getPendingOccurrencesCached(userId, todayStr, rangeEnd, accessToken);
 
   const match = occurrences.find(
@@ -641,7 +641,7 @@ export async function findMatchingOccurrence(
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return null;
 
-  const baseDateObj = parseISO(transactionDate);
+  const baseDateObj = parseISO(transactionDate + "T12:00:00");
   const rangeStart = toColombiaDateString(addDays(baseDateObj, -3));
   const rangeEnd = toColombiaDateString(addDays(baseDateObj, 3));
 
@@ -845,7 +845,7 @@ export async function getCandidateTransactionsForOccurrence(
     .limit(50);
 
   if (!showAll) {
-    const baseDateObj = parseISO(occurrence.occurrence_date);
+    const baseDateObj = parseISO(occurrence.occurrence_date + "T12:00:00");
     const rangeStart = toColombiaDateString(addDays(baseDateObj, -30));
     const rangeEnd = toColombiaDateString(addDays(baseDateObj, 30));
     query = query.gte("transaction_date", rangeStart).lte("transaction_date", rangeEnd);
@@ -911,7 +911,7 @@ export async function getCandidateOccurrencesForTransaction(
     return { success: false, error: "Transacción no encontrada" };
   }
 
-  const baseDateObj = parseISO(tx.transaction_date);
+  const baseDateObj = parseISO(tx.transaction_date + "T12:00:00");
   const rangeStart = toColombiaDateString(addDays(baseDateObj, -30));
   const rangeEnd = toColombiaDateString(addDays(baseDateObj, 30));
 

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -2,7 +2,7 @@
 
 import "server-only";
 import { revalidateTag, cacheTag, cacheLife } from "next/cache";
-import { addDays, startOfMonth, endOfMonth } from "date-fns";
+import { addDays, startOfMonth, endOfMonth, parseISO } from "date-fns";
 import { toColombiaDateString } from "@/lib/utils/date";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
@@ -28,8 +28,8 @@ function computeMatchScore(
   referenceDate: string,
   referenceAmount: number,
 ): number {
-  const cDate = new Date(`${candidateDate}T12:00:00`);
-  const rDate = new Date(`${referenceDate}T12:00:00`);
+  const cDate = parseISO(candidateDate);
+  const rDate = parseISO(referenceDate);
   const daysDiff = Math.abs(
     Math.round((cDate.getTime() - rDate.getTime()) / (1000 * 60 * 60 * 24))
   );
@@ -151,7 +151,7 @@ async function getOccurrencesForMonthCached(
 
   const supabase = createCachedClient(accessToken);
   const monthStart = `${month}-01`;
-  const monthDate = new Date(`${month}-01T12:00:00`);
+  const monthDate = parseISO(`${month}-01`);
   const monthEnd = endOfMonth(monthDate).toISOString().split("T")[0];
 
   const { data, error } = await supabase
@@ -212,7 +212,7 @@ export async function getNextIncomeOccurrenceCached(
   cacheTag("recurring");
   cacheLife("zeta");
 
-  const rangeEnd = toColombiaDateString(addDays(new Date(todayStr + "T12:00:00"), PAY_CYCLE_LOOKAHEAD_DAYS));
+  const rangeEnd = toColombiaDateString(addDays(parseISO(todayStr), PAY_CYCLE_LOOKAHEAD_DAYS));
   const occurrences = await getPendingOccurrencesCached(userId, todayStr, rangeEnd, accessToken);
 
   const match = occurrences.find(
@@ -223,8 +223,8 @@ export async function getNextIncomeOccurrenceCached(
   );
   if (!match) return null;
 
-  const occDate = new Date(match.occurrence_date + "T12:00:00");
-  const today = new Date(todayStr + "T12:00:00");
+  const occDate = parseISO(match.occurrence_date);
+  const today = parseISO(todayStr);
   const daysUntil = Math.max(
     1,
     Math.ceil((occDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
@@ -641,7 +641,7 @@ export async function findMatchingOccurrence(
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return null;
 
-  const baseDateObj = new Date(`${transactionDate}T12:00:00`);
+  const baseDateObj = parseISO(transactionDate);
   const rangeStart = toColombiaDateString(addDays(baseDateObj, -3));
   const rangeEnd = toColombiaDateString(addDays(baseDateObj, 3));
 
@@ -845,7 +845,7 @@ export async function getCandidateTransactionsForOccurrence(
     .limit(50);
 
   if (!showAll) {
-    const baseDateObj = new Date(`${occurrence.occurrence_date}T12:00:00`);
+    const baseDateObj = parseISO(occurrence.occurrence_date);
     const rangeStart = toColombiaDateString(addDays(baseDateObj, -30));
     const rangeEnd = toColombiaDateString(addDays(baseDateObj, 30));
     query = query.gte("transaction_date", rangeStart).lte("transaction_date", rangeEnd);
@@ -911,7 +911,7 @@ export async function getCandidateOccurrencesForTransaction(
     return { success: false, error: "Transacción no encontrada" };
   }
 
-  const baseDateObj = new Date(`${tx.transaction_date}T12:00:00`);
+  const baseDateObj = parseISO(tx.transaction_date);
   const rangeStart = toColombiaDateString(addDays(baseDateObj, -30));
   const rangeEnd = toColombiaDateString(addDays(baseDateObj, 30));
 

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { formatDate } from "@/lib/utils/date";
 import { SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
@@ -11,6 +11,7 @@ import { MovimientosLectura } from "./movimientos-lectura";
 import { MovimientosHerramientas } from "./movimientos-herramientas";
 import { MovimientosUtilidades } from "./movimientos-utilidades";
 import { MovimientosTransactionRow } from "./movimientos-transaction-row";
+import { getAccountIdsWithPendingOccurrences } from "@/actions/occurrences";
 import type {
   TransactionWithAccount,
   PendingEmailTransaction,
@@ -47,6 +48,12 @@ export function MovimientosRoot({
 }: MovimientosRootProps) {
   /** Page-level accordion — one expanded section at a time */
   const { activeZone, toggle } = useExpandableZone<string>();
+
+  /* ---- Linkable account IDs for "Vincular a recurrente" ---- */
+  const [linkableAccountIds, setLinkableAccountIds] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    getAccountIdsWithPendingOccurrences().then((ids) => setLinkableAccountIds(new Set(ids)));
+  }, []);
 
   const debtAccountIds = useMemo(
     () =>
@@ -163,7 +170,7 @@ export function MovimientosRoot({
               </p>
               <div className="space-y-0.5">
                 {txs.map((tx) => (
-                  <MovimientosTransactionRow key={tx.id} transaction={tx} categories={outflowCategories} tags={tagsByTxId.get(tx.id)} />
+                  <MovimientosTransactionRow key={tx.id} transaction={tx} categories={outflowCategories} tags={tagsByTxId.get(tx.id)} linkableAccountIds={linkableAccountIds} />
                 ))}
               </div>
             </div>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -12,6 +12,7 @@ import { CategoryZonePicker } from "@/components/categories/category-zone-picker
 import { TagChip } from "@/components/tags/tag-chip";
 import { CategoryIcon } from "@/components/categories/category-icon";
 import { LinkPickerSheet } from "@/components/recurring/link-picker-sheet";
+import { MOBILE_ACTION_BUTTON_CLASS } from "@/lib/constants/styles";
 import { categorizeTransaction, assignDestinatario, removeDestinatarioFromTransaction } from "@/actions/categorize";
 import {
   getCandidateOccurrencesForTransaction,
@@ -258,7 +259,7 @@ export function MovimientosTransactionRow({
               type="button"
               onClick={handleOpenLinkPicker}
               disabled={isLinking}
-              className="inline-flex items-center gap-1 rounded-full border border-z-brass/20 bg-z-brass/8 px-2.5 py-1 text-[10px] font-medium text-z-brass transition-colors hover:bg-z-brass/12"
+              className={cn(MOBILE_ACTION_BUTTON_CLASS, "inline-flex items-center gap-1 rounded-full hover:bg-z-brass/12")}
             >
               <Link2 className="size-2.5" />
               Vincular

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -4,15 +4,22 @@ import { useState, useTransition } from "react";
 
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { Pencil, ArrowDownLeft, ArrowUpRight } from "lucide-react";
+import { Pencil, ArrowDownLeft, ArrowUpRight, Link2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
 import { TagChip } from "@/components/tags/tag-chip";
 import { CategoryIcon } from "@/components/categories/category-icon";
+import { LinkPickerSheet } from "@/components/recurring/link-picker-sheet";
 import { categorizeTransaction, assignDestinatario, removeDestinatarioFromTransaction } from "@/actions/categorize";
+import {
+  getCandidateOccurrencesForTransaction,
+  linkExistingTransactionToOccurrence,
+} from "@/actions/occurrences";
+import type { CandidateOccurrence } from "@/actions/occurrences";
 import { toast } from "sonner";
-import type { TransactionWithAccount, CategoryWithChildren } from "@/types/domain";
+import type { TransactionWithAccount, CategoryWithChildren, CurrencyCode } from "@/types/domain";
 
 const DestinatarioZonePicker = dynamic(
   () => import("@/components/destinatarios/destinatario-zone-picker").then(m => ({ default: m.DestinatarioZonePicker })),
@@ -27,6 +34,8 @@ interface MovimientosTransactionRowProps {
   transaction: TransactionWithAccount;
   categories: CategoryWithChildren[];
   tags?: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
+  /** Account IDs that have pending recurring occurrences — enables "Vincular a recurrente" button */
+  linkableAccountIds?: Set<string>;
   /** Called after a successful category assignment — used by categorizar to remove from list / prompt bulk apply */
   onCategorized?: (txId: string, categoryId: string) => void;
 }
@@ -35,10 +44,42 @@ export function MovimientosTransactionRow({
   transaction: tx,
   categories,
   tags = [],
+  linkableAccountIds,
   onCategorized,
 }: MovimientosTransactionRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [, startTransition] = useTransition();
+
+  // Link to recurring state
+  const [linkPickerOpen, setLinkPickerOpen] = useState(false);
+  const [occurrenceCandidates, setOccurrenceCandidates] = useState<CandidateOccurrence[]>([]);
+  const [isLinking, startLinkTransition] = useTransition();
+
+  const canLink = linkableAccountIds?.has(tx.account_id) && !tx.recurrence_group_id;
+
+  function handleOpenLinkPicker() {
+    setLinkPickerOpen(true);
+    getCandidateOccurrencesForTransaction(tx.id).then((result) => {
+      if (result.success) {
+        setOccurrenceCandidates(result.data);
+      } else {
+        toast.error(result.error ?? "Error al buscar recurrentes");
+        setLinkPickerOpen(false);
+      }
+    });
+  }
+
+  function handleConfirmLink(occurrenceId: string) {
+    setLinkPickerOpen(false);
+    startLinkTransition(async () => {
+      const result = await linkExistingTransactionToOccurrence(occurrenceId, tx.id);
+      if (result.success) {
+        toast.success("Transacción vinculada a recurrente");
+      } else {
+        toast.error(result.error ?? "No se pudo vincular");
+      }
+    });
+  }
 
   // Optimistic local state
   const [localCategory, setLocalCategory] = useState(tx.category);
@@ -211,6 +252,19 @@ export function MovimientosTransactionRow({
 
           <div className="flex-1" />
 
+          {/* Link to recurring */}
+          {canLink && (
+            <button
+              type="button"
+              onClick={handleOpenLinkPicker}
+              disabled={isLinking}
+              className="inline-flex items-center gap-1 rounded-full border border-z-brass/20 bg-z-brass/8 px-2.5 py-1 text-[10px] font-medium text-z-brass transition-colors hover:bg-z-brass/12"
+            >
+              <Link2 className="size-2.5" />
+              Vincular
+            </button>
+          )}
+
           {/* Edit link */}
           <Link
             href={`/transactions/${tx.id}`}
@@ -220,6 +274,27 @@ export function MovimientosTransactionRow({
             Editar
           </Link>
         </div>
+      )}
+
+      {/* Link to recurring picker sheet */}
+      {linkPickerOpen && (
+        <LinkPickerSheet
+          open={linkPickerOpen}
+          onOpenChange={setLinkPickerOpen}
+          title="Vincular a recurrente"
+          subtitle={`${description} · ${formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}`}
+          candidates={occurrenceCandidates.map((o) => ({
+            id: o.id,
+            label: o.merchant,
+            sublabel: `${formatDate(o.occurrenceDate)} · ${formatCurrency(o.expectedAmount, o.currencyCode as CurrencyCode)} esperado`,
+            amount: o.expectedAmount,
+            currencyCode: o.currencyCode,
+            direction: tx.direction,
+            matchScore: o.matchScore,
+          }))}
+          onConfirm={handleConfirmLink}
+          isPending={isLinking}
+        />
       )}
     </div>
   );

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -1,7 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import {
   addMonths,
   endOfMonth,
@@ -90,7 +89,7 @@ export function useRecurringMonth(
   accounts: Account[],
   initialOccurrences?: RecurringOccurrence[]
 ) {
-  const router = useRouter();
+  const [, startTransition] = useTransition();
 
   /* ---- month cursor ---- */
   const [monthCursor, setMonthCursor] = useState(() => new Date());
@@ -211,7 +210,7 @@ export function useRecurringMonth(
 
   /* ---- confirm payment ---- */
   const confirmPayment = useCallback(
-    async (
+    (
       item: OccurrenceItem,
       overrides?: {
         actualAmount?: number;
@@ -246,50 +245,51 @@ export function useRecurringMonth(
 
       setBusyItems((prev) => ({ ...prev, [item.key]: true }));
 
-      const result = await recordRecurringOccurrencePayment({
-        templateId: item.templateId,
-        occurrenceDate: item.date,
-        paymentDate,
-        actualAmount,
-        sourceAccountId,
+      startTransition(async () => {
+        const result = await recordRecurringOccurrencePayment({
+          templateId: item.templateId,
+          occurrenceDate: item.date,
+          paymentDate,
+          actualAmount,
+          sourceAccountId,
+        });
+
+        setBusyItems((prev) => ({ ...prev, [item.key]: false }));
+
+        if (!result.success) {
+          toast.error(result.error ?? "No se pudo registrar el pago recurrente.");
+          return;
+        }
+
+        // Optimistically mark as paid in local state
+        setOccurrences((prev) =>
+          prev.map((o) =>
+            o.id === item.occurrenceId ? { ...o, status: "paid" as const } : o
+          )
+        );
+
+        const created = result.data?.created ?? 0;
+        const duplicates = result.data?.alreadyRecorded ?? 0;
+
+        if (created > 0) {
+          const msg = item.isDebtPayment
+            ? "Pago registrado como transferencia + abono a deuda"
+            : item.direction === "INFLOW"
+              ? "Ingreso recurrente registrado"
+              : "Pago recurrente registrado";
+
+          toast.success(msg);
+        } else if (duplicates > 0) {
+          toast.info("Este pago ya estaba registrado anteriormente.");
+        }
       });
-
-      setBusyItems((prev) => ({ ...prev, [item.key]: false }));
-
-      if (!result.success) {
-        toast.error(result.error ?? "No se pudo registrar el pago recurrente.");
-        return;
-      }
-
-      // Optimistically mark as paid in local state
-      setOccurrences((prev) =>
-        prev.map((o) =>
-          o.id === item.occurrenceId ? { ...o, status: "paid" as const } : o
-        )
-      );
-
-      const created = result.data?.created ?? 0;
-      const duplicates = result.data?.alreadyRecorded ?? 0;
-
-      if (created > 0) {
-        const msg = item.isDebtPayment
-          ? "Pago registrado como transferencia + abono a deuda"
-          : item.direction === "INFLOW"
-            ? "Ingreso recurrente registrado"
-            : "Pago recurrente registrado";
-
-        toast.success(msg);
-        router.refresh();
-      } else if (duplicates > 0) {
-        toast.info("Este pago ya estaba registrado anteriormente.");
-      }
     },
-    [todayStr, router]
+    [todayStr, startTransition]
   );
 
   /* ---- skip payment ---- */
   const skipPayment = useCallback(
-    async (item: OccurrenceItem) => {
+    (item: OccurrenceItem) => {
       // Optimistic update
       setOccurrences((prev) =>
         prev.map((o) =>
@@ -298,56 +298,57 @@ export function useRecurringMonth(
       );
       toast.success("Marcado como completado");
 
-      const result = await skipOccurrence(item.occurrenceId);
-      if (!result.success) {
-        // Revert on failure
-        setOccurrences((prev) =>
-          prev.map((o) =>
-            o.id === item.occurrenceId
-              ? { ...o, status: "pending" as const }
-              : o
-          )
-        );
-        toast.error("No se pudo guardar. Intenta de nuevo.");
-      } else {
-        router.refresh();
-      }
+      startTransition(async () => {
+        const result = await skipOccurrence(item.occurrenceId);
+        if (!result.success) {
+          // Revert on failure
+          setOccurrences((prev) =>
+            prev.map((o) =>
+              o.id === item.occurrenceId
+                ? { ...o, status: "pending" as const }
+                : o
+            )
+          );
+          toast.error("No se pudo guardar. Intenta de nuevo.");
+        }
+      });
     },
-    [router]
+    [startTransition]
   );
 
   /* ---- link existing transaction ---- */
   const linkExisting = useCallback(
-    async (item: OccurrenceItem, transactionId: string) => {
+    (item: OccurrenceItem, transactionId: string) => {
       setBusyItems((prev) => ({ ...prev, [item.key]: true }));
 
-      const result = await linkExistingTransactionToOccurrence(
-        item.occurrenceId,
-        transactionId,
-      );
+      startTransition(async () => {
+        const result = await linkExistingTransactionToOccurrence(
+          item.occurrenceId,
+          transactionId,
+        );
 
-      setBusyItems((prev) => ({ ...prev, [item.key]: false }));
+        setBusyItems((prev) => ({ ...prev, [item.key]: false }));
 
-      if (!result.success) {
-        toast.error(result.error ?? "No se pudo vincular la transacción.");
-        return;
-      }
+        if (!result.success) {
+          toast.error(result.error ?? "No se pudo vincular la transacción.");
+          return;
+        }
 
-      setOccurrences((prev) =>
-        prev.map((o) =>
-          o.id === item.occurrenceId ? { ...o, status: "paid" as const } : o
-        )
-      );
+        setOccurrences((prev) =>
+          prev.map((o) =>
+            o.id === item.occurrenceId ? { ...o, status: "paid" as const } : o
+          )
+        );
 
-      const isIncome = item.direction === "INFLOW" && !item.isDebtPayment;
-      toast.success(
-        isIncome
-          ? "Ingreso vinculado a recurrente"
-          : "Transacción vinculada a recurrente"
-      );
-      router.refresh();
+        const isIncome = item.direction === "INFLOW" && !item.isDebtPayment;
+        toast.success(
+          isIncome
+            ? "Ingreso vinculado a recurrente"
+            : "Transacción vinculada a recurrente"
+        );
+      });
     },
-    [router]
+    [startTransition]
   );
 
   /* ---- optimistic revert (for undo UI) ---- */


### PR DESCRIPTION
## Summary

- **Bug 1 — Dashboard ritmo stale after income linked**: `useRecurringMonth` used `router.refresh()` which only refreshes the current page's Route Cache. Replaced with `startTransition` wrapping so `revalidateTag` propagates to all affected routes (including the dashboard).
- **Bug 2 — Email import stale transaction lists**: Added `revalidateFinancialViews()` to `markEmailPdfStatementImported` as a safety net ensuring transaction/dashboard tags are invalidated even when called separately from `importTransactions`.
- **Bug 3 — "Vincular a recurrente" missing from movimientos**: Ported `LinkPickerSheet` pattern from `inicio-activity.tsx` to the movimientos transaction row expanded view. Uses `MOBILE_ACTION_BUTTON_CLASS` design token.
- **Code quality**: Replaced 8 `new Date()` template literals with `parseISO()` in `occurrences.ts`. Replaced `router.refresh()` → `startTransition` in all 3 `useRecurringMonth` callbacks.

## Review agents passed

- **cache-doctor**: All revalidation paths correct and complete
- **server-action-reviewer**: PASS — auth, defense-in-depth, revalidation compliant
- **zetas-front-guy**: PASS after applying `MOBILE_ACTION_BUTTON_CLASS`
- **perf-auditor**: PASS — no blocking issues

## Test plan

- [ ] Link an income transaction to a recurring occurrence from the plan page → dashboard ritmo/burn-rate should update without page refresh
- [ ] Import a pending email transaction → movimientos list and dashboard activity should update without page refresh
- [ ] Mark an email PDF statement as imported → pending card should clear and transaction list should reflect the import
- [ ] Expand a transaction row in movimientos that has a matching pending occurrence → "Vincular" button should appear
- [ ] Tap "Vincular" → LinkPickerSheet opens with candidates, confirm links the transaction
- [ ] Confirm/skip a recurring payment from the plan page → dashboard should reflect the change on next navigation

https://claude.ai/code/session_019H2jyPcvNxJnTUd9t6eyhS