### PR TITLE
fix: distinguish debt payment subcategories + back button fallback

### DIFF
--- a/packages/shared/src/constants/categories.ts
+++ b/packages/shared/src/constants/categories.ts
@@ -14,10 +14,24 @@ export const CATEGORY_OBLIGACIONES = "b0000001-0001-4000-8000-000000000006";
 export const CATEGORY_INGRESOS = "b0000001-0001-4000-8000-000000000007";
 export const CATEGORY_OTROS_INGRESOS = "b0000001-0001-4000-8000-000000000008";
 
+// ── Obligaciones subcategories ──────────────────────────────────────
+export const SUBCATEGORY_CUOTA_CREDITO = "c0000001-0006-4000-8000-000000000001";
+export const SUBCATEGORY_PAGO_TARJETA = "c0000001-0006-4000-8000-000000000002";
+
 // Convenience aliases for common usage patterns
 export const DEBT_PAYMENT_CATEGORY_ID = CATEGORY_OBLIGACIONES;
 export const TRANSFER_CATEGORY_ID = CATEGORY_OBLIGACIONES;
 export const SUBSCRIPTIONS_CATEGORY_ID = CATEGORY_OBLIGACIONES;
+
+/**
+ * Returns the appropriate debt payment subcategory based on account type.
+ * CREDIT_CARD → "Pago tarjeta", LOAN → "Cuota crédito", fallback → parent Obligaciones.
+ */
+export function getDebtPaymentCategoryId(accountType: string): string {
+  if (accountType === "CREDIT_CARD") return SUBCATEGORY_PAGO_TARJETA;
+  if (accountType === "LOAN") return SUBCATEGORY_CUOTA_CREDITO;
+  return DEBT_PAYMENT_CATEGORY_ID;
+}
 
 // Map object for auto-categorize engine (preserves existing CAT shape).
 // Old fine-grained names map to the 8 parent categories.

--- a/webapp/src/actions/extra-payment.ts
+++ b/webapp/src/actions/extra-payment.ts
@@ -3,8 +3,8 @@
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import {
   TRANSFER_CATEGORY_ID,
-  DEBT_PAYMENT_CATEGORY_ID,
   computeIdempotencyKey,
+  getDebtPaymentCategoryId,
 } from "@zeta/shared";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
