### PR TITLE
refactor: use isCrossAccountDebtPayment helper in findMatchingOccurrence

### DIFF
--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -718,7 +718,7 @@ export async function findMatchingOccurrence(
         const t = row.template as TemplateWithAccount | null;
         return (
           Math.abs(row.expected_amount - amount) <= tolerance &&
-          t?.account != null && isDebtAccountType(t.account.account_type)
+          t != null && isCrossAccountDebtPayment(t, direction, accountId)
         );
       });
       if (crossMatch) return crossMatch.id;


### PR DESCRIPTION
Replace inlined debt account type check with the existing centralized
helper to keep the cross-account debt payment definition in one place.

https://claude.ai/code/session_0166njYi49mcPFcXWsaXCTuC