### PR TITLE
fix(email): add QR inflow pattern to Bancolombia parser

### DIFF
--- a/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
+++ b/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
@@ -214,6 +214,22 @@ describe("parseBancolombiaEmail", () => {
     expect(result!.pattern_type).toBe("transferencia_recibida");
   });
 
+  // Pattern 12: QR received (INFLOW)
+  it("parses QR inflow (Recibiste por QR)", () => {
+    const line =
+      "Logo Bancolombia [https://bancolombia-email-wsuite.s3.amazonaws.com/templates/605ce7f68622a5425353ea51/img/header-logo.png]yellow-icon [https://bancolombia-email-wsuite.s3.amazonaws.com/templates/64e68b61fa57f445dc99747d/img/chulo.png] ¡Listo!Todo salió bien con tus movimientos Bancolombia: Recibiste $21,400.00 por QR de MATEO PEREZ HERNANDEZ en tu cuenta *4398 el 2026/04/15 a las 12:26. ¿Dudas? Llama al 018000931987. Estamos cerca.";
+    const result = parseBancolombiaEmail(line);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("INFLOW");
+    expect(result!.amount).toBe(21400);
+    expect(result!.merchant).toBe("MATEO PEREZ HERNANDEZ");
+    expect(result!.card_last4).toBe("4398");
+    expect(result!.card_type).toBe("Cta");
+    expect(result!.transaction_date).toBe("2026-04-15");
+    expect(result!.transaction_time).toBe("12:26");
+    expect(result!.pattern_type).toBe("qr_recibido");
+  });
+
   // Unrecognized emails
   it("returns null for non-Bancolombia email", () => {
     const line = "Your Amazon order has shipped!";

--- a/webapp/src/lib/parsers/bancolombia-email.ts
+++ b/webapp/src/lib/parsers/bancolombia-email.ts
@@ -21,6 +21,7 @@ export interface ParsedEmailTransaction {
     | "pago_recibido"
     | "nomina"
     | "avance"
+    | "qr_recibido"
     | "transferencia_recibida";
 }
 
@@ -267,6 +268,25 @@ const PATTERNS: PatternDef[] = [
       transaction_date: parseDateDMY(m[4]),
       transaction_time: m[3],
       pattern_type: "avance",
+    }),
+  },
+  // Pattern 12: QR received (INFLOW, YYYY/MM/DD date)
+  // "Recibiste $21,400.00 por QR de MATEO PEREZ HERNANDEZ en tu cuenta *4398 el 2026/04/15 a las 12:26"
+  {
+    type: "qr_recibido",
+    regex:
+      /Recibiste \$([\d.,]+) por QR de (.+?) en tu cuenta \*{1,2}(\d+) el (\d{4}\/\d{2}\/\d{2}) a las (\d{2}:\d{2})/,
+    extract: (m) => ({
+      direction: "INFLOW",
+      amount: parseAmount(m[1]),
+      currency: "COP",
+      merchant: m[2].trim(),
+      destination: null,
+      card_last4: m[3],
+      card_type: "Cta",
+      transaction_date: parseDateYMD(m[4]),
+      transaction_time: m[5],
+      pattern_type: "qr_recibido",
     }),
   },
   // Pattern 11: Transferencia recibida (incoming transfer — INFLOW)


### PR DESCRIPTION
## Summary
- Adds `qr_recibido` pattern to recognize Bancolombia QR inflow emails ("Recibiste $X por QR de [sender] en tu cuenta *XXXX")
- INFLOW direction, YYYY/MM/DD date format, sender as merchant
- Test covers actual email body from issue #158

Closes #158

## Test plan
- [x] `vitest run bancolombia-email.test.ts` — 18/18 pass
- [x] `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)