@@ -183,7 +183,7 @@ export async function applyExtraDebtPayment(
         raw_description: inflowDescription,
         clean_description: inflowDescription,
         merchant_name: debtAccountName,
-        category_id: DEBT_PAYMENT_CATEGORY_ID,
+        category_id: getDebtPaymentCategoryId(debtAccount.account_type),
         categorization_source: "SYSTEM_DEFAULT",
         provider: "MANUAL",
         capture_method: "MANUAL_FORM",

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -13,7 +13,6 @@ import { ensureCurrentOccurrences } from "@/actions/occurrences";
 import {
   getOccurrencesBetween,
   getNextOccurrence,
-  DEBT_PAYMENT_CATEGORY_ID,
   TRANSFER_CATEGORY_ID,
   getDebtPaymentCategoryId,
 } from "@zeta/shared";
@@ -648,7 +647,7 @@ function buildRecurringPaymentTransactions(params: {
           direction: "INFLOW",
           raw_description: `Abono deuda desde ${sourceAccount.name} - ${baseLabel}`,
           merchant_name: baseLabel,
-          category_id: params.template.category_id ?? DEBT_PAYMENT_CATEGORY_ID,
+          category_id: params.template.category_id ?? getDebtPaymentCategoryId(params.targetAccount.account_type),
           notes: "Abono de deuda marcado desde checklist recurrente",
         },
       ],

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -15,6 +15,7 @@ import {
   getNextOccurrence,
   DEBT_PAYMENT_CATEGORY_ID,
   TRANSFER_CATEGORY_ID,
+  getDebtPaymentCategoryId,
 } from "@zeta/shared";
 import { addDays } from "date-fns";
 import { toISODateString } from "@/lib/utils/date";
@@ -274,7 +275,7 @@ export async function createRecurringTemplate(
 
   if (DEBT_ACCOUNT_TYPES.has(account.account_type)) {
     payload.direction = "INFLOW";
-    payload.category_id = null;
+    payload.category_id = payload.category_id ?? getDebtPaymentCategoryId(account.account_type);
     if (!payload.transfer_source_account_id) {
       return { success: false, error: "Selecciona la cuenta origen para el pago de deuda." };
     }
@@ -348,7 +349,7 @@ export async function updateRecurringTemplate(
 
   if (DEBT_ACCOUNT_TYPES.has(account.account_type)) {
     payload.direction = "INFLOW";
-    payload.category_id = null;
+    payload.category_id = payload.category_id ?? getDebtPaymentCategoryId(account.account_type);
     if (!payload.transfer_source_account_id) {
       return { success: false, error: "Selecciona la cuenta origen para el pago de deuda." };
     }
@@ -647,7 +648,7 @@ function buildRecurringPaymentTransactions(params: {
           direction: "INFLOW",
           raw_description: `Abono deuda desde ${sourceAccount.name} - ${baseLabel}`,
           merchant_name: baseLabel,
-          category_id: DEBT_PAYMENT_CATEGORY_ID,
+          category_id: params.template.category_id ?? DEBT_PAYMENT_CATEGORY_ID,
           notes: "Abono de deuda marcado desde checklist recurrente",
         },
       ],

--- a/webapp/src/components/mobile/new-transaction-page-content.tsx
+++ b/webapp/src/components/mobile/new-transaction-page-content.tsx
@@ -24,7 +24,11 @@ export function NewTransactionPageContent() {
 
   const handleSuccess = useCallback(() => {
     toast.success("Guardado");
-    router.back();
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/dashboard");
+    }
   }, [router]);
 
   return (

--- a/webapp/src/components/mobile/v2/mobile-back-button.tsx
+++ b/webapp/src/components/mobile/v2/mobile-back-button.tsx
@@ -3,12 +3,18 @@
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
-export function MobileBackButton() {
+export function MobileBackButton({ fallbackHref = "/dashboard" }: { fallbackHref?: string }) {
   const router = useRouter();
   return (
     <button
       type="button"
-      onClick={() => router.back()}
+      onClick={() => {
+        if (window.history.length > 1) {
+          router.back();
+        } else {
+          router.push(fallbackHref);
+        }
+      }}
       className="flex size-8 shrink-0 items-center justify-center rounded-full text-z-sage-light transition-colors hover:bg-white/5"
       aria-label="Volver"
     >

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -101,7 +101,10 @@ export function RecurringForm({
         : SUBCATEGORY_CUOTA_CREDITO;
       setCategoryId(defaultCat);
     }
-  }, [isDebtAccount, categoryId, selectedAccount?.account_type]);
+    // categoryId intentionally omitted — only fire when account changes,
+    // not on every user category selection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDebtAccount, selectedAccount?.account_type]);
 
   function nextOccurrenceForDay(dayOfMonth: number): string {
     const now = new Date();

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { SUBCATEGORY_PAGO_TARJETA, SUBCATEGORY_CUOTA_CREDITO } from "@zeta/shared";
 import type { ActionResult } from "@/types/actions";
 import type { Account, CategoryWithChildren, RecurringTemplate, TransactionDirection } from "@/types/domain";
 
@@ -92,6 +93,15 @@ export function RecurringForm({
       setDirection("INFLOW");
     }
   }, [isDebtAccount, direction]);
+
+  useEffect(() => {
+    if (isDebtAccount && !categoryId) {
+      const defaultCat = selectedAccount?.account_type === "CREDIT_CARD"
+        ? SUBCATEGORY_PAGO_TARJETA
+        : SUBCATEGORY_CUOTA_CREDITO;
+      setCategoryId(defaultCat);
+    }
+  }, [isDebtAccount, categoryId, selectedAccount?.account_type]);
 
   function nextOccurrenceForDay(dayOfMonth: number): string {
     const now = new Date();
@@ -308,26 +318,22 @@ export function RecurringForm({
         )}
       </div>
 
-      {isDebtAccount ? (
-        <div className="space-y-2">
-          <Label>Categoría</Label>
-          <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-            Se asignará automáticamente como abono de deuda al registrar cada pago.
-          </div>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <Label>Categoría</Label>
-          <CategoryZonePicker
-            variant="popover"
-            categories={categories}
-            value={categoryId}
-            onValueChange={setCategoryId}
-            direction={direction}
-            name="category_id"
-          />
-        </div>
-      )}
+      <div className="space-y-2">
+        <Label>Categoría</Label>
+        <CategoryZonePicker
+          variant="popover"
+          categories={categories}
+          value={categoryId}
+          onValueChange={setCategoryId}
+          direction={direction}
+          name="category_id"
+        />
+        {isDebtAccount && (
+          <p className="text-xs text-muted-foreground">
+            Pre-seleccionada según tipo de cuenta. Puedes cambiarla si lo necesitas.
+          </p>
+        )}
+      </div>
 
       <div className="space-y-2">
         <Label htmlFor="description">Notas</Label>

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -95,16 +95,22 @@ export function RecurringForm({
   }, [isDebtAccount, direction]);
 
   useEffect(() => {
-    if (isDebtAccount && !categoryId) {
-      const defaultCat = selectedAccount?.account_type === "CREDIT_CARD"
+    if (!isDebtAccount) return;
+
+    const isDefault = !categoryId ||
+      categoryId === SUBCATEGORY_PAGO_TARJETA ||
+      categoryId === SUBCATEGORY_CUOTA_CREDITO;
+
+    if (isDefault) {
+      const targetCat = selectedAccount?.account_type === "CREDIT_CARD"
         ? SUBCATEGORY_PAGO_TARJETA
         : SUBCATEGORY_CUOTA_CREDITO;
-      setCategoryId(defaultCat);
+
+      if (categoryId !== targetCat) {
+        setCategoryId(targetCat);
+      }
     }
-    // categoryId intentionally omitted — only fire when account changes,
-    // not on every user category selection.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDebtAccount, selectedAccount?.account_type]);
+  }, [isDebtAccount, selectedAccount?.account_type, categoryId]);
 
   function nextOccurrenceForDay(dayOfMonth: number): string {
     const now = new Date();


### PR DESCRIPTION
## Summary

- **Debt categories**: CREDIT_CARD payments now use "Pago tarjeta" subcategory, LOAN payments use "Cuota crédito" instead of the parent "Obligaciones" category. RecurringForm shows category picker for debt accounts with smart pre-selection. Template create/update/payment-recording all respect the template's category with account-type-aware fallbacks.
- **Back button**: `MobileBackButton` accepts `fallbackHref` prop (default `/dashboard`) and checks `window.history.length` before calling `router.back()`. Same pattern applied to `NewTransactionPageContent` success handler.

### Files changed (6)

| File | Change |
|---|---|
| `packages/shared/src/constants/categories.ts` | Add `SUBCATEGORY_CUOTA_CREDITO`, `SUBCATEGORY_PAGO_TARJETA`, `getDebtPaymentCategoryId()` |
| `webapp/src/actions/recurring-templates.ts` | Use subcategory in create/update/payment-recording instead of forcing null or hardcoding parent |
| `webapp/src/actions/extra-payment.ts` | Use `getDebtPaymentCategoryId(accountType)` for debt inflow transactions |
| `webapp/src/components/recurring/recurring-form.tsx` | Show category picker for debt accounts with auto-pre-selection |
| `webapp/src/components/mobile/v2/mobile-back-button.tsx` | Add `fallbackHref` prop with history check |
| `webapp/src/components/mobile/new-transaction-page-content.tsx` | Add history check to success handler |

### Agent reviews

- **server-action-reviewer**: PASS — auth, defense-in-depth, validation, revalidation all clean
- **recurring-doctor**: PASS — occurrence lifecycle, matching, balance, idempotency unaffected
- **perf-auditor**: PASS — no new queries, no render regressions, no bundle impact
- **zetas-front-guy**: 4 pre-existing token violations in recurring-form.tsx (out of scope)

## Test plan

- [ ] Create a recurring template for a CREDIT_CARD account → verify category pre-selects "Tarjeta de crédito"
- [ ] Create a recurring template for a LOAN account → verify category pre-selects "Cuota crédito"
- [ ] Edit an existing debt template → verify category picker shows and preserves selection
- [ ] Record a payment from recurring checklist → verify transaction gets the template's subcategory
- [ ] Apply an extra debt payment → verify INFLOW transaction gets the correct subcategory
- [ ] Navigate directly to a subpage URL (no history) → verify back button goes to /dashboard
- [ ] Navigate to subpage via in-app link → verify back button returns to previous page
- [ ] Submit new transaction from direct URL → verify success navigates to /dashboard

https://claude.ai/code/session_01L37mLAHHaL9YCj89xFeT3w