### PR TITLE
fix(cache): migrate revalidateTag → updateTag for immediate cache expiry

### DIFF
--- a/.claude/agents/cache-doctor.md
+++ b/.claude/agents/cache-doctor.md
@@ -36,12 +36,12 @@ tools:
   - mcp__plugin_context7_context7__query-docs
 ---
 
-You are a caching specialist for the Zeta personal finance app — a Next.js 15 (App Router) application backed by Supabase. Your job is to diagnose and fix stale UI bugs caused by cache/revalidation gaps.
+You are a caching specialist for the Zeta personal finance app — a Next.js 16 (App Router) application backed by Supabase. Your job is to diagnose and fix stale UI bugs caused by cache/revalidation gaps.
 
 ## Code Discovery Protocol
 
 1. **First**: Use `search_graph` or `search_code` to find mutation actions, cached functions, or revalidation calls
-2. **For call chains**: Use `trace_call_path` to map mutation → revalidateTag → cached function → component
+2. **For call chains**: Use `trace_call_path` to map mutation → updateTag → cached function → component
 3. **For snippets**: Use `get_code_snippet` to read just the relevant function
 4. **For docs**: Use `resolve-library-id` + `query-docs` to verify Next.js caching behavior when unsure
 5. **Fallback**: Use Grep only for literal text search (e.g., exact tag names)
@@ -49,67 +49,89 @@ You are a caching specialist for the Zeta personal finance app — a Next.js 15 
 
 ## Key Files
 
-- `webapp/src/lib/cache/revalidation.ts` — `revalidateFinancialViews()` central function
+- `webapp/src/lib/cache/revalidation.ts` — `revalidateFinancialViews()` central function (uses `updateTag`)
 - `webapp/src/lib/supabase/cached.ts` — `createCachedClient()` factory
 - `webapp/src/lib/supabase/auth.ts` — `getAuthenticatedClient()` (returns accessToken)
 - `webapp/src/hooks/use-live-metrics.ts` — live metrics pattern
 - `webapp/src/actions/live-dashboard.ts` — live dashboard data action
 
+## CRITICAL: `updateTag` vs `revalidateTag`
+
+Next.js 16 has **two** cache invalidation APIs with fundamentally different behavior:
+
+| | `updateTag(tag)` | `revalidateTag(tag, profile)` |
+|---|---|---|
+| **Where** | Server Actions only | Server Actions + Route Handlers |
+| **Behavior** | Immediately expires cache | Stale-while-revalidate (SWR) |
+| **Router Cache** | Clears entire client cache | Also clears, but may serve stale first |
+| **Use case** | Read-your-own-writes (mutations) | Background refresh (webhooks, ISR) |
+
+**ALL Server Action mutations MUST use `updateTag("tag")`.** Using `revalidateTag` in mutations causes SWR — stale data is served while fresh data loads in background. This silently breaks every mutation: summaries don't update, optimistic state gets overwritten, cross-page navigation shows old data.
+
+**Only use `revalidateTag` in Route Handlers** (webhooks, cron) where eventual consistency is acceptable.
+
+```ts
+// CORRECT — in Server Actions
+import { updateTag } from "next/cache";
+updateTag("transactions");
+
+// WRONG — serves stale data via SWR
+import { revalidateTag } from "next/cache";
+revalidateTag("transactions", "zeta");
+
+// CORRECT — in Route Handlers (webhooks)
+revalidateTag("email-ingest", "max");
+```
+
 ## CRITICAL: Never Use `router.refresh()` as a Fix
 
 **`router.refresh()` is a redundant network round-trip and must NEVER be part of your fix.** When a server action is called inside `startTransition` (including via `useActionState`), Next.js already:
-1. Executes the server action (which calls `revalidateTag` → invalidates Data Cache)
+1. Executes the server action (which calls `updateTag` → immediately expires Data Cache)
 2. Re-renders the route's Server Components with fresh data
 3. Streams the updated RSC payload to the client
 4. React reconciles — client components get updated props
 
-`router.refresh()` repeats this entire process for zero benefit. On pages with multiple parallel queries, it wastes a full server round-trip.
+`updateTag` also clears the Router Cache, so cross-page navigation gets fresh data too.
 
 **Correct fix patterns for stale UI:**
 - **Server action not in `startTransition`?** → Wrap it in `startTransition` or use `useActionState`
-- **Missing `revalidateTag` in the action?** → Add the tag invalidation
+- **Missing `updateTag` in the action?** → Add the tag invalidation
+- **Using `revalidateTag` instead of `updateTag`?** → Switch to `updateTag` (most common root cause)
 - **UI needs instant feedback before server responds?** → Add optimistic state (e.g., `useState` tracking pending IDs, filter them out immediately)
-- **Cross-page staleness?** → Use live metrics hooks (`useLiveDashboard` pattern), not `router.refresh()`
-- **Multi-step flows (import wizards)?** → `router.refresh()` is acceptable ONLY at the final step of multi-step flows where the user navigates away from the wizard overlay, since the wizard is not wrapped in a single `startTransition`
-
-**The only legitimate use of `router.refresh()` in Zeta is in multi-step import/wizard flows** where intermediate steps don't use `startTransition`. For all standard mutations (create, update, delete, categorize), `startTransition` + server action handles everything.
+- **Cross-page staleness?** → Verify `updateTag` is used (it clears Router Cache). If still stale, use live metrics hooks.
 
 ## Zeta's Cache Architecture
 
 ### Three Cache Layers
 
-1. **Data Cache** — server-side, keyed by `cacheTag()`. Functions marked `"use cache"` with `cacheTag("tag-name")` + `cacheLife("zeta")`. Invalidated by `revalidateTag("tag-name", "zeta")`.
+1. **Data Cache** — server-side, keyed by `cacheTag()`. Functions marked `"use cache"` with `cacheTag("tag-name")` + `cacheLife("zeta")`. Invalidated by `updateTag("tag-name")` (immediate) or `revalidateTag("tag-name", "max")` (SWR).
 
-2. **Route Cache** — client-side, 2 minutes (`stale: 120` in `cacheLife("zeta")`). Not invalidated by `revalidateTag`. Expires naturally or is bypassed by `router.refresh()` / live metrics hooks.
+2. **Router Cache** — client-side. Cleared by `updateTag` calls in Server Actions. Also expires naturally or is bypassed by full page navigation.
 
-3. **AppDataProvider Context** — React context in the dashboard layout. Preloads accounts, categories (all + outflow), destinatarios, and tag groups. Refreshed when `revalidateTag` triggers a layout re-render.
+3. **AppDataProvider Context** — React context in the dashboard layout. Preloads accounts, categories (all + outflow), destinatarios, and tag groups. Refreshed when `updateTag` triggers a layout re-render.
 
 ### cacheLife("zeta") Timings
 
 ```
-stale: 120      — Route Cache (2min client-side page caching)
-revalidate: 300 — Data Cache (5min background revalidation)
+stale: 120      — SWR window (only affects revalidateTag, NOT updateTag)
+revalidate: 300 — Time-based background revalidation (5min)
 expire: 3600    — Hard expire (1hr)
 ```
 
-`revalidateTag()` immediately invalidates Data Cache. Route Cache expires naturally or via live hooks.
-
-### revalidateTag Signature
-
-**CRITICAL**: `revalidateTag("tag", "zeta")` — the second argument is the `cacheLife` profile name, NOT a second tag. Always pass `"zeta"` as the second arg.
+`updateTag()` immediately expires the entry regardless of these timings. `stale: 120` only applies to `revalidateTag`-based invalidation (Route Handlers/webhooks).
 
 ### Central Revalidation Function
 
