### PR TITLE
fix: cross-account debt matching + import queue cache

### DIFF
--- a/docs/plans/2026-04-15-effective-direction-audit.md
+++ b/docs/plans/2026-04-15-effective-direction-audit.md
@@ -90,6 +90,26 @@ Change `<SelectItem value="INFLOW">Ingreso</SelectItem>` to:
 - `webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx` — remove router.refresh
 - `webapp/src/components/recurring/recurring-form.tsx` — label fix
 
+## Agent Review Notes (2026-04-14)
+
+Reviewed by `cache-doctor` and `server-action-reviewer`. **Verdict: PASS.**
+
+### Implementation watch items
+
+| Severity | Change | Detail |
+|----------|--------|--------|
+| **HIGH** | 2e (`findMatchingOccurrence`) | Secondary query MUST use `!inner` join (like primary at line 648). Without it, PostgREST returns all parent rows with NULL template instead of filtering. Also include `account:accounts!...(account_type)` in select for the `isDebtAccountType()` client filter. |
+| **MEDIUM** | 2c (`getCandidateTransactionsForOccurrence`) | `and()` nesting inside `.or()` is valid PostgREST but first usage in this codebase. Verify with real data after implementation. |
+| **MEDIUM** | 2d (`linkExistingTransactionToOccurrence`) | Type assertion at line 722 must be updated to include `transfer_source_account_id: string \| null` and nested `account: { account_type: string }`. |
+
+### Confirmed safe
+
+- **Auth & defense-in-depth**: All 5 functions use `getAuthenticatedClient()` + `.eq("user_id", user.id)`. Cross-account changes only widen matching between rows owned by the same user. No IDOR surface.
+- **Cache invalidation**: `revalidateFinancialViews()` invalidates global tags (`"transactions"`, `"accounts"`, `"occurrences"`, etc.) — covers both source and debt accounts. No new tags needed.
+- **Income metrics**: No risk. Transaction directions unchanged; `getMonthlyCashflowCached()` debt-inflow exclusion unaffected.
+- **`router.refresh()` removal**: Safe. All 3 server actions already revalidate inside `startTransition`. The `router.refresh()` causes a race where stale Route Cache overwrites fresh revalidated data — removing it fixes the import queue → transaction list staleness bug.
+- **`isDebtAccountType`** already imported at line 11 of `occurrences.ts`. `OCCURRENCE_SELECT` already includes `transfer_source_account_id`. No new imports or migrations needed.
+
 ## Verification
 
 1. `pnpm build` passes

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -115,6 +115,29 @@ type RawOccurrenceRow = {
   } | null;
 };
 
