### PR TITLE
fix: add RECURRING_TEMPLATE to categorization_source enum + completed recurrentes actions

### DIFF
--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -755,6 +755,7 @@ export type Database = {
         | "ML_MODEL"
         | "USER_OVERRIDE"
         | "USER_LEARNED"
+        | "RECURRING_TEMPLATE"
       connection_status: "CONNECTED" | "DISCONNECTED" | "ERROR" | "PENDING"
       currency_code:
         | "COP"
@@ -932,6 +933,7 @@ export const Constants = {
         "ML_MODEL",
         "USER_OVERRIDE",
         "USER_LEARNED",
+        "RECURRING_TEMPLATE",
       ],
       connection_status: ["CONNECTED", "DISCONNECTED", "ERROR", "PENDING"],
       currency_code: ["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"],

--- a/supabase/migrations/20260415120000_add_recurring_template_categorization_source.sql
+++ b/supabase/migrations/20260415120000_add_recurring_template_categorization_source.sql
@@ -1,0 +1,4 @@
+-- Add RECURRING_TEMPLATE to categorization_source enum
+-- Fixes: "invalid input value for enum categorization_source: RECURRING_TEMPLATE"
+-- when linking a transaction to a recurring occurrence that enriches the category
+ALTER TYPE categorization_source ADD VALUE IF NOT EXISTS 'RECURRING_TEMPLATE';

--- a/webapp/src/components/recurring/recurring-completed-section.tsx
+++ b/webapp/src/components/recurring/recurring-completed-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle2, SkipForward, Undo2, Pencil } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -11,6 +11,7 @@ import { formatDate } from "@/lib/utils/date";
 import type { OccurrenceItem } from "./use-recurring-month";
 import type { CurrencyCode } from "@/types/domain";
 import { ChevronDown } from "lucide-react";
+import Link from "next/link";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -18,6 +19,7 @@ import { ChevronDown } from "lucide-react";
 
 interface RecurringCompletedSectionProps {
   completed: OccurrenceItem[];
+  onRevert?: (item: OccurrenceItem) => void;
 }
 
 /* ------------------------------------------------------------------ */
