### PR TITLE
feat(email): copy & report buttons for email debug

### DIFF
--- a/webapp/src/components/settings/email-ingest-logs-card.tsx
+++ b/webapp/src/components/settings/email-ingest-logs-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronUp, Loader2, RefreshCw, ScrollText, X } from "lucide-react";
+import { ChevronDown, ChevronUp, ClipboardList, Copy, Loader2, RefreshCw, ScrollText, X } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -37,6 +37,22 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
   const [dismissingId, setDismissingId] = useState<string | null>(null);
 
   if (logs.length === 0) return null;
+
+  function buildReport(log: EmailIngestLog) {
+    return [
+      `## Error en ingesta de correo`,
+      ``,
+      `- **Remitente:** ${log.from_address || "(desconocido)"}`,
+      `- **Estado:** ${log.status}`,
+      `- **Fecha:** ${log.created_at}`,
+      log.error_message ? `- **Error:** ${log.error_message}` : null,
+      ``,
+      `### Contenido`,
+      `\`\`\``,
+      log.raw_body || "(sin contenido)",
+      `\`\`\``,
+    ].filter(Boolean).join("\n");
+  }
 
   const errorCount = logs.filter(
     (l) => l.status === "parse_failed" || l.status === "sender_rejected" || l.status === "pdf_parse_failed"
@@ -149,6 +165,18 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
                       <Button
                         size="icon"
                         variant="ghost"
+                        className="size-8 text-muted-foreground hover:text-amber-400"
+                        onClick={() => {
+                          navigator.clipboard.writeText(buildReport(log));
+                          toast.success("Reporte copiado — pégalo en un issue de GitHub");
+                        }}
+                        aria-label="Copiar reporte"
+                      >
+                        <ClipboardList className="size-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
                         className="size-8 text-muted-foreground hover:text-z-brass"
                         onClick={() => handleRetry(log.id)}
                         disabled={retryingId === log.id || dismissingId === log.id}
@@ -190,7 +218,21 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
                     )}
                     {log.raw_body && (
                       <div className="space-y-1">
-                        <p className="text-xs font-medium text-muted-foreground">Contenido recibido</p>
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs font-medium text-muted-foreground">Contenido recibido</p>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-6 text-muted-foreground hover:text-z-brass"
+                            onClick={() => {
+                              navigator.clipboard.writeText(log.raw_body!);
+                              toast.success("Contenido copiado");
+                            }}
+                            aria-label="Copiar contenido"
+                          >
+                            <Copy className="size-3" />
+                          </Button>
+                        </div>
                         <pre className="max-h-36 overflow-y-auto whitespace-pre-wrap rounded-md border border-white/6 bg-black/20 p-3 text-xs leading-relaxed">
                           {log.raw_body}
                         </pre>

--- a/webapp/src/components/settings/email-ingest-logs-card.tsx
+++ b/webapp/src/components/settings/email-ingest-logs-card.tsx
@@ -48,9 +48,9 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
       log.error_message ? `- **Error:** ${log.error_message}` : null,
       ``,
       `### Contenido`,
-      `\`\`\``,
-      log.raw_body || "(sin contenido)",
-      `\`\`\``,
+      `\`\`\`\``,
+      log.raw_body?.slice(0, 5000) || "(sin contenido)",
+      `\`\`\`\``,
     ].filter(Boolean).join("\n");
   }
 
