### PR TITLE
feat: add month selector to mobile plan tabs and embed account cards in plan page

### DIFF
--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -16,6 +16,7 @@ import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 import { formatMonthLabel, parseMonth } from "@/lib/utils/date";
 import { PlanResumenZone } from "@/components/plan/zones/plan-resumen-zone";
 import { PlanMobileZone } from "@/components/plan/zones/plan-mobile-zone";
+import { PlanAccountsSection } from "@/components/plan/plan-accounts-section";
 import type { CurrencyCode } from "@/types/domain";
 
 const VALID_TABS: PlanTab[] = ["resumen", "presupuesto", "periodo", "recurrentes", "deseos"];
@@ -106,23 +107,44 @@ export default async function PlanPage({
       {/* ── Mobile ── */}
       <div className="lg:hidden">
         {isResumen ? (
-          <Suspense fallback={mobileSkeleton}>
-            <PlanMobileZone
-              month={month}
-              currency={currency as CurrencyCode}
-              monthLabel={monthLabel}
-              periodoSummary={periodoSummary}
-              wishlistCount={wishlistSummary?.totalCount ?? 0}
-            />
-          </Suspense>
+          <div className="space-y-6">
+            <Suspense fallback={mobileSkeleton}>
+              <PlanMobileZone
+                month={month}
+                currency={currency as CurrencyCode}
+                monthLabel={monthLabel}
+                periodoSummary={periodoSummary}
+                wishlistCount={wishlistSummary?.totalCount ?? 0}
+              />
+            </Suspense>
+            <Suspense fallback={
+              <div className="space-y-3 px-1">
+                <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+                <div className="grid grid-cols-1 gap-3">
+                  <div className="h-[160px] rounded-xl bg-z-surface-2 animate-pulse" />
+                  <div className="h-[160px] rounded-xl bg-z-surface-2 animate-pulse" />
+                </div>
+              </div>
+            }>
+              <div className="px-1">
+                <PlanAccountsSection />
+              </div>
+            </Suspense>
+          </div>
         ) : (
-          tabContent && (
-            <div className="mt-4">
+          <div className="mt-4 space-y-4">
+            {/* Month selector for non-resumen mobile tabs */}
+            <div className="flex justify-center">
+              <Suspense fallback={<div className="h-9 w-40 rounded-md bg-muted animate-pulse" />}>
+                <MonthSelector compact />
+              </Suspense>
+            </div>
+            {tabContent && (
               <Suspense fallback={<div className="h-64 rounded-xl bg-muted animate-pulse" />}>
                 {tabContent}
               </Suspense>
-            </div>
-          )
+            )}
+          </div>
         )}
       </div>
 

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -117,30 +117,17 @@ export default async function PlanPage({
                 wishlistCount={wishlistSummary?.totalCount ?? 0}
               />
             </Suspense>
-            <Suspense fallback={
-              <div className="space-y-3 px-1">
-                <div className="h-3 w-24 rounded bg-muted animate-pulse" />
-                <div className="grid grid-cols-1 gap-3">
-                  <div className="h-[160px] rounded-xl bg-z-surface-2 animate-pulse" />
-                  <div className="h-[160px] rounded-xl bg-z-surface-2 animate-pulse" />
-                </div>
-              </div>
-            }>
-              <div className="px-1">
-                <PlanAccountsSection />
-              </div>
-            </Suspense>
+            <PlanAccountsSection />
           </div>
         ) : (
           <div className="mt-4 space-y-4">
-            {/* Month selector for non-resumen mobile tabs */}
             <div className="flex justify-center">
-              <Suspense fallback={<div className="h-9 w-40 rounded-md bg-muted animate-pulse" />}>
+              <Suspense fallback={<div className="h-9 w-40 rounded-md bg-z-surface-2 animate-pulse" />}>
                 <MonthSelector compact />
               </Suspense>
             </div>
             {tabContent && (
-              <Suspense fallback={<div className="h-64 rounded-xl bg-muted animate-pulse" />}>
+              <Suspense fallback={<div className="h-64 rounded-xl bg-z-surface-2 animate-pulse" />}>
                 {tabContent}
               </Suspense>
             )}
@@ -163,8 +150,8 @@ export default async function PlanPage({
               </div>
             </div>
             <div className="flex items-center gap-3">
-              <PlanTabNav activeTab={activeTab} />
-              <Suspense fallback={<div className="h-9 w-40 rounded-md bg-muted animate-pulse" />}>
+              <PlanTabNav activeTab={activeTab} month={month} />
+              <Suspense fallback={<div className="h-9 w-40 rounded-md bg-z-surface-2 animate-pulse" />}>
                 <MonthSelector />
               </Suspense>
             </div>
@@ -184,7 +171,7 @@ export default async function PlanPage({
 
           {/* Tab content — already Suspensed */}
           {tabContent && (
-            <Suspense fallback={<div className="h-64 rounded-xl bg-muted animate-pulse" />}>
+            <Suspense fallback={<div className="h-64 rounded-xl bg-z-surface-2 animate-pulse" />}>
               {tabContent}
             </Suspense>
           )}

--- a/webapp/src/components/plan/plan-accounts-section.tsx
+++ b/webapp/src/components/plan/plan-accounts-section.tsx
@@ -1,20 +1,20 @@
+"use client";
+
 import Link from "next/link";
-import { getAccounts } from "@/actions/accounts";
+import { useAccounts } from "@/components/providers/app-data-provider";
 import { AccountCard } from "@/components/accounts/account-card";
 import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { ArrowRight } from "lucide-react";
 
-export async function PlanAccountsSection() {
-  const result = await getAccounts();
-  const accounts = result.success ? result.data : [];
+export function PlanAccountsSection() {
+  const accounts = useAccounts();
 
   if (accounts.length === 0) return null;
 
-  const debtAccounts = accounts.filter(
-    (a) => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN"
-  );
-  const liquidAccounts = accounts.filter((a) =>
-    ["CHECKING", "SAVINGS", "CASH", "INVESTMENT"].includes(a.account_type)
+  const debtAccounts = accounts.filter((a) => isDebtAccountType(a.account_type));
+  const liquidAccounts = accounts.filter(
+    (a) => !isDebtAccountType(a.account_type) && a.account_type !== "OTHER"
   );
 
   const allMinimal = accounts.map((a) => ({
@@ -39,7 +39,7 @@ export async function PlanAccountsSection() {
 
       {liquidAccounts.length > 0 && (
         <div>
-          <p className="mb-2 text-xs font-medium text-muted-foreground">Liquidez y ahorro</p>
+          <p className="mb-2 text-xs font-medium text-z-sage-dark">Liquidez y ahorro</p>
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {liquidAccounts.map((account) => (
               <AccountCard key={account.id} account={account} allAccounts={allMinimal} />
@@ -50,7 +50,7 @@ export async function PlanAccountsSection() {
 
       {debtAccounts.length > 0 && (
         <div>
-          <p className="mb-2 text-xs font-medium text-muted-foreground">Deuda</p>
+          <p className="mb-2 text-xs font-medium text-z-sage-dark">Deuda</p>
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {debtAccounts.map((account) => (
               <AccountCard key={account.id} account={account} allAccounts={allMinimal} />

--- a/webapp/src/components/plan/plan-accounts-section.tsx
+++ b/webapp/src/components/plan/plan-accounts-section.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { getAccounts } from "@/actions/accounts";
+import { AccountCard } from "@/components/accounts/account-card";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
+import { ArrowRight } from "lucide-react";
+
+export async function PlanAccountsSection() {
+  const result = await getAccounts();
+  const accounts = result.success ? result.data : [];
+
+  if (accounts.length === 0) return null;
+
+  const debtAccounts = accounts.filter(
+    (a) => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN"
+  );
+  const liquidAccounts = accounts.filter((a) =>
+    ["CHECKING", "SAVINGS", "CASH", "INVESTMENT"].includes(a.account_type)
+  );
+
+  const allMinimal = accounts.map((a) => ({
+    id: a.id,
+    name: a.name,
+    account_type: a.account_type,
+    currency_code: a.currency_code,
+  }));
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <SectionEyebrow>Mis cuentas</SectionEyebrow>
+        <Link
+          href="/accounts"
+          className="inline-flex items-center gap-1 text-xs font-medium text-z-brass hover:underline"
+        >
+          Ver todas
+          <ArrowRight className="size-3" />
+        </Link>
+      </div>
+
+      {liquidAccounts.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium text-muted-foreground">Liquidez y ahorro</p>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {liquidAccounts.map((account) => (
+              <AccountCard key={account.id} account={account} allAccounts={allMinimal} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {debtAccounts.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium text-muted-foreground">Deuda</p>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {debtAccounts.map((account) => (
+              <AccountCard key={account.id} account={account} allAccounts={allMinimal} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/webapp/src/components/plan/plan-tab-nav.tsx
+++ b/webapp/src/components/plan/plan-tab-nav.tsx
@@ -14,10 +14,7 @@ const PLAN_TABS = [
 
 export type PlanTab = (typeof PLAN_TABS)[number]["key"];
 
-export function PlanTabNav({ activeTab }: { activeTab: PlanTab }) {
-  const searchParams = useSearchParams();
-  const month = searchParams.get("month");
-
+export function PlanTabNav({ activeTab, month }: { activeTab: PlanTab; month?: string | null }) {
   function buildHref(tabKey: string) {
     const params = new URLSearchParams();
     if (tabKey !== "resumen") params.set("tab", tabKey);

--- a/webapp/src/components/plan/plan-tab-nav.tsx
+++ b/webapp/src/components/plan/plan-tab-nav.tsx
@@ -15,12 +15,23 @@ const PLAN_TABS = [
 export type PlanTab = (typeof PLAN_TABS)[number]["key"];
 
 export function PlanTabNav({ activeTab }: { activeTab: PlanTab }) {
+  const searchParams = useSearchParams();
+  const month = searchParams.get("month");
+
+  function buildHref(tabKey: string) {
+    const params = new URLSearchParams();
+    if (tabKey !== "resumen") params.set("tab", tabKey);
+    if (month) params.set("month", month);
+    const qs = params.toString();
+    return qs ? `/plan?${qs}` : "/plan";
+  }
+
   return (
     <nav className="hidden gap-1 overflow-x-auto scrollbar-none rounded-xl border border-white/6 bg-black/10 p-1 lg:flex">
       {PLAN_TABS.map((tab) => (
         <Link
           key={tab.key}
-          href={tab.key === "resumen" ? "/plan" : `/plan?tab=${tab.key}`}
+          href={buildHref(tab.key)}
           className={cn(
             "shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors whitespace-nowrap",
             activeTab === tab.key

--- a/webapp/src/components/plan/zones/plan-resumen-zone.tsx
+++ b/webapp/src/components/plan/zones/plan-resumen-zone.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { getPlanPageData } from "@/actions/plan";
 import { getCategoriesByRhythm } from "@/actions/categories";
 import { PlanHero } from "@/components/plan/plan-hero";
@@ -6,6 +7,7 @@ import { PlanBudgetToggle } from "@/components/plan/plan-budget-toggle";
 import { PlanDebtSection } from "@/components/plan/plan-debt-section";
 import { PlanRecurringSection } from "@/components/plan/plan-recurring-section";
 import { PlanScenarioPreview } from "@/components/plan/plan-scenario-preview";
+import { PlanAccountsSection } from "@/components/plan/plan-accounts-section";
 import { PlanTabNav, type PlanTab } from "@/components/plan/plan-tab-nav";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -59,6 +61,19 @@ export async function PlanResumenZone({
       </div>
 
       <PlanScenarioPreview scenarios={planData.scenarios} />
+
+      <Suspense fallback={
+        <div className="space-y-4">
+          <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+          <div className="grid gap-4 xl:grid-cols-3">
+            <div className="h-[180px] rounded-xl bg-z-surface-2 animate-pulse" />
+            <div className="h-[180px] rounded-xl bg-z-surface-2 animate-pulse" />
+            <div className="h-[180px] rounded-xl bg-z-surface-2 animate-pulse" />
+          </div>
+        </div>
+      }>
+        <PlanAccountsSection />
+      </Suspense>
     </>
   );
 }

--- a/webapp/src/components/plan/zones/plan-resumen-zone.tsx
+++ b/webapp/src/components/plan/zones/plan-resumen-zone.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { getPlanPageData } from "@/actions/plan";
 import { getCategoriesByRhythm } from "@/actions/categories";
 import { PlanHero } from "@/components/plan/plan-hero";
@@ -44,7 +43,7 @@ export async function PlanResumenZone({
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
             Módulos del plan
           </p>
-          <PlanTabNav activeTab={activeTab} />
+          <PlanTabNav activeTab={activeTab} month={month} />
         </div>
       </div>
 
@@ -62,18 +61,7 @@ export async function PlanResumenZone({
 
       <PlanScenarioPreview scenarios={planData.scenarios} />
 
-      <Suspense fallback={
-        <div className="space-y-4">
-          <div className="h-4 w-32 rounded bg-muted animate-pulse" />
-          <div className="grid gap-4 xl:grid-cols-3">
-            <div className="h-[180px] rounded-xl bg-z-surface-2 animate-pulse" />
-            <div className="h-[180px] rounded-xl bg-z-surface-2 animate-pulse" />
-            <div className="h-[180px] rounded-xl bg-z-surface-2 animate-pulse" />
-          </div>
-        </div>
-      }>
-        <PlanAccountsSection />
-      </Suspense>
+      <PlanAccountsSection />
     </>
   );
 }


### PR DESCRIPTION
- Fix PlanTabNav to preserve month query param when switching between tabs
- Add compact MonthSelector to non-resumen mobile tabs (was only visible on resumen)
- Create PlanAccountsSection server component showing account cards grouped by liquid/debt
- Embed accounts section at bottom of plan resumen zone (desktop + mobile)

https://claude.ai/code/session_01K5nK5dT5CbVxCsVmcWT6pt