### PR TITLE
feat: recurrentes unification — single page, tabbed actions, grid nav

### DIFF
--- a/webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx
@@ -29,7 +29,7 @@ export default async function EditRecurrentePage({
       <MobileHeader
         variant="sub"
         title={`Editar ${template.merchant_name}`}
-        backHref="/recurrentes"
+        backHref="/plan?tab=recurrentes"
       />
       <div className="px-4 pb-20">
         <RecurringForm

--- a/webapp/src/app/(dashboard)/recurrentes/new/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/new/page.tsx
@@ -15,7 +15,7 @@ export default async function NewRecurrentePage() {
 
   return (
     <div className={PAGE_STACK_CLASS}>
-      <MobileHeader variant="sub" title="Nueva recurrente" backHref="/recurrentes" />
+      <MobileHeader variant="sub" title="Nueva recurrente" backHref="/plan?tab=recurrentes" />
       <div className="px-4 pb-20">
         <RecurringForm
           accounts={accounts}

--- a/webapp/src/app/(dashboard)/recurrentes/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/page.tsx
@@ -1,37 +1,5 @@
-import { connection } from "next/server";
-import { MobileHeader } from "@/components/mobile/v2/mobile-header";
-import { MobileRecurringManager } from "@/components/recurring/mobile-recurring-manager";
-import { getRecurringTemplates } from "@/actions/recurring-templates";
-import { getAccounts } from "@/actions/accounts";
-import { getPreferredCurrency } from "@/actions/profile";
-import { ensureCurrentOccurrences, getOccurrencesForMonth } from "@/actions/occurrences";
-import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
-import type { CurrencyCode } from "@/types/domain";
+import { redirect } from "next/navigation";
 
-export default async function RecurrentesPage() {
-  await connection();
-  await ensureCurrentOccurrences();
-
-  const [templatesResult, accountsResult, currency, occurrencesResult] = await Promise.all([
-    getRecurringTemplates(),
-    getAccounts(),
-    getPreferredCurrency(),
-    getOccurrencesForMonth(),
-  ]);
-
-  const templates = templatesResult.success ? templatesResult.data : [];
-  const accounts = accountsResult.success ? accountsResult.data : [];
-  const initialOccurrences = occurrencesResult.success ? occurrencesResult.data : [];
-
-  return (
-    <div className={PAGE_STACK_CLASS}>
-      <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
-      <MobileRecurringManager
-        templates={templates}
-        accounts={accounts}
-        currency={currency as CurrencyCode}
-        initialOccurrences={initialOccurrences}
-      />
-    </div>
-  );
+export default function RecurrentesPage() {
+  redirect("/plan?tab=recurrentes");
 }

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -9,6 +9,7 @@ import {
   PANEL_INSET_CLASS,
   HERO_CARD_GRADIENT_CLASS,
   MOBILE_EYEBROW_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE_CLASS,
 } from "@/lib/constants/styles";
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
 import type { RecurringOccurrence } from "@/actions/occurrences";
@@ -176,6 +177,13 @@ export function MobileRecurrentesView({
             setImpactAction({ item, template, action: "pause" });
           }
         : undefined,
+      onResume: template
+        ? async () => {
+            setExpandedKey(null);
+            await toggleRecurringTemplate(template.id, true);
+            await hook.refreshOccurrences();
+          }
+        : undefined,
       onDelete: template
         ? () => {
             setExpandedKey(null);
@@ -190,13 +198,13 @@ export function MobileRecurrentesView({
   }
 
   return (
-    <div className="space-y-3 pb-20">
+    <div className={cn("space-y-3", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
       {/* Hero card */}
       <div className={cn("rounded-2xl border border-white/6 p-4", HERO_CARD_GRADIENT_CLASS)}>
         <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
           Compromiso mensual
         </p>
-        <p className="mt-1 text-3xl font-bold">
+        <p className="mt-1 text-3xl font-bold tabular-nums">
           {formatCurrency(hook.totalPlanned, currency)}
         </p>
 
@@ -534,6 +542,7 @@ function TemplatesSection({
   accounts,
   categories,
   currency,
+  onMutate,
 }: {
   templates: RecurringTemplateWithRelations[];
   accounts: Account[];
@@ -543,8 +552,12 @@ function TemplatesSection({
 }) {
   const [show, setShow] = useState(false);
 
-  const activeCount = templates.filter((t) => t.is_active).length;
-  const pausedCount = templates.filter((t) => !t.is_active).length;
+  let activeCount = 0;
+  let pausedCount = 0;
+  for (const t of templates) {
+    if (t.is_active) activeCount++;
+    else pausedCount++;
+  }
 
   return (
     <div>
@@ -565,6 +578,7 @@ function TemplatesSection({
           <RecurringFormDialog
             accounts={accounts}
             categories={categories}
+            onClose={onMutate}
             trigger={
               <button
                 type="button"
@@ -602,6 +616,7 @@ function TemplatesSection({
                   template={t}
                   accounts={accounts}
                   categories={categories}
+                  onClose={onMutate}
                   trigger={
                     <button
                       type="button"

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useState, useMemo, useTransition } from "react";
-import { Check, ChevronLeft, ChevronRight, MoreVertical, Pause, Pencil, Play, Tag, Trash2 } from "lucide-react";
+import { useState, useMemo } from "react";
+import { Check, ChevronLeft, ChevronRight, Plus, Tag } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
-import { PANEL_INSET_CLASS, HERO_CARD_GRADIENT_CLASS, MOBILE_ACTION_BUTTON_CLASS, MOBILE_EYEBROW_CLASS, MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import {
+  PANEL_INSET_CLASS,
+  HERO_CARD_GRADIENT_CLASS,
+  MOBILE_EYEBROW_CLASS,
+} from "@/lib/constants/styles";
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
 import type { RecurringOccurrence } from "@/actions/occurrences";
-import { RecurringConfirmInline } from "@/components/recurring/recurring-confirm-inline";
+import { OccurrenceActions } from "@/components/recurring/occurrence-actions";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringImpactDialog } from "@/components/recurring/recurring-impact-dialog";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { useCategories } from "@/components/providers/app-data-provider";
 import {
   deleteRecurringTemplate,
@@ -36,7 +39,7 @@ interface MobileRecurrentesViewProps {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Status styling                                                     */
+/*  Status helpers                                                     */
 /* ------------------------------------------------------------------ */
 
 function statusAccent(status: DateStatus) {
@@ -75,19 +78,19 @@ export function MobileRecurrentesView({
 }: MobileRecurrentesViewProps) {
   const hook = useRecurringMonth(templates, accounts, initialOccurrences);
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
-  const [actionItem, setActionItem] = useState<OccurrenceItem | null>(null);
   const categories = useCategories();
 
   const templateMap = useMemo(
     () => new Map(templates.map((t) => [t.id, t])),
-    [templates]
+    [templates],
   );
 
   const sourceAccounts = useMemo(
-    () => accounts
-      .filter((a) => a.account_type === "CHECKING" || a.account_type === "SAVINGS")
-      .map((a) => ({ id: a.id, name: a.name })),
-    [accounts]
+    () =>
+      accounts
+        .filter((a) => a.account_type === "CHECKING" || a.account_type === "SAVINGS")
+        .map((a) => ({ id: a.id, name: a.name })),
+    [accounts],
   );
 
   /* ---- Link existing transaction flow ---- */
@@ -108,13 +111,83 @@ export function MobileRecurrentesView({
     }
   };
 
+  /* ---- Impact dialog state (pause/delete) ---- */
+  const [impactAction, setImpactAction] = useState<{
+    item: OccurrenceItem;
+    template: RecurringTemplateWithRelations;
+    action: "pause" | "delete";
+  } | null>(null);
+
+  /* ---- Edit dialog state ---- */
+  const [editTemplate, setEditTemplate] = useState<RecurringTemplateWithRelations | null>(null);
+
+  const handleImpactConfirm = async () => {
+    if (!impactAction) return;
+    const { template, action } = impactAction;
+    if (action === "pause") {
+      await toggleRecurringTemplate(template.id, false);
+    } else {
+      await deleteRecurringTemplate(template.id);
+    }
+    await hook.refreshOccurrences();
+    setImpactAction(null);
+    setExpandedKey(null);
+  };
+
   const sortedDates = useMemo(
-    () => Array.from(hook.pendingByDate.keys())
-      .map((date) => ({ date, order: STATUS_ORDER[hook.getDateStatus(date)] }))
-      .sort((a, b) => a.order - b.order || a.date.localeCompare(b.date))
-      .map(({ date }) => date),
-    [hook.pendingByDate, hook.getDateStatus]
+    () =>
+      Array.from(hook.pendingByDate.keys())
+        .map((date) => ({ date, order: STATUS_ORDER[hook.getDateStatus(date)] }))
+        .sort((a, b) => a.order - b.order || a.date.localeCompare(b.date))
+        .map(({ date }) => date),
+    [hook.pendingByDate, hook.getDateStatus],
   );
+
+  /* ---- Shared action handlers ---- */
+  function makeActions(item: OccurrenceItem) {
+    const template = templateMap.get(item.templateId) ?? null;
+    return {
+      template,
+      onConfirm: (amount: number, paymentDate: string, sourceId?: string) => {
+        hook.confirmPayment(item, {
+          actualAmount: amount,
+          paymentDate,
+          sourceAccountId: sourceId ?? null,
+        });
+        setExpandedKey(null);
+      },
+      onSkip: () => {
+        hook.skipPayment(item);
+        setExpandedKey(null);
+      },
+      onLinkExisting: () => {
+        setExpandedKey(null);
+        handleOpenLinkPicker(item);
+      },
+      onEdit: template
+        ? () => {
+            setExpandedKey(null);
+            setEditTemplate(template);
+          }
+        : undefined,
+      onPause: template
+        ? () => {
+            setExpandedKey(null);
+            setImpactAction({ item, template, action: "pause" });
+          }
+        : undefined,
+      onDelete: template
+        ? () => {
+            setExpandedKey(null);
+            setImpactAction({ item, template, action: "delete" });
+          }
+        : undefined,
+    };
+  }
+
+  function handleRowTap(item: OccurrenceItem) {
+    setExpandedKey(expandedKey === item.key ? null : item.key);
+  }
 
   return (
     <div className="space-y-3 pb-20">
@@ -154,7 +227,7 @@ export function MobileRecurrentesView({
             <p className="text-[10px] text-z-alert">Pendientes</p>
             <p className="text-lg font-semibold text-z-alert">{hook.pending.length}</p>
           </div>
-          <div className="h-8 w-px bg-white/6 self-center" />
+          <div className="h-8 w-px self-center bg-white/6" />
           <div className="flex-1">
             <p className="text-[10px] text-z-income">Completados</p>
             <p className="text-lg font-semibold text-z-income">{hook.completed.length}</p>
@@ -164,7 +237,7 @@ export function MobileRecurrentesView({
 
       {/* Loading state */}
       {!hook.isHydrated && (
-        <div className="py-8 text-center text-sm text-muted-foreground animate-pulse">
+        <div className="animate-pulse py-8 text-center text-sm text-muted-foreground">
           Verificando estado de pagos...
         </div>
       )}
@@ -172,9 +245,7 @@ export function MobileRecurrentesView({
       {/* Pending payments grouped by date */}
       {hook.isHydrated && sortedDates.length > 0 && (
         <div className="space-y-2">
-          <p className={MOBILE_EYEBROW_CLASS}>
-            Pendientes
-          </p>
+          <p className={MOBILE_EYEBROW_CLASS}>Pendientes</p>
           {sortedDates.map((date) => {
             const items = hook.pendingByDate.get(date)!;
             const status = hook.getDateStatus(date);
@@ -186,7 +257,12 @@ export function MobileRecurrentesView({
               >
                 {/* Date header */}
                 <div className="px-3 py-1.5">
-                  <span className={cn("text-[10px] font-semibold uppercase tracking-[0.18em]", statusLabel(status))}>
+                  <span
+                    className={cn(
+                      "text-[10px] font-semibold uppercase tracking-[0.18em]",
+                      statusLabel(status),
+                    )}
+                  >
                     {status === "today" && "Hoy — "}
                     {formatDate(date, "EEEE d MMM")}
                   </span>
@@ -200,87 +276,45 @@ export function MobileRecurrentesView({
 
                     return (
                       <div key={item.key}>
-                        {/* Payment row — tap to expand, ⋮ for admin */}
-                        <div
+                        {/* Payment row */}
+                        <button
+                          type="button"
+                          onClick={() => handleRowTap(item)}
                           className={cn(
-                            "flex w-full items-center gap-2 px-3 py-2.5",
-                            isBusy && "opacity-50 pointer-events-none"
+                            "flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors active:bg-white/[0.03]",
+                            isBusy && "pointer-events-none opacity-50",
                           )}
                         >
-                          {/* Tap area for expand/collapse */}
-                          <button
-                            type="button"
-                            onClick={() => setExpandedKey(isExpanded ? null : item.key)}
-                            className="flex min-w-0 flex-1 items-center gap-2 text-left active:bg-white/[0.03]"
+                          {/* Category dot */}
+                          <span
+                            className="flex size-6 shrink-0 items-center justify-center rounded-md"
+                            style={{ backgroundColor: item.categoryColor + "20" }}
                           >
-                            {/* Category dot */}
-                            <span
-                              className="flex size-6 shrink-0 items-center justify-center rounded-md"
-                              style={{ backgroundColor: item.categoryColor + "20" }}
-                            >
-                              <Tag className="size-3" style={{ color: item.categoryColor }} />
-                            </span>
+                            <Tag className="size-3" style={{ color: item.categoryColor }} />
+                          </span>
 
-                            {/* Merchant + account */}
-                            <div className="min-w-0 flex-1">
-                              <p className="truncate text-xs font-medium">{item.merchant}</p>
-                              <p className="truncate text-[10px] text-muted-foreground">
-                                {item.accountName}
-                              </p>
-                            </div>
-                          </button>
+                          {/* Merchant + account */}
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-xs font-medium">{item.merchant}</p>
+                            <p className="truncate text-[10px] text-muted-foreground">
+                              {item.accountName}
+                            </p>
+                          </div>
 
                           {/* Amount */}
                           <span className="shrink-0 text-xs font-semibold tabular-nums">
                             {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
                           </span>
+                        </button>
 
-                          {/* Action hint */}
-                          <button
-                            type="button"
-                            onClick={() => setExpandedKey(isExpanded ? null : item.key)}
-                            className={cn("shrink-0", MOBILE_ACTION_BUTTON_CLASS)}
-                          >
-                            {isExpanded ? "Cerrar" : "Pagar"}
-                          </button>
-
-                          {/* Admin actions */}
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setActionItem(item);
-                            }}
-                            className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground active:bg-white/10"
-                          >
-                            <MoreVertical className="size-3.5" />
-                          </button>
-                        </div>
-
-                        {/* Inline confirm panel */}
+                        {/* Option A: Inline expand */}
                         {isExpanded && (
                           <div className="border-t border-white/5 bg-black/20 px-3 py-3">
-                            <RecurringConfirmInline
+                            <OccurrenceActions
                               item={item}
-                              onConfirm={(amount, paymentDate, sourceId) => {
-                                hook.confirmPayment(item, {
-                                  actualAmount: amount,
-                                  paymentDate,
-                                  sourceAccountId: sourceId ?? null,
-                                });
-                                setExpandedKey(null);
-                              }}
-                              onSkip={() => {
-                                hook.skipPayment(item);
-                                setExpandedKey(null);
-                              }}
-                              onCancel={() => setExpandedKey(null)}
-                              onLinkExisting={() => {
-                                setExpandedKey(null);
-                                handleOpenLinkPicker(item);
-                              }}
                               isPending={isBusy}
                               sourceAccounts={sourceAccounts}
+                              {...makeActions(item)}
                             />
                           </div>
                         )}
@@ -301,13 +335,14 @@ export function MobileRecurrentesView({
         </div>
       )}
 
-      {/* No pending state */}
+      {/* All done state */}
       {hook.isHydrated && sortedDates.length === 0 && hook.completed.length > 0 && (
         <div className={cn(PANEL_INSET_CLASS, "py-6 text-center")}>
           <Check className="mx-auto size-6 text-z-income" />
           <p className="mt-2 text-xs font-medium text-z-income">Todo al día</p>
           <p className="mt-0.5 text-[10px] text-muted-foreground">
-            {hook.completed.length} pago{hook.completed.length !== 1 ? "s" : ""} completado{hook.completed.length !== 1 ? "s" : ""}
+            {hook.completed.length} pago{hook.completed.length !== 1 ? "s" : ""} completado
+            {hook.completed.length !== 1 ? "s" : ""}
           </p>
         </div>
       )}
@@ -326,12 +361,29 @@ export function MobileRecurrentesView({
         />
       )}
 
+      {/* Templates section — admin for non-checklist management */}
+      {hook.isHydrated && (
+        <TemplatesSection
+          templates={templates}
+          accounts={accounts}
+          categories={categories}
+          currency={currency}
+          onMutate={hook.refreshOccurrences}
+        />
+      )}
+
       {/* Link existing transaction sheet */}
       <LinkPickerSheet
         open={!!linkingItem}
-        onOpenChange={(open) => { if (!open) setLinkingItem(null); }}
+        onOpenChange={(open) => {
+          if (!open) setLinkingItem(null);
+        }}
         title="Vincular transacción"
-        subtitle={linkingItem ? `${linkingItem.merchant} · ${formatCurrency(linkingItem.plannedAmount, linkingItem.currencyCode as CurrencyCode)} esperado · ${formatDate(linkingItem.date)}` : ""}
+        subtitle={
+          linkingItem
+            ? `${linkingItem.merchant} · ${formatCurrency(linkingItem.plannedAmount, linkingItem.currencyCode as CurrencyCode)} esperado · ${formatDate(linkingItem.date)}`
+            : ""
+        }
         candidates={linkCandidates.map((c) => ({
           id: c.id,
           label: c.description,
@@ -352,166 +404,46 @@ export function MobileRecurrentesView({
         onShowAll={async () => {
           if (!linkingItem) return;
           setIsLoadingCandidates(true);
-          const result = await getCandidateTransactionsForOccurrence(linkingItem.occurrenceId, true);
+          const result = await getCandidateTransactionsForOccurrence(
+            linkingItem.occurrenceId,
+            true,
+          );
           setIsLoadingCandidates(false);
           if (result.success) setLinkCandidates(result.data);
         }}
         isLoadingAll={isLoadingCandidates}
       />
 
-      {/* Admin action sheet */}
-      <TemplateActionSheet
-        item={actionItem}
-        template={actionItem ? templateMap.get(actionItem.templateId) ?? null : null}
-        accounts={accounts}
-        categories={categories}
-        onClose={() => setActionItem(null)}
-        onMutate={hook.refreshOccurrences}
-      />
+      {/* Edit dialog (controlled, opens AFTER sheet closes to avoid z-index bug) */}
+      {editTemplate && (
+        <RecurringFormDialog
+          template={editTemplate}
+          accounts={accounts}
+          categories={categories}
+          trigger={null}
+          controlledOpen
+          onClose={() => {
+            setEditTemplate(null);
+            hook.refreshOccurrences();
+          }}
+        />
+      )}
+
+      {/* Impact dialog (pause/delete) */}
+      {impactAction && (
+        <RecurringImpactDialog
+          templateId={impactAction.template.id}
+          templateName={impactAction.template.merchant_name ?? "Recurrente"}
+          currencyCode={(impactAction.template.currency_code ?? "COP") as CurrencyCode}
+          action={impactAction.action}
+          onConfirm={handleImpactConfirm}
+          open={!!impactAction}
+          onOpenChange={(open) => {
+            if (!open) setImpactAction(null);
+          }}
+        />
+      )}
     </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  Template Action Sheet                                              */
-/* ------------------------------------------------------------------ */
-
-const SHEET_CHIP_CLASS =
-  "flex flex-col items-center gap-1.5 rounded-xl border border-white/6 bg-white/4 px-3 py-3 active:bg-white/8 disabled:opacity-50";
-
-function TemplateActionSheet({
-  item,
-  template,
-  accounts,
-  categories,
-  onClose,
-  onMutate,
-}: {
-  item: OccurrenceItem | null;
-  template: RecurringTemplateWithRelations | null;
-  accounts: Account[];
-  categories: CategoryWithChildren[];
-  onClose: () => void;
-  onMutate: () => Promise<void>;
-}) {
-  const [isPending, startTransition] = useTransition();
-
-  const open = !!item && !!template;
-
-  const handleActivate = () => {
-    if (!template) return;
-    startTransition(async () => {
-      await toggleRecurringTemplate(template.id, true);
-      await onMutate();
-      onClose();
-    });
-  };
-
-  const handlePauseConfirm = () => {
-    if (!template) return;
-    startTransition(async () => {
-      await toggleRecurringTemplate(template.id, false);
-      await onMutate();
-      onClose();
-    });
-  };
-
-  const handleDeleteConfirm = () => {
-    if (!template) return;
-    startTransition(async () => {
-      await deleteRecurringTemplate(template.id);
-      await onMutate();
-      onClose();
-    });
-  };
-
-  return (
-    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
-      <SheetContent side="bottom" className={cn("rounded-t-2xl", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
-        <SheetHeader>
-          <SheetTitle className="text-left">{template?.merchant_name}</SheetTitle>
-        </SheetHeader>
-
-        {template && (
-          <div className="mt-3 grid grid-cols-3 gap-2">
-            {/* Edit */}
-            <RecurringFormDialog
-              template={template ?? undefined}
-              accounts={accounts}
-              categories={categories}
-              trigger={
-                <button
-                  type="button"
-                  disabled={isPending}
-                  className={SHEET_CHIP_CLASS}
-                >
-                  <span className="flex size-8 items-center justify-center rounded-full bg-z-brass/15">
-                    <Pencil className="size-4 text-z-brass" />
-                  </span>
-                  <span className="text-xs">Editar</span>
-                </button>
-              }
-            />
-
-            {/* Pause / Activate */}
-            {template.is_active ? (
-              <RecurringImpactDialog
-                templateId={template.id}
-                templateName={template.merchant_name ?? "Recurrente"}
-                currencyCode={(template.currency_code ?? "COP") as CurrencyCode}
-                action="pause"
-                onConfirm={handlePauseConfirm}
-                trigger={
-                  <button
-                    type="button"
-                    disabled={isPending}
-                    className={SHEET_CHIP_CLASS}
-                  >
-                    <span className="flex size-8 items-center justify-center rounded-full bg-z-alert/15">
-                      <Pause className="size-4 text-z-alert" />
-                    </span>
-                    <span className="text-xs">Pausar</span>
-                  </button>
-                }
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={handleActivate}
-                disabled={isPending}
-                className={SHEET_CHIP_CLASS}
-              >
-                <span className="flex size-8 items-center justify-center rounded-full bg-z-income/15">
-                  <Play className="size-4 text-z-income" />
-                </span>
-                <span className="text-xs">{isPending ? "..." : "Activar"}</span>
-              </button>
-            )}
-
-            {/* Delete */}
-            <RecurringImpactDialog
-              templateId={template.id}
-              templateName={template.merchant_name ?? "Recurrente"}
-              currencyCode={(template.currency_code ?? "COP") as CurrencyCode}
-              action="delete"
-              onConfirm={handleDeleteConfirm}
-              trigger={
-                <button
-                  type="button"
-                  disabled={isPending}
-                  className={SHEET_CHIP_CLASS}
-                >
-                  <span className="flex size-8 items-center justify-center rounded-full bg-z-debt/15">
-                    <Trash2 className="size-4 text-z-debt" />
-                  </span>
-                  <span className="text-xs text-z-debt">Eliminar</span>
-                </button>
-              }
-            />
-          </div>
-        )}
-      </SheetContent>
-    </Sheet>
   );
 }
 
@@ -558,14 +490,19 @@ function CompletedSection({
           {completed.map((item) => {
             const isReverting = revertingId === item.occurrenceId;
             return (
-              <div key={item.key} className={cn(
-                "flex items-center gap-2 px-3 py-2.5 opacity-60",
-                isReverting && "opacity-30 pointer-events-none"
-              )}>
+              <div
+                key={item.key}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2.5 opacity-60",
+                  isReverting && "pointer-events-none opacity-30",
+                )}
+              >
                 <Check className="size-4 shrink-0 text-z-income" />
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-xs">{item.merchant}</p>
-                  <p className="text-[10px] text-muted-foreground">{formatDate(item.date, "dd MMM")}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDate(item.date, "dd MMM")}
+                  </p>
                 </div>
                 <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                   {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
@@ -584,7 +521,101 @@ function CompletedSection({
           })}
         </div>
       )}
+    </div>
+  );
+}
 
+/* ------------------------------------------------------------------ */
+/*  Templates section (admin — create, see all, manage paused)         */
+/* ------------------------------------------------------------------ */
+
+function TemplatesSection({
+  templates,
+  accounts,
+  categories,
+  currency,
+}: {
+  templates: RecurringTemplateWithRelations[];
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  currency: CurrencyCode;
+  onMutate: () => Promise<void>;
+}) {
+  const [show, setShow] = useState(false);
+
+  const activeCount = templates.filter((t) => t.is_active).length;
+  const pausedCount = templates.filter((t) => !t.is_active).length;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setShow((prev) => !prev)}
+        className={cn("flex w-full items-center justify-between py-2", MOBILE_EYEBROW_CLASS)}
+      >
+        <span>
+          Mis plantillas ({activeCount} activas{pausedCount > 0 ? ` · ${pausedCount} pausadas` : ""})
+        </span>
+        <span>{show ? "Ocultar ↑" : "Ver ↓"}</span>
+      </button>
+
+      {show && (
+        <div className="space-y-2">
+          {/* Create new */}
+          <RecurringFormDialog
+            accounts={accounts}
+            categories={categories}
+            trigger={
+              <button
+                type="button"
+                className={cn(
+                  "flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-brass/20 py-3 text-xs font-semibold text-z-brass active:bg-z-brass/5",
+                )}
+              >
+                <Plus className="size-3.5" />
+                Nueva plantilla
+              </button>
+            }
+          />
+
+          {/* Template list */}
+          <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
+            {templates.map((t) => (
+              <div
+                key={t.id}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2.5",
+                  !t.is_active && "opacity-50",
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium">{t.merchant_name}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {t.account?.name ?? "—"} · {t.frequency ?? "mensual"}
+                    {!t.is_active && " · Pausada"}
+                  </p>
+                </div>
+                <span className="shrink-0 text-xs font-semibold tabular-nums">
+                  {formatCurrency(Number(t.amount), currency)}
+                </span>
+                <RecurringFormDialog
+                  template={t}
+                  accounts={accounts}
+                  categories={categories}
+                  trigger={
+                    <button
+                      type="button"
+                      className="shrink-0 rounded-md px-2 py-0.5 text-[10px] text-z-brass active:bg-white/5"
+                    >
+                      Editar
+                    </button>
+                  }
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -125,14 +125,17 @@ export function MobileRecurrentesView({
   const handleImpactConfirm = async () => {
     if (!impactAction) return;
     const { template, action } = impactAction;
-    if (action === "pause") {
-      await toggleRecurringTemplate(template.id, false);
+    const result = action === "pause"
+      ? await toggleRecurringTemplate(template.id, false)
+      : await deleteRecurringTemplate(template.id);
+
+    if (result.success) {
+      await hook.refreshOccurrences();
+      setImpactAction(null);
+      setExpandedKey(null);
     } else {
-      await deleteRecurringTemplate(template.id);
+      toast.error(result.error ?? "Error al procesar la acción");
     }
-    await hook.refreshOccurrences();
-    setImpactAction(null);
-    setExpandedKey(null);
   };
 
   const sortedDates = useMemo(
@@ -179,9 +182,13 @@ export function MobileRecurrentesView({
         : undefined,
       onResume: template
         ? async () => {
-            setExpandedKey(null);
-            await toggleRecurringTemplate(template.id, true);
-            await hook.refreshOccurrences();
+            const result = await toggleRecurringTemplate(template.id, true);
+            if (result.success) {
+              setExpandedKey(null);
+              await hook.refreshOccurrences();
+            } else {
+              toast.error(result.error ?? "Error al activar la plantilla");
+            }
           }
         : undefined,
       onDelete: template

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -59,9 +59,9 @@ export function PlanDrillCards({
         <div className="space-y-2">
           <div className="flex items-center justify-between text-xs">
             <span className="text-muted-foreground">Gastado</span>
-            <span className="font-medium">{formatCurrency(budget.totalSpent, currency)} de {formatCurrency(budget.totalBudgeted, currency)}</span>
+            <span className="font-medium tabular-nums">{formatCurrency(budget.totalSpent, currency)} de {formatCurrency(budget.totalBudgeted, currency)}</span>
           </div>
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
             <div
               className={cn("h-full rounded-full", budgetPct > 100 ? "bg-z-debt" : "bg-z-income")}
               style={{ width: `${Math.min(budgetPct, 100)}%` }}
@@ -88,7 +88,7 @@ export function PlanDrillCards({
             <span className="text-muted-foreground">Asignado</span>
             <span className="font-medium">{periodoSummary.percentAssigned}%</span>
           </div>
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
             <div className="h-full rounded-full bg-z-income" style={{ width: `${Math.min(periodoSummary.percentAssigned, 100)}%` }} />
           </div>
           {(periodoSummary.unassignedCount ?? 0) > 0 && (

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -1,21 +1,32 @@
+"use client";
+
 import Link from "next/link";
-import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
+import { ArrowRight, Wallet, CalendarClock, RotateCcw, Heart } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { PANEL_INSET_CLASS, MOBILE_ACTION_BUTTON_CLASS } from "@/lib/constants/styles";
+import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
 import type { CurrencyCode } from "@/types/domain";
 
 interface DrillCard {
+  key: string;
   title: string;
   hint: string;
   hintColor: string;
   href: string;
+  icon: React.ReactNode;
+  expandedContent: React.ReactNode;
 }
 
 interface PlanDrillCardsProps {
   budget: PlanBudgetSummary;
   recurring: PlanRecurringSummary;
-  periodoSummary: { hasActive: boolean; percentAssigned: number } | null;
+  periodoSummary: { hasActive: boolean; percentAssigned: number; unassignedCount?: number } | null;
   wishlistCount: number;
   currency: CurrencyCode;
+  expanded?: string | null;
+  onToggle?: (id: string) => void;
 }
 
 export function PlanDrillCards({
@@ -24,60 +35,186 @@ export function PlanDrillCards({
   periodoSummary,
   wishlistCount,
   currency,
+  expanded,
+  onToggle,
 }: PlanDrillCardsProps) {
   const budgetPct = budget.totalBudgeted > 0
     ? Math.round((budget.totalSpent / budget.totalBudgeted) * 100)
     : 0;
 
+  const nextPayment = recurring.upcoming?.[0];
+  const pendingCount = (recurring.upcoming?.length ?? 0) + (recurring.upcomingIncome?.length ?? 0);
+
   const cards: DrillCard[] = [
     {
+      key: "drill-presupuesto",
       title: "Presupuesto",
+      icon: <Wallet className="size-3.5" />,
       hint: budget.overLimitCount > 0
-        ? `${budgetPct}% · ${budget.overLimitCount} sobre límite`
-        : `${budgetPct}% gastado`,
-      hintColor: budget.overLimitCount > 0 ? "text-red-400" : "text-emerald-400",
+        ? `${budget.overLimitCount} sobre límite`
+        : `${budgetPct}%`,
+      hintColor: budget.overLimitCount > 0 ? "text-z-debt" : "text-z-income",
       href: "/plan?tab=presupuesto",
+      expandedContent: (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Gastado</span>
+            <span className="font-medium">{formatCurrency(budget.totalSpent, currency)} de {formatCurrency(budget.totalBudgeted, currency)}</span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn("h-full rounded-full", budgetPct > 100 ? "bg-z-debt" : "bg-z-income")}
+              style={{ width: `${Math.min(budgetPct, 100)}%` }}
+            />
+          </div>
+          {budget.overLimitCount > 0 && (
+            <p className="text-[10px] text-z-debt">{budget.overLimitCount} categoría{budget.overLimitCount !== 1 ? "s" : ""} sobre límite</p>
+          )}
+        </div>
+      ),
     },
     {
+      key: "drill-periodo",
       title: "Periodo",
+      icon: <CalendarClock className="size-3.5" />,
       hint: periodoSummary?.hasActive
-        ? `${periodoSummary.percentAssigned}% asignado`
-        : "Sin periodo activo",
-      hintColor: periodoSummary?.hasActive ? "text-emerald-400" : "text-muted-foreground",
+        ? `${periodoSummary.percentAssigned}%`
+        : "—",
+      hintColor: periodoSummary?.hasActive ? "text-z-income" : "text-muted-foreground",
       href: "/plan?tab=periodo",
+      expandedContent: periodoSummary?.hasActive ? (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Asignado</span>
+            <span className="font-medium">{periodoSummary.percentAssigned}%</span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full bg-z-income" style={{ width: `${Math.min(periodoSummary.percentAssigned, 100)}%` }} />
+          </div>
+          {(periodoSummary.unassignedCount ?? 0) > 0 && (
+            <p className="text-[10px] text-z-alert">{periodoSummary.unassignedCount} gasto{periodoSummary.unassignedCount !== 1 ? "s" : ""} sin asignar</p>
+          )}
+        </div>
+      ) : (
+        <p className="text-[10px] text-muted-foreground">No hay periodo activo este mes</p>
+      ),
     },
     {
+      key: "drill-recurrentes",
       title: "Recurrentes",
-      hint: `${formatCurrency(recurring.totalMonthlyExpenses, currency)}/mes`,
-      hintColor: "text-amber-400",
+      icon: <RotateCcw className="size-3.5" />,
+      hint: `${pendingCount}`,
+      hintColor: pendingCount > 0 ? "text-z-alert" : "text-z-income",
       href: "/plan?tab=recurrentes",
+      expandedContent: (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            {formatCurrency(recurring.totalMonthlyExpenses, currency)}/mes en gastos
+          </p>
+          {nextPayment && (
+            <div className="flex items-center justify-between text-xs">
+              <span className="truncate text-muted-foreground">{nextPayment.template.merchant_name}</span>
+              <span className="shrink-0 font-medium">{formatDate(nextPayment.next_date, "dd MMM")}</span>
+            </div>
+          )}
+          <p className="text-[10px] text-muted-foreground">
+            {pendingCount} pendiente{pendingCount !== 1 ? "s" : ""} este mes
+          </p>
+        </div>
+      ),
     },
     {
+      key: "drill-deseos",
       title: "Deseos",
-      hint: `${wishlistCount} item${wishlistCount !== 1 ? "s" : ""}`,
+      icon: <Heart className="size-3.5" />,
+      hint: `${wishlistCount}`,
       hintColor: "text-muted-foreground",
       href: "/plan?tab=deseos",
+      expandedContent: (
+        <p className="text-xs text-muted-foreground">
+          {wishlistCount} item{wishlistCount !== 1 ? "s" : ""} en tu lista de deseos
+        </p>
+      ),
     },
   ];
+
+  const toggle = (key: string) => onToggle?.(key);
+  const activeKey = expanded?.startsWith("drill-") ? expanded : null;
+
+  // Group into rows of 2
+  const rows: DrillCard[][] = [];
+  for (let i = 0; i < cards.length; i += 2) {
+    rows.push(cards.slice(i, i + 2));
+  }
 
   return (
     <div className="space-y-1.5">
       <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
         Ir a
       </p>
-      {cards.map((card) => (
-        <Link
-          key={card.href}
-          href={card.href}
-          className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2/60 px-4 py-3 transition-colors active:bg-z-surface-2"
-        >
-          <div>
-            <p className="text-[13px] font-semibold">{card.title}</p>
-            <p className={`text-[11px] ${card.hintColor}`}>{card.hint}</p>
+
+      {rows.map((row, rowIdx) => {
+        const expandedCard = activeKey ? row.find((c) => c.key === activeKey) : null;
+
+        return (
+          <div key={rowIdx}>
+            {/* Row of 2 cards */}
+            <div className="grid grid-cols-2 gap-1.5">
+              {row.map((card) => (
+                <button
+                  key={card.key}
+                  type="button"
+                  onClick={() => toggle(card.key)}
+                  className={cn(
+                    PANEL_INSET_CLASS,
+                    "flex w-full flex-col items-start gap-1 px-3 py-2.5 text-left transition-colors active:bg-white/[0.03]",
+                    activeKey === card.key && "ring-1 ring-z-brass/30 bg-z-brass/[0.06]",
+                    activeKey && activeKey !== card.key && "opacity-50",
+                  )}
+                  aria-expanded={activeKey === card.key}
+                >
+                  <div className="flex w-full items-center justify-between">
+                    <span className="text-muted-foreground">{card.icon}</span>
+                    <span className={cn("text-sm font-bold tabular-nums", card.hintColor)}>
+                      {card.hint}
+                    </span>
+                  </div>
+                  <p className="text-[11px] font-semibold">{card.title}</p>
+                </button>
+              ))}
+            </div>
+
+            {/* Animated expand panel — same pattern as InicioDiscovery */}
+            <div
+              className="grid transition-[grid-template-rows] duration-200 ease-out"
+              style={{ gridTemplateRows: expandedCard ? "1fr" : "0fr" }}
+            >
+              <div className="overflow-hidden">
+                <div
+                  className={cn(
+                    "mt-1.5 transition-opacity duration-150",
+                    expandedCard ? "opacity-100 delay-75" : "opacity-0",
+                  )}
+                >
+                  {expandedCard && (
+                    <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 space-y-3 px-4 py-3")}>
+                      <p className="text-xs font-semibold">{expandedCard.title}</p>
+                      {expandedCard.expandedContent}
+                      <Link
+                        href={expandedCard.href}
+                        className={cn(MOBILE_ACTION_BUTTON_CLASS, "inline-flex items-center gap-1.5")}
+                      >
+                        Ver {expandedCard.title.toLowerCase()}
+                        <ArrowRight className="size-3" />
+                      </Link>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
-          <span className="text-muted-foreground">›</span>
-        </Link>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -12,6 +12,8 @@ interface PlanExpandableChipsProps {
   incomes: UpcomingRecurrence[];
   payments: UpcomingRecurrence[];
   currency: CurrencyCode;
+  expanded?: string | null;
+  onToggle?: (id: string) => void;
 }
 
 type ChipType = "income" | "payment" | null;
@@ -53,14 +55,28 @@ export function PlanExpandableChips({
   incomes,
   payments,
   currency,
+  expanded: externalExpanded,
+  onToggle: externalToggle,
 }: PlanExpandableChipsProps) {
-  const [expanded, setExpanded] = useState<ChipType>(null);
+  const [internalExpanded, setInternalExpanded] = useState<ChipType>(null);
+
+  // Use external zone if provided, otherwise internal state
+  const chipKeys = { income: "chip-income", payment: "chip-payment" } as const;
+  const activeChip: ChipType = externalExpanded
+    ? (externalExpanded === chipKeys.income ? "income" : externalExpanded === chipKeys.payment ? "payment" : null)
+    : internalExpanded;
 
   const items = { income: incomes, payment: payments } as const;
-  const toggle = (type: ChipType) => setExpanded((prev) => (prev === type ? null : type));
+  const toggle = (type: ChipType) => {
+    if (type && externalToggle) {
+      externalToggle(chipKeys[type]);
+    } else {
+      setInternalExpanded((prev) => (prev === type ? null : type));
+    }
+  };
 
-  const expandedList = expanded ? items[expanded] : [];
-  const config = expanded ? CHIP_CONFIG[expanded] : null;
+  const expandedList = activeChip ? items[activeChip] : [];
+  const config = activeChip ? CHIP_CONFIG[activeChip] : null;
 
   return (
     <div className="space-y-2">
@@ -75,8 +91,8 @@ export function PlanExpandableChips({
               onClick={() => toggle(type)}
               className={cn(
                 "rounded-xl border p-3 text-left transition-all",
-                expanded === type ? c.borderActive : c.borderInactive,
-                expanded === OPPOSITE[type] && "opacity-50"
+                activeChip === type ? c.borderActive : c.borderInactive,
+                activeChip === OPPOSITE[type] && "opacity-50"
               )}
             >
               {next ? (
@@ -103,7 +119,7 @@ export function PlanExpandableChips({
         })}
       </div>
 
-      {expanded && config && (
+      {activeChip && config && (
         <div className={cn("rounded-xl border p-3", config.panelBorder)}>
           <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", config.text)}>
             {config.expandedLabel}

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -25,13 +25,13 @@ const CHIP_CONFIG = {
     emptyHint: "Agrega un ingreso recurrente",
     expandedLabel: "Ingresos esperados",
     emptyMessage: "No tienes ingresos recurrentes configurados",
-    text: "text-emerald-400",
-    textMuted: "text-emerald-400/80",
-    textEmpty: "text-emerald-400/60",
-    borderActive: "border-emerald-500/50 bg-emerald-950/30",
-    borderInactive: "border-white/6 bg-emerald-950/20",
-    panelBorder: "border-emerald-500/20 bg-emerald-950/20",
-    ctaBg: "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30",
+    text: "text-z-income",
+    textMuted: "text-z-income/80",
+    textEmpty: "text-z-income/60",
+    borderActive: "border-z-income/50 bg-z-income/10",
+    borderInactive: "border-white/6 bg-z-income/5",
+    panelBorder: "border-z-income/20 bg-z-income/5",
+    ctaBg: "bg-z-income/15 text-z-income hover:bg-z-income/20",
   },
   payment: {
     label: "Próximo pago",
@@ -39,17 +39,18 @@ const CHIP_CONFIG = {
     emptyHint: "Agrega un pago recurrente",
     expandedLabel: "Pagos programados",
     emptyMessage: "No tienes pagos recurrentes configurados",
-    text: "text-red-400",
-    textMuted: "text-red-400/80",
-    textEmpty: "text-red-400/60",
-    borderActive: "border-red-500/50 bg-red-950/30",
-    borderInactive: "border-white/6 bg-red-950/20",
-    panelBorder: "border-red-500/20 bg-red-950/20",
-    ctaBg: "bg-red-500/20 text-red-400 hover:bg-red-500/30",
+    text: "text-z-debt",
+    textMuted: "text-z-debt/80",
+    textEmpty: "text-z-debt/60",
+    borderActive: "border-z-debt/50 bg-z-debt/10",
+    borderInactive: "border-white/6 bg-z-debt/5",
+    panelBorder: "border-z-debt/20 bg-z-debt/5",
+    ctaBg: "bg-z-debt/15 text-z-debt hover:bg-z-debt/20",
   },
 } as const;
 
 const OPPOSITE: Record<"income" | "payment", ChipType> = { income: "payment", payment: "income" };
+const CHIP_KEYS = { income: "chip-income", payment: "chip-payment" } as const;
 
 export function PlanExpandableChips({
   incomes,
@@ -61,15 +62,14 @@ export function PlanExpandableChips({
   const [internalExpanded, setInternalExpanded] = useState<ChipType>(null);
 
   // Use external zone if provided, otherwise internal state
-  const chipKeys = { income: "chip-income", payment: "chip-payment" } as const;
   const activeChip: ChipType = externalExpanded
-    ? (externalExpanded === chipKeys.income ? "income" : externalExpanded === chipKeys.payment ? "payment" : null)
+    ? (externalExpanded === CHIP_KEYS.income ? "income" : externalExpanded === CHIP_KEYS.payment ? "payment" : null)
     : internalExpanded;
 
   const items = { income: incomes, payment: payments } as const;
   const toggle = (type: ChipType) => {
     if (type && externalToggle) {
-      externalToggle(chipKeys[type]);
+      externalToggle(CHIP_KEYS[type]);
     } else {
       setInternalExpanded((prev) => (prev === type ? null : type));
     }
@@ -97,7 +97,7 @@ export function PlanExpandableChips({
             >
               {next ? (
                 <>
-                  <p className={cn("text-lg font-bold", c.text)}>
+                  <p className={cn("text-lg font-bold tabular-nums", c.text)}>
                     {formatCurrency(next.template.amount ?? 0, currency)}
                   </p>
                   <p className={cn("text-[10px]", c.textMuted)}>{c.label}</p>
@@ -121,7 +121,7 @@ export function PlanExpandableChips({
 
       {activeChip && config && (
         <div className={cn("rounded-xl border p-3", config.panelBorder)}>
-          <p className={cn("text-[10px] font-semibold uppercase tracking-widest mb-2", config.text)}>
+          <p className={cn("text-[10px] font-semibold uppercase tracking-[0.18em] mb-2", config.text)}>
             {config.expandedLabel}
           </p>
           {expandedList.length > 0 ? (
@@ -136,7 +136,7 @@ export function PlanExpandableChips({
                         {item.template.account && ` · ${item.template.account.name}`}
                       </p>
                     </div>
-                    <p className={cn("text-sm font-semibold", config.text)}>
+                    <p className={cn("text-sm font-semibold tabular-nums", config.text)}>
                       {formatCurrency(item.template.amount ?? 0, currency)}
                     </p>
                   </div>
@@ -144,7 +144,7 @@ export function PlanExpandableChips({
               </div>
               <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
                 <span className="text-muted-foreground">Total</span>
-                <span className={cn("font-bold", config.text)}>
+                <span className={cn("font-bold tabular-nums", config.text)}>
                   {formatCurrency(
                     expandedList.reduce((sum, item) => sum + (item.template.amount ?? 0), 0),
                     currency

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -6,6 +6,7 @@ import { PlanNetHero } from "./plan-net-hero";
 import { PlanExpandableChips } from "./plan-expandable-chips";
 import { PlanDrillCards } from "./plan-drill-cards";
 import { MonthSelector } from "@/components/month-selector";
+import { useExpandableZone } from "@/components/mobile/v2/use-expandable-zone";
 import type { PlanPageData } from "@/types/plan";
 import type { PlanTimelineData } from "@/actions/plan-timeline";
 import type { CurrencyCode } from "@/types/domain";
@@ -17,7 +18,7 @@ interface PlanRootProps {
   monthLabel: string;
   dayOfMonth: number;
   daysInMonth: number;
-  periodoSummary: { hasActive: boolean; percentAssigned: number } | null;
+  periodoSummary: { hasActive: boolean; percentAssigned: number; unassignedCount?: number } | null;
   wishlistCount: number;
 }
 
@@ -31,6 +32,7 @@ export function PlanRoot({
   periodoSummary,
   wishlistCount,
 }: PlanRootProps) {
+  const { activeZone, toggle } = useExpandableZone<string>();
   const incomes = planData.recurring.upcomingIncome;
   const payments = planData.recurring.upcoming;
 
@@ -63,6 +65,8 @@ export function PlanRoot({
         incomes={incomes}
         payments={payments}
         currency={currency}
+        expanded={activeZone}
+        onToggle={toggle}
       />
 
       {/* Drill cards — navigate to Presupuesto, Periodo, Recurrentes, Deseos */}
@@ -72,6 +76,8 @@ export function PlanRoot({
         periodoSummary={periodoSummary}
         wishlistCount={wishlistCount}
         currency={currency}
+        expanded={activeZone}
+        onToggle={toggle}
       />
 
       {/* Scenarios — only when stable */}

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -7,6 +7,7 @@ import { PlanExpandableChips } from "./plan-expandable-chips";
 import { PlanDrillCards } from "./plan-drill-cards";
 import { MonthSelector } from "@/components/month-selector";
 import { useExpandableZone } from "@/components/mobile/v2/use-expandable-zone";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import type { PlanPageData } from "@/types/plan";
 import type { PlanTimelineData } from "@/actions/plan-timeline";
 import type { CurrencyCode } from "@/types/domain";
@@ -37,7 +38,7 @@ export function PlanRoot({
   const payments = planData.recurring.upcoming;
 
   return (
-    <div className="space-y-2 pb-20">
+    <div className={`space-y-2 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
       <MobileHeader
         variant="main"
         title="Plan"

--- a/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
@@ -1,5 +1,4 @@
 import { getAccounts } from "@/actions/accounts";
-import { getCategories } from "@/actions/categories";
 import { getPreferredCurrency } from "@/actions/profile";
 import { getAttentionSnapshot } from "@/actions/attention";
 import {
@@ -7,8 +6,6 @@ import {
   getRecurringSummary,
 } from "@/actions/recurring-templates";
 import { getOccurrencesForMonth } from "@/actions/occurrences";
-import Link from "next/link";
-import { ChevronRight } from "lucide-react";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringList } from "@/components/recurring/recurring-list";
 import { RecurringTimelineView } from "@/components/recurring/recurring-timeline-view";
@@ -17,6 +14,7 @@ import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { DesktopOnly } from "@/components/ui/responsive-render";
 import { SummaryCard } from "@/components/ui/summary-card";
 import { AttentionCard } from "@/components/ui/attention-card";
+import { getCategories } from "@/actions/categories";
 import { formatCurrency } from "@/lib/utils/currency";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -39,25 +37,9 @@ export async function PlanTabRecurrentes() {
 
   return (
     <div className="space-y-6">
-      {/* Mobile — checklist + link to manager */}
+      {/* Mobile — unified checklist + templates */}
       <div className="lg:hidden">
         <MobileHeader variant="sub" title="Recurrentes" backHref="/plan" />
-        {/* Link to template manager */}
-        <div className="px-4 pb-3">
-          <Link
-            href="/recurrentes"
-            className="flex items-center justify-between rounded-xl border border-z-brass/20 bg-z-brass/5 px-4 py-2.5"
-          >
-            <div>
-              <p className="text-xs font-semibold text-z-brass">Administrar plantillas</p>
-              <p className="text-[10px] text-muted-foreground">
-                {summary.activeCount} activos · {formatCurrency(summary.totalMonthlyExpenses + summary.totalMonthlyIncome, currency as CurrencyCode)}/mes
-              </p>
-            </div>
-            <ChevronRight className="size-4 text-z-brass/60" />
-          </Link>
-        </div>
-        {/* Payment checklist */}
         <MobileRecurrentesView
           templates={templates}
           accounts={accounts}
@@ -66,7 +48,7 @@ export async function PlanTabRecurrentes() {
         />
       </div>
 
-      {/* Desktop — only mounted on desktop viewports */}
+      {/* Desktop */}
       <DesktopOnly>
         <div className="flex items-center justify-between gap-4">
           <div>

--- a/webapp/src/components/recurring/occurrence-actions.tsx
+++ b/webapp/src/components/recurring/occurrence-actions.tsx
@@ -181,7 +181,10 @@ export function OccurrenceActions({
             {/* Primary CTA */}
             <button
               type="button"
-              onClick={() => setPhase("confirm")}
+              onClick={() => {
+                setPaymentDate(format(new Date(), "yyyy-MM-dd"));
+                setPhase("confirm");
+              }}
               disabled={isPending}
               className={cn(
                 "rounded-xl px-10 py-2.5 text-xs font-semibold",

--- a/webapp/src/components/recurring/occurrence-actions.tsx
+++ b/webapp/src/components/recurring/occurrence-actions.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 import type { OccurrenceItem } from "./use-recurring-month";
 import type { RecurringTemplateWithRelations } from "@/types/domain";
 
@@ -50,6 +50,12 @@ export interface OccurrenceActionsProps {
 const CHIP_CLASS =
   "flex items-center justify-center gap-1.5 rounded-lg border px-4 py-2.5 text-xs font-semibold transition-colors active:opacity-70 disabled:opacity-40";
 
+const CHIP_VARIANT = {
+  default: "border-white/8 bg-white/[0.04] text-foreground",
+  danger: "border-z-debt/20 bg-z-debt/8 text-z-debt",
+  income: "border-z-income/20 bg-z-income/8 text-z-income",
+} as const;
+
 function ActionChip({
   icon,
   label,
@@ -59,22 +65,17 @@ function ActionChip({
 }: {
   icon: React.ReactNode;
   label: string;
-  variant?: "default" | "danger" | "income";
+  variant?: keyof typeof CHIP_VARIANT;
   onClick?: () => void;
   disabled?: boolean;
 }) {
-  const colorMap = {
-    default: "border-white/8 bg-white/[0.04] text-foreground",
-    danger: "border-z-debt/20 bg-z-debt/8 text-z-debt",
-    income: "border-z-income/20 bg-z-income/8 text-z-income",
-  };
 
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={cn(CHIP_CLASS, colorMap[variant])}
+      className={cn(CHIP_CLASS, CHIP_VARIANT[variant])}
     >
       {icon}
       {label}
@@ -116,7 +117,7 @@ function TabBar({
         className={cn(
           TAB_BASE,
           active === "administrar"
-            ? "border border-white/10 bg-white/[0.06] text-foreground"
+            ? "border border-white/6 bg-white/[0.06] text-foreground"
             : "text-muted-foreground",
         )}
       >
@@ -320,7 +321,7 @@ export function OccurrenceActions({
           type="button"
           onClick={() => setPhase("actions")}
           disabled={isPending}
-          className="rounded-lg border border-white/8 bg-white/[0.04] px-4 py-2 text-xs font-semibold text-muted-foreground"
+          className={cn("rounded-lg px-4 py-2 text-xs font-semibold", GHOST_BUTTON_CLASS)}
         >
           Atrás
         </button>

--- a/webapp/src/components/recurring/occurrence-actions.tsx
+++ b/webapp/src/components/recurring/occurrence-actions.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useState } from "react";
+import { format } from "date-fns";
+import { Check, CircleSlash, Link2, Pencil, Pause, Play, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import { DatePicker } from "@/components/ui/date-picker";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import type { OccurrenceItem } from "./use-recurring-month";
+import type { RecurringTemplateWithRelations } from "@/types/domain";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface SourceAccount {
+  id: string;
+  name: string;
+}
+
+type ActionPhase = "actions" | "confirm";
+type ActionTab = "pagar" | "administrar";
+
+export interface OccurrenceActionsProps {
+  item: OccurrenceItem;
+  template: RecurringTemplateWithRelations | null;
+  onConfirm: (amount: number, date: string, sourceAccountId?: string) => void;
+  onSkip: () => void;
+  onLinkExisting?: () => void;
+  onEdit?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
+  onDelete?: () => void;
+  isPending: boolean;
+  sourceAccounts?: SourceAccount[];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Chip                                                               */
+/* ------------------------------------------------------------------ */
+
+const CHIP_CLASS =
+  "flex items-center justify-center gap-1.5 rounded-lg border px-4 py-2.5 text-xs font-semibold transition-colors active:opacity-70 disabled:opacity-40";
+
+function ActionChip({
+  icon,
+  label,
+  variant = "default",
+  onClick,
+  disabled,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  variant?: "default" | "danger" | "income";
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  const colorMap = {
+    default: "border-white/8 bg-white/[0.04] text-foreground",
+    danger: "border-z-debt/20 bg-z-debt/8 text-z-debt",
+    income: "border-z-income/20 bg-z-income/8 text-z-income",
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(CHIP_CLASS, colorMap[variant])}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tab bar                                                            */
+/* ------------------------------------------------------------------ */
+
+const TAB_BASE =
+  "flex-1 rounded-lg py-1.5 text-center text-[11px] font-semibold transition-colors";
+
+function TabBar({
+  active,
+  onChange,
+}: {
+  active: ActionTab;
+  onChange: (tab: ActionTab) => void;
+}) {
+  return (
+    <div className="flex rounded-xl border border-white/6 bg-white/[0.03] p-1">
+      <button
+        type="button"
+        onClick={() => onChange("pagar")}
+        className={cn(
+          TAB_BASE,
+          active === "pagar"
+            ? "border border-z-brass/30 bg-z-brass/15 text-z-brass"
+            : "text-muted-foreground",
+        )}
+      >
+        Pagar
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("administrar")}
+        className={cn(
+          TAB_BASE,
+          active === "administrar"
+            ? "border border-white/10 bg-white/[0.06] text-foreground"
+            : "text-muted-foreground",
+        )}
+      >
+        Administrar
+      </button>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
+
+export function OccurrenceActions({
+  item,
+  template,
+  onConfirm,
+  onSkip,
+  onLinkExisting,
+  onEdit,
+  onPause,
+  onResume,
+  onDelete,
+  isPending,
+  sourceAccounts,
+}: OccurrenceActionsProps) {
+  const [phase, setPhase] = useState<ActionPhase>("actions");
+  const [activeTab, setActiveTab] = useState<ActionTab>("pagar");
+  const isIncome = item.direction === "INFLOW" && !item.isDebtPayment;
+  const isActive = template?.is_active !== false;
+
+  // Form state
+  const [amount, setAmount] = useState<string>(String(item.plannedAmount));
+  const [paymentDate, setPaymentDate] = useState<string>(
+    format(new Date(), "yyyy-MM-dd"),
+  );
+  const [sourceAccountId, setSourceAccountId] = useState<string>(
+    item.transferSourceAccountId ?? "",
+  );
+  const needsSource = item.isDebtPayment;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const numericAmount = parseFloat(amount);
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) return;
+    onConfirm(
+      numericAmount,
+      paymentDate,
+      needsSource ? sourceAccountId || undefined : undefined,
+    );
+  }
+
+  /* ---- Phase: Actions (tabbed) ---- */
+  if (phase === "actions") {
+    return (
+      <div className="space-y-3">
+        <TabBar active={activeTab} onChange={setActiveTab} />
+
+        {activeTab === "pagar" && (
+          <div className="flex flex-col items-center gap-2.5">
+            {/* Primary CTA */}
+            <button
+              type="button"
+              onClick={() => setPhase("confirm")}
+              disabled={isPending}
+              className={cn(
+                "rounded-xl px-10 py-2.5 text-xs font-semibold",
+                BRASS_BUTTON_CLASS,
+              )}
+            >
+              <Check className="mr-1.5 inline-block size-3.5" />
+              {isIncome ? "Confirmar ingreso" : "Confirmar pago"}
+            </button>
+
+            {/* Secondary actions */}
+            <div className="flex flex-wrap justify-center gap-2">
+              <ActionChip
+                icon={<CircleSlash className="size-3.5" />}
+                label="Omitir"
+                onClick={onSkip}
+                disabled={isPending}
+              />
+              {onLinkExisting && (
+                <ActionChip
+                  icon={<Link2 className="size-3.5" />}
+                  label="Vincular"
+                  onClick={onLinkExisting}
+                  disabled={isPending}
+                />
+              )}
+            </div>
+          </div>
+        )}
+
+        {activeTab === "administrar" && (
+          <div className="space-y-2">
+            {/* Edit + Pause/Resume */}
+            <div className="flex flex-wrap justify-center gap-2">
+              {onEdit && (
+                <ActionChip
+                  icon={<Pencil className="size-3" />}
+                  label="Editar"
+                  onClick={onEdit}
+                  disabled={isPending}
+                />
+              )}
+              {isActive && onPause && (
+                <ActionChip
+                  icon={<Pause className="size-3" />}
+                  label="Pausar"
+                  onClick={onPause}
+                  disabled={isPending}
+                />
+              )}
+              {!isActive && onResume && (
+                <ActionChip
+                  icon={<Play className="size-3" />}
+                  label="Activar"
+                  variant="income"
+                  onClick={onResume}
+                  disabled={isPending}
+                />
+              )}
+            </div>
+
+            {/* Danger zone */}
+            {onDelete && (
+              <div className="flex justify-center">
+                <ActionChip
+                  icon={<Trash2 className="size-3" />}
+                  label="Eliminar"
+                  variant="danger"
+                  onClick={onDelete}
+                  disabled={isPending}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  /* ---- Phase: Confirm form ---- */
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <p className="text-xs font-semibold">
+        {isIncome ? "Confirmar ingreso" : "Confirmar pago"}
+      </p>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <label className="text-[10px] font-medium text-muted-foreground">Monto</label>
+          <CurrencyInput
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="h-8 text-sm"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[10px] font-medium text-muted-foreground">Fecha</label>
+          <DatePicker
+            value={paymentDate}
+            onChange={(v) => setPaymentDate(v ?? format(new Date(), "yyyy-MM-dd"))}
+            className="h-8 w-full"
+          />
+        </div>
+
+        {needsSource && sourceAccounts && sourceAccounts.length > 0 && (
+          <div className="col-span-2 space-y-1">
+            <label className="text-[10px] font-medium text-muted-foreground">Cuenta origen</label>
+            <Select value={sourceAccountId} onValueChange={setSourceAccountId}>
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue placeholder="Seleccionar..." />
+              </SelectTrigger>
+              <SelectContent>
+                {sourceAccounts.map((acc) => (
+                  <SelectItem key={acc.id} value={acc.id}>
+                    {acc.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className={cn(
+            "flex-1 rounded-lg py-2 text-xs font-semibold",
+            BRASS_BUTTON_CLASS,
+          )}
+        >
+          {isPending ? "Registrando..." : isIncome ? "Confirmar" : "Registrar pago"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setPhase("actions")}
+          disabled={isPending}
+          className="rounded-lg border border-white/8 bg-white/[0.04] px-4 py-2 text-xs font-semibold text-muted-foreground"
+        >
+          Atrás
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/webapp/src/components/recurring/recurring-form-dialog.tsx
+++ b/webapp/src/components/recurring/recurring-form-dialog.tsx
@@ -18,24 +18,36 @@ export function RecurringFormDialog({
   accounts,
   categories,
   trigger,
+  controlledOpen,
+  onClose,
 }: {
   template?: RecurringTemplate;
   accounts: Account[];
   categories: CategoryWithChildren[];
   trigger?: React.ReactNode;
+  /** When true, dialog opens immediately without a trigger */
+  controlledOpen?: boolean;
+  onClose?: () => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (v: boolean) => {
+    if (!v && onClose) onClose();
+    setInternalOpen(v);
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        {trigger ?? (
-          <Button>
-            <Plus className="h-4 w-4 mr-2" />
-            Nueva recurrente
-          </Button>
-        )}
-      </DialogTrigger>
+      {trigger !== null && (
+        <DialogTrigger asChild>
+          {trigger ?? (
+            <Button>
+              <Plus className="h-4 w-4 mr-2" />
+              Nueva recurrente
+            </Button>
+          )}
+        </DialogTrigger>
+      )}
       <DialogContent className="max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>


### PR DESCRIPTION
## Summary

- **Merge two recurrentes views into one plan tab** — checklist + template management in a single page. `/recurrentes` now redirects to `/plan?tab=recurrentes`. "Administrar plantillas" banner removed.
- **Replace vertical "Ir a" nav with 2x2 expandable grid** — uses shared `useExpandableZone` hook so only one zone expands at a time across chips + drill cards, with the same animation pattern as the rest of the app.
- **Unify checklist UX with tabbed Pagar/Administrar** — tap row → inline expand with tab bar. "Pagar" tab shows big CTA + secondary chips (Omitir, Vincular). "Administrar" tab shows Editar/Pausar/Eliminar. Form deferred to phase 2 (only after tapping "Confirmar pago"). Fixes dialog-behind-sheet z-index bug.

### New components
- `OccurrenceActions` — tabbed action panel with two-phase confirm flow
- `TemplatesSection` — collapsible admin section for all templates (create, edit, see paused)

### Agent reviews (5 parallel)
- `zetas-front-guy` — fixed token violations (emerald/red → z-income/z-debt, tabular-nums, tracking, progress bar height, tab bar clearance)
- `server-action-reviewer` — PASS, no action files modified
- Code reuse — fixed GHOST_BUTTON_CLASS usage, hoisted constants
- Code quality — fixed 2 bugs (onMutate unused, onResume not wired)
- Efficiency — all low-impact, hoisted module-scope constants

## Test plan

- [ ] Navigate to `/plan` → verify 2x2 grid with icons + metrics
- [ ] Tap a grid card → verify expand below that row with animation, other cards dim
- [ ] Tap an expandable chip above → verify grid card collapses (shared zone)
- [ ] Navigate to `/plan?tab=recurrentes` → verify unified view (hero, checklist, completed, templates)
- [ ] Tap a pending payment → verify Pagar/Administrar tabs appear inline
- [ ] Tap "Confirmar pago" → verify form appears (amount, date, source for debt)
- [ ] Tap "Atrás" → verify returns to action chips
- [ ] Switch to "Administrar" tab → verify Editar/Pausar/Eliminar chips
- [ ] Tap "Editar" → verify edit dialog opens (no z-index bug)
- [ ] Expand "Mis plantillas" section → verify template list with edit buttons
- [ ] Visit `/recurrentes` directly → verify redirect to `/plan?tab=recurrentes`
- [ ] Verify desktop view unchanged (summary cards, timeline, template list)
- [ ] Test income variant (Nomina BC) → verify "Confirmar ingreso" same size as "Confirmar pago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)