### PR TITLE
feat(debt): month-aware debt overview

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -112,6 +112,12 @@
 - **What:** Auto-tag from destinatario during import — transactions inherit their matched destinatario's tags. Reconciliation merges also preserve existing tags. Batched for performance.
 - **Remaining:** Tags on recurring templates (needs `recurring_template_tags` migration + form changes + occurrence-to-tx tag copy). Nómina tag variants.
 
+### Accounts — `deactivated_at` timestamp
+- **Priority:** Medium
+- **What:** Add `deactivated_at` column to accounts table. When a user deactivates an account, store the date. Use in historical debt views to show "Cerrada en abril 2026" label on account cards. Currently only `is_active` boolean — no record of when.
+- **Migration:** 6-step encrypted table process (accounts is a view over `accounts_enc`). Spawn `supabase-migrator`.
+- **Found:** Debt page month selector work, 2026-04-15
+
 ### Categorization view enhancements
 - **Priority:** Medium
 - **What:** Show similar transactions when categorizing, more action options in the categorization inbox

--- a/mobile/lib/sync/pull.ts
+++ b/mobile/lib/sync/pull.ts
@@ -227,12 +227,12 @@ async function pullTable(
   }
 
   // Update sync metadata
-  const now = new Date().toISOString();
+  const syncedAt = new Date().toISOString();
   await db.runAsync(
     `INSERT INTO sync_metadata (table_name, last_synced_at)
      VALUES (?, ?)
      ON CONFLICT(table_name) DO UPDATE SET last_synced_at = excluded.last_synced_at`,
-    [table, now]
+    [table, syncedAt]
   );
 
   return upserted;

--- a/supabase/migrations/20260415220431_add_snapshot_user_period_index.sql
+++ b/supabase/migrations/20260415220431_add_snapshot_user_period_index.sql
@@ -1,0 +1,5 @@
+-- Index for getDebtOverviewForMonthCached: filters user_id + period_to <= X + ORDER BY period_to DESC.
+-- Without this, PostgreSQL seq-scans statement_snapshots_enc for every historical debt page load.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_statement_snapshots_enc_user_period
+  ON statement_snapshots_enc(user_id, period_to DESC NULLS LAST);

--- a/webapp/src/actions/debt.ts
+++ b/webapp/src/actions/debt.ts
@@ -8,9 +8,12 @@ import {
   calcUtilization,
   estimateMonthlyInterest,
   generateInsights,
+  sanitizeInterestRate,
   type DebtOverview,
+  type DebtAccount,
 } from "@zeta/shared";
 import type { CurrencyCode } from "@zeta/shared";
+import { toColombiaDateString } from "@/lib/utils/date";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -24,34 +27,19 @@ const EMPTY_DEBT_OVERVIEW: DebtOverview = {
   debtByCurrency: [],
 };
 
-// ─── Cached inner function ────────────────────────────────────────────────────
+/** Check if month string (YYYY-MM) is the current month or absent */
+function isCurrentMonth(month?: string): boolean {
+  if (!month) return true;
+  const current = toColombiaDateString(new Date()).slice(0, 7);
+  return month === current;
+}
 