@@ -129,6 +129,7 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
           {logs.map((log) => {
             const isExpanded = expanded.has(log.id);
             const isRetryable = RETRYABLE_STATUSES.has(log.status) && !!log.raw_body;
+            const isReportable = !!log.raw_body && (isRetryable || log.status === "pdf_parse_failed");
             const config = STATUS_CONFIG[log.status] ?? {
               label: log.status,
               className: "bg-white/6 text-muted-foreground",
@@ -160,48 +161,54 @@ export function EmailIngestLogsCard({ initialLogs }: EmailIngestLogsCardProps) {
                       </p>
                     </div>
                   </button>
-                  {isRetryable && (
+                  {(isReportable || isRetryable) && (
                     <div className="flex shrink-0 gap-1">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="size-8 text-muted-foreground hover:text-amber-400"
-                        onClick={() => {
-                          navigator.clipboard.writeText(buildReport(log));
-                          toast.success("Reporte copiado — pégalo en un issue de GitHub");
-                        }}
-                        aria-label="Copiar reporte"
-                      >
-                        <ClipboardList className="size-4" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="size-8 text-muted-foreground hover:text-z-brass"
-                        onClick={() => handleRetry(log.id)}
-                        disabled={retryingId === log.id || dismissingId === log.id}
-                        aria-label="Reintentar"
-                      >
-                        {retryingId === log.id ? (
-                          <Loader2 className="size-4 animate-spin" />
-                        ) : (
-                          <RefreshCw className="size-4" />
-                        )}
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="size-8 text-muted-foreground hover:text-destructive"
-                        onClick={() => handleDismiss(log.id)}
-                        disabled={retryingId === log.id || dismissingId === log.id}
-                        aria-label="Descartar"
-                      >
-                        {dismissingId === log.id ? (
-                          <Loader2 className="size-4 animate-spin" />
-                        ) : (
-                          <X className="size-4" />
-                        )}
-                      </Button>
+                      {isReportable && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="size-8 text-muted-foreground hover:text-amber-400"
+                          onClick={() => {
+                            navigator.clipboard.writeText(buildReport(log));
+                            toast.success("Reporte copiado — pégalo en un issue de GitHub");
+                          }}
+                          aria-label="Copiar reporte"
+                        >
+                          <ClipboardList className="size-4" />
+                        </Button>
+                      )}
+                      {isRetryable && (
+                        <>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-8 text-muted-foreground hover:text-z-brass"
+                            onClick={() => handleRetry(log.id)}
+                            disabled={retryingId === log.id || dismissingId === log.id}
+                            aria-label="Reintentar"
+                          >
+                            {retryingId === log.id ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              <RefreshCw className="size-4" />
+                            )}
+                          </Button>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-8 text-muted-foreground hover:text-destructive"
+                            onClick={() => handleDismiss(log.id)}
+                            disabled={retryingId === log.id || dismissingId === log.id}
+                            aria-label="Descartar"
+                          >
+                            {dismissingId === log.id ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              <X className="size-4" />
+                            )}
+                          </Button>
+                        </>
+                      )}
                     </div>
                   )}
                 </div>

--- a/webapp/src/components/settings/unrecognized-emails-card.tsx
+++ b/webapp/src/components/settings/unrecognized-emails-card.tsx
@@ -22,7 +22,7 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
   if (emails.length === 0) return null;
 
   function buildReport(email: UnrecognizedEmail) {
-    const body = email.text_body || email.html_body?.slice(0, 3000) || "(sin contenido)";
+    const body = (email.text_body || email.html_body)?.slice(0, 3000) || "(sin contenido)";
     const type = email.text_body ? "text" : "html";
     return [
       `## Correo no reconocido`,
@@ -33,9 +33,9 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
       `- **Tipo de cuerpo:** ${type}`,
       ``,
       `### Contenido`,
-      `\`\`\``,
+      `\`\`\`\``,
       body,
-      `\`\`\``,
+      `\`\`\`\``,
     ].filter(Boolean).join("\n");
   }
 

--- a/webapp/src/components/settings/unrecognized-emails-card.tsx
+++ b/webapp/src/components/settings/unrecognized-emails-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { AlertTriangle, ChevronDown, ChevronUp, Loader2, RefreshCw, X } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronUp, ClipboardList, Copy, Loader2, RefreshCw, X } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,24 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
   const [retryingId, setRetryingId] = useState<string | null>(null);
 
   if (emails.length === 0) return null;
+
+  function buildReport(email: UnrecognizedEmail) {
+    const body = email.text_body || email.html_body?.slice(0, 3000) || "(sin contenido)";
+    const type = email.text_body ? "text" : "html";
+    return [
+      `## Correo no reconocido`,
+      ``,
+      `- **Remitente:** ${email.from_address}`,
+      email.subject ? `- **Asunto:** ${email.subject}` : null,
+      `- **Fecha:** ${email.created_at}`,
+      `- **Tipo de cuerpo:** ${type}`,
+      ``,
+      `### Contenido`,
+      `\`\`\``,
+      body,
+      `\`\`\``,
+    ].filter(Boolean).join("\n");
+  }
 
   function toggleExpand(id: string) {
     setExpanded((prev) => {
@@ -110,6 +128,18 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
                     <Button
                       size="icon"
                       variant="ghost"
+                      className="size-8 text-muted-foreground hover:text-amber-400"
+                      onClick={() => {
+                        navigator.clipboard.writeText(buildReport(email));
+                        toast.success("Reporte copiado — pégalo en un issue de GitHub");
+                      }}
+                      aria-label="Copiar reporte"
+                    >
+                      <ClipboardList className="size-4" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
                       className="size-8 text-muted-foreground hover:text-z-brass"
                       onClick={() => handleRetry(email.id)}
                       disabled={retryingId === email.id || isPending}
@@ -142,7 +172,21 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
                   <div className="mt-3 space-y-2">
                     {email.text_body && (
                       <div className="space-y-1">
-                        <p className="text-xs font-medium text-muted-foreground">Texto plano</p>
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs font-medium text-muted-foreground">Texto plano</p>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-6 text-muted-foreground hover:text-z-brass"
+                            onClick={() => {
+                              navigator.clipboard.writeText(email.text_body!);
+                              toast.success("Contenido copiado");
+                            }}
+                            aria-label="Copiar contenido"
+                          >
+                            <Copy className="size-3" />
+                          </Button>
+                        </div>
                         <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap rounded-md border border-border/40 bg-black/20 p-3 text-xs leading-relaxed">
                           {email.text_body}
                         </pre>
@@ -150,7 +194,21 @@ export function UnrecognizedEmailsCard({ initialEmails }: UnrecognizedEmailsCard
                     )}
                     {email.html_body && !email.text_body && (
                       <div className="space-y-1">
-                        <p className="text-xs font-medium text-muted-foreground">HTML (sin texto plano)</p>
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs font-medium text-muted-foreground">HTML (sin texto plano)</p>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-6 text-muted-foreground hover:text-z-brass"
+                            onClick={() => {
+                              navigator.clipboard.writeText(email.html_body!);
+                              toast.success("Contenido copiado");
+                            }}
+                            aria-label="Copiar contenido"
+                          >
+                            <Copy className="size-3" />
+                          </Button>
+                        </div>
                         <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap rounded-md border border-border/40 bg-black/20 p-3 text-xs leading-relaxed">
                           {email.html_body.slice(0, 2000)}
                         </pre>


### PR DESCRIPTION
## Summary
- **Copy button** on expanded email content (raw_body, text_body, html_body) for quick clipboard grab
- **Report button** (ClipboardList icon) generates formatted markdown with sender, date, error, and body — ready to paste into a GitHub issue for parser debugging
- Added to both `EmailIngestLogsCard` (failed entries) and `UnrecognizedEmailsCard` (all entries)

## Test plan
- [ ] Open Settings → Email section
- [ ] Expand a failed ingest log → verify copy button copies raw_body
- [ ] Click report button (clipboard icon) on failed log → paste in text editor, verify markdown format
- [ ] Expand an unrecognized email → verify copy button copies text_body
- [ ] Click report button on unrecognized email → paste, verify includes subject/sender/body
- [ ] Toast messages appear on both actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)