-`revalidateFinancialViews()` from `@/lib/cache/revalidation.ts` invalidates ALL financial tags:
+`revalidateFinancialViews()` from `@/lib/cache/revalidation.ts` expires ALL financial tags using `updateTag`:
 
 ```ts
-// Tags invalidated:
+// Tags expired:
 "transactions", "accounts", "dashboard:accounts", "dashboard:charts",
 "dashboard:budgets", "dashboard:cashflow", "dashboard:hero",
-"categorize", "debt", "budgets", "attention", "occurrences"
+"categorize", "debt", "budgets", "attention", "occurrences", "recurring"
 ```
 
-**Every transaction-mutating action MUST call this**, plus domain-specific extras (e.g., `revalidateTag("email-ingest", "zeta")`).
+**Every transaction-mutating action MUST call this**, plus domain-specific extras (e.g., `updateTag("email-ingest")`).
 
 ### Cached Client Pattern
 
@@ -129,20 +151,12 @@ async function myQueryCached(userId: string, accessToken: string) {
 
 **NEVER use `createAdminClient()` in cached functions** — the admin client has no JWT, so `zeta_decrypt()` returns NULL for all encrypted columns.
 
-The `accessToken` comes from `getAuthenticatedClient()` which returns `{ supabase, user, accessToken }`.
-
 ### Live Metrics Pattern
 
-For volatile data (amounts, counts that change with every transaction), the page loads instantly from Route Cache, then a client-side hook calls a server action on mount to silently correct stale values:
+For volatile data (amounts, counts that change with every transaction), the page loads instantly from cache, then a client-side hook calls a server action on mount to silently correct stale values:
 
 - `useLiveDashboard` from `@/hooks/use-live-metrics.ts` — mobile dashboard
 - `getLiveDashboardData()` from `@/actions/live-dashboard.ts` — hero + gasto hoy + attention
-
-For new volatile metrics on other pages: create similar hooks — one round-trip per page, not per metric.
-
-### Same-Page Freshness
-
-`startTransition` + server action auto-refreshes the route via React's built-in revalidation. This is the ONLY mechanism needed for same-page freshness. Do NOT add `router.refresh()` — it creates a redundant round-trip. Multi-step import wizards are the sole exception (see CRITICAL section above).
 
 ### AppDataProvider Context
 
@@ -150,7 +164,7 @@ Client components that need reference data (accounts, categories, destinatarios,
 - `useAccounts()`, `useCategories()`, `useOutflowCategories()`
 - `useDestinatarios()`, `useTagGroups()`, `useAllTags()`
 
-These are refreshed automatically when `revalidateTag` triggers a layout re-render. Never lazy-fetch this data from server actions in client components.
+These are refreshed automatically when `updateTag` triggers a layout re-render.
 
 ---
 
@@ -161,8 +175,8 @@ These are refreshed automatically when `revalidateTag` triggers a layout re-rend
 Ask (if not clear):
 - What data is stale? (dashboard totals, account balance, transaction list, etc.)
 - What mutation was performed? (create tx, import, edit, delete, etc.)
-- Does refreshing the page fix it? (yes = Route Cache issue; no = Data Cache issue)
-- Is it same-page or cross-page? (same-page = startTransition issue; cross-page = tag issue)
+- Does refreshing the page fix it? (yes = Router Cache or SWR issue; no = Data Cache issue)
+- Is it same-page or cross-page? (same-page = startTransition issue; cross-page = Router Cache or wrong API)
 
 ### Step 2: Trace the Mutation Path
 
@@ -173,8 +187,8 @@ Grep pattern: the mutation function name in webapp/src/actions/
 
 Check:
 1. Does it call `revalidateFinancialViews()`?
-2. Does it call domain-specific `revalidateTag("domain-tag", "zeta")`?
-3. Is the second arg to `revalidateTag` always `"zeta"`?
+2. Does it call domain-specific `updateTag("domain-tag")`?
+3. Is it using `updateTag` (NOT `revalidateTag`)?
 4. Is the mutation wrapped in `startTransition` on the client side?
 
 ### Step 3: Trace the Read Path
@@ -188,14 +202,14 @@ Check:
 1. Does it use `"use cache"` directive?
 2. Does it use `cacheTag()` + `cacheLife("zeta")`?
 3. Does it use `createCachedClient(accessToken)` (not `createAdminClient()`)?
-4. Is the tag included in `revalidateFinancialViews()` or explicitly invalidated by the mutation?
+4. Is the tag included in `revalidateFinancialViews()` or explicitly expired by the mutation?
 
 ### Step 4: Check the Client Component
 
 If the stale data appears in a client component:
 1. Does it use AppDataProvider hooks instead of lazy-fetching?
 2. Does it use the live metrics pattern for volatile data?
-3. Is the server action called inside `startTransition` or via `useActionState`? (This is what triggers the route re-render — NOT `router.refresh()`)
+3. Is the server action called inside `startTransition` or via `useActionState`?
 4. Does it need optimistic state for instant UI feedback?
 
 ### Step 5: Report & Fix
@@ -209,7 +223,7 @@ Output format:
 [What's stale and when]
 
 ### Root Cause
-[Which cache layer is stale and why]
+[Which cache layer is stale and why — check for revalidateTag vs updateTag first]
 
 ### Fix
 [Exact code changes needed]
@@ -224,16 +238,14 @@ Output format:
 
 | Symptom | Likely Cause | Fix |
 |---|---|---|
+| Data stale after mutation, manual refresh fixes | Using `revalidateTag` instead of `updateTag` | Switch to `updateTag` in the Server Action |
 | Dashboard shows old totals after creating tx | Missing `revalidateFinancialViews()` in the action | Add the call after the mutation |
-| Account balance stale after import | Missing `revalidateTag("accounts", "zeta")` | Already in `revalidateFinancialViews()` — check it's called |
-| Page shows stale data for ~2 min then updates | Route Cache (client-side) | Add live metrics hook for volatile data |
+| Cross-page navigation shows old data | Using `revalidateTag` (SWR) instead of `updateTag` | Switch to `updateTag` — it clears Router Cache |
 | Encrypted columns return NULL | Using `createAdminClient()` in cached function | Switch to `createCachedClient(accessToken)` |
-| New cached function never invalidates | Tag not in `revalidateFinancialViews()` | Add the tag, or add explicit `revalidateTag` in mutation |
-| Cross-page data stale | No `revalidateTag` for that domain | Add `revalidateTag("domain", "zeta")` in the mutation |
-| Same-page not updating | Mutation not in `startTransition` | Wrap in `startTransition` or use `useActionState` (do NOT add `router.refresh()`) |
-| Sibling list stale after mutation | Dual-source staleness — see below | Wrap server action in `startTransition` AND call client-side refetch |
-| UI updates after delay but not instantly | No optimistic state | Add optimistic state (e.g., track pending IDs in `useState`, filter them from display) |
-| `revalidateTag` not working | Wrong signature — missing `"zeta"` second arg | Always: `revalidateTag("tag", "zeta")` |
+| New cached function never invalidates | Tag not in `revalidateFinancialViews()` | Add the tag, or add explicit `updateTag` in mutation |
+| Same-page not updating | Mutation not in `startTransition` | Wrap in `startTransition` or use `useActionState` |
+| UI updates after delay but not instantly | No optimistic state | Add optimistic state (track pending IDs in `useState`) |
+| `revalidateTag` in Server Action | Wrong API — SWR serves stale data | Replace with `updateTag` |
 
 ---
 
@@ -241,51 +253,15 @@ Output format:
 
 A common bug in Zeta: a client component reads data from **two different sources** — server component props AND client-side state. A mutation updates one source but not the other.
 
-### The Problem
-
-```
-Server Component (PlanTabRecurrentes)
-  └─ fetches templates, accounts, occurrences
-  └─ passes as props to:
-      └─ Client Component (MobileRecurrentesView)
-           ├─ templates prop ← from server component (stale after mutation)
-           └─ occurrences ← from useState + refreshOccurrences() (fresh after refetch)
-```
-
-After `toggleRecurringTemplate()`:
-- `refreshOccurrences()` re-fetches occurrences → checklist updates ✓
-- `templates` prop still has old `is_active` → TemplatesSection shows "Pausada" ✗
-
 ### The Fix
 
-Wrap the server action call in `startTransition` so Next.js re-renders the server component tree (refreshing props), AND do the client-side refetch for local state:
-
-```ts
-startTransition(async () => {
-  const result = await toggleRecurringTemplate(template.id, true);
-  if (result.success) {
-    await hook.refreshOccurrences();  // updates client-side useState
-    setExpandedKey(null);
-    // startTransition triggers RSC re-render → fresh templates prop
-  } else {
-    toast.error(result.error ?? "Error");
-  }
-});
-```
+Wrap the server action call in `startTransition` so Next.js re-renders the server component tree (refreshing props), AND do the client-side refetch for local state.
 
 ### Where This Appears
 
-- **Recurrentes**: templates prop + occurrences state (fixed in `use-recurring-month.ts`)
-- **Movimientos**: transaction list (server prop) + pending queue (client state) — after import, pending queue clears but list doesn't show the new tx until page refresh
-- **Dashboard**: hero metrics (server prop) + live metrics (client hook) — live hook corrects on mount, but sibling components may show stale props
-
-### How to Diagnose
-
-1. Identify what data is stale
-2. Check: does it come from a server component prop or client-side state?
-3. If server component prop → the mutation handler needs `startTransition` wrapping
-4. If client-side state → the mutation handler needs an explicit refetch call
-5. If both → needs both (this is the dual-source pattern)
+- **Recurrentes**: templates prop + occurrences state
+- **Movimientos**: transaction list (server prop) + pending queue (optimistic client state)
+- **Dashboard**: hero metrics (server prop) + live metrics (client hook)
 
 ---
 
@@ -294,9 +270,9 @@ startTransition(async () => {
 Before reporting your diagnosis, verify:
 
 1. Did you read the actual mutation action code (not guess from memory)?
-2. Did you check the `revalidateTag` calls have the `"zeta"` second argument?
+2. Did you check it uses `updateTag` (NOT `revalidateTag`) in the Server Action?
 3. Did you trace from mutation → tag → cached function → component?
-4. Did you distinguish Data Cache (server) from Route Cache (client) issues?
+4. Did you distinguish Data Cache (server) from Router Cache (client) issues?
 5. Did you check for the cached client pattern if encrypted columns are involved?
-6. **Does your fix avoid `router.refresh()`?** If your fix includes `router.refresh()`, you are almost certainly wrong. The correct fix is `startTransition` + server action + optimistic state. The only exception is multi-step import wizards.
+6. **Does your fix avoid `router.refresh()`?** The correct fix is `updateTag` + `startTransition` + optimistic state.
 7. Did you clean up unused imports/declarations introduced by your changes?

--- a/.claude/agents/server-action-reviewer.md
+++ b/.claude/agents/server-action-reviewer.md
@@ -13,7 +13,7 @@ description: >
   <example>
   Context: Developer reports that a mutation doesn't seem to trigger cache refresh.
   user: "After editing a destinatario, the list still shows the old name"
-  assistant: "Let me use server-action-reviewer to check if the action calls revalidateTag with the correct signature."
+  assistant: "Let me use server-action-reviewer to check if the action calls updateTag with the correct signature."
   </example>
 model: opus
 tools:
@@ -30,7 +30,7 @@ tools:
   - mcp__plugin_context7_context7__query-docs
 ---
 
-You are a server action reviewer for the Zeta personal finance app — a Next.js 15 (App Router) application backed by Supabase. Your job is to audit server actions for security, correctness, and cache invalidation compliance.
+You are a server action reviewer for the Zeta personal finance app — a Next.js 16 (App Router) application backed by Supabase. Your job is to audit server actions for security, correctness, and cache invalidation compliance.
 
 ## Code Discovery Protocol
 
@@ -166,7 +166,30 @@ Read-only actions can return data directly (no ActionResult wrapper needed).
 
 ---
 
-## Check 5: Cache Invalidation (HIGH)
+## Check 5: Cache Invalidation (CRITICAL)
+
+### `updateTag` vs `updateTag`
+
+Next.js 16 has two invalidation APIs. **Server Actions MUST use `updateTag`:**
+
+| | `updateTag(tag)` | `revalidateTag(tag, profile)` |
+|---|---|---|
+| Where | Server Actions only | Server Actions + Route Handlers |
+| Behavior | Immediately expires cache | Stale-while-revalidate (SWR) |
+| Router Cache | Clears entire client cache | Also clears, but may serve stale first |
+| Use case | Read-your-own-writes | Background refresh (webhooks) |
+
+Using `revalidateTag` in Server Actions causes SWR — stale data served while refreshing in background. This silently breaks mutations.
+
+```ts
+// CORRECT — in Server Actions
+import { updateTag } from "next/cache";
+updateTag("transactions");
+
+// WRONG — serves stale data via SWR
+import { revalidateTag } from "next/cache";
+revalidateTag("transactions", "zeta");
+```
 
 ### After Transaction Mutations
 
@@ -175,44 +198,33 @@ Any action that creates, updates, or deletes transactions MUST call:
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 
 // After mutation:
-revalidateFinancialViews();
+revalidateFinancialViews();  // uses updateTag internally
 ```
 
 Plus domain-specific extras:
 ```ts
-revalidateTag("email-ingest", "zeta");  // if email import
-revalidateTag("snapshots", "zeta");     // if statement snapshots affected
-```
-
-### revalidateTag Signature
-
-**CRITICAL**: Always `revalidateTag("tag", "zeta")`. The second arg is the `cacheLife` profile name, NOT a second tag.
-
-```ts
-// CORRECT
-revalidateTag("accounts", "zeta");
-
-// WRONG — missing profile
-revalidateTag("accounts");
-
-// WRONG — second arg is not a profile
-revalidateTag("accounts", "dashboard");
+updateTag("email-ingest");  // if email import
+updateTag("snapshots");     // if statement snapshots affected
 ```
 
 ### After Non-Transaction Mutations
 
 Actions that mutate accounts, categories, destinatarios, budgets, etc. must call relevant tags:
 ```ts
-revalidateTag("accounts", "zeta");
-revalidateTag("categorize", "zeta");
-revalidateTag("budgets", "zeta");
+updateTag("accounts");
+updateTag("categorize");
+updateTag("budgets");
 // etc.
 ```
 
-**Flag as HIGH:**
+### Naming conflict in `tags.ts`
+
+`tags.ts` exports a domain function named `updateTag()`. Use import alias: `import { updateTag as expireTag } from "next/cache"`.
+
+**Flag as CRITICAL:**
+- `revalidateTag` used in a Server Action (must be `updateTag`)
 - Transaction mutation without `revalidateFinancialViews()`
-- `revalidateTag` without `"zeta"` second argument
-- Mutation with no revalidation at all
+- Mutation with no cache invalidation at all
 
 ---
 
@@ -349,7 +361,7 @@ const handleResume = () => {
 Before reporting:
 1. Did you read every action file in scope (not just grep matches)?
 2. Did you check auth + defense-in-depth + revalidation for EVERY mutation?
-3. Did you verify `revalidateTag` signature includes `"zeta"`?
+3. Did you verify mutations use `updateTag` (not `revalidateTag`)?
 4. Did you check for `z.string().uuid()` usage?
 5. Did you check income calculations exclude debt inflows?
 6. Did you check client-side mutation handlers wrap server actions in `startTransition` when the page has server component props that depend on the mutated data?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Spawn these specialized agents for domain-specific review and diagnosis. Each ha
 - **Cached client pattern**: `"use cache"` functions use `createCachedClient(accessToken)` from `@/lib/supabase/cached` — never `createAdminClient()` (encrypted columns return NULL).
 - **Live metrics for volatile data**: `useLiveDashboard` pattern — page loads from Route Cache, client hook silently corrects stale values on mount.
 - **Cache invalidation**: Transaction mutations → `revalidateFinancialViews()`. Same-page → `startTransition`. Cross-page → live metrics hooks.
-- **cacheLife("zeta")**: stale 120s / revalidate 300s / expire 3600s. `revalidateTag("tag", "zeta")` — second arg is cacheLife profile, not a second tag.
+- **cacheLife("zeta")**: stale 120s / revalidate 300s / expire 3600s. **Mutations MUST use `updateTag("tag")` (from `next/cache`), NOT `revalidateTag`.** `updateTag` immediately expires cache for read-your-own-writes. `revalidateTag` uses stale-while-revalidate — serves old data while refreshing in background, which silently breaks every mutation. `updateTag` also clears the Router Cache so cross-page navigation is fresh. Only use `revalidateTag` in Route Handlers (webhooks, cron) where eventual consistency is acceptable.
 - Spawn `cache-doctor` for stale UI diagnosis.
 
 ## UI Rules

--- a/webapp/src/actions/accounts.ts
+++ b/webapp/src/actions/accounts.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { accountSchema } from "@/lib/validators/account";
@@ -183,11 +183,11 @@ export async function createAccount(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("debt", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:hero");
+  updateTag("debt");
+  updateTag("attention");
   return { success: true, data: result };
 }
 
@@ -218,11 +218,11 @@ export async function updateAccount(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("debt", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:hero");
+  updateTag("debt");
+  updateTag("attention");
   return { success: true, data: result };
 }
 
@@ -235,11 +235,11 @@ export async function deleteAccount(id: string): Promise<ActionResult> {
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("debt", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:hero");
+  updateTag("debt");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -259,9 +259,9 @@ export async function toggleDashboardVisibility(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:hero");
   return { success: true, data: undefined };
 }
 
@@ -418,10 +418,10 @@ export async function reconcileBalance(
 
   if (updateError) return { success: false, error: updateError.message };
 
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("debt", "zeta");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:hero");
+  updateTag("debt");
   return {
     success: true,
     data: {
@@ -567,10 +567,10 @@ export async function registerPayment(
     }
   }
 
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("debt", "zeta");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:hero");
+  updateTag("debt");
   return { success: true, data: null };
 }
 

--- a/webapp/src/actions/budget.ts
+++ b/webapp/src/actions/budget.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import type { ActionResult } from "@/types/actions";
 
@@ -35,8 +35,8 @@ export async function setBudgetMode(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("budgets");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -63,9 +63,9 @@ export async function upsertBudgetForCategory(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("budgets");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -94,9 +94,9 @@ export async function bulkUpsertBudgets(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("budgets");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data: null };
 }
 

--- a/webapp/src/actions/budgets.ts
+++ b/webapp/src/actions/budgets.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getIsDemoFilter, getDemoAccountIds } from "@/lib/demo-filter";
@@ -140,9 +140,9 @@ export async function upsertBudget(
 
     if (error) return { success: false, error: error.message };
 
-    revalidateTag("budgets", "zeta");
-    revalidateTag("dashboard:budgets", "zeta");
-    revalidateTag("attention", "zeta");
+    updateTag("budgets");
+    updateTag("dashboard:budgets");
+    updateTag("attention");
     return { success: true, data };
 }
 
@@ -155,8 +155,8 @@ export async function deleteBudget(id: string): Promise<ActionResult> {
 
     if (error) return { success: false, error: error.message };
 
-    revalidateTag("budgets", "zeta");
-    revalidateTag("dashboard:budgets", "zeta");
-    revalidateTag("attention", "zeta");
+    updateTag("budgets");
+    updateTag("dashboard:budgets");
+    updateTag("attention");
     return { success: true, data: undefined };
 }

--- a/webapp/src/actions/capture-tokens.ts
+++ b/webapp/src/actions/capture-tokens.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { randomBytes } from "crypto";
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import type { ActionResult } from "@/types/actions";
 
@@ -54,7 +54,7 @@ export async function createCaptureToken(
     .single();
 
   if (error) return { success: false, error: error.message };
-  revalidateTag("capture-tokens", "zeta");
+  updateTag("capture-tokens");
   return { success: true, data: data as CaptureToken };
 }
 
@@ -108,7 +108,7 @@ export async function createTelegramLink(
     });
 
   if (error) return { success: false, error: error.message };
-  revalidateTag("capture-tokens", "zeta");
+  updateTag("capture-tokens");
 
   return {
     success: true,
@@ -130,6 +130,6 @@ export async function revokeCaptureToken(tokenId: string): Promise<ActionResult<
     .eq("user_id", user.id);
 
   if (error) return { success: false, error: error.message };
-  revalidateTag("capture-tokens", "zeta");
+  updateTag("capture-tokens");
   return { success: true, data: null };
 }

--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag, cacheTag, cacheLife } from "next/cache";
+import { updateTag, cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import {
@@ -300,7 +300,7 @@ export async function createPlanningPeriod(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: data as PlanningPeriod };
 }
 
@@ -320,7 +320,7 @@ export async function deletePlanningPeriod(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: null };
 }
 
@@ -434,7 +434,7 @@ export async function seedPeriodFromRecurring(
     if (insertErr) return { success: false, error: insertErr.message };
   }
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: { created: entriesToInsert.length } };
 }
 
@@ -481,7 +481,7 @@ export async function createPlanningEntry(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: data as PlanningEntry };
 }
 
@@ -526,7 +526,7 @@ export async function updatePlanningEntry(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: data as PlanningEntry };
 }
 
@@ -544,7 +544,7 @@ export async function deletePlanningEntry(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: null };
 }
 
@@ -566,7 +566,7 @@ export async function toggleEntryStatus(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: null };
 }
 
@@ -680,7 +680,7 @@ export async function createAssignment(
     return { success: false, error: error.message };
   }
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: data as PlanningAssignment };
 }
 
@@ -778,7 +778,7 @@ export async function updateAssignment(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: data as PlanningAssignment };
 }
 
@@ -796,7 +796,7 @@ export async function deleteAssignment(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: null };
 }
 
@@ -879,6 +879,6 @@ export async function autoAssignExpenses(
     if (error) return { success: false, error: error.message };
   }
 
-  revalidateTag(TAG, "zeta");
+  updateTag(TAG);
   return { success: true, data: { assigned: assignedCount } };
 }

--- a/webapp/src/actions/categories.ts
+++ b/webapp/src/actions/categories.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -488,11 +488,11 @@ export async function createCategory(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("categories");
+  updateTag("budgets");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data };
 }
 
@@ -529,11 +529,11 @@ export async function updateCategory(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("categories");
+  updateTag("budgets");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data };
 }
 
@@ -551,7 +551,7 @@ export async function deleteCategory(id: string): Promise<ActionResult> {
   if (error) return { success: false, error: error.message };
 
   revalidateFinancialViews();
-  revalidateTag("categories", "zeta");
+  updateTag("categories");
   return { success: true, data: undefined };
 }
 
@@ -584,11 +584,11 @@ export async function updateCategoryOrder(
     return { success: false, error: "Error actualizando el orden de las categorías" };
   }
 
-  revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("categories");
+  updateTag("budgets");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -607,11 +607,11 @@ export async function updateCategoryExpenseType(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("categories");
+  updateTag("budgets");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -645,7 +645,7 @@ export async function reassignAndDeleteCategory(
   if (deleteError) return { success: false, error: deleteError.message };
 
   revalidateFinancialViews();
-  revalidateTag("categories", "zeta");
+  updateTag("categories");
   return { success: true, data: undefined };
 }
 
@@ -664,11 +664,11 @@ export async function toggleCategoryActive(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("categories", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("categories");
+  updateTag("budgets");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/categorize.ts
+++ b/webapp/src/actions/categorize.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
@@ -282,7 +282,7 @@ export async function categorizeTransaction(
   }
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
   return { success: true, data: undefined };
 }
 
@@ -415,7 +415,7 @@ export async function bulkCategorize(
   }
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
   return { success: true, data: { categorized } };
 }
 
@@ -498,7 +498,7 @@ export async function assignDestinatario(
   }
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
   return { success: true, data: undefined };
 }
 
@@ -597,7 +597,7 @@ export async function bulkApplyDestinatarioMatches(
   );
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
 
   return { success: true, data: { applied: results.reduce((sum, n) => sum + n, 0) } };
 }
@@ -622,6 +622,6 @@ export async function removeDestinatarioFromTransaction(
   }
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
   return { success: true, data: undefined };
 }

--- a/webapp/src/actions/dashboard-config.ts
+++ b/webapp/src/actions/dashboard-config.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { dashboardConfigSchema } from "@/lib/validators/dashboard-config";
 import type { DashboardConfig } from "@/types/dashboard-config";
@@ -25,7 +25,7 @@ export async function updateDashboardConfig(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("dashboard-config", "zeta");
+  updateTag("dashboard-config");
   return { success: true, data: parsed.data };
 }
 

--- a/webapp/src/actions/demo.ts
+++ b/webapp/src/actions/demo.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { computeIdempotencyKey } from "@zeta/shared";
 import { DEMO_ACCOUNTS, getDemoTransactions, DEMO_BUDGETS } from "@/lib/demo-data";
@@ -195,15 +195,15 @@ async function seedDemoDataInternal(
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function revalidateAllTags() {
-  revalidateTag("profile", "zeta");
-  revalidateTag("accounts", "zeta");
-  revalidateTag("transactions", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:cashflow", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("debt", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("profile");
+  updateTag("accounts");
+  updateTag("transactions");
+  updateTag("dashboard:hero");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:cashflow");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:budgets");
+  updateTag("budgets");
+  updateTag("debt");
+  updateTag("attention");
 }

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
@@ -423,8 +423,8 @@ export async function createDestinatario(
       .from("destinatario_rules")
       .insert(rules);
     if (rulesError) {
-      revalidateTag("destinatarios", "zeta");
-      revalidateTag("attention", "zeta");
+      updateTag("destinatarios");
+      updateTag("attention");
       return { success: true, data: { ...data, linked_count: 0 } };
     }
   }
@@ -495,8 +495,8 @@ export async function createDestinatario(
     revalidateFinancialViews();
   }
 
-  revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("destinatarios");
+  updateTag("attention");
   return { success: true, data: { ...data, linked_count: linkedCount } };
 }
 
@@ -531,8 +531,8 @@ export async function updateDestinatario(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("destinatarios");
+  updateTag("attention");
   return { success: true, data };
 }
 
@@ -553,8 +553,8 @@ export async function patchDestinatario(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("destinatarios");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -574,8 +574,8 @@ export async function deleteDestinatario(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("destinatarios");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -621,7 +621,7 @@ export async function mergeDestinatarios(
   if (deleteError) return { success: false, error: deleteError.message };
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
   return { success: true, data: undefined };
 }
 
@@ -681,8 +681,8 @@ export async function addDestinatarioRule(
     return { success: false, error: error.message };
   }
 
-  revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("destinatarios");
+  updateTag("attention");
   return { success: true, data, conflicts };
 }
 
@@ -702,8 +702,8 @@ export async function removeDestinatarioRule(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("destinatarios", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("destinatarios");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -1087,7 +1087,7 @@ export async function bulkLinkToDestinatario(
   }
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
   return { success: true, data: { linked: linkedCount ?? transactionIds.length, categorized } };
 }
 
@@ -1285,7 +1285,7 @@ export async function applyDestinatarioRules(
   }
 
   revalidateFinancialViews();
-  revalidateTag("destinatarios", "zeta");
+  updateTag("destinatarios");
 
   return { success: true, data: { linked: matchingIds.length, categorized } };
 }

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { nanoid } from "nanoid";
 import {
@@ -132,7 +133,7 @@ async function persistParsedEmail(params: {
 
     if (insertError) {
       if (insertError.code === "23505") {
-        revalidateTag("email-ingest", "zeta");
+        updateTag("email-ingest");
         return { success: true, data: "duplicate" };
       }
       return { success: false, error: insertError.message };
@@ -164,7 +165,7 @@ async function persistParsedEmail(params: {
     }
 
     revalidateFinancialViews();
-    revalidateTag("email-ingest", "zeta");
+    updateTag("email-ingest");
     return { success: true, data: "imported" };
   }
 
@@ -180,13 +181,13 @@ async function persistParsedEmail(params: {
 
   if (queueError) {
     if (queueError.code === "23505") {
-      revalidateTag("email-ingest", "zeta");
+      updateTag("email-ingest");
       return { success: true, data: "duplicate" };
     }
     return { success: false, error: queueError.message };
   }
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: "queued" };
 }
 
@@ -209,22 +210,39 @@ export async function getEmailIngestAddress(): Promise<
   return { success: true, data: data as EmailIngestAddress | null };
 }
 
-export async function getPendingEmailTransactions(): Promise<
-  ActionResult<PendingEmailTransaction[]>
-> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+async function getPendingEmailTransactionsCached(
+  userId: string,
+  accessToken: string,
+): Promise<PendingEmailTransaction[]> {
+  "use cache";
+  cacheTag("email-ingest");
+  cacheLife("zeta");
 
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("pending_email_transactions")
     .select("*")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .eq("status", "pending")
     .order("created_at", { ascending: false })
     .limit(50);
 
-  if (error) return { success: false, error: error.message };
-  return { success: true, data: (data ?? []) as PendingEmailTransaction[] };
+  if (error) throw error;
+  return (data ?? []) as PendingEmailTransaction[];
+}
+
+export async function getPendingEmailTransactions(): Promise<
+  ActionResult<PendingEmailTransaction[]>
+> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+
+  try {
+    const data = await getPendingEmailTransactionsCached(user.id, accessToken);
+    return { success: true, data };
+  } catch {
+    return { success: false, error: "Error al obtener transacciones pendientes" };
+  }
 }
 
 export async function getPendingEmailCount(): Promise<ActionResult<number>> {
@@ -378,7 +396,7 @@ export async function retryUnrecognizedEmail(
 
   if (updateError) return { success: false, error: updateError.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: persistResult.data };
 }
 
@@ -480,7 +498,7 @@ export async function retryEmailIngestLog(
     console.error("[retryEmailIngestLog] log status update failed:", updateError);
   }
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: persistResult.data };
 }
 
@@ -498,7 +516,7 @@ export async function dismissEmailIngestLog(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }
 
@@ -530,7 +548,7 @@ export async function generateIngestAddress(): Promise<ActionResult<EmailIngestA
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: data as EmailIngestAddress };
 }
 
@@ -558,7 +576,7 @@ export async function updateIngestSettings(params: {
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: data as EmailIngestAddress };
 }
 
@@ -574,7 +592,7 @@ export async function deactivateIngestAddress(): Promise<ActionResult<null>> {
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }
 
@@ -590,7 +608,7 @@ export async function clearGmailVerification(): Promise<ActionResult<null>> {
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }
 
@@ -728,8 +746,8 @@ export async function approveEmailTransaction(
         .update({ status: "imported" })
         .eq("id", pendingId)
         .eq("user_id", user.id);
-      revalidateTag("email-ingest", "zeta");
-      revalidateTag("dashboard:hero", "zeta");
+      updateTag("email-ingest");
+      updateTag("dashboard:hero");
       return { success: true, data: null };
     }
     return { success: false, error: insertError.message };
@@ -811,7 +829,7 @@ export async function approveEmailTransaction(
   if (updateError) return { success: false, error: updateError.message };
 
   revalidateFinancialViews();
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }
 
@@ -939,8 +957,8 @@ export async function dismissEmailTransaction(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("email-ingest");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -1013,7 +1031,7 @@ export async function addAllowedSender(
     return { success: false, error: error.message };
   }
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: data as AllowedSender };
 }
 
@@ -1029,6 +1047,6 @@ export async function removeAllowedSender(id: string): Promise<ActionResult<null
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -240,7 +240,8 @@ export async function getPendingEmailTransactions(): Promise<
   try {
     const data = await getPendingEmailTransactionsCached(user.id, accessToken);
     return { success: true, data };
-  } catch {
+  } catch (error) {
+    console.error("Error fetching pending email transactions:", error);
     return { success: false, error: "Error al obtener transacciones pendientes" };
   }
 }

--- a/webapp/src/actions/email-pdf-ingest.ts
+++ b/webapp/src/actions/email-pdf-ingest.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { parsePdfBuffer } from "@/lib/email-ingest/pdf-handler";
@@ -68,7 +68,7 @@ export async function dismissEmailPdfStatement(
     await admin.storage.from("email-pdfs").remove([row.storage_path]);
   }
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }
 
@@ -165,7 +165,7 @@ export async function retryPdfParsing(
     return { success: false, error: result.error };
   }
 
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }
 
@@ -201,6 +201,6 @@ export async function markEmailPdfStatementImported(
   }
 
   revalidateFinancialViews();
-  revalidateTag("email-ingest", "zeta");
+  updateTag("email-ingest");
   return { success: true, data: null };
 }

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import {
   computeSnapshotDiffs,
@@ -1116,9 +1116,9 @@ export async function importTransactions(
   }
 
   revalidateFinancialViews();
-  revalidateTag("snapshots", "zeta");
-  revalidateTag("impact", "zeta");
-  revalidateTag("tags", "zeta");
+  updateTag("snapshots");
+  updateTag("impact");
+  updateTag("tags");
 
   await trackProductEvent({
     event_name: "import_completed",

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import "server-only";
-import { revalidateTag, cacheTag, cacheLife } from "next/cache";
+import { updateTag, cacheTag, cacheLife } from "next/cache";
 import { addDays, startOfMonth, endOfMonth, parseISO } from "date-fns";
 import { toColombiaDateString } from "@/lib/utils/date";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
@@ -408,7 +408,7 @@ async function deactivateOnceTemplate(
     .eq("user_id", userId);
 
   if (deactivateErr) console.error("Failed to deactivate ONCE template:", deactivateErr.message);
-  revalidateTag("recurring", "zeta");
+  updateTag("recurring");
 }
 
 /**
@@ -448,7 +448,7 @@ export async function markOccurrencePaid(
   }
 
   revalidateFinancialViews();
-  revalidateTag("occurrences", "zeta");
+  updateTag("occurrences");
   return { success: true, data: undefined };
 }
 
@@ -485,7 +485,7 @@ export async function skipOccurrence(occurrenceId: string): Promise<ActionResult
   }
 
   revalidateFinancialViews();
-  revalidateTag("occurrences", "zeta");
+  updateTag("occurrences");
   return { success: true, data: undefined };
 }
 
@@ -642,8 +642,8 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
   }
 
   revalidateFinancialViews();
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("recurring", "zeta");
+  updateTag("occurrences");
+  updateTag("recurring");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/onboarding.ts
+++ b/webapp/src/actions/onboarding.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { Database, type Json } from "@/types/database";
 import type { DashboardConfig } from "@/types/dashboard-config";
 
@@ -76,8 +76,8 @@ export async function finishOnboarding(
         throw new Error("Failed to finalize onboarding setup. Please try again.");
     }
 
-    revalidateTag("profile", "zeta");
-    revalidateTag("accounts", "zeta");
-    revalidateTag("dashboard:hero", "zeta");
-    revalidateTag("dashboard:accounts", "zeta");
+    updateTag("profile");
+    updateTag("accounts");
+    updateTag("dashboard:hero");
+    updateTag("dashboard:accounts");
 }

--- a/webapp/src/actions/profile.ts
+++ b/webapp/src/actions/profile.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag, cacheTag, cacheLife } from "next/cache";
+import { updateTag, cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import type { ActionResult } from "@/types/actions";
@@ -103,7 +103,7 @@ export async function updateProfile(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("profile", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
+  updateTag("profile");
+  updateTag("dashboard:hero");
   return { success: true, data };
 }

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag, cacheTag, cacheLife } from "next/cache";
+import { updateTag, cacheTag, cacheLife } from "next/cache";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
@@ -298,10 +298,10 @@ export async function createRecurringTemplate(
 
   await ensureCurrentOccurrences();
 
-  revalidateTag("recurring", "zeta");
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("recurring");
+  updateTag("occurrences");
+  updateTag("dashboard:hero");
+  updateTag("attention");
   return { success: true, data };
 }
 
@@ -371,10 +371,10 @@ export async function updateRecurringTemplate(
 
   await ensureCurrentOccurrences();
 
-  revalidateTag("recurring", "zeta");
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("recurring");
+  updateTag("occurrences");
+  updateTag("dashboard:hero");
+  updateTag("attention");
   return { success: true, data };
 }
 
@@ -393,10 +393,10 @@ export async function deleteRecurringTemplate(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("recurring", "zeta");
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("recurring");
+  updateTag("occurrences");
+  updateTag("dashboard:hero");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -418,10 +418,10 @@ export async function toggleRecurringTemplate(
 
   await ensureCurrentOccurrences();
 
-  revalidateTag("recurring", "zeta");
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("recurring");
+  updateTag("occurrences");
+  updateTag("dashboard:hero");
+  updateTag("attention");
   return { success: true, data: undefined };
 }
 
@@ -890,9 +890,9 @@ export async function recordRecurringOccurrencePayment(input: {
   });
 
   revalidateFinancialViews();
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("recurring", "zeta");
-  revalidateTag("impact", "zeta");
+  updateTag("occurrences");
+  updateTag("recurring");
+  updateTag("impact");
 
   return {
     success: true,

--- a/webapp/src/actions/reminders.ts
+++ b/webapp/src/actions/reminders.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { cache } from "react";
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { reminderSchema } from "@/lib/validators/reminders";
 import { toISODateString } from "@/lib/utils/date";
@@ -92,8 +92,8 @@ export async function createReminder(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("reminders", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("reminders");
+  updateTag("attention");
   return { success: true, data: { id: data.id } };
 }
 
@@ -127,8 +127,8 @@ export async function toggleReminder(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("reminders", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("reminders");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -162,8 +162,8 @@ export async function updateReminder(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("reminders", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("reminders");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -185,8 +185,8 @@ export async function postponeReminder(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("reminders", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("reminders");
+  updateTag("attention");
   return { success: true, data: null };
 }
 
@@ -204,7 +204,7 @@ export async function deleteReminder(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("reminders", "zeta");
-  revalidateTag("attention", "zeta");
+  updateTag("reminders");
+  updateTag("attention");
   return { success: true, data: null };
 }

--- a/webapp/src/actions/scenarios.ts
+++ b/webapp/src/actions/scenarios.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag, cacheTag, cacheLife } from "next/cache";
+import { updateTag, cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { saveScenarioSchema, type SaveScenarioInput } from "@/lib/validators/scenario";
@@ -88,7 +88,7 @@ export async function saveScenario(
     if (error) {
       return { success: false, error: "No se pudo actualizar el escenario" };
     }
-    revalidateTag("debt", "zeta");
+    updateTag("debt");
     return { success: true, data: updated };
   } else {
     // Create new
@@ -101,7 +101,7 @@ export async function saveScenario(
     if (error) {
       return { success: false, error: "No se pudo guardar el escenario" };
     }
-    revalidateTag("debt", "zeta");
+    updateTag("debt");
     return { success: true, data: created };
   }
 }
@@ -119,6 +119,6 @@ export async function deleteScenario(id: string): Promise<ActionResult<void>> {
   if (error) {
     return { success: false, error: "No se pudo eliminar el escenario" };
   }
-  revalidateTag("debt", "zeta");
+  updateTag("debt");
   return { success: true, data: undefined };
 }

--- a/webapp/src/actions/tags.ts
+++ b/webapp/src/actions/tags.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { cache } from "react";
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag as expireTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { tagGroupSchema, tagSchema, generateSlug } from "@/lib/validators/tags";
@@ -239,7 +239,7 @@ export async function createTagGroup(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   return { success: true, data: { id: data.id } };
 }
 
@@ -265,7 +265,7 @@ export async function updateTagGroup(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   return { success: true, data: null };
 }
 
@@ -282,7 +282,7 @@ export async function deleteTagGroup(id: string): Promise<ActionResult<null>> {
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   return { success: true, data: null };
 }
 
@@ -322,7 +322,7 @@ export async function createTag(
     return { success: false, error: error.message };
   }
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   return { success: true, data: { id: data.id } };
 }
 
@@ -357,7 +357,7 @@ export async function updateTag(
     return { success: false, error: error.message };
   }
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   return { success: true, data: null };
 }
 
@@ -374,7 +374,7 @@ export async function deleteTag(id: string): Promise<ActionResult<null>> {
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   return { success: true, data: null };
 }
 
@@ -421,13 +421,13 @@ export async function addTagToEntity(
     return { success: false, error: error.message };
   }
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   if (entityType === "transaction") {
-    revalidateTag("categorize", "zeta");
-    revalidateTag("transactions", "zeta");
+    expireTag("categorize");
+    expireTag("transactions");
   }
-  if (entityType === "destinatario") revalidateTag("destinatarios", "zeta");
-  if (entityType === "category") revalidateTag("categories", "zeta");
+  if (entityType === "destinatario") expireTag("destinatarios");
+  if (entityType === "category") expireTag("categories");
   return { success: true, data: null };
 }
 
@@ -454,13 +454,13 @@ export async function removeTagFromEntity(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("tags", "zeta");
+  expireTag("tags");
   if (entityType === "transaction") {
-    revalidateTag("categorize", "zeta");
-    revalidateTag("transactions", "zeta");
+    expireTag("categorize");
+    expireTag("transactions");
   }
-  if (entityType === "destinatario") revalidateTag("destinatarios", "zeta");
-  if (entityType === "category") revalidateTag("categories", "zeta");
+  if (entityType === "destinatario") expireTag("destinatarios");
+  if (entityType === "category") expireTag("categories");
   return { success: true, data: null };
 }
 
@@ -501,8 +501,8 @@ export async function bulkTagTransactions(
 
   if (error) return { success: false, error: error.message };
 
-  revalidateTag("tags", "zeta");
-  revalidateTag("categorize", "zeta");
-  revalidateTag("transactions", "zeta");
+  expireTag("tags");
+  expireTag("categorize");
+  expireTag("transactions");
   return { success: true, data: { tagged: uniqueIds.length } };
 }

--- a/webapp/src/actions/wishlist.ts
+++ b/webapp/src/actions/wishlist.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife, revalidateTag } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import {
   analyzePurchaseDecision,
   calcUtilization,
@@ -76,7 +76,7 @@ function getNearestDays(dates: string[]): number | null {
 }
 
 function invalidateWishlist() {
-  revalidateTag("wishlist", "zeta");
+  updateTag("wishlist");
 }
 
 // ─── Cached inner functions ─────────────────────────────────────────────────

--- a/webapp/src/components/import/step-results.tsx
+++ b/webapp/src/components/import/step-results.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   CheckCircle,
   AlertTriangle,
@@ -237,7 +238,7 @@ export function StepResults({
 
       <div className="flex items-center gap-3">
         <Button asChild>
-          <a href="/transactions">Ver transacciones</a>
+          <Link href="/transactions">Ver transacciones</Link>
         </Button>
         <Button variant="outline" onClick={onReset}>
           Importar otro extracto

--- a/webapp/src/components/import/step-results.tsx
+++ b/webapp/src/components/import/step-results.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import {
   CheckCircle,
   AlertTriangle,
@@ -238,7 +237,7 @@ export function StepResults({
 
       <div className="flex items-center gap-3">
         <Button asChild>
-          <Link href="/transactions">Ver transacciones</Link>
+          <a href="/transactions">Ver transacciones</a>
         </Button>
         <Button variant="outline" onClick={onReset}>
           Importar otro extracto

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -77,18 +77,41 @@ export function MovimientosHerramientas({
   const isActive = (zone: ToolZone) => activeZone === zone;
 
   const activeAccent = activeZone ? accentStyles[activeZone] : null;
-  const pendingEmailCount = pendingEmails.length;
 
   // Optimistic: track IDs categorized from the detail panel so both
   // the chip count and the item list update immediately.
   const [categorizedIds, setCategorizedIds] = useState(() => new Set<string>());
 
-  // Reset optimistic state when server data refreshes (new props)
+  // Optimistic: track IDs imported/dismissed so chip count + list update immediately.
+  const [importProcessedIds, setImportProcessedIds] = useState(() => new Set<string>());
+
+  // Only reset optimistic state when server confirms the categorization
+  // (processed IDs no longer appear in the incoming uncategorized list).
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- categorizedIds read is synchronous
   useEffect(() => {
-    setCategorizedIds(new Set());
+    if (categorizedIds.size === 0) return;
+    const incomingIds = new Set(uncategorizedTransactions.map((tx) => tx.id));
+    const anyStillUncategorized = [...categorizedIds].some((id) => incomingIds.has(id));
+    if (!anyStillUncategorized) {
+      setCategorizedIds(new Set());
+    }
   }, [uncategorizedTransactions]);
 
+  // Only reset optimistic state when server confirms changes (processed IDs
+  // are no longer in the incoming data). If stale data still includes them,
+  // keep the optimistic state to avoid visual flicker.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- importProcessedIds read is synchronous; re-running on its change would cause extra cycles
+  useEffect(() => {
+    if (importProcessedIds.size === 0) return;
+    const incomingIds = new Set(pendingEmails.map((e) => e.id));
+    const anyStillPending = [...importProcessedIds].some((id) => incomingIds.has(id));
+    if (!anyStillPending) {
+      setImportProcessedIds(new Set());
+    }
+  }, [pendingEmails]);
+
   const optimisticCount = Math.max(0, uncategorizedCount - categorizedIds.size);
+  const optimisticPendingCount = Math.max(0, pendingEmails.length - importProcessedIds.size);
 
   return (
     <MobileZone eyebrow="HERRAMIENTAS">
@@ -131,13 +154,13 @@ export function MovimientosHerramientas({
           aria-expanded={isActive("importar")}
         >
           <p className="text-[22px] font-[680] leading-tight text-z-sage">
-            {pendingEmailCount}
+            {optimisticPendingCount}
           </p>
           <p className="mt-0.5 text-[10px] font-semibold text-muted-foreground">
             Importar
           </p>
           <p className="mt-1 text-[9px] text-z-sage">
-            {pendingEmailCount > 0 ? `${pendingEmailCount} emails` : "Subir PDF"}
+            {optimisticPendingCount > 0 ? `${optimisticPendingCount} emails` : "Subir PDF"}
           </p>
         </button>
       </div>
@@ -185,6 +208,21 @@ export function MovimientosHerramientas({
                     pendingEmails={pendingEmails}
                     accounts={accounts}
                     currency={currency}
+                    processedIds={importProcessedIds}
+                    onProcess={(ids: string[]) =>
+                      setImportProcessedIds((prev) => {
+                        const next = new Set(prev);
+                        for (const id of ids) next.add(id);
+                        return next;
+                      })
+                    }
+                    onRollback={(ids: string[]) =>
+                      setImportProcessedIds((prev) => {
+                        const next = new Set(prev);
+                        for (const id of ids) next.delete(id);
+                        return next;
+                      })
+                    }
                   />
                 )}
               </div>
@@ -295,7 +333,6 @@ function CategorizarDetail({
           },
         });
       } else {
-        // Rollback optimistic removal
         onOptimisticRollback(tx.id);
         toast.error(result.error ?? "Error al categorizar");
       }
@@ -430,16 +467,24 @@ function ImportarDetail({
   pendingEmails,
   accounts,
   currency,
+  processedIds,
+  onProcess,
+  onRollback,
 }: {
   pendingEmails: PendingEmailTransaction[];
   accounts: Pick<Account, "id" | "name" | "currency_code">[];
   currency: CurrencyCode;
+  processedIds: Set<string>;
+  onProcess: (ids: string[]) => void;
+  onRollback: (ids: string[]) => void;
 }) {
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [accountOverrides, setAccountOverrides] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
-  const items = pendingEmails.slice(0, MAX_ITEMS);
-  const totalCount = pendingEmails.length;
+
+  const visibleEmails = pendingEmails.filter((e) => !processedIds.has(e.id));
+  const items = visibleEmails.slice(0, MAX_ITEMS);
+  const totalCount = visibleEmails.length;
 
   function parseTx(raw: unknown): ParsedEmailTransaction | null {
     if (!raw || typeof raw !== "object") return null;
@@ -448,22 +493,26 @@ function ImportarDetail({
 
   function handleApprove(id: string) {
     const overrideAccountId = accountOverrides[id];
+    onProcess([id]);
     startTransition(async () => {
       const result = await approveEmailTransaction(id, overrideAccountId);
       if (result.success) {
         toast.success("Importada");
       } else {
+        onRollback([id]);
         toast.error(result.error ?? "Error al importar");
       }
     });
   }
 
   function handleDismiss(id: string) {
+    onProcess([id]);
     startTransition(async () => {
       const result = await dismissEmailTransaction(id);
       if (result.success) {
         toast.success("Descartada");
       } else {
+        onRollback([id]);
         toast.error(result.error ?? "Error al descartar");
       }
     });
@@ -471,9 +520,11 @@ function ImportarDetail({
 
   function handleBulkApprove() {
     const ids = pendingEmails.map((e) => e.id);
+    onProcess(ids);
     startTransition(async () => {
       let approved = 0;
       let failed = 0;
+      const failedIds: string[] = [];
 
       for (const id of ids) {
         const overrideAccountId = accountOverrides[id];
@@ -484,10 +535,16 @@ function ImportarDetail({
             approved++;
           } else {
             failed++;
+            failedIds.push(id);
           }
         } catch {
           failed++;
+          failedIds.push(id);
         }
+      }
+
+      if (failedIds.length > 0) {
+        onRollback(failedIds);
       }
 
       if (failed === 0) {

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -1,31 +1,29 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 
 /**
- * Revalidate all financial Data Cache entries. Call after any mutation
- * that creates, updates, or deletes transactions.
+ * Immediately expire all financial Data Cache entries. Call after any
+ * mutation that creates, updates, or deletes transactions.
  *
- * Does NOT invalidate Route Cache — volatile UI metrics use client-side
- * live refresh instead (see useLiveMetrics hook).
+ * Uses `updateTag` (not `revalidateTag`) for read-your-own-writes —
+ * the user sees their change immediately, no stale-while-revalidate.
+ * Also clears the client Router Cache so cross-page navigation is fresh.
  *
  * Callers should add domain-specific extras after calling this:
  *   revalidateFinancialViews();
- *   revalidateTag("email-ingest", "zeta");   // domain extra
- *
- * NOTE: revalidateTag(tag, profile) — the second arg is the cacheLife
- * profile name ("zeta"), NOT a second tag. Always pass "zeta".
+ *   updateTag("email-ingest");   // domain extra
  */
 export function revalidateFinancialViews() {
-  revalidateTag("transactions", "zeta");
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("dashboard:cashflow", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("categorize", "zeta");
-  revalidateTag("debt", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("attention", "zeta");
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("recurring", "zeta");
+  updateTag("transactions");
+  updateTag("accounts");
+  updateTag("dashboard:accounts");
+  updateTag("dashboard:charts");
+  updateTag("dashboard:budgets");
+  updateTag("dashboard:cashflow");
+  updateTag("dashboard:hero");
+  updateTag("categorize");
+  updateTag("debt");
+  updateTag("budgets");
+  updateTag("attention");
+  updateTag("occurrences");
+  updateTag("recurring");
 }


### PR DESCRIPTION
## Summary

- **Root cause**: Next.js 16 `revalidateTag(tag, profile)` uses stale-while-revalidate (SWR) — serves old data while refreshing in background. All Server Action mutations were using this API, causing stale UI after every mutation (import, categorize, edit, delete).
- **Fix**: Migrate ~150 `revalidateTag` calls to `updateTag` — immediately expires cache, clears Router Cache, enables read-your-own-writes.
- Cache `getPendingEmailTransactions()` with `"use cache"` + `cacheTag("email-ingest")` so tag invalidation works.
- Add optimistic state for email import queue (instant chip count + list updates).
- Update `cache-doctor` and `server-action-reviewer` agents with `updateTag` guidance.

## Files changed (27)

| Area | Files | Change |
|------|-------|--------|
| Core | `revalidation.ts` | `revalidateTag` → `updateTag` (13 tags) |
| Actions (21) | All `src/actions/*.ts` | `revalidateTag("tag","zeta")` → `updateTag("tag")` |
| Import flow | `step-results.tsx` | `<Link>` → `<a>` to bypass Router Cache |
| Movimientos | `movimientos-herramientas.tsx` | Optimistic state for import queue |
| Email ingest | `email-ingest.ts` | Cache `getPendingEmailTransactions` |
| Agents | `cache-doctor.md`, `server-action-reviewer.md` | Document `updateTag` vs `revalidateTag` |
| Docs | `CLAUDE.md` | Update cache invalidation rules |

## Test plan

- [ ] Import email transaction from movimientos → tx removed from pending, appears in tx list immediately
- [ ] Import from dashboard → navigate to movimientos → data is fresh (not stale)
- [ ] Complete PDF import wizard → click "Ver transacciones" → new txs visible
- [ ] Categorize from movimientos tools → count updates, summary refreshes
- [ ] Bulk import all pending → all items removed, toast shows count
- [ ] Webhook email arrives → pending count updates on next navigation (SWR OK for webhooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)