@@ -26,6 +28,7 @@ interface RecurringCompletedSectionProps {
 
 export function RecurringCompletedSection({
   completed,
+  onRevert,
 }: RecurringCompletedSectionProps) {
   if (completed.length === 0) return null;
 
@@ -48,7 +51,11 @@ export function RecurringCompletedSection({
               key={item.key}
               className="flex items-center gap-2 px-3 py-2"
             >
-              <CheckCircle2 className="size-4 shrink-0 text-green-600 dark:text-green-500" />
+              {item.status === "paid" ? (
+                <CheckCircle2 className="size-4 shrink-0 text-green-600 dark:text-green-500" />
+              ) : (
+                <SkipForward className="size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+              )}
 
               <div className="min-w-0 flex-1">
                 <span className="truncate text-sm font-medium text-green-800 dark:text-green-300">
@@ -56,6 +63,7 @@ export function RecurringCompletedSection({
                 </span>
                 <span className="ml-1.5 text-xs text-green-600/70 dark:text-green-500/70">
                   {formatDate(item.date, "d MMM")}
+                  {item.status === "skipped" && " · Omitido"}
                 </span>
               </div>
 
@@ -65,6 +73,27 @@ export function RecurringCompletedSection({
                   item.currencyCode as CurrencyCode
                 )}
               </span>
+
+              {/* Actions */}
+              <div className="flex shrink-0 items-center gap-1 ml-1">
+                <Link
+                  href={`/recurrentes/${item.templateId}/edit`}
+                  className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"
+                  title="Editar plantilla"
+                >
+                  <Pencil className="size-3.5" />
+                </Link>
+                {onRevert && (
+                  <button
+                    type="button"
+                    onClick={() => onRevert(item)}
+                    className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"
+                    title="Deshacer — volver a pendiente"
+                  >
+                    <Undo2 className="size-3.5" />
+                  </button>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/webapp/src/components/recurring/recurring-timeline-view.tsx
+++ b/webapp/src/components/recurring/recurring-timeline-view.tsx
@@ -93,7 +93,10 @@ export function RecurringTimelineView({
                   )
                   .map((a) => ({ id: a.id, name: a.name }))}
               />
-              <RecurringCompletedSection completed={hook.completed} />
+              <RecurringCompletedSection
+                completed={hook.completed}
+                onRevert={hook.revertPayment}
+              />
             </>
           )}
         </div>

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -15,6 +15,7 @@ import {
 import {
   getOccurrencesForMonth,
   skipOccurrence,
+  revertOccurrence,
   ensureOccurrencesForRange,
   linkExistingTransactionToOccurrence,
 } from "@/actions/occurrences";
@@ -46,6 +47,7 @@ export interface OccurrenceItem {
   isDebtPayment: boolean;
   transferSourceAccountId: string | null;
   accountLastFour: string;
+  status: "pending" | "paid" | "skipped";
 }
 
 export type DateStatus = "today" | "past" | "future";
@@ -77,6 +79,7 @@ function mapToOccurrenceItem(
     isDebtPayment,
     transferSourceAccountId: o.transfer_source_account_id,
     accountLastFour: accounts.find((a) => a.id === o.account_id)?.mask ?? "",
+    status: o.status as "pending" | "paid" | "skipped",
   };
 }
 
@@ -360,6 +363,37 @@ export function useRecurringMonth(
     );
   }, []);
 
+  /* ---- revert payment (full: optimistic + server action) ---- */
+  const revertPayment = useCallback(
+    (item: OccurrenceItem) => {
+      // Optimistic
+      setOccurrences((prev) =>
+        prev.map((o) =>
+          o.id === item.occurrenceId
+            ? { ...o, status: "pending" as const, transaction_id: null }
+            : o
+        )
+      );
+      toast.success("Pago revertido a pendiente");
+
+      startTransition(async () => {
+        const result = await revertOccurrence(item.occurrenceId);
+        if (!result.success) {
+          // Revert optimistic update
+          setOccurrences((prev) =>
+            prev.map((o) =>
+              o.id === item.occurrenceId
+                ? { ...o, status: item.status, transaction_id: null }
+                : o
+            )
+          );
+          toast.error(result.error ?? "No se pudo revertir el pago.");
+        }
+      });
+    },
+    [startTransition]
+  );
+
   /* ---- totals ---- */
   const totalPlanned = useMemo(
     () =>
@@ -399,6 +433,7 @@ export function useRecurringMonth(
     skipPayment,
     linkExisting,
     optimisticRevert,
+    revertPayment,
     busyItems,
 
     // Helpers

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -48,6 +48,7 @@ export interface OccurrenceItem {
   transferSourceAccountId: string | null;
   accountLastFour: string;
   status: "pending" | "paid" | "skipped";
+  transactionId: string | null;
 }
 
 export type DateStatus = "today" | "past" | "future";
@@ -80,6 +81,7 @@ function mapToOccurrenceItem(
     transferSourceAccountId: o.transfer_source_account_id,
     accountLastFour: accounts.find((a) => a.id === o.account_id)?.mask ?? "",
     status: o.status as "pending" | "paid" | "skipped",
+    transactionId: o.transaction_id,
   };
 }
 
@@ -383,7 +385,7 @@ export function useRecurringMonth(
           setOccurrences((prev) =>
             prev.map((o) =>
               o.id === item.occurrenceId
-                ? { ...o, status: item.status, transaction_id: null }
+                ? { ...o, status: item.status, transaction_id: item.transactionId }
                 : o
             )
           );

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -3363,6 +3363,7 @@ export type Database = {
         | "ML_MODEL"
         | "USER_OVERRIDE"
         | "USER_LEARNED"
+        | "RECURRING_TEMPLATE"
       connection_status: "CONNECTED" | "DISCONNECTED" | "ERROR" | "PENDING"
       currency_code:
         | "COP"
@@ -3544,6 +3545,7 @@ export const Constants = {
         "ML_MODEL",
         "USER_OVERRIDE",
         "USER_LEARNED",
+        "RECURRING_TEMPLATE",
       ],
       connection_status: ["CONNECTED", "DISCONNECTED", "ERROR", "PENDING"],
       currency_code: ["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"],


### PR DESCRIPTION
The RECURRING_TEMPLATE value was used in occurrences.ts when linking a
transaction to a recurring template, but the DB enum didn't have it —
causing "invalid input value for enum categorization_source" errors.

Also adds edit and undo actions to completed recurring payments, which
were previously a read-only list with no interaction options.

https://claude.ai/code/session_01DqanEnsXdEzwGiQPBKkHTp