### PR TITLE
feat: add account cards and month selector to debt page

### DIFF
--- a/webapp/src/app/(dashboard)/deudas/page.tsx
+++ b/webapp/src/app/(dashboard)/deudas/page.tsx
@@ -20,6 +20,7 @@ import type { CurrencyCode } from "@/types/domain";
 import { getPreferredCurrency } from "@/actions/profile";
 import { getRecentImpactEvents } from "@/actions/impact-events";
 import { AccountImpactTimeline } from "@/components/impact/account-impact-timeline";
+import { AccountsSection } from "@/components/accounts/accounts-section";
 import { computeDebtStats, getCurrentSalaryBreakdown, getMinPayment } from "@zeta/shared";
 import { getExchangeRate } from "@/actions/exchange-rate";
 import { ExchangeRateNudge } from "@/components/debt/exchange-rate-nudge";
@@ -241,7 +242,12 @@ export default async function DeudasPage({
   return (
     <div className="space-y-3 lg:space-y-8">
       {/* ── Mobile ── */}
-      <div className="lg:hidden">
+      <div className="lg:hidden space-y-4">
+        <div className="flex justify-center">
+          <Suspense fallback={<div className="h-9 w-40 rounded-md bg-z-surface-2 animate-pulse" />}>
+            <MonthSelector compact />
+          </Suspense>
+        </div>
         <Suspense
           fallback={
             <div className="space-y-3">
@@ -253,6 +259,7 @@ export default async function DeudasPage({
         >
           <MobileDebtSection currency={currency} month={month} />
         </Suspense>
+        <AccountsSection />
       </div>
 
       {/* ── Desktop ── */}
@@ -292,6 +299,8 @@ export default async function DeudasPage({
         </Suspense>
 
         <AccountImpactTimeline events={impactEvents} />
+
+        <AccountsSection />
       </div>
     </div>
   );

--- a/webapp/src/app/(dashboard)/deudas/page.tsx
+++ b/webapp/src/app/(dashboard)/deudas/page.tsx
@@ -15,7 +15,7 @@ import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { DeudasRoot } from "@/components/mobile/v2/deudas/deudas-root";
 import { PageHeaderRow } from "@/components/ui/page-header-row";
 import { Button } from "@/components/ui/button";
-import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS, MOBILE_TAB_BAR_CLEARANCE_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 import { getPreferredCurrency } from "@/actions/profile";
 import { getRecentImpactEvents } from "@/actions/impact-events";
@@ -242,7 +242,7 @@ export default async function DeudasPage({
   return (
     <div className="space-y-3 lg:space-y-8">
       {/* ── Mobile ── */}
-      <div className="lg:hidden space-y-4">
+      <div className={`lg:hidden space-y-4 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
         <div className="flex justify-center">
           <Suspense fallback={<div className="h-9 w-40 rounded-md bg-z-surface-2 animate-pulse" />}>
             <MonthSelector compact />
@@ -278,7 +278,7 @@ export default async function DeudasPage({
               <Button asChild variant="outline" className={GHOST_BUTTON_CLASS}>
                 <Link href="/plan">Volver a Plan</Link>
               </Button>
-              <Suspense>
+              <Suspense fallback={<div className="h-9 w-40 rounded-md bg-z-surface-2 animate-pulse" />}>
                 <MonthSelector />
               </Suspense>
             </>

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -16,7 +16,6 @@ import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 import { formatMonthLabel, parseMonth } from "@/lib/utils/date";
 import { PlanResumenZone } from "@/components/plan/zones/plan-resumen-zone";
 import { PlanMobileZone } from "@/components/plan/zones/plan-mobile-zone";
-import { PlanAccountsSection } from "@/components/plan/plan-accounts-section";
 import type { CurrencyCode } from "@/types/domain";
 
 const VALID_TABS: PlanTab[] = ["resumen", "presupuesto", "periodo", "recurrentes", "deseos"];
@@ -107,18 +106,15 @@ export default async function PlanPage({
       {/* ── Mobile ── */}
       <div className="lg:hidden">
         {isResumen ? (
-          <div className="space-y-6">
-            <Suspense fallback={mobileSkeleton}>
-              <PlanMobileZone
-                month={month}
-                currency={currency as CurrencyCode}
-                monthLabel={monthLabel}
-                periodoSummary={periodoSummary}
-                wishlistCount={wishlistSummary?.totalCount ?? 0}
-              />
-            </Suspense>
-            <PlanAccountsSection />
-          </div>
+          <Suspense fallback={mobileSkeleton}>
+            <PlanMobileZone
+              month={month}
+              currency={currency as CurrencyCode}
+              monthLabel={monthLabel}
+              periodoSummary={periodoSummary}
+              wishlistCount={wishlistSummary?.totalCount ?? 0}
+            />
+          </Suspense>
         ) : (
           <div className="mt-4 space-y-4">
             <div className="flex justify-center">

--- a/webapp/src/components/accounts/accounts-section.tsx
+++ b/webapp/src/components/accounts/accounts-section.tsx
@@ -7,7 +7,7 @@ import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { ArrowRight } from "lucide-react";
 
-export function PlanAccountsSection() {
+export function AccountsSection() {
   const accounts = useAccounts();
 
   if (accounts.length === 0) return null;

--- a/webapp/src/components/plan/zones/plan-resumen-zone.tsx
+++ b/webapp/src/components/plan/zones/plan-resumen-zone.tsx
@@ -6,7 +6,6 @@ import { PlanBudgetToggle } from "@/components/plan/plan-budget-toggle";
 import { PlanDebtSection } from "@/components/plan/plan-debt-section";
 import { PlanRecurringSection } from "@/components/plan/plan-recurring-section";
 import { PlanScenarioPreview } from "@/components/plan/plan-scenario-preview";
-import { PlanAccountsSection } from "@/components/plan/plan-accounts-section";
 import { PlanTabNav, type PlanTab } from "@/components/plan/plan-tab-nav";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -60,8 +59,6 @@ export async function PlanResumenZone({
       </div>
 
       <PlanScenarioPreview scenarios={planData.scenarios} />
-
-      <PlanAccountsSection />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Move `AccountsSection` (grouped account cards) from plan page to debt page — visible at the bottom on both mobile and desktop
- Add compact `MonthSelector` to mobile debt view (desktop already had one in the header)
- Remove account cards from plan page (resumen zone + mobile view)
- Rename `PlanAccountsSection` → `AccountsSection` and relocate to `components/accounts/` for reusability

## Test plan
- [ ] Open `/deudas` on desktop — account cards should appear below the impact timeline
- [ ] Open `/deudas` on mobile — month selector visible at top, account cards at bottom
- [ ] Navigate months on mobile debt page — data should update accordingly
- [ ] Open `/plan` — no account cards should appear (resumen or other tabs)
- [ ] Plan page month selector + tab navigation still works on mobile and desktop

https://claude.ai/code/session_01K5nK5dT5CbVxCsVmcWT6pt