+/** Minimal template shape for cross-account debt matching queries. */
+type TemplateWithAccount = {
+  account_id: string;
+  direction: "INFLOW" | "OUTFLOW";
+  transfer_source_account_id: string | null;
+  account: { account_type: string } | null;
+};
+
+/** True when an OUTFLOW tx from a source account matches an INFLOW template on a debt account. */
+function isCrossAccountDebtPayment(
+  template: TemplateWithAccount,
+  txDirection: "INFLOW" | "OUTFLOW",
+  txAccountId: string,
+): boolean {
+  return (
+    template.direction === "INFLOW" &&
+    txDirection === "OUTFLOW" &&
+    template.transfer_source_account_id === txAccountId &&
+    template.account != null &&
+    isDebtAccountType(template.account.account_type)
+  );
+}
+
 function mapOccurrenceRow(row: RawOccurrenceRow): RecurringOccurrence | null {
   if (!row.template || !row.template.account) return null;
   return {
@@ -667,7 +690,42 @@ export async function findMatchingOccurrence(
   const match = data.find(
     (row) => Math.abs(row.expected_amount - amount) <= tolerance,
   );
-  return match?.id ?? null;
+  if (match) return match.id;
+
+  // Secondary query: cross-account debt payment matching.
+  // If this is an OUTFLOW from a source account, check if a debt payment template
+  // has transfer_source_account_id pointing here.
+  if (direction === "OUTFLOW") {
+    const { data: crossData, error: crossErr } = await supabase
+      .from("recurring_occurrences")
+      .select(
+        `id, expected_amount,
+         template:recurring_transaction_templates!recurring_occurrences_template_id_fkey!inner(
+           account_id, transfer_source_account_id, direction, is_active,
+           account:accounts!recurring_transaction_templates_account_id_fkey(account_type)
+         )`
+      )
+      .eq("user_id", user.id)
+      .eq("status", "pending")
+      .eq("template.transfer_source_account_id", accountId)
+      .eq("template.direction", "INFLOW")
+      .eq("template.is_active", true)
+      .gte("occurrence_date", rangeStart)
+      .lte("occurrence_date", rangeEnd);
+
+    if (!crossErr && crossData) {
+      const crossMatch = crossData.find((row) => {
+        const t = row.template as TemplateWithAccount | null;
+        return (
+          Math.abs(row.expected_amount - amount) <= tolerance &&
+          t?.account != null && isDebtAccountType(t.account.account_type)
+        );
+      });
+      if (crossMatch) return crossMatch.id;
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -709,7 +767,11 @@ export async function linkExistingTransactionToOccurrence(
   // Fetch occurrence — must be pending
   const { data: occurrence, error: occErr } = await supabase
     .from("recurring_occurrences")
-    .select("id, template_id, occurrence_date, template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(account_id, direction, frequency, category_id)")
+    .select(`id, template_id, occurrence_date,
+      template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
+        account_id, direction, frequency, category_id, transfer_source_account_id,
+        account:accounts!recurring_transaction_templates_account_id_fkey(account_type)
+      )`)
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
     .eq("status", "pending")
@@ -719,7 +781,7 @@ export async function linkExistingTransactionToOccurrence(
     return { success: false, error: "Ocurrencia no encontrada o ya no está pendiente" };
   }
 
-  const template = occurrence.template as { account_id: string; direction: "INFLOW" | "OUTFLOW"; frequency: string; category_id: string | null } | null;
+  const template = occurrence.template as (TemplateWithAccount & { frequency: string; category_id: string | null }) | null;
   if (!template) return { success: false, error: "Plantilla no encontrada" };
 
   // Fetch transaction — must exist and match account + direction
@@ -734,7 +796,10 @@ export async function linkExistingTransactionToOccurrence(
     return { success: false, error: "Transacción no encontrada" };
   }
 
-  if (tx.account_id !== template.account_id || tx.direction !== template.direction) {
+  const directMatch = tx.account_id === template.account_id && tx.direction === template.direction;
+  const crossAccountDebt = isCrossAccountDebtPayment(template, tx.direction as "INFLOW" | "OUTFLOW", tx.account_id);
+
+  if (!directMatch && !crossAccountDebt) {
     return { success: false, error: "La transacción no coincide con la cuenta o dirección de la plantilla" };
   }
 
@@ -821,7 +886,11 @@ export async function getCandidateTransactionsForOccurrence(
 
   const { data: occurrence, error: occErr } = await supabase
     .from("recurring_occurrences")
-    .select("id, occurrence_date, expected_amount, template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(account_id, direction)")
+    .select(`id, occurrence_date, expected_amount,
+      template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
+        account_id, direction, transfer_source_account_id,
+        account:accounts!recurring_transaction_templates_account_id_fkey(account_type)
+      )`)
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
     .eq("status", "pending")
@@ -831,16 +900,27 @@ export async function getCandidateTransactionsForOccurrence(
     return { success: false, error: "Ocurrencia no encontrada" };
   }
 
-  const template = occurrence.template as { account_id: string; direction: "INFLOW" | "OUTFLOW" } | null;
+  const template = occurrence.template as TemplateWithAccount | null;
   if (!template) return { success: false, error: "Plantilla no encontrada" };
+
+  const isCrossAccountDebt = template.transfer_source_account_id &&
+    isCrossAccountDebtPayment(template, "OUTFLOW", template.transfer_source_account_id);
 
   let query = supabase
     .from("transactions")
     .select("id, clean_description, merchant_name, raw_description, amount, currency_code, transaction_date, provider")
     .eq("user_id", user.id)
-    .eq("account_id", template.account_id)
-    .eq("direction", template.direction)
-    .is("recurrence_group_id", null)
+    .is("recurrence_group_id", null);
+
+  if (isCrossAccountDebt) {
+    query = query.or(
+      `and(account_id.eq.${template.account_id},direction.eq.INFLOW),and(account_id.eq.${template.transfer_source_account_id},direction.eq.OUTFLOW)`
+    );
+  } else {
+    query = query.eq("account_id", template.account_id).eq("direction", template.direction);
+  }
+
+  query = query
     .order("transaction_date", { ascending: false })
     .limit(50);
 
@@ -920,7 +1000,8 @@ export async function getCandidateOccurrencesForTransaction(
     .select(`
       id, template_id, occurrence_date, expected_amount,
       template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
-        merchant_name, description, direction, currency_code, account_id,
+        merchant_name, description, direction, currency_code, account_id, transfer_source_account_id,
+        account:accounts!recurring_transaction_templates_account_id_fkey(account_type),
         category:categories!recurring_transaction_templates_category_id_fkey(icon, color)
       )
     `)
@@ -933,8 +1014,10 @@ export async function getCandidateOccurrencesForTransaction(
 
   // Filter by account + direction (nested join filter not reliable in Supabase)
   const filtered = (data ?? []).filter((o) => {
-    const t = o.template as { account_id: string; direction: string } | null;
-    return t && t.account_id === tx.account_id && t.direction === tx.direction;
+    const t = o.template as TemplateWithAccount | null;
+    if (!t) return false;
+    if (t.account_id === tx.account_id && t.direction === tx.direction) return true;
+    return isCrossAccountDebtPayment(t, tx.direction as "INFLOW" | "OUTFLOW", tx.account_id);
   });
 
   const candidates: CandidateOccurrence[] = filtered.map((o) => {
@@ -983,14 +1066,17 @@ async function getAccountIdsWithPendingOccurrencesCached(
   const supabase = createCachedClient(accessToken);
   const { data } = await supabase
     .from("recurring_occurrences")
-    .select("template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(account_id)")
+    .select("template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(account_id, transfer_source_account_id)")
     .eq("user_id", userId)
     .eq("status", "pending");
 
   const ids = new Set<string>();
   for (const row of data ?? []) {
-    const t = row.template as { account_id: string } | null;
-    if (t) ids.add(t.account_id);
+    const t = row.template as { account_id: string; transfer_source_account_id: string | null } | null;
+    if (t) {
+      ids.add(t.account_id);
+      if (t.transfer_source_account_id) ids.add(t.transfer_source_account_id);
+    }
   }
   return Array.from(ids);
 }

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+
 import Link from "next/link";
 import { ArrowUpRight, ArrowDownLeft, ArrowRight, QrCode, CreditCard, Banknote, Building, Wallet, ArrowUpRight as TransferIcon, Mail, Hash, UserRound, Pencil, FileUp } from "lucide-react";
 import {
@@ -435,7 +435,6 @@ function ImportarDetail({
   accounts: Pick<Account, "id" | "name" | "currency_code">[];
   currency: CurrencyCode;
 }) {
-  const router = useRouter();
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [accountOverrides, setAccountOverrides] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
@@ -452,7 +451,6 @@ function ImportarDetail({
     startTransition(async () => {
       const result = await approveEmailTransaction(id, overrideAccountId);
       if (result.success) {
-        router.refresh();
         toast.success("Importada");
       } else {
         toast.error(result.error ?? "Error al importar");
@@ -464,7 +462,6 @@ function ImportarDetail({
     startTransition(async () => {
       const result = await dismissEmailTransaction(id);
       if (result.success) {
-        router.refresh();
         toast.success("Descartada");
       } else {
         toast.error(result.error ?? "Error al descartar");
@@ -493,7 +490,6 @@ function ImportarDetail({
         }
       }
 
-      router.refresh();
       if (failed === 0) {
         toast.success(`${approved} importadas`);
       } else {

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -160,7 +160,7 @@ export function RecurringForm({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="OUTFLOW">Gasto</SelectItem>
-              <SelectItem value="INFLOW">Ingreso</SelectItem>
+              <SelectItem value="INFLOW">{isDebtAccount ? "Abono a deuda" : "Ingreso"}</SelectItem>
             </SelectContent>
           </Select>
           {isDebtAccount && (


### PR DESCRIPTION
## Summary

- **Cross-account debt payment matching**: Debt payment templates (INFLOW to LOAN/CREDIT_CARD) now match transactions from the source account (OUTFLOW from SAVINGS/CHECKING) via `transfer_source_account_id`. All 5 occurrence functions updated: `findMatchingOccurrence`, `linkExistingTransactionToOccurrence`, `getCandidateTransactionsForOccurrence`, `getCandidateOccurrencesForTransaction`, `getAccountIdsWithPendingOccurrencesCached`.
- **Import queue cache fix**: Removed redundant `router.refresh()` in `movimientos-herramientas.tsx` — server actions already `revalidateTag()` inside `startTransition`. The refresh caused a race where stale Route Cache overwrote fresh data (transactions disappear from queue but don't appear in list).
- **UI label**: Recurring form shows "Abono a deuda" instead of "Ingreso" for debt accounts.
- **Code quality**: Extracted `isCrossAccountDebtPayment()` helper + `TemplateWithAccount` type to deduplicate the 4-site cross-account predicate.

## Review notes

Plan reviewed by `cache-doctor` and `server-action-reviewer` agents before implementation. See `docs/plans/2026-04-15-effective-direction-audit.md` for full review notes.

## Test plan

- [ ] Create OUTFLOW transaction from savings account matching a debt payment template amount/date → should auto-link
- [ ] "Vincular" button appears on savings-account OUTFLOW transactions when debt-payment occurrences are pending
- [ ] Recurring form shows "Abono a deuda" for debt accounts
- [ ] Approve/dismiss email in import queue → transactions list refreshes without stale state
- [ ] `pnpm build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)