-async function getDebtOverviewCached(
-  userId: string,
-  currency: CurrencyCode,
-  accessToken: string
-): Promise<DebtOverview> {
-  "use cache";
-  cacheTag("debt");
-  cacheLife("zeta");
+// ─── Build DebtOverview from DebtAccount[] ───────────────────────────────────
 
-  const supabase = createCachedClient(accessToken);
-  const baseCurrency = currency;
-
-  const { data: accounts, error } = await supabase
-    .from("accounts")
-    .select("*")
-    .eq("user_id", userId)
-    .eq("is_active", true)
-    .in("account_type", ["CREDIT_CARD", "LOAN"])
-    .order("display_order");
-
-  if (error) throw error;
-  if (!accounts) return EMPTY_DEBT_OVERVIEW;
-
-  const debtAccounts = extractDebtAccounts(accounts);
-
-  // Group debt totals by currency (using breakdowns when available)
+function buildOverview(
+  debtAccounts: DebtAccount[],
+  baseCurrency: CurrencyCode
+): DebtOverview {
   const byCurrency = new Map<CurrencyCode, { debt: number; limit: number }>();
   for (const a of debtAccounts) {
     if (a.currencyBreakdown) {
@@ -74,7 +62,6 @@ async function getDebtOverviewCached(
     totalCreditLimit: limit,
   }));
 
-  // Primary totals use baseCurrency if available, otherwise sum all
   const copEntry = byCurrency.get(baseCurrency);
   const totalDebt = copEntry ? copEntry.debt : debtAccounts.reduce((sum, a) => sum + a.balance, 0);
   const totalCreditLimit = copEntry
@@ -110,12 +97,132 @@ async function getDebtOverviewCached(
   };
 }
 
+// ─── Cached: current month (live account data) ──────────────────────────────
+
+async function getDebtOverviewLiveCached(
+  userId: string,
+  currency: CurrencyCode,
+  accessToken: string
+): Promise<DebtOverview> {
+  "use cache";
+  cacheTag("debt");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+
+  const { data: accounts, error } = await supabase
+    .from("accounts")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .in("account_type", ["CREDIT_CARD", "LOAN"])
+    .order("display_order");
+
+  if (error) throw error;
+  if (!accounts) return EMPTY_DEBT_OVERVIEW;
+
+  return buildOverview(extractDebtAccounts(accounts), currency);
+}
+
+// ─── Cached: past month (statement snapshots) ───────────────────────────────
+
+async function getDebtOverviewForMonthCached(
+  userId: string,
+  currency: CurrencyCode,
+  month: string,
+  accessToken: string
+): Promise<DebtOverview> {
+  "use cache";
+  cacheTag("debt", "snapshots");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+
+  // Parse month to get end-of-month date
+  const [year, mon] = month.split("-").map(Number);
+  const endOfMonth = new Date(year, mon, 0); // last day of month
+  const endStr = `${year}-${String(mon).padStart(2, "0")}-${String(endOfMonth.getDate()).padStart(2, "0")}`;
+
+  // Fetch debt accounts (for static fields: name, type, color, payment_day, etc.)
+  // and snapshots for the month in parallel
+  const [accountsResult, snapshotsResult] = await Promise.all([
+    supabase
+      .from("accounts")
+      .select("id, name, account_type, currency_code, payment_day, cutoff_day, color, institution_name, loan_amount, display_order")
+      .eq("user_id", userId)
+      .in("account_type", ["CREDIT_CARD", "LOAN"])
+      .order("display_order"),
+    supabase
+      .from("statement_snapshots")
+      .select("account_id, final_balance, remaining_balance, credit_limit, interest_rate, minimum_payment, total_payment_due, currency_code, period_to, initial_amount")
+      .eq("user_id", userId)
+      .lte("period_to", endStr)
+      .order("period_to", { ascending: false }),
+  ]);
+
+  if (accountsResult.error) throw accountsResult.error;
+  if (snapshotsResult.error) throw snapshotsResult.error;
+
+  const accounts = accountsResult.data ?? [];
+  const snapshots = snapshotsResult.data ?? [];
+
+  if (accounts.length === 0) return EMPTY_DEBT_OVERVIEW;
+
+  // Take the most recent snapshot per account (first seen wins since ordered DESC)
+  const latestSnap = new Map<string, (typeof snapshots)[number]>();
+  for (const snap of snapshots) {
+    if (!latestSnap.has(snap.account_id)) {
+      latestSnap.set(snap.account_id, snap);
+    }
+  }
+
+  // Build DebtAccount[] by merging static account data with snapshot financials
+  const debtAccounts: DebtAccount[] = [];
+  for (const acct of accounts) {
+    const snap = latestSnap.get(acct.id);
+    if (!snap) continue; // No snapshot data for this account in/before this month
+
+    const acctType = acct.account_type as "CREDIT_CARD" | "LOAN";
+    const balance = snap.final_balance ?? snap.remaining_balance ?? 0;
+
+    debtAccounts.push({
+      id: acct.id,
+      name: acct.name,
+      type: acctType,
+      balance: Math.abs(balance),
+      creditLimit: snap.credit_limit ?? null,
+      interestRate: sanitizeInterestRate(snap.interest_rate, acctType),
+      monthlyPayment: snap.minimum_payment ?? snap.total_payment_due ?? null,
+      paymentDay: acct.payment_day,
+      cutoffDay: acct.cutoff_day,
+      currency: (snap.currency_code ?? acct.currency_code) as CurrencyCode,
+      color: acct.color,
+      institutionName: acct.institution_name,
+      currencyBreakdown: null, // Snapshots don't have multi-currency breakdown
+      loanAmount: snap.initial_amount ?? acct.loan_amount,
+    });
+  }
+
+  if (debtAccounts.length === 0) return EMPTY_DEBT_OVERVIEW;
+  return buildOverview(debtAccounts, currency);
+}
+
 // ─── Public wrapper ───────────────────────────────────────────────────────────
 
-export async function getDebtOverview(currency?: CurrencyCode): Promise<DebtOverview> {
+export async function getDebtOverview(
+  currency?: CurrencyCode,
+  month?: string
+): Promise<DebtOverview> {
   const baseCurrency = currency ?? "COP";
   const { user, accessToken } = await getAuthenticatedClient();
 
   if (!user || !accessToken) return EMPTY_DEBT_OVERVIEW;
-  return getDebtOverviewCached(user.id, baseCurrency, accessToken);
+
+  if (isCurrentMonth(month)) {
+    return getDebtOverviewLiveCached(user.id, baseCurrency, accessToken);
+  }
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(month!)) {
+    return EMPTY_DEBT_OVERVIEW;
+  }
+  return getDebtOverviewForMonthCached(user.id, baseCurrency, month!, accessToken);
 }

--- a/webapp/src/actions/debt.ts
+++ b/webapp/src/actions/debt.ts
@@ -27,11 +27,11 @@ const EMPTY_DEBT_OVERVIEW: DebtOverview = {
   debtByCurrency: [],
 };
 
-/** Check if month string (YYYY-MM) is the current month or absent */
-function isCurrentMonth(month?: string): boolean {
+/** Check if month string (YYYY-MM) is the current or future month, or absent */
+function isCurrentOrFutureMonth(month?: string): boolean {
   if (!month) return true;
   const current = toColombiaDateString(new Date()).slice(0, 7);
-  return month === current;
+  return month >= current;
 }
 
 // ─── Build DebtOverview from DebtAccount[] ───────────────────────────────────
@@ -133,7 +133,7 @@ async function getDebtOverviewForMonthCached(
   accessToken: string
 ): Promise<DebtOverview> {
   "use cache";
-  cacheTag("debt", "snapshots");
+  cacheTag("snapshots");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
@@ -157,7 +157,8 @@ async function getDebtOverviewForMonthCached(
       .select("account_id, final_balance, remaining_balance, credit_limit, interest_rate, minimum_payment, total_payment_due, currency_code, period_to, initial_amount")
       .eq("user_id", userId)
       .lte("period_to", endStr)
-      .order("period_to", { ascending: false }),
+      .order("period_to", { ascending: false })
+      .limit(200),
   ]);
 
   if (accountsResult.error) throw accountsResult.error;
@@ -218,7 +219,7 @@ export async function getDebtOverview(
 
   if (!user || !accessToken) return EMPTY_DEBT_OVERVIEW;
 
-  if (isCurrentMonth(month)) {
+  if (isCurrentOrFutureMonth(month)) {
     return getDebtOverviewLiveCached(user.id, baseCurrency, accessToken);
   }
   if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(month!)) {

--- a/webapp/src/app/(dashboard)/deudas/page.tsx
+++ b/webapp/src/app/(dashboard)/deudas/page.tsx
@@ -44,7 +44,7 @@ async function MobileDebtSection({
   month: string | undefined;
 }) {
   const [overview, incomeEstimate, sourceAccountsResult, usdRateResult] = await Promise.all([
-    getDebtOverview(currency),
+    getDebtOverview(currency, month),
     getEstimatedIncome(currency, month),
     getNonDebtAccounts(),
     currency !== "USD" ? getExchangeRate("USD", currency) : Promise.resolve(null),
@@ -114,7 +114,7 @@ async function DesktopDebtSection({
   month: string | undefined;
 }) {
   const [overview, incomeEstimate, exchangeRateResult, sourceAccountsResult] = await Promise.all([
-    getDebtOverview(currency),
+    getDebtOverview(currency, month),
     getEstimatedIncome(currency, month),
     getExchangeRate("USD" as CurrencyCode, currency).catch(() => null),
     getNonDebtAccounts(),


### PR DESCRIPTION
## Summary
- Debt page month selector now updates **all metrics** (total debt, credit utilization, monthly payments, interest) — not just income
- For past months, queries `statement_snapshots` to reconstruct historical debt state
- Current month keeps existing live-data behavior (unchanged)
- Deactivated accounts still appear in past month views if they have snapshot data

## Changes
- `webapp/src/actions/debt.ts` — split into live + historical cached functions, added month param
- `webapp/src/app/(dashboard)/deudas/page.tsx` — pass `month` to `getDebtOverview()`
- `BACKLOG.md` — added `deactivated_at` column item for future "Cerrada en..." labels
- `supabase/migrations/` — index on `statement_snapshots_enc(user_id, period_to DESC)` for query perf

## Review agents ran
- **server-action-reviewer**: PASS — auth, defense-in-depth, cache tags all correct
- **cache-doctor**: PASS — found timezone bug in `isCurrentMonth()`, fixed with `toColombiaDateString()`
- **perf-auditor**: PASS — found 4 issues, all addressed (index, over-invalidation, unbounded query, future-month guard)
- **code-reviewer**: APPROVED — no blockers

## Test plan
- [ ] Navigate to `/deudas` — current month shows live data (unchanged)
- [ ] Switch to a past month with imported PDFs — metrics should reflect historical balances
- [ ] Switch to a month with no prior snapshots for any account — shows empty state
- [ ] For months where only some accounts have snapshots — shows only those accounts with data
- [ ] Verify credit utilization ring updates per month
- [ ] Import a PDF for a past month, then revisit that month — new data should appear (cache invalidated via "snapshots" tag)
- [ ] Future months route to live data (same as current month)

🤖 Generated with [Claude Code](https://claude.com/claude-code)