### PR TITLE
feat(mobile): live plan execution, cashflow chart, dark theme, sync fixes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,12 +10,6 @@
 
 ---
 
-## In Review
-
-| PR | Description | Branch |
-|---|---|---|
-| — | Recurring impact preview + recurring income + account detail redesign | `feat/recurring-impact-income` |
-
 ## Features
 
 ### Account detail page — deferred items
@@ -23,94 +17,20 @@
 - **What:** Statement snapshots visual redesign, auto-populate `card_brand` from PDF parsers, composite `(account_id, user_id, transaction_date)` index, use `useAccounts()` hook instead of server-side `getAccounts()` in QuickActionsBar
 - **Context:** Shipped card hero, flip-to-graph, transaction-based balance history, transfer dialog, quick actions. Deferred items noted by perf-auditor and design reviews.
 
-### Income occurrence UX — different actions from expenses
-- **Priority:** Done (this branch)
-- **What:** Direction-aware labels: "Confirmar ingreso" / "Ya recibí" for INFLOW, "Confirmar pago" / "Ya pagué" for OUTFLOW. Covers confirm inline, timeline, toasts, and attention fallback labels.
-- **Remaining:** Skip/delete option for clearing occurrences without marking received — deferred.
-
-### Undo completed occurrences
-- **Priority:** Done (this branch)
-- **What:** Revert paid/skipped occurrences back to pending. For paid: deletes transactions via `recurrence_group_id`, reverses balance deltas. For skipped: resets status. "Deshacer" button on each completed item.
-
-### Template active state — query-side filtering
-- **Priority:** Done (implemented in this branch)
-- **What:** Paused template occurrences are filtered at query time via `is_active` check in `getPendingOccurrencesCached` and `getNextIncomeOccurrenceCached`. No destructive status changes — occurrences stay `pending`, just invisible when template is paused. Reactivating brings them back automatically.
-- **Found:** Visual testing, 2026-04-13
-
-### Mobile recurring admin actions
-- **Priority:** Done (this branch)
-- **What:** MoreVertical (⋮) button on each occurrence row opens bottom Sheet with Edit, Pause/Activate, Delete. Reuses RecurringFormDialog and RecurringImpactDialog from desktop.
-- **Remaining:** Edit dialog opens behind the action sheet (nested Radix portal). Needs to close Sheet first, then open Dialog sequentially. Full recurring form also needs mobile redesign.
-
-### Manual transaction-to-recurring matching
-- **Priority:** Done (this branch)
-- **What:** Manual link from both sides: occurrence → transaction picker, transaction → occurrence picker. Smart undo via `linked_manually` flag. Bottom drawer with ranked match scoring.
-- **Spec:** `docs/superpowers/specs/2026-04-14-manual-tx-recurring-linking.md`
-
 ### Recurring stats — historical backfill
 - **Priority:** Medium
 - **What:** Template stats (YTD, streak, annual estimate) are empty for newly created templates. Options: (1) backfill from `statement_snapshots` minimum payments or balance changes, (2) when creating a recurring template, auto-create historical occurrences as "paid" based on matching past transactions, (3) use snapshot history alongside occurrence history for the metrics.
 - **Context:** `getTemplateStats()` in `actions/template-stats.ts` only queries `recurring_occurrences`. New templates have no occurrences yet even if the user has been paying for months.
 - **Found:** User feedback, 2026-04-14
 
-### Email import — stale transaction lists after import
-- **Priority:** Medium
-- **What:** Importing pending email transactions removes them from queue but transaction lists (movimientos + dashboard) don't update. Desktop "Pendientes por correo" card also stays stale. Need page refresh.
-- **Context:** Revalidation from email import action may not cover all transaction list cache tags.
-- **Found:** User testing, 2026-04-14
-
-### "Vincular a recurrente" in movimientos expanded view
-- **Priority:** Medium
-- **What:** The "Vincular a recurrente" action was added to inicio-activity (dashboard) but not to the movimientos (transactions) mobile expanded view. Need to add it there too.
-- **Found:** User testing, 2026-04-14
-
-### Merge recurrentes pages into one
-- **Priority:** Medium
-- **What:** Two separate recurrentes views (plan tab + standalone page) is confusing. They offer different things. Unify into a single page with all features (checklist + admin actions + templates).
-- **Found:** User feedback, 2026-04-14
-
-### Plan page mobile — grid navigation instead of list
-- **Priority:** Medium
-- **What:** The "Ir a" section on the plan page mobile view shows Presupuesto, Periodo, Recurrentes, Deseos as a vertical list of link cards. Replace with a 2x2 grid of buttons for better visual density and scannability.
-- **Found:** User feedback, 2026-04-14
-
-### Dashboard ritmo/burn-rate stale after income received
-- **Priority:** Medium
-- **What:** After linking a nómina (income) to a recurring occurrence, the dashboard ritmo card and burn-rate chart don't update to reflect the new pay-cycle window. "Próximo ingreso" still shows the just-received income instead of advancing to the next one. "día 14 de 30" doesn't shift. Need page refresh.
-- **Context:** `linkExistingTransactionToOccurrence` calls `revalidateFinancialViews()` which should invalidate `dashboard:hero` and `burn-rate` tags. The issue is likely that `useLiveDashboard` or the Route Cache doesn't pick up the change until a full page refresh.
-- **Found:** User testing, 2026-04-14
-
 ### Recurring checklist — unify inline expand + action drawer
 - **Priority:** Medium
 - **What:** The plan tab checklist has two disconnected interaction patterns: (1) tap row → inline payment form with flat buttons, (2) tap ⋮ → bottom Sheet with chip-style admin actions. They look like different apps. Unify into a single cohesive pattern — either improve inline to match chip style with small confirmation Sheet, or merge both into one bottom drawer per-item.
 - **Found:** Visual testing, 2026-04-14
 
-### Debt payment category — distinguish CREDIT_CARD vs LOAN
-- **Priority:** Medium
-- **What:** All debt payments auto-assign `CATEGORY_OBLIGACIONES` (parent). Should distinguish: CREDIT_CARD → "Pago tarjeta" subcategory, LOAN → "Cuota crédito" subcategory. Three changes needed: (1) add seed subcategories for "Pago tarjeta" and "Cuota crédito" under Obligaciones if they don't exist, (2) allow category picker in RecurringForm for debt accounts (pre-select correct subcategory based on `account_type`), (3) update `recordRecurringOccurrencePayment` to use template's `category_id` instead of hardcoded `DEBT_PAYMENT_CATEGORY_ID`.
-- **Context:** Currently `category_id` is forced to `null` on template create (lines 277/351 in recurring-templates.ts), and payment recording hardcodes `DEBT_PAYMENT_CATEGORY_ID` (line 650). User already has manual subcategories mapped correctly.
-- **Found:** User feedback, 2026-04-14
-
 ### Audit effectiveDirection usage across app
-- **Priority:** Low
-- **What:** The recurring manager introduced `effectiveDirection()` (INFLOW to debt account = expense, not income). Audit the whole app for places that classify by raw `template.direction` without checking account type — dashboards, budget calculations, income metrics, etc.
-- **Found:** Bug fix during recurring manager development, 2026-04-14
-
-
-### Income-aware runway & daily budget
-- **Priority:** Done (shipped in PR #134)
-- **What:** Dashboard hero and runway use pay-cycle budgeting (now → next income date). Obligations scoped to window. Burn-rate chart shows single segment with obligation markers.
-- **Context:** Spec: `docs/superpowers/specs/2026-04-13-income-aware-runway.md`
-
-### Multi-currency aggregation in dashboard metrics
 - **Priority:** Done (this branch)
-- **What:** Dashboard hero, burn rate, runway, and net worth now aggregate all currencies by converting to base via `getRatesForCurrencies()`. Accounts/obligations with unavailable rates are excluded (not mixed raw). UI shows "tasa del día" hint when conversions are included.
-- **Known limitation:** Net worth history steps backward using single-currency cashflow, so the foreign portion floats as a constant — acceptable approximation for now.
-
-### Tag system broader reach
-- **Priority:** Partial (this branch)
-- **What:** Auto-tag from destinatario during import — transactions inherit their matched destinatario's tags. Reconciliation merges also preserve existing tags. Batched for performance.
-- **Remaining:** Tags on recurring templates (needs `recurring_template_tags` migration + form changes + occurrence-to-tx tag copy). Nómina tag variants.
+- **What:** Audited all `direction === "INFLOW"` usages. Fixed 3 bugs where raw template direction was used without debt account check: `plan-flow-timeline.tsx` (icon/color), `attention-items.ts` (fallback label), `recurring-template-card.tsx` (grid layout + pause button visibility). Transaction-level displays are correct (actual money flow per account).
 
 ### Accounts — `deactivated_at` timestamp
 - **Priority:** Medium
@@ -132,7 +52,11 @@
 - **Priority:** Medium
 - **What:** Same action chip pattern (destinatario, tag, edit) for desktop table rows. Migrate desktop consumers from old pickers (`destinatario-picker.tsx`, `tag-picker.tsx`) to zone pickers, then delete old files.
 - **Context:** PR #130 only covers mobile. Desktop table still uses inline category popover only.
-- **Blocked by:** PR #130 merge
+
+### Tag system broader reach — remaining items
+- **Priority:** Medium
+- **What:** Tags on recurring templates (needs `recurring_template_tags` migration + form changes + occurrence-to-tx tag copy). Nómina tag variants.
+- **Context:** Auto-tag from destinatario during import shipped in PR #138. This is the remaining work.
 
 ### Mobile app — Apple compliance (pre-submission)
 - **Priority:** High (blocks App Store submission)
@@ -162,18 +86,6 @@
 - **Found:** Mobile audit, 2026-04-15
 
 ## Tech Debt
-
-### Defense-in-depth gaps
-- **Priority:** Done (this branch)
-- **What:** Added `.eq("user_id")` to `getCategoriesByRhythm` transactions query. Added ownership verification to `bulkTagTransactions`.
-
-### Missing revalidation
-- **Priority:** Done (this branch)
-- **What:** `createDestinatario` with `link_matching_transactions` now calls `revalidateFinancialViews()`.
-
-### Uncached server action
-- **Priority:** Done (this branch)
-- **What:** `getTagsForEntity` extracted to `"use cache"` inner with `cacheTag("tags")` + `cacheLife("zeta")`.
 
 ### `useRecurringMonth` callbacks use `router.refresh()` instead of `startTransition`
 - **Priority:** Medium
@@ -212,4 +124,3 @@
 | PR | Description | Status |
 |---|---|---|
 | #98 | Demo mode with mock accounts | Open since 2026-04-08 |
-| #84 | Design review system in production | Open since 2026-04-06 |

--- a/mobile/app/(auth)/forgot-password.tsx
+++ b/mobile/app/(auth)/forgot-password.tsx
@@ -42,7 +42,7 @@ export default function ForgotPasswordScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#F3F4F6" }}
+      style={{ flex: 1, backgroundColor: "#121412" }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",
@@ -51,19 +51,19 @@ export default function ForgotPasswordScreen() {
       }}
       bottomOffset={20}
     >
-        <Text className="text-3xl font-bold text-center text-gray-900 mb-2">
+        <Text className="text-3xl font-bold text-center text-foreground mb-2">
           Recuperar contraseña
         </Text>
-        <Text className="text-base text-center text-gray-500 mb-10">
+        <Text className="text-base text-center text-muted-foreground mb-10">
           Te enviaremos un enlace a tu correo
         </Text>
 
         {success ? (
-          <View className="bg-green-50 border border-green-200 rounded-lg p-4 mb-6">
-            <Text className="text-green-700 text-sm text-center font-medium">
+          <View className="bg-z-income-12 border border-z-income-25 rounded-lg p-4 mb-6">
+            <Text className="text-z-income text-sm text-center font-medium">
               Correo enviado
             </Text>
-            <Text className="text-green-600 text-sm text-center mt-1">
+            <Text className="text-z-income text-sm text-center mt-1">
               Revisa tu bandeja de entrada y sigue las instrucciones para
               recuperar tu contraseña.
             </Text>
@@ -71,20 +71,20 @@ export default function ForgotPasswordScreen() {
         ) : (
           <>
             {error && (
-              <View className="bg-red-50 border border-red-200 rounded-lg p-3 mb-4">
-                <Text className="text-red-700 text-sm text-center">
+              <View className="bg-z-debt-12 border border-z-debt-25 rounded-lg p-3 mb-4">
+                <Text className="text-z-debt text-sm text-center">
                   {error}
                 </Text>
               </View>
             )}
 
-            <Text className="text-sm font-medium text-gray-700 mb-1">
+            <Text className="text-sm font-medium text-muted-foreground mb-1">
               Correo electrónico
             </Text>
             <TextInput
-              className="border border-gray-300 rounded-lg px-4 py-3 mb-6 text-base text-gray-900 bg-gray-50"
+              className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
               placeholder="correo@ejemplo.com"
-              placeholderTextColor="#9CA3AF"
+              placeholderTextColor="#938C7E"
               value={email}
               onChangeText={setEmail}
               autoCapitalize="none"
@@ -95,16 +95,16 @@ export default function ForgotPasswordScreen() {
 
             <TouchableOpacity
               className={`rounded-lg py-3.5 items-center ${
-                loading ? "bg-primary-light" : "bg-primary"
+                loading ? "bg-z-brass-70" : "bg-z-brass"
               }`}
               onPress={handleResetRequest}
               disabled={loading}
               activeOpacity={0.8}
             >
               {loading ? (
-                <ActivityIndicator color="#fff" />
+                <ActivityIndicator color="#121412" />
               ) : (
-                <Text className="text-white font-semibold text-base">
+                <Text className="text-z-ink font-semibold text-base">
                   Enviar enlace
                 </Text>
               )}
@@ -116,7 +116,7 @@ export default function ForgotPasswordScreen() {
           className="mt-6 items-center"
           onPress={() => router.replace("/(auth)/login")}
         >
-          <Text className="text-sm text-primary font-medium">
+          <Text className="text-sm text-z-brass font-medium">
             Volver al inicio de sesión
           </Text>
         </TouchableOpacity>

--- a/mobile/app/(auth)/forgot-password.tsx
+++ b/mobile/app/(auth)/forgot-password.tsx
@@ -1,3 +1,4 @@
+import { COLORS } from "../../lib/constants/colors";
 import { useState } from "react";
 import {
   View,
@@ -42,7 +43,7 @@ export default function ForgotPasswordScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#121412" }}
+      style={{ flex: 1, backgroundColor: COLORS.ink }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -145,7 +145,7 @@ export default function LoginScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#F3F4F6" }}
+      style={{ flex: 1, backgroundColor: "#121412" }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",
@@ -154,13 +154,13 @@ export default function LoginScreen() {
       }}
       bottomOffset={20}
     >
-        <Text className="text-base font-inter-bold text-center text-emerald-600 mb-3">
+        <Text className="text-base font-inter-bold text-center text-z-brass mb-3">
           Zeta
         </Text>
-        <Text className="text-3xl font-bold text-center text-gray-900 mb-2">
+        <Text className="text-3xl font-bold text-center text-foreground mb-2">
           Bienvenido
         </Text>
-        <Text className="text-base text-center text-gray-500 mb-10">
+        <Text className="text-base text-center text-muted-foreground mb-10">
           Tu dinero, con identidad y foco
         </Text>
 
@@ -171,31 +171,31 @@ export default function LoginScreen() {
             disabled={loading}
             activeOpacity={0.7}
           >
-            <View className="bg-emerald-50 border border-emerald-200 rounded-full p-4">
-              <Fingerprint size={36} color="#C5BFAE" />
+            <View className="bg-z-brass-12 border border-z-brass-25 rounded-full p-4">
+              <Fingerprint size={36} color="#937844" />
             </View>
-            <Text className="text-emerald-700 font-inter-medium text-sm">
+            <Text className="text-z-brass font-inter-medium text-sm">
               Ingresar con biometría
             </Text>
-            <Text className="text-gray-400 font-inter text-xs">
+            <Text className="text-muted-fg-50 font-inter text-xs">
               o usa tu correo y contraseña
             </Text>
           </TouchableOpacity>
         )}
 
         {error && (
-          <View className="bg-red-50 border border-red-200 rounded-lg p-3 mb-4">
-            <Text className="text-red-700 text-sm text-center">{error}</Text>
+          <View className="bg-z-debt-12 border border-z-debt-25 rounded-lg p-3 mb-4">
+            <Text className="text-z-debt text-sm text-center">{error}</Text>
           </View>
         )}
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Correo electronico
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-4 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="correo@ejemplo.com"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -204,13 +204,13 @@ export default function LoginScreen() {
           textContentType="emailAddress"
         />
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Contrasena
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-6 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
           placeholder="Tu contrasena"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -220,16 +220,16 @@ export default function LoginScreen() {
 
         <TouchableOpacity
           className={`rounded-lg py-3.5 items-center ${
-            loading ? "bg-primary-light" : "bg-primary"
+            loading ? "bg-z-brass-70" : "bg-z-brass"
           }`}
           onPress={handleLogin}
           disabled={loading}
           activeOpacity={0.8}
         >
           {loading ? (
-            <ActivityIndicator color="#fff" />
+            <ActivityIndicator color="#121412" />
           ) : (
-            <Text className="text-white font-semibold text-base">
+            <Text className="text-z-ink font-semibold text-base">
               Iniciar sesion
             </Text>
           )}
@@ -237,16 +237,16 @@ export default function LoginScreen() {
 
         <TouchableOpacity
           className={`mt-3 rounded-lg py-3.5 items-center border ${
-            demoLoading ? "border-gray-200 bg-gray-100" : "border-gray-300 bg-white"
+            demoLoading ? "border-white-6 bg-white-5" : "border-white-6 bg-z-surface-2-55"
           }`}
           onPress={handleTryDemo}
           disabled={demoLoading || loading}
           activeOpacity={0.8}
         >
           {demoLoading ? (
-            <ActivityIndicator color="#6B7280" />
+            <ActivityIndicator color="#938C7E" />
           ) : (
-            <Text className="text-gray-700 font-semibold text-base">
+            <Text className="text-foreground font-semibold text-base">
               Probar demo sin cuenta
             </Text>
           )}
@@ -256,7 +256,7 @@ export default function LoginScreen() {
           className="mt-4 items-center"
           onPress={() => router.push("/(auth)/forgot-password")}
         >
-          <Text className="text-sm text-emerald-600 font-medium">
+          <Text className="text-sm text-z-brass font-medium">
             ¿Olvidaste tu contraseña?
           </Text>
         </TouchableOpacity>
@@ -265,9 +265,9 @@ export default function LoginScreen() {
           className="mt-4 items-center"
           onPress={() => router.push("/(auth)/signup")}
         >
-          <Text className="text-sm text-gray-500">
+          <Text className="text-sm text-muted-foreground">
             ¿No tienes cuenta?{" "}
-            <Text className="text-emerald-600 font-medium">Regístrate</Text>
+            <Text className="text-z-brass font-medium">Regístrate</Text>
           </Text>
         </TouchableOpacity>
     </AppKeyboardAwareScrollView>

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -1,3 +1,4 @@
+import { COLORS } from "../../lib/constants/colors";
 import { useState, useEffect } from "react";
 import {
   Alert,
@@ -145,7 +146,7 @@ export default function LoginScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#121412" }}
+      style={{ flex: 1, backgroundColor: COLORS.ink }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -94,7 +94,7 @@ export default function ResetPasswordScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#F3F4F6" }}
+      style={{ flex: 1, backgroundColor: "#121412" }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",
@@ -103,26 +103,26 @@ export default function ResetPasswordScreen() {
       }}
       bottomOffset={20}
     >
-        <Text className="text-3xl font-bold text-center text-gray-900 mb-2">
+        <Text className="text-3xl font-bold text-center text-foreground mb-2">
           Nueva contraseña
         </Text>
-        <Text className="text-base text-center text-gray-500 mb-10">
+        <Text className="text-base text-center text-muted-foreground mb-10">
           Elige una contraseña segura para tu cuenta
         </Text>
 
         {error && (
-          <View className="bg-red-50 border border-red-200 rounded-lg p-3 mb-4">
-            <Text className="text-red-700 text-sm text-center">{error}</Text>
+          <View className="bg-z-debt-12 border border-z-debt-25 rounded-lg p-3 mb-4">
+            <Text className="text-z-debt text-sm text-center">{error}</Text>
           </View>
         )}
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Nueva contraseña
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-4 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="Mínimo 6 caracteres"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -130,13 +130,13 @@ export default function ResetPasswordScreen() {
           textContentType="newPassword"
         />
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Confirmar contraseña
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-6 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
           placeholder="Repite tu nueva contraseña"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={confirmPassword}
           onChangeText={setConfirmPassword}
           secureTextEntry
@@ -146,16 +146,16 @@ export default function ResetPasswordScreen() {
 
         <TouchableOpacity
           className={`rounded-lg py-3.5 items-center ${
-            loading ? "bg-primary-light" : "bg-primary"
+            loading ? "bg-z-brass-70" : "bg-z-brass"
           }`}
           onPress={handleResetPassword}
           disabled={loading}
           activeOpacity={0.8}
         >
           {loading ? (
-            <ActivityIndicator color="#fff" />
+            <ActivityIndicator color="#121412" />
           ) : (
-            <Text className="text-white font-semibold text-base">
+            <Text className="text-z-ink font-semibold text-base">
               Guardar contraseña
             </Text>
           )}
@@ -165,7 +165,7 @@ export default function ResetPasswordScreen() {
           className="mt-6 items-center"
           onPress={() => router.replace("/(auth)/login")}
         >
-          <Text className="text-sm text-primary font-medium">
+          <Text className="text-sm text-z-brass font-medium">
             Volver al inicio de sesión
           </Text>
         </TouchableOpacity>

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -1,3 +1,4 @@
+import { COLORS } from "../../lib/constants/colors";
 import { useState, useEffect } from "react";
 import {
   View,
@@ -94,7 +95,7 @@ export default function ResetPasswordScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#121412" }}
+      style={{ flex: 1, backgroundColor: COLORS.ink }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",

--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -53,7 +53,7 @@ export default function SignupScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#F3F4F6" }}
+      style={{ flex: 1, backgroundColor: "#121412" }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",
@@ -62,29 +62,29 @@ export default function SignupScreen() {
       }}
       bottomOffset={20}
     >
-        <Text className="text-base font-inter-bold text-center text-emerald-600 mb-3">
+        <Text className="text-base font-inter-bold text-center text-z-brass mb-3">
           Zeta
         </Text>
-        <Text className="text-3xl font-bold text-center text-gray-900 mb-2">
+        <Text className="text-3xl font-bold text-center text-foreground mb-2">
           Crear cuenta
         </Text>
-        <Text className="text-base text-center text-gray-500 mb-10">
+        <Text className="text-base text-center text-muted-foreground mb-10">
           Empieza con claridad financiera
         </Text>
 
         {error && (
-          <View className="bg-red-50 border border-red-200 rounded-lg p-3 mb-4">
-            <Text className="text-red-700 text-sm text-center">{error}</Text>
+          <View className="bg-z-debt-12 border border-z-debt-25 rounded-lg p-3 mb-4">
+            <Text className="text-z-debt text-sm text-center">{error}</Text>
           </View>
         )}
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Correo electrónico
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-4 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="correo@ejemplo.com"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -93,13 +93,13 @@ export default function SignupScreen() {
           textContentType="emailAddress"
         />
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Contraseña
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-4 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="Mínimo 6 caracteres"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -107,13 +107,13 @@ export default function SignupScreen() {
           textContentType="newPassword"
         />
 
-        <Text className="text-sm font-medium text-gray-700 mb-1">
+        <Text className="text-sm font-medium text-muted-foreground mb-1">
           Confirmar contraseña
         </Text>
         <TextInput
-          className="border border-gray-300 rounded-lg px-4 py-3 mb-6 text-base text-gray-900 bg-gray-50"
+          className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
           placeholder="Repite tu contraseña"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor="#938C7E"
           value={confirmPassword}
           onChangeText={setConfirmPassword}
           secureTextEntry
@@ -123,16 +123,16 @@ export default function SignupScreen() {
 
         <TouchableOpacity
           className={`rounded-lg py-3.5 items-center ${
-            loading ? "bg-primary-light" : "bg-primary"
+            loading ? "bg-z-brass-70" : "bg-z-brass"
           }`}
           onPress={handleSignup}
           disabled={loading}
           activeOpacity={0.8}
         >
           {loading ? (
-            <ActivityIndicator color="#fff" />
+            <ActivityIndicator color="#121412" />
           ) : (
-            <Text className="text-white font-semibold text-base">
+            <Text className="text-z-ink font-semibold text-base">
               Crear cuenta
             </Text>
           )}
@@ -142,9 +142,9 @@ export default function SignupScreen() {
           className="mt-6 items-center"
           onPress={() => router.replace("/(auth)/login")}
         >
-          <Text className="text-sm text-gray-500">
+          <Text className="text-sm text-muted-foreground">
             ¿Ya tienes cuenta?{" "}
-            <Text className="text-emerald-600 font-medium">Inicia sesión</Text>
+            <Text className="text-z-brass font-medium">Inicia sesión</Text>
           </Text>
         </TouchableOpacity>
     </AppKeyboardAwareScrollView>

--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -1,3 +1,4 @@
+import { COLORS } from "../../lib/constants/colors";
 import { useState } from "react";
 import {
   View,
@@ -53,7 +54,7 @@ export default function SignupScreen() {
 
   return (
     <AppKeyboardAwareScrollView
-      style={{ flex: 1, backgroundColor: "#121412" }}
+      style={{ flex: 1, backgroundColor: COLORS.ink }}
       contentContainerStyle={{
         flexGrow: 1,
         justifyContent: "center",

--- a/mobile/app/(tabs)/budgets.tsx
+++ b/mobile/app/(tabs)/budgets.tsx
@@ -22,11 +22,13 @@ import {
 import { parseLocalizedAmount } from "../../lib/amount";
 import { useAuth } from "../../lib/auth";
 import { MonthSelector } from "../../components/common/MonthSelector";
+import { toLocalMonthString } from "../../lib/utils/date";
+import { COLORS } from "../../lib/constants/colors";
 
 function getProgressColor(progress: number) {
-  if (progress >= 100) return "bg-red-500";
-  if (progress >= 80) return "bg-amber-500";
-  return "bg-emerald-500";
+  if (progress >= 100) return "bg-z-debt";
+  if (progress >= 80) return "bg-z-alert";
+  return "bg-z-income";
 }
 
 export default function BudgetsScreen() {
@@ -39,7 +41,7 @@ export default function BudgetsScreen() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [amountInput, setAmountInput] = useState("");
   const [currentMonth, setCurrentMonth] = useState(
-    () => new Date().toISOString().slice(0, 7)
+    () => toLocalMonthString()
   );
 
   const loadData = useCallback(async () => {
@@ -123,21 +125,21 @@ export default function BudgetsScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-gray-100">
-        <ActivityIndicator size="large" color="#C5BFAE" />
+      <View className="flex-1 items-center justify-center bg-background">
+        <ActivityIndicator size="large" color={COLORS.brass} />
       </View>
     );
   }
 
   return (
     <KeyboardAvoidingView
-      className="flex-1 bg-gray-100"
+      className="flex-1 bg-background"
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <ScrollView
-        className="flex-1 bg-gray-100"
+        className="flex-1 bg-background"
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor="#C5BFAE" />
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={COLORS.brass} />
         }
         contentContainerStyle={{ paddingBottom: 120 }}
         keyboardShouldPersistTaps="handled"
@@ -147,15 +149,16 @@ export default function BudgetsScreen() {
           <MonthSelector month={currentMonth} onChange={setCurrentMonth} />
         </View>
 
-        <View className="mx-4 mt-3 rounded-2xl bg-white p-5 shadow-sm">
-          <Text className="text-sm text-gray-500 font-inter-medium">Control mensual</Text>
-          <Text className="mt-1 text-2xl text-gray-900 font-inter-bold">
+        {/* Summary card */}
+        <View className="mx-4 mt-3 rounded-2xl border border-white-6 bg-z-surface-2-55 p-5">
+          <Text className="text-sm text-muted-foreground font-inter-medium">Control mensual</Text>
+          <Text className="mt-1 text-2xl text-foreground font-inter-bold">
             {formatCurrency(totals.spent, "COP" as CurrencyCode)}
           </Text>
-          <Text className="mt-1 text-xs text-gray-500 font-inter">
+          <Text className="mt-1 text-xs text-muted-foreground font-inter">
             de {formatCurrency(totals.target, "COP" as CurrencyCode)} presupuestado
           </Text>
-          <View className="mt-4 h-2 rounded-full bg-gray-200">
+          <View className="mt-4 h-2 rounded-full bg-black-10">
             <View
               className={`${getProgressColor(totals.progress)} h-2 rounded-full`}
               style={{ width: `${Math.min(totals.progress, 100)}%` }}
@@ -163,21 +166,22 @@ export default function BudgetsScreen() {
           </View>
         </View>
 
+        {/* Section header */}
         <View className="px-4 pt-5 pb-2">
-          <Text className="text-gray-500 font-inter-semibold text-xs uppercase">
+          <Text className="text-muted-foreground font-inter-semibold text-xs uppercase">
             Presupuestos por categoria
           </Text>
-          <Text className="mt-1 text-xs text-gray-500 font-inter">
+          <Text className="mt-1 text-xs text-muted-foreground font-inter">
             Toca una categoria para definir o editar su tope mensual.
           </Text>
         </View>
 
         {items.length === 0 ? (
-          <View className="mx-4 mt-2 rounded-2xl bg-white p-6">
-            <Text className="text-center text-base text-gray-700 font-inter-medium">
+          <View className="mx-4 mt-2 rounded-2xl border border-white-6 bg-z-surface-2-55 p-6">
+            <Text className="text-center text-base text-foreground font-inter-medium">
               Aun no hay presupuestos configurados
             </Text>
-            <Text className="mt-1 text-center text-sm text-gray-500 font-inter">
+            <Text className="mt-1 text-center text-sm text-muted-foreground font-inter">
               Crea presupuestos desde Categorias en web y aqui podras revisarlos.
             </Text>
           </View>
@@ -188,25 +192,25 @@ export default function BudgetsScreen() {
               const isEditing = editingId === rowId;
               const isSaving = savingId === rowId;
               return (
-                <View key={rowId} className="mb-3 rounded-2xl bg-white p-4 shadow-sm">
+                <View key={rowId} className="mb-3 rounded-2xl border border-white-6 bg-z-surface-2-55 p-4">
                   <View className="mb-2 flex-row items-center justify-between">
                     <View className="flex-row items-center gap-2">
                       <View
                         className="h-2.5 w-2.5 rounded-full"
-                        style={{ backgroundColor: item.category_color ?? "#C5BFAE" }}
+                        style={{ backgroundColor: item.category_color ?? COLORS.sageDark }}
                       />
-                      <Text className="text-gray-900 font-inter-semibold">{item.category_name}</Text>
+                      <Text className="text-foreground font-inter-semibold">{item.category_name}</Text>
                     </View>
-                    <Text className="text-xs text-gray-500 font-inter-medium">
+                    <Text className="text-xs text-muted-foreground font-inter-medium">
                       {Math.round(item.progress)}%
                     </Text>
                   </View>
 
-                  <Text className="text-sm text-gray-600 font-inter">
+                  <Text className="text-sm text-muted-foreground font-inter">
                     {formatCurrency(item.spent, "COP" as CurrencyCode)} / {formatCurrency(item.amount, "COP" as CurrencyCode)}
                   </Text>
 
-                  <View className="mt-3 h-2 rounded-full bg-gray-200">
+                  <View className="mt-3 h-2 rounded-full bg-black-10">
                     <View
                       className={`${getProgressColor(item.progress)} h-2 rounded-full`}
                       style={{ width: `${Math.min(item.progress, 100)}%` }}
@@ -220,42 +224,43 @@ export default function BudgetsScreen() {
                         onChangeText={setAmountInput}
                         keyboardType="numeric"
                         placeholder="Monto mensual"
-                        className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+                        placeholderTextColor="#938C7E"
+                        className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
                       />
                       <View className="mt-2 flex-row gap-2">
                         <Pressable
-                          className="flex-1 rounded-xl bg-emerald-600 py-2.5 items-center active:bg-emerald-700"
+                          className="flex-1 rounded-xl bg-z-brass py-2.5 items-center active:opacity-80"
                           onPress={() => handleSave(item)}
                           disabled={isSaving}
                         >
-                          <Text className="text-white font-inter-semibold">
+                          <Text className="text-z-ink font-inter-semibold">
                             {isSaving ? "Guardando..." : "Guardar"}
                           </Text>
                         </Pressable>
                         <Pressable
-                          className="rounded-xl border border-gray-300 px-4 py-2.5 items-center"
+                          className="rounded-xl border border-white-6 px-4 py-2.5 items-center"
                           onPress={() => {
                             setEditingId(null);
                             setAmountInput("");
                           }}
                           disabled={isSaving}
                         >
-                          <Text className="text-gray-700 font-inter-medium">Cancelar</Text>
+                          <Text className="text-muted-foreground font-inter-medium">Cancelar</Text>
                         </Pressable>
                         {!!item.id && (
                           <Pressable
-                            className="rounded-xl border border-red-200 px-4 py-2.5 items-center"
+                            className="rounded-xl border border-z-debt/25 px-4 py-2.5 items-center"
                             onPress={() => handleDelete(item)}
                             disabled={isSaving}
                           >
-                            <Text className="text-red-600 font-inter-medium">Eliminar</Text>
+                            <Text className="text-z-expense font-inter-medium">Eliminar</Text>
                           </Pressable>
                         )}
                       </View>
                     </View>
                   ) : (
                     <Pressable className="mt-3 items-start" onPress={() => beginEdit(item)}>
-                      <Text className="text-sm text-emerald-700 font-inter-semibold">
+                      <Text className="text-sm text-z-brass font-inter-semibold">
                         {item.id ? "Editar presupuesto" : "Definir presupuesto"}
                       </Text>
                     </Pressable>

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -34,7 +34,7 @@ import { disableDemoMode } from "../../lib/demo-mode";
 
 function SectionHeader({ title }: { title: string }) {
   return (
-    <Text className="text-gray-500 font-inter-semibold text-xs uppercase px-4 pt-5 pb-2">
+    <Text className="text-muted-foreground font-inter-semibold text-xs uppercase px-4 pt-5 pb-2">
       {title}
     </Text>
   );
@@ -56,19 +56,19 @@ function SettingsRow({
   const Wrapper = onPress ? Pressable : View;
   return (
     <Wrapper
-      className="flex-row items-center px-4 py-3.5 bg-white active:bg-gray-50"
+      className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55 active:bg-black-10"
       {...(onPress ? { onPress } : {})}
     >
       <View className="mr-3">{icon}</View>
       <Text
         className={`flex-1 font-inter-medium text-sm ${
-          destructive ? "text-red-500" : "text-gray-900"
+          destructive ? "text-z-expense" : "text-foreground"
         }`}
       >
         {label}
       </Text>
       {value && (
-        <Text className="text-gray-500 font-inter text-sm">{value}</Text>
+        <Text className="text-muted-foreground font-inter text-sm">{value}</Text>
       )}
     </Wrapper>
   );
@@ -231,24 +231,24 @@ export default function SettingsScreen() {
         : "Sincronizado";
 
   return (
-    <ScrollView className="flex-1 bg-gray-100">
+    <ScrollView className="flex-1 bg-z-card">
       {/* Profile section */}
       <SectionHeader title="Perfil" />
-      <View className="bg-white">
+      <View className="bg-z-surface-2-55">
         <SettingsRow
-          icon={<User size={18} color="#6B7280" />}
+          icon={<User size={18} color="#938C7E" />}
           label="Nombre"
           value={profile?.full_name || session?.user?.user_metadata?.full_name || "---"}
         />
-        <View className="h-px bg-gray-100 ml-12" />
+        <View className="h-px bg-white-6 ml-12" />
         <SettingsRow
-          icon={<Mail size={18} color="#6B7280" />}
+          icon={<Mail size={18} color="#938C7E" />}
           label="Email"
           value={session?.user?.email || "---"}
         />
-        <View className="h-px bg-gray-100 ml-12" />
+        <View className="h-px bg-white-6 ml-12" />
         <SettingsRow
-          icon={<Shield size={18} color="#6B7280" />}
+          icon={<Shield size={18} color="#938C7E" />}
           label="Plan"
           value="Gratuito"
         />
@@ -256,26 +256,26 @@ export default function SettingsScreen() {
 
       {/* Sync section */}
       <SectionHeader title="Sincronizacion" />
-      <View className="bg-white">
+      <View className="bg-z-surface-2-55">
         <SettingsRow
           icon={
             <RefreshCw
               size={18}
-              color={status === "error" ? "#EF4444" : "#6B7280"}
+              color={status === "error" ? "#EF4444" : "#938C7E"}
             />
           }
           label="Estado"
           value={syncStatusLabel}
         />
-        <View className="h-px bg-gray-100 ml-12" />
+        <View className="h-px bg-white-6 ml-12" />
         <SettingsRow
-          icon={<Clock size={18} color="#6B7280" />}
+          icon={<Clock size={18} color="#938C7E" />}
           label="Ultima sincronizacion"
           value={lastSynced ? formatRelativeDate(lastSynced) : "Nunca"}
         />
-        <View className="h-px bg-gray-100 ml-12" />
+        <View className="h-px bg-white-6 ml-12" />
         <Pressable
-          className="flex-row items-center px-4 py-3.5 bg-white active:bg-gray-50"
+          className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55 active:bg-black-10"
           onPress={handleSyncNow}
           disabled={syncing}
         >
@@ -284,26 +284,26 @@ export default function SettingsScreen() {
             {syncing ? "Sincronizando..." : "Sincronizar ahora"}
           </Text>
         </Pressable>
-        <View className="h-px bg-gray-100 ml-12" />
+        <View className="h-px bg-white-6 ml-12" />
         <Pressable
-          className="flex-row items-center px-4 py-3.5 bg-white active:bg-gray-50"
+          className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55 active:bg-black-10"
           onPress={handleClearSyncQueue}
         >
           <Trash2 size={18} color="#EF4444" />
-          <Text className="ml-3 text-red-500 font-inter-medium text-sm">
+          <Text className="ml-3 text-z-expense font-inter-medium text-sm">
             Limpiar cola de sincronizacion
           </Text>
         </Pressable>
         {!demoMode && (
           <>
-            <View className="h-px bg-gray-100 ml-12" />
+            <View className="h-px bg-white-6 ml-12" />
             <Pressable
-              className="flex-row items-center px-4 py-3.5 bg-white active:bg-gray-50"
+              className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55 active:bg-black-10"
               onPress={handleFullResync}
               disabled={syncing}
             >
               <RefreshCw size={18} color="#EF4444" />
-              <Text className="ml-3 text-red-500 font-inter-medium text-sm">
+              <Text className="ml-3 text-z-expense font-inter-medium text-sm">
                 Resincronizar desde cero
               </Text>
             </Pressable>
@@ -313,31 +313,31 @@ export default function SettingsScreen() {
 
       {/* Accounts section */}
       <SectionHeader title="Cuentas" />
-      <View className="bg-white">
+      <View className="bg-z-surface-2-55">
         <Pressable
-          className="flex-row items-center px-4 py-3.5 active:bg-gray-50"
+          className="flex-row items-center px-4 py-3.5 active:bg-black-10"
           onPress={() => router.navigate("/(tabs)/accounts")}
         >
           <View className="mr-3">
-            <Wallet size={18} color="#6B7280" />
+            <Wallet size={18} color="#938C7E" />
           </View>
-          <Text className="flex-1 font-inter-medium text-sm text-gray-900">
+          <Text className="flex-1 font-inter-medium text-sm text-foreground">
             Administrar cuentas
           </Text>
-          <ChevronRight size={16} color="#9CA3AF" />
+          <ChevronRight size={16} color="#938C7E" />
         </Pressable>
-        <View className="h-px bg-gray-100 ml-12" />
+        <View className="h-px bg-white-6 ml-12" />
         <Pressable
-          className="flex-row items-center px-4 py-3.5 active:bg-gray-50"
+          className="flex-row items-center px-4 py-3.5 active:bg-black-10"
           onPress={() => router.push("/subscriptions" as never)}
         >
           <View className="mr-3">
-            <Repeat size={18} color="#6B7280" />
+            <Repeat size={18} color="#938C7E" />
           </View>
-          <Text className="flex-1 font-inter-medium text-sm text-gray-900">
+          <Text className="flex-1 font-inter-medium text-sm text-foreground">
             Suscripciones
           </Text>
-          <ChevronRight size={16} color="#9CA3AF" />
+          <ChevronRight size={16} color="#938C7E" />
         </Pressable>
       </View>
 
@@ -345,38 +345,38 @@ export default function SettingsScreen() {
       {biometricsAvailable && (
         <>
           <SectionHeader title="Seguridad" />
-          <View className="bg-white">
-            <View className="flex-row items-center px-4 py-3.5 bg-white">
+          <View className="bg-z-surface-2-55">
+            <View className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55">
               <View className="mr-3">
-                <Fingerprint size={18} color="#6B7280" />
+                <Fingerprint size={18} color="#938C7E" />
               </View>
-              <Text className="flex-1 font-inter-medium text-sm text-gray-900">
+              <Text className="flex-1 font-inter-medium text-sm text-foreground">
                 Desbloqueo biometrico
               </Text>
               <Switch
                 value={biometricsOn}
                 onValueChange={handleToggleBiometrics}
-                trackColor={{ false: "#E5E7EB", true: "#10B981" }}
+                trackColor={{ false: "#3A3A3A", true: "#10B981" }}
                 thumbColor="#FFFFFF"
-                ios_backgroundColor="#E5E7EB"
+                ios_backgroundColor="#3A3A3A"
               />
             </View>
             {biometricsOn && (
               <>
-                <View className="h-px bg-gray-100 ml-12" />
-                <View className="flex-row items-center px-4 py-3.5 bg-white">
+                <View className="h-px bg-white-6 ml-12" />
+                <View className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55">
                   <View className="mr-3">
-                    <ShieldCheck size={18} color="#6B7280" />
+                    <ShieldCheck size={18} color="#938C7E" />
                   </View>
-                  <Text className="flex-1 font-inter-medium text-sm text-gray-900">
+                  <Text className="flex-1 font-inter-medium text-sm text-foreground">
                     Bloquear al salir de la app
                   </Text>
                   <Switch
                     value={bgReauthOn}
                     onValueChange={handleToggleBgReauth}
-                    trackColor={{ false: "#E5E7EB", true: "#10B981" }}
+                    trackColor={{ false: "#3A3A3A", true: "#10B981" }}
                     thumbColor="#FFFFFF"
-                    ios_backgroundColor="#E5E7EB"
+                    ios_backgroundColor="#3A3A3A"
                   />
                 </View>
               </>
@@ -387,7 +387,7 @@ export default function SettingsScreen() {
 
       {/* Session section */}
       <SectionHeader title="Sesion" />
-      <View className="bg-white mb-8">
+      <View className="bg-z-surface-2-55 mb-8">
         {demoMode ? (
           <SettingsRow
             icon={<LogOut size={18} color="#EF4444" />}
@@ -406,9 +406,9 @@ export default function SettingsScreen() {
       </View>
 
       <SectionHeader title="Soporte" />
-      <View className="bg-white mb-8">
+      <View className="bg-z-surface-2-55 mb-8">
         <SettingsRow
-          icon={<Bug size={18} color="#6B7280" />}
+          icon={<Bug size={18} color="#938C7E" />}
           label="Quick capture de bug"
           onPress={() => router.push("/bug-report" as never)}
         />

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -231,7 +231,7 @@ export default function SettingsScreen() {
         : "Sincronizado";
 
   return (
-    <ScrollView className="flex-1 bg-z-card">
+    <ScrollView className="flex-1 bg-background">
       {/* Profile section */}
       <SectionHeader title="Perfil" />
       <View className="bg-z-surface-2-55">
@@ -289,7 +289,7 @@ export default function SettingsScreen() {
           className="flex-row items-center px-4 py-3.5 bg-z-surface-2-55 active:bg-black-10"
           onPress={handleClearSyncQueue}
         >
-          <Trash2 size={18} color="#EF4444" />
+          <Trash2 size={18} color={COLORS.debt} />
           <Text className="ml-3 text-z-expense font-inter-medium text-sm">
             Limpiar cola de sincronizacion
           </Text>
@@ -302,7 +302,7 @@ export default function SettingsScreen() {
               onPress={handleFullResync}
               disabled={syncing}
             >
-              <RefreshCw size={18} color="#EF4444" />
+              <RefreshCw size={18} color={COLORS.debt} />
               <Text className="ml-3 text-z-expense font-inter-medium text-sm">
                 Resincronizar desde cero
               </Text>
@@ -356,8 +356,8 @@ export default function SettingsScreen() {
               <Switch
                 value={biometricsOn}
                 onValueChange={handleToggleBiometrics}
-                trackColor={{ false: "#3A3A3A", true: "#10B981" }}
-                thumbColor="#FFFFFF"
+                trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                thumbColor={COLORS.foreground}
                 ios_backgroundColor="#3A3A3A"
               />
             </View>
@@ -374,8 +374,8 @@ export default function SettingsScreen() {
                   <Switch
                     value={bgReauthOn}
                     onValueChange={handleToggleBgReauth}
-                    trackColor={{ false: "#3A3A3A", true: "#10B981" }}
-                    thumbColor="#FFFFFF"
+                    trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                    thumbColor={COLORS.foreground}
                     ios_backgroundColor="#3A3A3A"
                   />
                 </View>
@@ -390,14 +390,14 @@ export default function SettingsScreen() {
       <View className="bg-z-surface-2-55 mb-8">
         {demoMode ? (
           <SettingsRow
-            icon={<LogOut size={18} color="#EF4444" />}
+            icon={<LogOut size={18} color={COLORS.debt} />}
             label="Salir modo demo"
             onPress={handleExitDemoMode}
             destructive
           />
         ) : (
           <SettingsRow
-            icon={<LogOut size={18} color="#EF4444" />}
+            icon={<LogOut size={18} color={COLORS.debt} />}
             label="Cerrar sesion"
             onPress={handleSignOut}
             destructive

--- a/mobile/app/annotate-screenshot.tsx
+++ b/mobile/app/annotate-screenshot.tsx
@@ -163,7 +163,7 @@ export default function AnnotateScreenshotScreen() {
             onPress={handleUndo}
             disabled={!paths.length}
           >
-            <Undo2 size={18} color={paths.length ? "#374151" : "#D1D5DB"} />
+            <Undo2 size={18} color={paths.length ? "#C5BFAE" : "#4A4A4A"} />
           </Pressable>
 
           <Pressable
@@ -171,7 +171,7 @@ export default function AnnotateScreenshotScreen() {
             onPress={handleClear}
             disabled={!paths.length}
           >
-            <Trash2 size={18} color={paths.length ? "#374151" : "#D1D5DB"} />
+            <Trash2 size={18} color={paths.length ? "#C5BFAE" : "#4A4A4A"} />
           </Pressable>
 
           <View style={styles.colorPicker}>
@@ -241,7 +241,7 @@ const styles = StyleSheet.create({
   toolbarRow: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: "rgba(255,255,255,0.95)",
+    backgroundColor: "rgba(18,20,18,0.95)",
     borderRadius: 14,
     paddingHorizontal: 12,
     paddingVertical: 8,
@@ -251,7 +251,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 10,
-    backgroundColor: "#F3F4F6",
+    backgroundColor: "#1A1C1A",
     alignItems: "center",
     justifyContent: "center",
   },
@@ -279,7 +279,7 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   strokePreview: {
-    backgroundColor: "#374151",
+    backgroundColor: "#C5BFAE",
     borderRadius: 3,
   },
   cancelBtn: {
@@ -288,13 +288,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 8,
     borderRadius: 10,
-    backgroundColor: "#F3F4F6",
+    backgroundColor: "#1A1C1A",
     gap: 4,
   },
   cancelLabel: {
     fontSize: 14,
     fontWeight: "500",
-    color: "#6B7280",
+    color: "#938C7E",
   },
   doneBtn: {
     marginLeft: "auto",
@@ -306,6 +306,6 @@ const styles = StyleSheet.create({
   doneLabel: {
     fontSize: 14,
     fontWeight: "600",
-    color: "#FFF",
+    color: "#121412",
   },
 });

--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -20,6 +20,7 @@ import {
   createQuickCaptureTransaction,
   createTransaction,
 } from "../lib/repositories/transactions";
+import { toLocalDateString } from "../lib/utils/date";
 
 const DEFAULT_ACCOUNT_KEY = "zeta.last_capture_account_id";
 
@@ -39,7 +40,7 @@ export default function CaptureScreen() {
   const [direction, setDirection] = useState<TransactionDirection>("OUTFLOW");
   const [amountInput, setAmountInput] = useState("");
   const [transactionDate, setTransactionDate] = useState(
-    new Date().toISOString().slice(0, 10)
+    toLocalDateString()
   );
   const [description, setDescription] = useState("");
   const [notes, setNotes] = useState("");

--- a/mobile/app/periodo.tsx
+++ b/mobile/app/periodo.tsx
@@ -1,0 +1,544 @@
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useFocusEffect } from "expo-router";
+import { ArrowLeft, Check, ChevronDown, Banknote } from "lucide-react-native";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import { supabase } from "../lib/supabase";
+import { useAuth } from "../lib/auth";
+import { COLORS } from "../lib/constants/colors";
+import { isDebtAccountType } from "../lib/constants/accounts";
+import { PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "../lib/constants/styles";
+import {
+  PaymentSheet,
+  type PaymentEntry,
+  type PaymentAccount,
+} from "../components/plan/PaymentSheet";
+import {
+  ReassignSheet,
+  type ReassignTarget,
+} from "../components/plan/ReassignSheet";
+
+import { ENVELOPE_COLORS } from "../lib/constants/envelope-colors";
+
+interface PlanningPeriod {
+  id: string;
+  start_date: string;
+  end_date: string;
+  currency_code: string;
+  is_active: boolean;
+}
+
+interface PlanningEntry {
+  id: string;
+  label: string;
+  amount: number;
+  currency_code: string;
+  entry_type: "INCOME" | "EXPENSE";
+  status: "PLANNED" | "COMPLETED" | "SKIPPED";
+  expected_date: string;
+  account_id: string | null;
+  account_name?: string | null;
+  recurring_template_id: string | null;
+  category_id: string | null;
+  /** Resolved debt account ID from template (when entry.account_id is the source account) */
+  debt_account_id?: string | null;
+}
+
+interface PlanningAssignment {
+  id: string;
+  income_entry_id: string;
+  expense_entry_id: string;
+  assigned_amount: number;
+}
+
+interface IncomeEnvelope {
+  entry: PlanningEntry;
+  totalAmount: number;
+  assignedAmount: number;
+  remainingAmount: number;
+  assignments: Array<{ assignment: PlanningAssignment; expenseLabel: string }>;
+}
+
+interface AccountDetail {
+  id: string;
+  name: string;
+  account_type: string;
+  current_balance: number;
+  currency_code: string;
+}
+
+interface PeriodoData {
+  period: PlanningPeriod;
+  currency: CurrencyCode;
+  incomeEnvelopes: IncomeEnvelope[];
+  expenseEntries: Array<PlanningEntry & { assignmentChips: Array<{ colorIndex: number; amount: number; assignmentId: string; incomeEntryId: string }> }>;
+  totalExpenses: number;
+  totalAssigned: number;
+  accountDetails: Map<string, AccountDetail>;
+}
+
+export default function PeriodoScreen() {
+  const router = useRouter();
+  const { session } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<PeriodoData | null>(null);
+  const [expandedIncome, setExpandedIncome] = useState<string | null>(null);
+  const [paymentEntry, setPaymentEntry] = useState<PaymentEntry | null>(null);
+  const [reassignTarget, setReassignTarget] = useState<ReassignTarget | null>(null);
+
+  const loadData = useCallback(async () => {
+    if (!session?.user?.id) { setLoading(false); return; }
+
+    try {
+      // Cast to any — planning tables not in mobile's generated types
+      const sb = supabase as any;
+
+      // 1. Get active period
+      const { data: period } = await sb
+        .from("planning_periods")
+        .select("*")
+        .eq("user_id", session.user.id)
+        .eq("is_active", true)
+        .order("start_date", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (!period) { setData(null); setLoading(false); return; }
+
+      // 2. Get entries + assignments
+      const [{ data: entries }, { data: assignments }, { data: accounts }] = await Promise.all([
+        sb
+          .from("planning_entries")
+          .select("id, label, amount, currency_code, entry_type, status, expected_date, account_id, recurring_template_id, category_id")
+          .eq("period_id", period.id)
+          .eq("user_id", session.user.id)
+          .order("expected_date")
+          .order("sort_order"),
+        sb
+          .from("planning_assignments")
+          .select("id, income_entry_id, expense_entry_id, assigned_amount")
+          .eq("period_id", period.id)
+          .eq("user_id", session.user.id),
+        supabase
+          .from("accounts")
+          .select("id, name, account_type, current_balance, currency_code")
+          .eq("user_id", session.user.id),
+      ]);
+
+      const accountMap = new Map((accounts ?? []).map((a: any) => [a.id, a.name]));
+      const accountDetailMap = new Map<string, AccountDetail>(
+        (accounts ?? []).map((a: any) => [a.id, {
+          id: a.id,
+          name: a.name,
+          account_type: a.account_type,
+          current_balance: a.current_balance ?? 0,
+          currency_code: a.currency_code,
+        }])
+      );
+      const allEntries = (entries ?? []) as PlanningEntry[];
+      const allAssignments = (assignments ?? []) as PlanningAssignment[];
+
+      // Fetch templates to resolve actual debt accounts for debt payment entries
+      // (entry.account_id may be the source account when transfer_source_account_id is set)
+      const templateIds = allEntries
+        .filter((e) => e.recurring_template_id)
+        .map((e) => e.recurring_template_id!);
+
+      let templateMap = new Map<string, { account_id: string; transfer_source_account_id: string | null }>();
+      if (templateIds.length > 0) {
+        const { data: templates } = await sb
+          .from("recurring_transaction_templates")
+          .select("id, account_id, transfer_source_account_id")
+          .in("id", templateIds);
+
+        if (templates) {
+          templateMap = new Map(
+            (templates as Array<{ id: string; account_id: string; transfer_source_account_id: string | null }>)
+              .map((t) => [t.id, { account_id: t.account_id, transfer_source_account_id: t.transfer_source_account_id }])
+          );
+        }
+      }
+
+      // Enrich entries with account names + resolve debt account from template
+      for (const e of allEntries) {
+        e.account_name = accountMap.get(e.account_id ?? "") ?? null;
+
+        // For debt payment templates, the template's account_id is the debt account
+        // and entry.account_id may be the source (checking/savings) account
+        if (e.recurring_template_id) {
+          const template = templateMap.get(e.recurring_template_id);
+          if (template) {
+            const templateAccount = accountDetailMap.get(template.account_id);
+            if (templateAccount && isDebtAccountType(templateAccount.account_type)) {
+              e.debt_account_id = template.account_id;
+            }
+          }
+        }
+      }
+
+      // Build income envelopes
+      const incomeEntries = allEntries.filter((e) => e.entry_type === "INCOME");
+      const expenseEntries = allEntries.filter((e) => e.entry_type === "EXPENSE");
+      const expenseMap = new Map(expenseEntries.map((e) => [e.id, e]));
+
+      const incomeEnvelopes: IncomeEnvelope[] = incomeEntries.map((entry) => {
+        const entryAssignments = allAssignments.filter((a) => a.income_entry_id === entry.id);
+        const assignedAmount = entryAssignments.reduce((s, a) => s + a.assigned_amount, 0);
+        return {
+          entry,
+          totalAmount: entry.amount,
+          assignedAmount,
+          remainingAmount: entry.amount - assignedAmount,
+          assignments: entryAssignments.map((a) => ({
+            assignment: a,
+            expenseLabel: expenseMap.get(a.expense_entry_id)?.label ?? "Gasto",
+          })),
+        };
+      });
+
+      // Build assignment chips per expense
+      const incomeIndexMap = new Map(incomeEntries.map((e, i) => [e.id, i]));
+      const expenseWithChips = expenseEntries.map((entry) => {
+        const chips = allAssignments
+          .filter((a) => a.expense_entry_id === entry.id)
+          .map((a) => ({
+            colorIndex: incomeIndexMap.get(a.income_entry_id) ?? 0,
+            amount: a.assigned_amount,
+            assignmentId: a.id,
+            incomeEntryId: a.income_entry_id,
+          }));
+        return { ...entry, assignmentChips: chips };
+      });
+
+      const totalExpenses = expenseEntries.reduce((s, e) => s + e.amount, 0);
+      const totalAssigned = allAssignments.reduce((s, a) => s + a.assigned_amount, 0);
+
+      setData({
+        period: period as PlanningPeriod,
+        currency: period.currency_code as CurrencyCode,
+        incomeEnvelopes,
+        expenseEntries: expenseWithChips,
+        totalExpenses,
+        totalAssigned,
+        accountDetails: accountDetailMap,
+      });
+    } catch (error) {
+      console.error("Failed to load periodo:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.user?.id]);
+
+  useFocusEffect(useCallback(() => { loadData(); }, [loadData]));
+
+  if (loading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-background">
+        <ActivityIndicator size="large" color={COLORS.brass} />
+      </View>
+    );
+  }
+
+  if (!data) {
+    return (
+      <View className="flex-1 bg-background">
+        <Header onBack={() => router.back()} />
+        <View className="flex-1 items-center justify-center px-8">
+          <Text className="text-foreground font-inter-semibold text-base text-center">
+            No hay periodo activo
+          </Text>
+          <Text className="text-muted-foreground font-inter text-sm text-center mt-2">
+            Crea un periodo desde la web para empezar a planificar tus ingresos y gastos del mes.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const percentAssigned = data.totalExpenses > 0
+    ? Math.round((data.totalAssigned / data.totalExpenses) * 100) : 0;
+
+  return (
+    <View className="flex-1 bg-background">
+      <Header onBack={() => router.back()} />
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: 100 }}
+      >
+        {/* Period summary */}
+        <View className={`${PANEL_INSET_CLASS} flex-row items-center justify-between px-4 py-2.5`}>
+          <Text className="text-xs font-inter text-muted-foreground">
+            {formatDate(data.period.start_date, "dd MMM")} — {formatDate(data.period.end_date, "dd MMM yyyy")}
+          </Text>
+          <View className={`rounded-md px-2 py-0.5 ${percentAssigned >= 100 ? "bg-z-income/10" : "bg-z-brass/10"}`}>
+            <Text className={`text-[10px] font-inter-semibold ${percentAssigned >= 100 ? "text-z-income" : "text-z-brass"}`}>
+              {percentAssigned}% asignado
+            </Text>
+          </View>
+        </View>
+
+        {/* ── INGRESOS ── */}
+        <Text className={SECTION_EYEBROW_CLASS}>Ingresos</Text>
+        {data.incomeEnvelopes.map((envelope, idx) => (
+          <IncomeCard
+            key={envelope.entry.id}
+            envelope={envelope}
+            colorIndex={idx}
+            currency={data.currency}
+            isExpanded={expandedIncome === envelope.entry.id}
+            onToggle={() => setExpandedIncome(expandedIncome === envelope.entry.id ? null : envelope.entry.id)}
+          />
+        ))}
+
+        {/* ── GASTOS ── */}
+        <Text className={`${SECTION_EYEBROW_CLASS} mt-2`}>Gastos</Text>
+        {data.expenseEntries.length > 0 && (
+          <View className={`${PANEL_INSET_CLASS} overflow-hidden`}>
+            {data.expenseEntries.map((entry, i) => (
+              <View key={entry.id} className={`px-3.5 py-3 ${i > 0 ? "border-t border-white-6" : ""}`}>
+                <View className="flex-row items-center justify-between">
+                  <View className="flex-1">
+                    <Text className="text-xs font-inter-medium text-foreground">{entry.label}</Text>
+                    <Text className="text-[10px] font-inter text-muted-foreground">
+                      {formatDate(entry.expected_date, "dd MMM yyyy")}
+                      {entry.account_name ? ` · ${entry.account_name}` : ""}
+                    </Text>
+                    {/* Assignment chips — tappable to reassign */}
+                    {entry.assignmentChips.length > 0 && (
+                      <View className="flex-row flex-wrap gap-1 mt-1">
+                        {entry.assignmentChips.map((chip, ci) => (
+                          <Pressable
+                            key={ci}
+                            onPress={() => setReassignTarget({
+                              assignmentId: chip.assignmentId,
+                              expenseEntryId: entry.id,
+                              expenseLabel: entry.label,
+                              currentIncomeEntryId: chip.incomeEntryId,
+                              currentAmount: chip.amount,
+                            })}
+                            className="flex-row items-center gap-1 rounded-md px-1.5 py-0.5 active:opacity-70"
+                            style={{ backgroundColor: ENVELOPE_COLORS[chip.colorIndex % ENVELOPE_COLORS.length] + "15" }}
+                          >
+                            <View
+                              className="h-1.5 w-1.5 rounded-full"
+                              style={{ backgroundColor: ENVELOPE_COLORS[chip.colorIndex % ENVELOPE_COLORS.length] }}
+                            />
+                            <Text
+                              className="text-[9px] font-inter-medium"
+                              style={{ color: ENVELOPE_COLORS[chip.colorIndex % ENVELOPE_COLORS.length] }}
+                            >
+                              {formatCurrency(chip.amount, data.currency)}
+                            </Text>
+                          </Pressable>
+                        ))}
+                      </View>
+                    )}
+                  </View>
+                  <View className="flex-row items-center gap-2">
+                    {entry.status !== "COMPLETED" && (
+                      <Pressable
+                        onPress={() =>
+                          setPaymentEntry({
+                            id: entry.id,
+                            label: entry.label,
+                            amount: entry.amount,
+                            currency_code: entry.currency_code,
+                            expected_date: entry.expected_date,
+                            account_id: entry.account_id,
+                            recurring_template_id: entry.recurring_template_id,
+                            category_id: entry.category_id,
+                            debt_account_id: entry.debt_account_id ?? null,
+                          })
+                        }
+                        className="flex-row items-center gap-1 rounded-lg border border-z-brass-20 bg-z-brass-8 px-2 py-1"
+                      >
+                        <Banknote size={12} color={COLORS.brass} />
+                        <Text className="text-[10px] font-inter-semibold text-z-brass">
+                          Pagar
+                        </Text>
+                      </Pressable>
+                    )}
+                    <Text className="text-sm font-inter-semibold text-z-debt">
+                      {formatCurrency(entry.amount, data.currency)}
+                    </Text>
+                    <StatusBadge status={entry.status} />
+                  </View>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Payment sheet */}
+      {paymentEntry && data && (() => {
+        // Resolve debt account: prefer debt_account_id from template, fallback to entry's account_id
+        const debtAccountId = paymentEntry.debt_account_id ?? paymentEntry.account_id;
+        const debtAcc = debtAccountId ? data.accountDetails.get(debtAccountId) ?? null : null;
+        const debtAccount = debtAcc && isDebtAccountType(debtAcc.account_type)
+          ? (debtAcc as PaymentAccount)
+          : null;
+
+        return (
+          <PaymentSheet
+            visible={!!paymentEntry}
+            entry={paymentEntry}
+            debtAccount={debtAccount}
+            sourceAccounts={Array.from(data.accountDetails.values())
+              .filter(
+                (a) =>
+                  !isDebtAccountType(a.account_type) &&
+                  (a.account_type === "CHECKING" || a.account_type === "SAVINGS")
+              )
+              .map((a) => a as PaymentAccount)}
+            currency={data.currency}
+            onClose={() => setPaymentEntry(null)}
+            onSuccess={() => {
+              setPaymentEntry(null);
+              loadData();
+            }}
+          />
+        );
+      })()}
+
+      {/* Reassign sheet */}
+      <ReassignSheet
+        visible={!!reassignTarget}
+        target={reassignTarget}
+        incomeOptions={data.incomeEnvelopes.map((env, idx) => ({
+          entryId: env.entry.id,
+          label: env.entry.label,
+          remainingAmount: env.remainingAmount,
+          colorIndex: idx,
+        }))}
+        currency={data.currency}
+        onClose={() => setReassignTarget(null)}
+        onSuccess={() => {
+          setReassignTarget(null);
+          loadData();
+        }}
+      />
+    </View>
+  );
+}
+
+// ── Header ──
+function Header({ onBack }: { onBack: () => void }) {
+  return (
+    <View className="flex-row items-center px-4 pt-14 pb-2">
+      <Pressable onPress={onBack} className="mr-3 p-1">
+        <ArrowLeft size={20} color={COLORS.sageLight} />
+      </Pressable>
+      <Text className="text-lg font-inter-bold text-foreground">Plan del periodo</Text>
+    </View>
+  );
+}
+
+// ── Status badge ──
+function StatusBadge({ status }: { status: string }) {
+  const config: Record<string, { label: string; bg: string; text: string }> = {
+    PLANNED: { label: "Pendiente", bg: "bg-z-alert/10", text: "text-z-alert" },
+    COMPLETED: { label: "Pagado", bg: "bg-z-income/10", text: "text-z-income" },
+    SKIPPED: { label: "Omitido", bg: "bg-white/5", text: "text-muted-foreground" },
+  };
+  const c = config[status] ?? config.PLANNED;
+  return (
+    <View className={`rounded-md px-2 py-0.5 ${c.bg}`}>
+      <Text className={`text-[10px] font-inter-medium ${c.text}`}>{c.label}</Text>
+    </View>
+  );
+}
+
+// ── Income envelope card ──
+function IncomeCard({
+  envelope,
+  colorIndex,
+  currency,
+  isExpanded,
+  onToggle,
+}: {
+  envelope: IncomeEnvelope;
+  colorIndex: number;
+  currency: CurrencyCode;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const { entry, totalAmount, assignedAmount, remainingAmount, assignments } = envelope;
+  const pct = totalAmount > 0 ? Math.min(100, (assignedAmount / totalAmount) * 100) : 0;
+  const color = ENVELOPE_COLORS[colorIndex % ENVELOPE_COLORS.length];
+
+  return (
+    <Pressable onPress={onToggle}>
+      <View
+        className={`${PANEL_INSET_CLASS} overflow-hidden`}
+        style={{ borderLeftWidth: 2, borderLeftColor: color }}
+      >
+        <View className="p-3.5 gap-2">
+          {/* Name + amount + status */}
+          <View className="flex-row items-start justify-between gap-2">
+            <View className="flex-1">
+              <Text className="text-sm font-inter-semibold text-foreground">{entry.label}</Text>
+              <Text className="text-[10px] font-inter text-muted-foreground">
+                {formatDate(entry.expected_date, "dd MMM yyyy")}
+                {entry.account_name ? ` · ${entry.account_name}` : ""}
+              </Text>
+            </View>
+            <View className="flex-row items-center gap-2">
+              <Text className="text-sm font-inter-semibold" style={{ color }}>
+                {formatCurrency(totalAmount, currency)}
+              </Text>
+              {entry.status === "COMPLETED" ? (
+                <View className="h-5 w-5 items-center justify-center rounded-md" style={{ backgroundColor: color + "20", borderColor: color + "50", borderWidth: 1 }}>
+                  <Check size={12} color={color} />
+                </View>
+              ) : (
+                <View className="h-5 w-5 rounded-md border border-white/10 bg-white/5" />
+              )}
+            </View>
+          </View>
+
+          {/* Progress bar */}
+          <View className="h-1.5 w-full rounded-full bg-white-6 overflow-hidden">
+            <View className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
+          </View>
+
+          {/* Disponible + expand arrow */}
+          <View className="flex-row items-center justify-between">
+            <Text className="text-xs font-inter text-muted-foreground">
+              Disponible:{" "}
+              <Text className={`font-inter-semibold ${remainingAmount > 0 ? "text-z-brass" : "text-z-income"}`}>
+                {formatCurrency(remainingAmount, currency)}
+              </Text>
+            </Text>
+            <ChevronDown
+              size={14}
+              color={COLORS.sageDark}
+              style={{ transform: [{ rotate: isExpanded ? "180deg" : "0deg" }] }}
+            />
+          </View>
+        </View>
+
+        {/* Expanded assignments */}
+        {isExpanded && assignments.length > 0 && (
+          <View className="border-t border-white-6">
+            {assignments.map(({ assignment, expenseLabel }) => (
+              <View key={assignment.id} className="flex-row items-center justify-between px-3.5 py-2 border-b border-white-6">
+                <Text className="text-[11px] font-inter-medium text-muted-foreground">{expenseLabel}</Text>
+                <Text className="text-[11px] font-inter-semibold text-z-debt">
+                  {formatCurrency(assignment.assigned_amount, currency)}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+    </Pressable>
+  );
+}

--- a/mobile/app/purchase-decision.tsx
+++ b/mobile/app/purchase-decision.tsx
@@ -16,6 +16,7 @@ import {
 import { getAllAccounts, type AccountRow } from "../lib/repositories/accounts";
 import { analyzeLocally } from "../lib/services/purchase-decision";
 import { KeyboardScreen } from "../components/common/KeyboardScreen";
+import { toLocalMonthString } from "../lib/utils/date";
 
 const urgencyOptions: { value: PurchaseUrgency; label: string }[] = [
   { value: "NECESSARY", label: "Necesidad" },
@@ -102,7 +103,7 @@ export default function PurchaseDecisionScreen() {
 
     setLoading(true);
     try {
-      const month = new Date().toISOString().slice(0, 7);
+      const month = toLocalMonthString();
       const res = await analyzeLocally({
         amount: numAmount,
         accountId: selectedAccountId,

--- a/mobile/app/subscriptions.tsx
+++ b/mobile/app/subscriptions.tsx
@@ -56,7 +56,11 @@ type RecurringTemplateRow = Pick<
 >;
 
 function getTodayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 function getScheduleLabel(template: RecurringTemplateRow): string {
@@ -350,9 +354,9 @@ export default function SubscriptionsScreen() {
             <Pressable
               onPress={resetForm}
               disabled={saving || loading}
-              className="rounded-xl border border-gray-300 px-4 py-3 items-center justify-center"
+              className="rounded-xl border border-white-6 px-4 py-3 items-center justify-center"
             >
-              <Text className="text-gray-700 font-inter-medium text-sm">Cancelar</Text>
+              <Text className="text-foreground font-inter-medium text-sm">Cancelar</Text>
             </Pressable>
           ) : null}
         </View>
@@ -364,11 +368,11 @@ export default function SubscriptionsScreen() {
         </View>
       ) : (
         <>
-          <View className="rounded-xl border border-gray-200 bg-white p-4">
-            <Text className="text-gray-900 font-inter-semibold text-base">
+          <View className="rounded-xl border border-white-6 bg-z-surface-2-55 p-4">
+            <Text className="text-foreground font-inter-semibold text-base">
               {editingId ? "Editar suscripción" : "Nueva suscripción"}
             </Text>
-            <Text className="text-gray-500 font-inter text-xs mt-1">
+            <Text className="text-muted-foreground font-inter text-xs mt-1">
               Registra pagos como gym, Netflix, YouTube Premium, Codex, Supabase o Notion.
             </Text>
 
@@ -377,38 +381,40 @@ export default function SubscriptionsScreen() {
                 <Pressable
                   key={name}
                   onPress={() => useSuggestedName(name)}
-                  className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 active:bg-emerald-100"
+                  className="rounded-full border border-z-brass/30 bg-z-brass/10 px-3 py-1.5 active:bg-z-brass/20"
                 >
-                  <Text className="text-emerald-700 font-inter-medium text-xs">{name}</Text>
+                  <Text className="text-z-brass font-inter-medium text-xs">{name}</Text>
                 </Pressable>
               ))}
             </View>
 
-            <Text className="mt-4 mb-1 text-sm font-inter-medium text-gray-700">
+            <Text className="mt-4 mb-1 text-sm font-inter-medium text-foreground">
               Servicio / Membresía
             </Text>
             <TextInput
               value={merchantName}
               onChangeText={setMerchantName}
               placeholder="Ej: Netflix"
-              className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+              placeholderTextColor="#938C7E"
+              className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
-            <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">Monto</Text>
+            <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">Monto</Text>
             <TextInput
               value={amountInput}
               onChangeText={setAmountInput}
               keyboardType="decimal-pad"
               placeholder="Ej: 49900"
-              className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+              placeholderTextColor="#938C7E"
+              className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
-            <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">
+            <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">
               Cuenta de cobro
             </Text>
             {accounts.length === 0 ? (
-              <View className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2.5">
-                <Text className="text-amber-700 font-inter text-xs">
+              <View className="rounded-xl border border-amber-700/30 bg-amber-900/20 px-3 py-2.5">
+                <Text className="text-amber-400 font-inter text-xs">
                   Crea una cuenta primero para registrar suscripciones.
                 </Text>
               </View>
@@ -423,12 +429,12 @@ export default function SubscriptionsScreen() {
                       className={`rounded-xl border px-3 py-2 ${
                         selected
                           ? "border-primary bg-primary-light"
-                          : "border-gray-300 bg-white"
+                          : "border-white-6 bg-black-10"
                       }`}
                     >
                       <Text
                         className={`font-inter-medium text-xs ${
-                          selected ? "text-primary-dark" : "text-gray-700"
+                          selected ? "text-primary-dark" : "text-foreground"
                         }`}
                       >
                         {account.name}
@@ -439,7 +445,7 @@ export default function SubscriptionsScreen() {
               </View>
             )}
 
-            <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">Frecuencia</Text>
+            <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">Frecuencia</Text>
             <View className="flex-row gap-2">
               {FREQUENCY_OPTIONS.map((option) => {
                 const selected = frequency === option.value;
@@ -448,12 +454,12 @@ export default function SubscriptionsScreen() {
                     key={option.value}
                     onPress={() => setFrequency(option.value)}
                     className={`rounded-xl border px-3 py-2 ${
-                      selected ? "border-primary bg-primary-light" : "border-gray-300 bg-white"
+                      selected ? "border-primary bg-primary-light" : "border-white-6 bg-black-10"
                     }`}
                   >
                     <Text
                       className={`font-inter-medium text-xs ${
-                        selected ? "text-primary-dark" : "text-gray-700"
+                        selected ? "text-primary-dark" : "text-foreground"
                       }`}
                     >
                       {option.label}
@@ -463,36 +469,38 @@ export default function SubscriptionsScreen() {
               })}
             </View>
 
-            <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">Día de cobro</Text>
+            <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">Día de cobro</Text>
             <TextInput
               value={dayOfMonthInput}
               onChangeText={setDayOfMonthInput}
               keyboardType="number-pad"
               placeholder="1 - 31"
-              className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+              placeholderTextColor="#938C7E"
+              className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
-            <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">
+            <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">
               Nota (opcional)
             </Text>
             <TextInput
               value={description}
               onChangeText={setDescription}
               placeholder="Ej: Plan familiar"
-              className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+              placeholderTextColor="#938C7E"
+              className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
           </View>
 
           <View className="pt-5 pb-2">
-            <Text className="text-gray-500 font-inter-semibold text-xs uppercase">
+            <Text className="text-muted-foreground font-inter-semibold text-xs uppercase">
               Suscripciones registradas
             </Text>
           </View>
 
           {items.length === 0 ? (
-            <View className="rounded-2xl bg-white p-5">
-              <Text className="text-center text-sm text-gray-600 font-inter">
+            <View className="rounded-2xl bg-z-surface-2-55 p-5">
+              <Text className="text-center text-sm text-muted-foreground font-inter">
                 No hay suscripciones todavía.
               </Text>
             </View>
@@ -502,25 +510,25 @@ export default function SubscriptionsScreen() {
                 const account = accountsById.get(item.account_id);
                 const isBusy = togglingId === item.id || deletingId === item.id;
                 return (
-                  <View key={item.id} className="mb-3 rounded-2xl bg-white p-4 shadow-sm">
+                  <View key={item.id} className="mb-3 rounded-2xl bg-z-surface-2-55 p-4">
                     <View className="flex-row items-start justify-between">
                       <View className="flex-1 pr-3">
-                        <Text className="text-gray-900 font-inter-semibold text-base">
+                        <Text className="text-foreground font-inter-semibold text-base">
                           {item.merchant_name ?? "Suscripción"}
                         </Text>
-                        <Text className="text-gray-500 font-inter text-xs mt-1">
+                        <Text className="text-muted-foreground font-inter text-xs mt-1">
                           {account?.name ?? "Cuenta no disponible"}
                         </Text>
                       </View>
 
                       <View
                         className={`rounded-full px-2.5 py-1 ${
-                          item.is_active ? "bg-emerald-100" : "bg-gray-200"
+                          item.is_active ? "bg-z-income/10" : "bg-black-10"
                         }`}
                       >
                         <Text
                           className={`font-inter-medium text-xs ${
-                            item.is_active ? "text-emerald-700" : "text-gray-600"
+                            item.is_active ? "text-z-income" : "text-muted-foreground"
                           }`}
                         >
                           {item.is_active ? "Activa" : "Pausada"}
@@ -529,19 +537,19 @@ export default function SubscriptionsScreen() {
                     </View>
 
                     <View className="mt-3 flex-row items-center justify-between">
-                      <Text className="text-gray-900 font-inter-bold text-base">
+                      <Text className="text-foreground font-inter-bold text-base">
                         {formatCurrency(item.amount, item.currency_code as CurrencyCode)}
                       </Text>
                       <View className="flex-row items-center">
-                        <Repeat size={14} color="#6B7280" />
-                        <Text className="ml-1 text-gray-500 font-inter text-xs">
+                        <Repeat size={14} color="#938C7E" />
+                        <Text className="ml-1 text-muted-foreground font-inter text-xs">
                           {getScheduleLabel(item)}
                         </Text>
                       </View>
                     </View>
 
                     {item.description ? (
-                      <Text className="mt-2 text-gray-500 font-inter text-xs">
+                      <Text className="mt-2 text-muted-foreground font-inter text-xs">
                         {item.description}
                       </Text>
                     ) : null}
@@ -549,21 +557,21 @@ export default function SubscriptionsScreen() {
                     <View className="mt-3 flex-row gap-2">
                       <Pressable
                         onPress={() => beginEdit(item)}
-                        className="rounded-xl border border-gray-300 px-3 py-2 active:bg-gray-50"
+                        className="rounded-xl border border-white-6 px-3 py-2 active:bg-black-10"
                         disabled={isBusy || saving}
                       >
-                        <Text className="text-gray-700 font-inter-medium text-xs">Editar</Text>
+                        <Text className="text-foreground font-inter-medium text-xs">Editar</Text>
                       </Pressable>
 
                       <Pressable
                         onPress={() => toggleActive(item)}
-                        className="rounded-xl border border-sky-200 px-3 py-2 active:bg-sky-50"
+                        className="rounded-xl border border-sky-700/30 px-3 py-2 active:bg-sky-900/20"
                         disabled={isBusy || saving}
                       >
                         {togglingId === item.id ? (
                           <ActivityIndicator size="small" color="#0284C7" />
                         ) : (
-                          <Text className="text-sky-700 font-inter-medium text-xs">
+                          <Text className="text-sky-400 font-inter-medium text-xs">
                             {item.is_active ? "Pausar" : "Activar"}
                           </Text>
                         )}
@@ -571,7 +579,7 @@ export default function SubscriptionsScreen() {
 
                       <Pressable
                         onPress={() => handleDelete(item)}
-                        className="rounded-xl border border-red-200 px-3 py-2 active:bg-red-50"
+                        className="rounded-xl border border-z-debt/30 px-3 py-2 active:bg-z-debt/10"
                         disabled={isBusy || saving}
                       >
                         {deletingId === item.id ? (
@@ -579,7 +587,7 @@ export default function SubscriptionsScreen() {
                         ) : (
                           <View className="flex-row items-center">
                             <Trash2 size={12} color="#DC2626" />
-                            <Text className="ml-1 text-red-600 font-inter-medium text-xs">
+                            <Text className="ml-1 text-z-expense font-inter-medium text-xs">
                               Eliminar
                             </Text>
                           </View>

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -69,9 +69,9 @@ function DetailRow({
 }) {
   if (!value) return null;
   return (
-    <View className="flex-row items-start py-3 border-b border-gray-100">
-      <Text className="text-gray-500 font-inter text-sm w-20 mt-0.5">{label}</Text>
-      <Text className="text-gray-900 font-inter-medium text-sm text-right flex-1 ml-4 leading-5">
+    <View className="flex-row items-start py-3 border-b border-white-6">
+      <Text className="text-muted-foreground font-inter text-sm w-20 mt-0.5">{label}</Text>
+      <Text className="text-foreground font-inter-medium text-sm text-right flex-1 ml-4 leading-5">
         {value}
       </Text>
     </View>
@@ -89,9 +89,9 @@ function FormField({
 }) {
   return (
     <View className="mb-4">
-      <Text className="text-gray-700 font-inter-medium text-sm mb-1.5">
+      <Text className="text-foreground font-inter-medium text-sm mb-1.5">
         {label}
-        {required && <Text className="text-red-500"> *</Text>}
+        {required && <Text className="text-z-expense"> *</Text>}
       </Text>
       {children}
     </View>
@@ -115,10 +115,10 @@ function getHeroAmountColorClass(
   isDebtPayment: boolean,
   isInflow: boolean
 ): string {
-  if (isExcluded) return "text-gray-300";
+  if (isExcluded) return "text-muted-fg-50";
   if (isDebtPayment) return "text-sky-600";
-  if (isInflow) return "text-green-600";
-  return "text-gray-900";
+  if (isInflow) return "text-z-income";
+  return "text-foreground";
 }
 
 export default function TransactionDetailScreen() {
@@ -299,7 +299,7 @@ export default function TransactionDetailScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-white">
+      <View className="flex-1 items-center justify-center bg-z-card">
         <ActivityIndicator size="large" color="#10B981" />
       </View>
     );
@@ -307,21 +307,21 @@ export default function TransactionDetailScreen() {
 
   if (!transaction) {
     return (
-      <View className="flex-1 bg-white">
+      <View className="flex-1 bg-z-card">
         <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
           <Pressable
             onPress={() => router.back()}
-            className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+            className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
           >
-            <X size={18} color="#6B7280" />
+            <X size={18} color="#938C7E" />
           </Pressable>
-          <Text className="text-gray-900 font-inter-bold text-base">
+          <Text className="text-foreground font-inter-bold text-base">
             Detalle
           </Text>
           <View className="w-8" />
         </View>
         <View className="flex-1 items-center justify-center px-8">
-          <Text className="text-gray-400 font-inter text-base">
+          <Text className="text-muted-fg-50 font-inter text-base">
             Transaccion no encontrada
           </Text>
         </View>
@@ -343,7 +343,7 @@ export default function TransactionDetailScreen() {
   const statusLabel = STATUS_LABELS[transaction.status ?? ""] ?? (transaction.status ?? "Desconocido");
 
   return (
-    <View className="flex-1 bg-white">
+    <View className="flex-1 bg-z-card">
       {/* Header */}
       <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
         {isEditing ? (
@@ -353,11 +353,11 @@ export default function TransactionDetailScreen() {
               className="h-8 px-2 items-center justify-center"
               disabled={saving}
             >
-              <Text className="text-gray-500 font-inter-medium text-sm">
+              <Text className="text-muted-foreground font-inter-medium text-sm">
                 Cancelar
               </Text>
             </Pressable>
-            <Text className="text-gray-900 font-inter-bold text-base">
+            <Text className="text-foreground font-inter-bold text-base">
               Editar transacción
             </Text>
             <Pressable
@@ -378,23 +378,23 @@ export default function TransactionDetailScreen() {
           <>
             <Pressable
               onPress={() => router.back()}
-              className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
             >
-              <X size={18} color="#6B7280" />
+              <X size={18} color="#938C7E" />
             </Pressable>
-            <Text className="text-gray-900 font-inter-bold text-base">
+            <Text className="text-foreground font-inter-bold text-base">
               Detalle
             </Text>
             <View className="flex-row gap-2">
               <Pressable
                 onPress={enterEditMode}
-                className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+                className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
               >
-                <Pencil size={16} color="#6B7280" />
+                <Pencil size={16} color="#938C7E" />
               </Pressable>
               <Pressable
                 onPress={handleDelete}
-                className="w-8 h-8 items-center justify-center rounded-full bg-red-50 active:bg-red-100"
+                className="w-8 h-8 items-center justify-center rounded-full bg-z-debt/10 active:bg-z-debt/20"
               >
                 <Trash2 size={16} color="#EF4444" />
               </Pressable>
@@ -405,8 +405,8 @@ export default function TransactionDetailScreen() {
 
       {/* Success banner */}
       {successVisible && (
-        <View className="mx-4 mb-2 bg-green-50 rounded-xl px-4 py-2.5">
-          <Text className="text-green-700 font-inter-medium text-sm">
+        <View className="mx-4 mb-2 bg-z-income/10 rounded-xl px-4 py-2.5">
+          <Text className="text-z-income font-inter-medium text-sm">
             Cambios guardados correctamente
           </Text>
         </View>
@@ -427,11 +427,11 @@ export default function TransactionDetailScreen() {
             {/* Merchant */}
             <FormField label="Comercio">
               <TextInput
-                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 text-foreground font-inter text-sm"
                 value={editMerchantName}
                 onChangeText={setEditMerchantName}
                 placeholder="Nombre del comercio"
-                placeholderTextColor="#9CA3AF"
+                placeholderTextColor="#938C7E"
                 autoCapitalize="words"
               />
             </FormField>
@@ -439,22 +439,22 @@ export default function TransactionDetailScreen() {
             {/* Description */}
             <FormField label="Descripción">
               <TextInput
-                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 text-foreground font-inter text-sm"
                 value={editDescription}
                 onChangeText={setEditDescription}
                 placeholder="Descripción de la transacción"
-                placeholderTextColor="#9CA3AF"
+                placeholderTextColor="#938C7E"
               />
             </FormField>
 
             {/* Amount */}
             <FormField label="Monto" required>
               <TextInput
-                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 text-foreground font-inter text-sm"
                 value={editAmount}
                 onChangeText={setEditAmount}
                 placeholder="0"
-                placeholderTextColor="#9CA3AF"
+                placeholderTextColor="#938C7E"
                 keyboardType="decimal-pad"
               />
             </FormField>
@@ -463,43 +463,43 @@ export default function TransactionDetailScreen() {
             <FormField label="Fecha" required>
               <Pressable
                 onPress={() => setShowDatePicker(true)}
-                className="bg-white border border-gray-200 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-gray-50"
+                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-white/10"
               >
-                <Text className="text-gray-900 font-inter text-sm">
+                <Text className="text-foreground font-inter text-sm">
                   {editDate.toLocaleDateString("es-CO", {
                     year: "numeric",
                     month: "long",
                     day: "numeric",
                   })}
                 </Text>
-                <Calendar size={16} color="#9CA3AF" />
+                <Calendar size={16} color="#938C7E" />
               </Pressable>
             </FormField>
 
             {/* Category */}
             <FormField label="Categoría">
               {isDebtPayment ? (
-                <View className="bg-sky-50 border border-sky-200 rounded-xl px-4 py-3 flex-row items-center justify-between">
-                  <Text className="font-inter-medium text-sm text-sky-700">
+                <View className="bg-sky-900/20 border border-sky-700/30 rounded-xl px-4 py-3 flex-row items-center justify-between">
+                  <Text className="font-inter-medium text-sm text-sky-400">
                     Abono a deuda
                   </Text>
-                  <Text className="font-inter text-xs text-sky-600">
+                  <Text className="font-inter text-xs text-sky-500">
                     Categoria fija
                   </Text>
                 </View>
               ) : (
                 <Pressable
                   onPress={() => setShowCategoryPicker(true)}
-                  className="bg-white border border-gray-200 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-gray-50"
+                  className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-white/10"
                 >
                   <Text
                     className={`font-inter text-sm ${
-                      editCategoryName ? "text-gray-900" : "text-gray-400"
+                      editCategoryName ? "text-foreground" : "text-muted-fg-50"
                     }`}
                   >
                     {editCategoryName ?? "Sin categoría"}
                   </Text>
-                  <Tag size={16} color="#9CA3AF" />
+                  <Tag size={16} color="#938C7E" />
                 </Pressable>
               )}
             </FormField>
@@ -507,32 +507,32 @@ export default function TransactionDetailScreen() {
             {/* Notes */}
             <FormField label="Notas">
               <TextInput
-                className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 text-foreground font-inter text-sm"
                 value={editNotes}
                 onChangeText={setEditNotes}
                 placeholder="Agregar nota..."
-                placeholderTextColor="#9CA3AF"
+                placeholderTextColor="#938C7E"
                 multiline
                 style={{ minHeight: 72, textAlignVertical: "top" }}
               />
             </FormField>
 
             {/* Exclude from totals */}
-            <View className="flex-row items-center justify-between bg-white border border-gray-200 rounded-xl px-4 py-3 mb-4">
+            <View className="flex-row items-center justify-between bg-black-10 border border-white-6 rounded-xl px-4 py-3 mb-4">
               <View className="flex-1 mr-4">
-                <Text className="text-gray-700 font-inter-medium text-sm">
+                <Text className="text-foreground font-inter-medium text-sm">
                   Excluir de totales
                 </Text>
-                <Text className="text-gray-500 font-inter text-xs mt-0.5">
+                <Text className="text-muted-foreground font-inter text-xs mt-0.5">
                   No contabilizar en estadísticas
                 </Text>
               </View>
               <Switch
                 value={editIsExcluded}
                 onValueChange={setEditIsExcluded}
-                trackColor={{ false: "#E5E7EB", true: "#10B981" }}
+                trackColor={{ false: "#3A3A3A", true: "#10B981" }}
                 thumbColor="#FFFFFF"
-                ios_backgroundColor="#E5E7EB"
+                ios_backgroundColor="#3A3A3A"
               />
             </View>
           </ScrollView>
@@ -541,16 +541,16 @@ export default function TransactionDetailScreen() {
         /* ── Read-only view ── */
         <ScrollView className="flex-1">
           {/* Amount hero */}
-          <View className="items-center pt-6 pb-5 border-b border-gray-100 mx-4">
-            <Text className="text-gray-500 font-inter text-sm mb-1">
+          <View className="items-center pt-6 pb-5 border-b border-white-6 mx-4">
+            <Text className="text-muted-foreground font-inter text-sm mb-1">
               {getTransactionTypeLabel({
                 direction: transaction.direction,
                 accountType: transaction.account_type,
               })}
             </Text>
             {isExcluded && (
-              <View className="flex-row items-center bg-amber-50 px-3 py-1 rounded-full mb-2">
-                <Text className="text-amber-600 font-inter-medium text-xs">
+              <View className="flex-row items-center bg-amber-900/20 px-3 py-1 rounded-full mb-2">
+                <Text className="text-amber-400 font-inter-medium text-xs">
                   Excluido de totales
                 </Text>
               </View>
@@ -568,7 +568,7 @@ export default function TransactionDetailScreen() {
             {transaction.merchant_name && (
               <Text
                 className={`font-inter-medium text-base mt-2 ${
-                  isExcluded ? "text-gray-400" : "text-gray-700"
+                  isExcluded ? "text-muted-fg-50" : "text-foreground"
                 }`}
               >
                 {transaction.merchant_name}
@@ -603,21 +603,21 @@ export default function TransactionDetailScreen() {
             <DetailRow label="Notas" value={transaction.notes} />
 
             {/* Exclude toggle */}
-            <View className="flex-row items-center justify-between py-3 border-b border-gray-100">
+            <View className="flex-row items-center justify-between py-3 border-b border-white-6">
               <View>
-                <Text className="text-gray-500 font-inter text-sm">
+                <Text className="text-muted-foreground font-inter text-sm">
                   Excluir de totales
                 </Text>
-                <Text className="text-gray-400 font-inter text-xs mt-0.5">
+                <Text className="text-muted-fg-50 font-inter text-xs mt-0.5">
                   No afecta estadísticas ni presupuestos
                 </Text>
               </View>
               <Switch
                 value={isExcluded}
                 onValueChange={handleToggleExclude}
-                trackColor={{ false: "#E5E7EB", true: "#10B981" }}
+                trackColor={{ false: "#3A3A3A", true: "#10B981" }}
                 thumbColor="#FFFFFF"
-                ios_backgroundColor="#E5E7EB"
+                ios_backgroundColor="#3A3A3A"
               />
             </View>
           </View>
@@ -640,7 +640,7 @@ export default function TransactionDetailScreen() {
       {showDatePicker && Platform.OS === "ios" ? (
         <Modal transparent animationType="slide">
           <View className="flex-1 justify-end bg-black/40">
-            <View className="bg-white rounded-t-2xl pt-2 pb-6">
+            <View className="bg-z-surface-2-55 rounded-t-2xl pt-2 pb-6">
               <View className="flex-row justify-end px-4 pb-2">
                 <Pressable
                   onPress={() => setShowDatePicker(false)}

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -116,7 +116,7 @@ function getHeroAmountColorClass(
   isInflow: boolean
 ): string {
   if (isExcluded) return "text-muted-fg-50";
-  if (isDebtPayment) return "text-sky-600";
+  if (isDebtPayment) return "text-z-brass";
   if (isInflow) return "text-z-income";
   return "text-foreground";
 }
@@ -299,15 +299,15 @@ export default function TransactionDetailScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-z-card">
-        <ActivityIndicator size="large" color="#10B981" />
+      <View className="flex-1 items-center justify-center bg-background">
+        <ActivityIndicator size="large" color=COLORS.income />
       </View>
     );
   }
 
   if (!transaction) {
     return (
-      <View className="flex-1 bg-z-card">
+      <View className="flex-1 bg-background">
         <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
           <Pressable
             onPress={() => router.back()}
@@ -343,7 +343,7 @@ export default function TransactionDetailScreen() {
   const statusLabel = STATUS_LABELS[transaction.status ?? ""] ?? (transaction.status ?? "Desconocido");
 
   return (
-    <View className="flex-1 bg-z-card">
+    <View className="flex-1 bg-background">
       {/* Header */}
       <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
         {isEditing ? (
@@ -366,7 +366,7 @@ export default function TransactionDetailScreen() {
               disabled={saving}
             >
               {saving ? (
-                <ActivityIndicator size="small" color="#10B981" />
+                <ActivityIndicator size="small" color=COLORS.income />
               ) : (
                 <Text className="text-primary font-inter-bold text-sm">
                   Guardar
@@ -396,7 +396,7 @@ export default function TransactionDetailScreen() {
                 onPress={handleDelete}
                 className="w-8 h-8 items-center justify-center rounded-full bg-z-debt/10 active:bg-z-debt/20"
               >
-                <Trash2 size={16} color="#EF4444" />
+                <Trash2 size={16} color={COLORS.debt} />
               </Pressable>
             </View>
           </>
@@ -530,8 +530,8 @@ export default function TransactionDetailScreen() {
               <Switch
                 value={editIsExcluded}
                 onValueChange={setEditIsExcluded}
-                trackColor={{ false: "#3A3A3A", true: "#10B981" }}
-                thumbColor="#FFFFFF"
+                trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                thumbColor={COLORS.foreground}
                 ios_backgroundColor="#3A3A3A"
               />
             </View>
@@ -550,7 +550,7 @@ export default function TransactionDetailScreen() {
             </Text>
             {isExcluded && (
               <View className="flex-row items-center bg-amber-900/20 px-3 py-1 rounded-full mb-2">
-                <Text className="text-amber-400 font-inter-medium text-xs">
+                <Text className="text-z-alert font-inter-medium text-xs">
                   Excluido de totales
                 </Text>
               </View>
@@ -615,8 +615,8 @@ export default function TransactionDetailScreen() {
               <Switch
                 value={isExcluded}
                 onValueChange={handleToggleExclude}
-                trackColor={{ false: "#3A3A3A", true: "#10B981" }}
-                thumbColor="#FFFFFF"
+                trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                thumbColor={COLORS.foreground}
                 ios_backgroundColor="#3A3A3A"
               />
             </View>

--- a/mobile/components/ScreenshotAnnotator.tsx
+++ b/mobile/components/ScreenshotAnnotator.tsx
@@ -34,12 +34,12 @@ export function ScreenshotAnnotator({ screenshotUri, onAnnotated }: Props) {
           style={styles.annotateButton}
           onPress={() => router.push("/annotate-screenshot" as never)}
         >
-          <Pencil size={14} color="#FFFFFF" />
+          <Pencil size={14} color="#121412" />
           <Text style={styles.annotateLabel}>Anotar</Text>
         </Pressable>
 
         <Pressable style={styles.toolButton} onPress={() => onAnnotated("")}>
-          <Trash2 size={14} color="#374151" />
+          <Trash2 size={14} color="#C5BFAE" />
           <Text style={styles.toolLabel}>Quitar</Text>
         </Pressable>
 
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
+    borderColor: "rgba(255,255,255,0.06)",
     overflow: "hidden",
   },
   image: {
@@ -68,9 +68,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingHorizontal: 12,
     paddingVertical: 8,
-    backgroundColor: "#F9FAFB",
+    backgroundColor: "#121412",
     borderTopWidth: 1,
-    borderTopColor: "#E5E7EB",
+    borderTopColor: "rgba(255,255,255,0.06)",
     gap: 8,
   },
   annotateButton: {
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
   annotateLabel: {
     fontSize: 12,
     fontWeight: "600",
-    color: "#FFFFFF",
+    color: "#121412",
   },
   toolButton: {
     flexDirection: "row",
@@ -93,28 +93,28 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 6,
     borderRadius: 8,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "#1A1C1A",
     borderWidth: 1,
-    borderColor: "#E5E7EB",
+    borderColor: "rgba(255,255,255,0.06)",
     gap: 4,
   },
   toolLabel: {
     fontSize: 12,
     fontWeight: "500",
-    color: "#374151",
+    color: "#C5BFAE",
   },
   doneButton: {
     marginLeft: "auto",
     paddingHorizontal: 16,
     paddingVertical: 6,
     borderRadius: 8,
-    backgroundColor: "#F3F4F6",
+    backgroundColor: "#1A1C1A",
     borderWidth: 1,
-    borderColor: "#E5E7EB",
+    borderColor: "rgba(255,255,255,0.06)",
   },
   doneLabel: {
     fontSize: 12,
     fontWeight: "600",
-    color: "#374151",
+    color: "#C5BFAE",
   },
 });

--- a/mobile/components/accounts/CurrencyPicker.tsx
+++ b/mobile/components/accounts/CurrencyPicker.tsx
@@ -21,13 +21,13 @@ export function CurrencyPicker({ selected, onSelect }: Props) {
             className={`rounded-full px-4 py-2 border-2 active:opacity-80 ${
               isSelected
                 ? "bg-primary border-primary"
-                : "bg-white border-gray-200"
+                : "bg-z-surface-2-55 border-white-6"
             }`}
             onPress={() => onSelect(currency.code)}
           >
             <Text
               className={`font-inter-semibold text-sm ${
-                isSelected ? "text-white" : "text-gray-700"
+                isSelected ? "text-white" : "text-muted-foreground"
               }`}
             >
               {currency.code}

--- a/mobile/components/common/KeyboardScreen.tsx
+++ b/mobile/components/common/KeyboardScreen.tsx
@@ -17,17 +17,17 @@ export function KeyboardScreen({
 }) {
   return (
     <KeyboardAvoidingView
-      className="flex-1 bg-gray-100"
+      className="flex-1 bg-background"
       behavior="padding"
     >
-      <View className="flex-row items-center justify-between border-b border-gray-100 bg-white px-4 pb-2 pt-4">
+      <View className="flex-row items-center justify-between border-b border-white-6 bg-z-surface-2-55 px-4 pb-2 pt-4">
         <Pressable
           onPress={onBack}
-          className="h-8 w-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+          className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
         >
-          <ArrowLeft size={18} color="#6B7280" />
+          <ArrowLeft size={18} color="#938C7E" />
         </Pressable>
-        <Text className="text-base font-inter-bold text-gray-900">{title}</Text>
+        <Text className="text-base font-inter-bold text-foreground">{title}</Text>
         <View className="w-8" />
       </View>
 
@@ -41,7 +41,7 @@ export function KeyboardScreen({
       </AppKeyboardAwareScrollView>
 
       {footer ? (
-        <View className="border-t border-gray-200 bg-white p-4">{footer}</View>
+        <View className="border-t border-white-6 bg-z-surface-2-55 p-4">{footer}</View>
       ) : null}
     </KeyboardAvoidingView>
   );

--- a/mobile/components/dashboard/BalanceCard.tsx
+++ b/mobile/components/dashboard/BalanceCard.tsx
@@ -14,17 +14,17 @@ export function BalanceCard({
   currencyCode = "COP",
 }: BalanceCardProps) {
   return (
-    <View className="bg-white rounded-lg shadow-sm p-5 mx-4 mt-4">
+    <View className="bg-z-surface-2-55 rounded-lg p-5 mx-4 mt-4">
       <View className="flex-row items-center mb-2">
-        <Wallet size={18} color="#6B7280" />
-        <Text className="text-gray-500 font-inter-medium text-sm ml-2">
+        <Wallet size={18} color="#938C7E" />
+        <Text className="text-muted-foreground font-inter-medium text-sm ml-2">
           Balance total
         </Text>
       </View>
-      <Text className="text-gray-900 font-inter-bold text-3xl mb-1">
+      <Text className="text-foreground font-inter-bold text-3xl mb-1">
         {formatCurrency(totalBalance, currencyCode)}
       </Text>
-      <Text className="text-gray-400 font-inter text-sm">
+      <Text className="text-muted-fg-50 font-inter text-sm">
         {accountCount} {accountCount === 1 ? "cuenta activa" : "cuentas activas"}
       </Text>
     </View>

--- a/mobile/components/dashboard/CategoryBreakdown.tsx
+++ b/mobile/components/dashboard/CategoryBreakdown.tsx
@@ -20,13 +20,13 @@ export function CategoryBreakdown({
   const maxTotal = categories.length > 0 ? categories[0].total : 1;
 
   return (
-    <View className="bg-white rounded-lg shadow-sm p-4 mx-4 mt-4 mb-6">
-      <Text className="text-gray-900 font-inter-bold text-base mb-4">
+    <View className="bg-z-surface-2-55 rounded-lg p-4 mx-4 mt-4 mb-6">
+      <Text className="text-foreground font-inter-bold text-base mb-4">
         Gastos por categoria
       </Text>
 
       {categories.length === 0 ? (
-        <Text className="text-gray-400 font-inter text-sm text-center py-4">
+        <Text className="text-muted-fg-50 font-inter text-sm text-center py-4">
           Sin gastos este mes
         </Text>
       ) : (
@@ -43,17 +43,17 @@ export function CategoryBreakdown({
                     style={{ backgroundColor: color }}
                   />
                   <Text
-                    className="text-gray-700 font-inter-medium text-sm"
+                    className="text-foreground font-inter-medium text-sm"
                     numberOfLines={1}
                   >
                     {cat.category_name_es || "Sin categoria"}
                   </Text>
                 </View>
-                <Text className="text-gray-900 font-inter-semibold text-sm ml-2">
+                <Text className="text-foreground font-inter-semibold text-sm ml-2">
                   {formatCurrency(cat.total, currencyCode)}
                 </Text>
               </View>
-              <View className="h-2 bg-gray-100 rounded-full overflow-hidden">
+              <View className="h-2 bg-black-10 rounded-full overflow-hidden">
                 <View
                   className="h-full rounded-full"
                   style={{

--- a/mobile/components/dashboard/MonthSummary.tsx
+++ b/mobile/components/dashboard/MonthSummary.tsx
@@ -16,31 +16,31 @@ export function MonthSummary({
   return (
     <View className="flex-row mx-4 mt-4 gap-3">
       {/* Income card */}
-      <View className="flex-1 bg-white rounded-lg shadow-sm p-4">
+      <View className="flex-1 bg-z-surface-2-55 rounded-lg p-4">
         <View className="flex-row items-center mb-2">
-          <View className="bg-green-100 rounded-full p-1.5">
+          <View className="bg-z-income/10 rounded-full p-1.5">
             <TrendingUp size={14} color="#22C55E" />
           </View>
-          <Text className="text-gray-500 font-inter text-xs ml-2">
+          <Text className="text-muted-foreground font-inter text-xs ml-2">
             Ingresos
           </Text>
         </View>
-        <Text className="text-green-600 font-inter-bold text-lg">
+        <Text className="text-z-income font-inter-bold text-lg">
           {formatCurrency(income, currencyCode)}
         </Text>
       </View>
 
       {/* Expenses card */}
-      <View className="flex-1 bg-white rounded-lg shadow-sm p-4">
+      <View className="flex-1 bg-z-surface-2-55 rounded-lg p-4">
         <View className="flex-row items-center mb-2">
-          <View className="bg-red-100 rounded-full p-1.5">
+          <View className="bg-z-expense/10 rounded-full p-1.5">
             <TrendingDown size={14} color="#EF4444" />
           </View>
-          <Text className="text-gray-500 font-inter text-xs ml-2">
+          <Text className="text-muted-foreground font-inter text-xs ml-2">
             Gastos
           </Text>
         </View>
-        <Text className="text-red-500 font-inter-bold text-lg">
+        <Text className="text-z-expense font-inter-bold text-lg">
           {formatCurrency(expenses, currencyCode)}
         </Text>
       </View>

--- a/mobile/components/dashboard/PurchaseDecisionCard.tsx
+++ b/mobile/components/dashboard/PurchaseDecisionCard.tsx
@@ -8,17 +8,17 @@ export function PurchaseDecisionCard() {
   return (
     <Pressable
       onPress={() => router.push("/purchase-decision" as never)}
-      className="mx-4 mt-4 rounded-lg bg-white p-4 shadow-sm active:bg-gray-50"
+      className="mx-4 mt-4 rounded-lg bg-z-surface-2-55 p-4 active:bg-black-10"
     >
       <View className="flex-row items-center gap-3">
-        <View className="h-10 w-10 rounded-full bg-emerald-50 items-center justify-center">
+        <View className="h-10 w-10 rounded-full bg-z-brass/10 items-center justify-center">
           <Brain size={20} color="#C5BFAE" />
         </View>
         <View className="flex-1">
-          <Text className="text-sm font-inter-semibold text-gray-900">
+          <Text className="text-sm font-inter-semibold text-foreground">
             ¿Deberia comprar esto?
           </Text>
-          <Text className="text-xs font-inter text-gray-500 mt-0.5">
+          <Text className="text-xs font-inter text-muted-foreground mt-0.5">
             Evalua el impacto en liquidez, deuda y presupuesto
           </Text>
         </View>

--- a/mobile/components/inicio/InicioHero.tsx
+++ b/mobile/components/inicio/InicioHero.tsx
@@ -8,6 +8,7 @@ interface InicioHeroProps {
   availablePerDay: number;
   availableTotal: number;
   daysRemaining: number;
+  daysLabel: string; // e.g. "12 días hasta 27 abr" or "15 días restantes"
   currency: CurrencyCode;
   breakdown?: {
     totalLiquid: number;
@@ -22,6 +23,7 @@ export function InicioHero({
   availablePerDay,
   availableTotal,
   daysRemaining,
+  daysLabel,
   currency,
   breakdown,
   expanded,
@@ -44,7 +46,7 @@ export function InicioHero({
         </View>
 
         <Text className="mt-2 text-xs font-inter text-muted-foreground">
-          = {formatCurrency(availableTotal, currency)} este mes · {daysRemaining} dias restantes
+          = {formatCurrency(availableTotal, currency)} · {daysLabel}
         </Text>
 
         {/* Expandable math breakdown */}
@@ -57,7 +59,7 @@ export function InicioHero({
                 </Text>
                 <View className="flex-row justify-between">
                   <Text className="text-xs font-inter text-z-sage-light">
-                    Ingresos del mes
+                    Saldo liquido
                   </Text>
                   <Text className="text-xs font-inter text-z-sage-light">
                     {formatCurrency(breakdown.totalLiquid, currency)}
@@ -65,7 +67,7 @@ export function InicioHero({
                 </View>
                 <View className="flex-row justify-between">
                   <Text className="text-xs font-inter text-z-sage-light">
-                    - Gastos fijos pendientes
+                    - Obligaciones pendientes
                   </Text>
                   <Text className="text-xs font-inter text-z-expense">
                     -{formatCurrency(breakdown.fixedExpenses, currency)}

--- a/mobile/components/inicio/InicioHero.tsx
+++ b/mobile/components/inicio/InicioHero.tsx
@@ -32,12 +32,12 @@ export function InicioHero({
   return (
     <Pressable onPress={onToggle} accessibilityLabel="Expandir desglose del disponible diario">
       <GradientCard>
-        <Text className="text-[10px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">
+        <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">
           Disponible para gastar
         </Text>
 
         <View className="mt-2 flex-row items-baseline gap-0.5">
-          <Text className="text-[36px] font-inter-bold text-foreground">
+          <Text className="text-[36px] font-inter-bold tabular-nums text-foreground">
             {formatCurrency(availablePerDay, currency)}
           </Text>
           <Text className="text-sm font-inter-medium text-muted-foreground">
@@ -54,7 +54,7 @@ export function InicioHero({
           <View className="mt-3">
             {breakdown && (
               <View className={`${PANEL_INSET_CLASS} border-white-8 bg-black-20 p-3 gap-1.5`}>
-                <Text className="text-[10px] font-inter-bold uppercase tracking-[3px] text-z-brass">
+                <Text className="text-[10px] font-inter-bold uppercase tracking-[0.18em] text-z-brass">
                   Como se calcula
                 </Text>
                 <View className="flex-row justify-between">

--- a/mobile/components/inicio/InicioRoot.tsx
+++ b/mobile/components/inicio/InicioRoot.tsx
@@ -1,12 +1,13 @@
 import { View, ScrollView, RefreshControl } from "react-native";
 import { useCallback, useState } from "react";
 import { useFocusEffect } from "expo-router";
-import type { CurrencyCode } from "@zeta/shared";
+import { formatDate, type CurrencyCode } from "@zeta/shared";
 import { useSync } from "../../lib/sync/hooks";
 import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
 import { getTransactions } from "../../lib/repositories/transactions";
-import { DEBT_ACCOUNT_TYPES } from "../../lib/constants/accounts";
-import { computeCashflow } from "../../lib/utils/cashflow";
+import { getPendingOccurrences, type OccurrenceWithTemplate } from "../../lib/repositories/recurring";
+import { DEBT_ACCOUNT_TYPES, isDebtAccountType, LIQUID_ACCOUNT_TYPES } from "../../lib/constants/accounts";
+import { toLocalDateString, toLocalMonthString } from "../../lib/utils/date";
 import { COLORS } from "../../lib/constants/colors";
 import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
@@ -23,6 +24,7 @@ interface DashboardState {
     availablePerDay: number;
     availableTotal: number;
     daysRemaining: number;
+    daysLabel: string;
     breakdown: { totalLiquid: number; fixedExpenses: number; alreadySpent: number };
   };
   metrics: {
@@ -38,7 +40,7 @@ interface DashboardState {
 }
 
 const INITIAL_STATE: DashboardState = {
-  hero: { availablePerDay: 0, availableTotal: 0, daysRemaining: 0, breakdown: { totalLiquid: 0, fixedExpenses: 0, alreadySpent: 0 } },
+  hero: { availablePerDay: 0, availableTotal: 0, daysRemaining: 0, daysLabel: "", breakdown: { totalLiquid: 0, fixedExpenses: 0, alreadySpent: 0 } },
   metrics: { daysInMonth: 30, dayOfMonth: 1, spentToday: 0, spentYesterday: 0, avgLast7: 0 },
   accounts: { count: 0, netWorth: 0 },
   upcomingPayments: [],
@@ -57,65 +59,120 @@ export function InicioRoot() {
   const loadData = useCallback(async () => {
     try {
       const now = new Date();
-      const currentMonth = now.toISOString().slice(0, 7);
-      const today = now.toISOString().slice(0, 10);
+      const currentMonth = toLocalMonthString(now);
+      const today = toLocalDateString(now);
       const dayOfMonth = now.getDate();
       const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-      const daysRemaining = daysInMonth - dayOfMonth;
 
-      const [accounts, transactions] = await Promise.all([
+      const [accounts, transactions, pendingOccs] = await Promise.all([
         getAllAccounts(),
         getTransactions({ month: currentMonth, limit: 500 }),
+        getPendingOccurrences(),
       ]);
 
       const txRows = transactions as any[];
-
-      // Build lookup map once
       const accountMap = new Map(accounts.map((a: AccountRow) => [a.id, a]));
 
-      // Net worth
+      // ── Liquid balance (CHECKING + SAVINGS only, matching webapp) ──
+      const liquidBalance = accounts
+        .filter((a: AccountRow) => LIQUID_ACCOUNT_TYPES.has(a.account_type))
+        .reduce((sum: number, a: AccountRow) => sum + a.current_balance, 0);
+
+      // ── Next income occurrence ──
+      const nextIncome = pendingOccs.find(
+        (o: OccurrenceWithTemplate) =>
+          o.direction === "INFLOW" &&
+          !isDebtAccountType(accountMap.get(o.account_id)?.account_type ?? "") &&
+          o.occurrence_date >= today
+      );
+
+      // Window end: next income date or month end
+      const windowEndDate = nextIncome
+        ? nextIncome.occurrence_date
+        : `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(daysInMonth).padStart(2, "0")}`;
+
+      const daysRemaining = Math.max(
+        1,
+        Math.ceil(
+          (new Date(windowEndDate + "T12:00:00").getTime() - now.getTime()) /
+            (1000 * 60 * 60 * 24)
+        )
+      );
+
+      // ── Pending obligations (effective outflows, excl credit card) ──
+      const pendingObligations = pendingOccs
+        .filter((o: OccurrenceWithTemplate) => {
+          const acctType = accountMap.get(o.account_id)?.account_type ?? "";
+          const isEffectiveOutflow =
+            o.direction === "OUTFLOW" ||
+            (o.direction === "INFLOW" && isDebtAccountType(acctType));
+          return (
+            isEffectiveOutflow &&
+            o.occurrence_date >= today &&
+            o.occurrence_date <= windowEndDate &&
+            acctType !== "CREDIT_CARD"
+          );
+        })
+        .reduce((sum: number, o: OccurrenceWithTemplate) => sum + o.expected_amount, 0);
+
+      const disponible = Math.max(0, liquidBalance - pendingObligations);
+      const availablePerDay = Math.round(disponible / daysRemaining);
+
+      // ── Net worth ──
       const netWorth = accounts.reduce((sum: number, a: AccountRow) => {
         return DEBT_ACCOUNT_TYPES.has(a.account_type) ? sum - a.current_balance : sum + a.current_balance;
       }, 0);
 
-      // Single-pass cashflow + daily metrics
-      const { totalInflow, totalOutflow } = computeCashflow(txRows, accounts);
-
+      // ── Daily spending metrics ──
       let spentToday = 0;
       let spentYesterday = 0;
       let last7Total = 0;
+      let totalOutflow = 0;
 
       const yesterdayDate = new Date(now);
       yesterdayDate.setDate(yesterdayDate.getDate() - 1);
-      const yesterdayStr = yesterdayDate.toISOString().slice(0, 10);
+      const yesterdayStr = toLocalDateString(yesterdayDate);
 
       for (const tx of txRows) {
         if (tx.is_excluded || tx.direction !== "OUTFLOW") continue;
+        if (tx.transfer_group_id || tx.reconciled_into_transaction_id) continue;
         const amount = Math.abs(tx.amount ?? 0);
+        totalOutflow += amount;
         if (tx.transaction_date === today) spentToday += amount;
         if (tx.transaction_date === yesterdayStr) spentYesterday += amount;
-        const txDate = new Date(tx.transaction_date);
+        const txDate = new Date(tx.transaction_date + "T12:00:00");
         const diffDays = Math.floor((now.getTime() - txDate.getTime()) / (1000 * 60 * 60 * 24));
         if (diffDays >= 0 && diffDays < 7) last7Total += amount;
       }
 
       const avgLast7 = last7Total / 7;
-      const availableTotal = Math.max(0, totalInflow - totalOutflow);
-      const availablePerDay = daysRemaining > 0 ? Math.round(availableTotal / daysRemaining) : availableTotal;
 
-      // Upcoming payments
-      const payments: AttentionPayment[] = accounts
-        .filter((a: AccountRow) => a.is_active === 1 && a.payment_day)
-        .map((a: AccountRow) => {
-          const dueDate = new Date(now.getFullYear(), now.getMonth(), a.payment_day ?? 1);
-          if (dueDate < now) dueDate.setMonth(dueDate.getMonth() + 1);
-          const daysUntil = Math.ceil((dueDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-          return { name: a.name, amount: Math.abs(a.current_balance), daysUntil, accountName: a.name };
+      // ── Upcoming payments (from recurring occurrences) ──
+      const payments: AttentionPayment[] = pendingOccs
+        .filter((o: OccurrenceWithTemplate) => {
+          const acctType = accountMap.get(o.account_id)?.account_type ?? "";
+          const isEffectiveOutflow =
+            o.direction === "OUTFLOW" ||
+            (o.direction === "INFLOW" && isDebtAccountType(acctType));
+          const daysUntil = Math.ceil(
+            (new Date(o.occurrence_date + "T12:00:00").getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+          );
+          return isEffectiveOutflow && daysUntil >= 0 && daysUntil <= 7;
         })
-        .filter((p) => p.daysUntil >= 0 && p.daysUntil <= 7)
+        .map((o: OccurrenceWithTemplate) => {
+          const daysUntil = Math.ceil(
+            (new Date(o.occurrence_date + "T12:00:00").getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+          );
+          return {
+            name: o.merchant_name ?? o.description ?? "Recurrente",
+            amount: o.expected_amount,
+            daysUntil,
+            accountName: accountMap.get(o.account_id)?.name ?? "",
+          };
+        })
         .sort((a, b) => a.daysUntil - b.daysUntil);
 
-      // Recent transactions — use accountMap for O(1) lookup
+      // ── Recent transactions ──
       const recent: RecentTransaction[] = txRows
         .filter((tx: any) => !tx.is_excluded && !tx.reconciled_into_transaction_id)
         .slice(0, 10)
@@ -134,11 +191,15 @@ export function InicioRoot() {
           };
         });
 
-      // Single setState — one render
+      // Build human-readable days label
+      const daysLabel = nextIncome
+        ? `${daysRemaining} dias hasta ${formatDate(nextIncome.occurrence_date, "dd MMM")}`
+        : `${daysRemaining} dias restantes`;
+
       setData({
         hero: {
-          availablePerDay, availableTotal, daysRemaining,
-          breakdown: { totalLiquid: totalInflow, fixedExpenses: 0, alreadySpent: totalOutflow },
+          availablePerDay, availableTotal: disponible, daysRemaining, daysLabel,
+          breakdown: { totalLiquid: liquidBalance, fixedExpenses: pendingObligations, alreadySpent: totalOutflow },
         },
         metrics: { daysInMonth, dayOfMonth, spentToday, spentYesterday, avgLast7 },
         accounts: { count: accounts.length, netWorth },
@@ -180,6 +241,7 @@ export function InicioRoot() {
           availablePerDay={data.hero.availablePerDay}
           availableTotal={data.hero.availableTotal}
           daysRemaining={data.hero.daysRemaining}
+          daysLabel={data.hero.daysLabel}
           currency={currency}
           breakdown={data.hero.breakdown}
           expanded={activeZone === "hero"}

--- a/mobile/components/movimientos/MovimientosRoot.tsx
+++ b/mobile/components/movimientos/MovimientosRoot.tsx
@@ -6,6 +6,7 @@ import { useSync } from "../../lib/sync/hooks";
 import { getTransactions, type TransactionListRow } from "../../lib/repositories/transactions";
 import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
 import { computeCashflow } from "../../lib/utils/cashflow";
+import { toLocalMonthString } from "../../lib/utils/date";
 import { COLORS } from "../../lib/constants/colors";
 import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
@@ -26,7 +27,7 @@ export function MovimientosRoot() {
   const [accounts, setAccounts] = useState<AccountRow[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [currentMonth, setCurrentMonth] = useState(
-    () => new Date().toISOString().slice(0, 7)
+    () => toLocalMonthString()
   );
 
   const loadData = useCallback(async () => {
@@ -110,9 +111,6 @@ export function MovimientosRoot() {
           <MonthSelector month={currentMonth} onChange={setCurrentMonth} />
         </View>
 
-        {/* Search */}
-        <SearchBar onSearch={setSearchQuery} />
-
         {/* Lectura — month summary */}
         <MovimientosLectura
           count={count}
@@ -125,6 +123,9 @@ export function MovimientosRoot() {
 
         {/* Herramientas — tools grid */}
         <MovimientosHerramientas uncategorizedCount={uncategorizedCount} />
+
+        {/* Search — right above feed */}
+        <SearchBar onSearch={setSearchQuery} />
 
         {/* Feed — date-grouped transaction rows */}
         {transactions.length === 0 ? (

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -1,0 +1,628 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Check, ChevronDown, X, Link2 } from "lucide-react-native";
+import * as Crypto from "expo-crypto";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import { supabase } from "../../lib/supabase";
+import { useAuth } from "../../lib/auth";
+import { COLORS } from "../../lib/constants/colors";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { toLocalDateString, toLocalMonthString } from "../../lib/utils/date";
+import { parseLocalizedAmount } from "../../lib/amount";
+import { isDebtAccountType } from "../../lib/constants/accounts";
+
+// ── Types ──
+
+export interface PaymentEntry {
+  id: string;
+  label: string;
+  amount: number;
+  currency_code: string;
+  expected_date: string;
+  account_id: string | null;
+  recurring_template_id: string | null;
+  category_id: string | null;
+  debt_account_id?: string | null;
+}
+
+export interface PaymentAccount {
+  id: string;
+  name: string;
+  account_type: string;
+  current_balance: number;
+  currency_code: string;
+}
+
+interface CandidateTransaction {
+  id: string;
+  description: string;
+  merchant_name: string | null;
+  amount: number;
+  transaction_date: string;
+  account_id: string;
+  direction: string;
+}
+
+interface PaymentSheetProps {
+  visible: boolean;
+  entry: PaymentEntry;
+  debtAccount: PaymentAccount | null;
+  sourceAccounts: PaymentAccount[];
+  currency: CurrencyCode;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+type AmountOption = "planned" | "total_debt" | "custom";
+type SheetMode = "loading" | "link" | "create";
+
+// ── Component ──
+
+export function PaymentSheet({
+  visible,
+  entry,
+  debtAccount,
+  sourceAccounts,
+  currency,
+  onClose,
+  onSuccess,
+}: PaymentSheetProps) {
+  const { session } = useAuth();
+
+  // State
+  const [mode, setMode] = useState<SheetMode>("loading");
+  const [candidates, setCandidates] = useState<CandidateTransaction[]>([]);
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
+  const [amountOption, setAmountOption] = useState<AmountOption>("planned");
+  const [customAmount, setCustomAmount] = useState("");
+  const [selectedSourceId, setSelectedSourceId] = useState<string>(sourceAccounts[0]?.id ?? "");
+  const [showSourcePicker, setShowSourcePicker] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Search for candidate transactions when sheet opens
+  useEffect(() => {
+    if (!visible || !session?.user?.id) return;
+    let cancelled = false;
+
+    setMode("loading");
+    setCandidates([]);
+    setSelectedCandidateId(null);
+    setAmountOption("planned");
+    setCustomAmount("");
+    setError(null);
+    setShowSourcePicker(false);
+
+    (async () => {
+      try {
+        const sb = supabase as any;
+        const month = toLocalMonthString();
+        const monthStart = `${month}-01`;
+        const monthEnd = `${month}-31`;
+
+        // Search for transactions that might match this expense:
+        // - Same month, OUTFLOW, similar amount (±50%), or matching merchant name
+        // - Not already linked to another occurrence
+        const { data: txs } = await sb
+          .from("transactions")
+          .select("id, description, merchant_name, amount, transaction_date, account_id, direction")
+          .eq("user_id", session.user.id)
+          .eq("is_excluded", false)
+          .is("reconciled_into_transaction_id", null)
+          .gte("transaction_date", monthStart)
+          .lte("transaction_date", monthEnd)
+          .order("transaction_date", { ascending: false })
+          .limit(50);
+
+        if (!txs || txs.length === 0) {
+          setMode("create");
+          return;
+        }
+
+        // Filter candidates: match by amount range or merchant name similarity
+        const targetAmount = entry.amount;
+        const lowerBound = targetAmount * 0.5;
+        const upperBound = targetAmount * 2.0;
+        const labelLower = entry.label.toLowerCase();
+
+        const matched = (txs as CandidateTransaction[]).filter((tx) => {
+          const amt = Math.abs(tx.amount);
+          const amountMatch = amt >= lowerBound && amt <= upperBound;
+          const nameMatch =
+            (tx.merchant_name && tx.merchant_name.toLowerCase().includes(labelLower)) ||
+            (tx.description && tx.description.toLowerCase().includes(labelLower)) ||
+            (tx.merchant_name && labelLower.includes(tx.merchant_name.toLowerCase()));
+
+          // For debt accounts, also check transactions on the debt account itself
+          const isOnDebtAccount = debtAccount && tx.account_id === debtAccount.id && tx.direction === "INFLOW";
+
+          return amountMatch || nameMatch || isOnDebtAccount;
+        });
+
+        if (matched.length > 0) {
+          setCandidates(matched.slice(0, 5));
+          setMode("link");
+        } else {
+          setMode("create");
+        }
+      } catch {
+        setMode("create");
+      }
+    })();
+  }, [visible, session?.user?.id, entry, debtAccount]);
+
+  const showTotalDebt = debtAccount != null && isDebtAccountType(debtAccount.account_type);
+
+  const resolvedAmount = useMemo(() => {
+    if (amountOption === "planned") return entry.amount;
+    if (amountOption === "total_debt" && debtAccount) return Math.abs(debtAccount.current_balance);
+    if (amountOption === "custom") {
+      const parsed = parseLocalizedAmount(customAmount);
+      return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
+    }
+    return null;
+  }, [amountOption, entry.amount, debtAccount, customAmount]);
+
+  const selectedSource = sourceAccounts.find((a) => a.id === selectedSourceId);
+  const canSubmit = resolvedAmount != null && resolvedAmount > 0 && selectedSourceId !== "" && !submitting;
+
+  const handleClose = useCallback(() => {
+    setMode("loading");
+    setCandidates([]);
+    setSelectedCandidateId(null);
+    setAmountOption("planned");
+    setCustomAmount("");
+    setError(null);
+    setShowSourcePicker(false);
+    onClose();
+  }, [onClose]);
+
+  // ── Link existing transaction ──
+  const handleLinkTransaction = useCallback(async () => {
+    if (!selectedCandidateId || !session?.user?.id) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const userId = session.user.id;
+      const sb = supabase as any;
+
+      // 1. Link to recurring occurrence
+      if (entry.recurring_template_id) {
+        const monthPrefix = toLocalMonthString() + "%";
+        const { data: occurrences } = await sb
+          .from("recurring_occurrences")
+          .select("id")
+          .eq("template_id", entry.recurring_template_id)
+          .eq("user_id", userId)
+          .eq("status", "pending")
+          .like("occurrence_date", monthPrefix)
+          .order("occurrence_date", { ascending: true })
+          .limit(1);
+
+        if (occurrences && occurrences.length > 0) {
+          await sb
+            .from("recurring_occurrences")
+            .update({
+              status: "paid",
+              transaction_id: selectedCandidateId,
+              paid_at: new Date().toISOString(),
+            })
+            .eq("id", occurrences[0].id)
+            .eq("user_id", userId);
+        }
+      }
+
+      // 2. Mark planning entry as COMPLETED
+      await sb
+        .from("planning_entries")
+        .update({
+          status: "COMPLETED",
+          completed_at: new Date().toISOString(),
+        })
+        .eq("id", entry.id)
+        .eq("user_id", userId);
+
+      handleClose();
+      onSuccess();
+    } catch (err: any) {
+      setError(err?.message ?? "Error al vincular transaccion");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selectedCandidateId, session?.user?.id, entry, handleClose, onSuccess]);
+
+  // ── Create new transaction ──
+  const handleCreatePayment = useCallback(async () => {
+    if (!canSubmit || !session?.user?.id || resolvedAmount == null) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const userId = session.user.id;
+      const today = toLocalDateString();
+      const outflowTxId = Crypto.randomUUID();
+      const transferGroupId = debtAccount ? Crypto.randomUUID() : null;
+      const sb = supabase as any;
+
+      // 1. OUTFLOW from source
+      const { error: outflowErr } = await sb
+        .from("transactions")
+        .insert({
+          id: outflowTxId,
+          user_id: userId,
+          account_id: selectedSourceId,
+          amount: resolvedAmount,
+          currency_code: entry.currency_code,
+          direction: "OUTFLOW",
+          transaction_date: today,
+          description: `Pago: ${entry.label}`,
+          merchant_name: entry.label,
+          capture_method: "MANUAL_FORM",
+          category_id: entry.category_id,
+          transfer_group_id: transferGroupId,
+          idempotency_key: `MANUAL_FORM|${outflowTxId}|${today}|${resolvedAmount}|${entry.label}`,
+          is_recurring: !!entry.recurring_template_id,
+        });
+
+      if (outflowErr) throw new Error(outflowErr.message);
+
+      // 2. INFLOW on debt account
+      if (debtAccount && transferGroupId) {
+        const inflowTxId = Crypto.randomUUID();
+        const { error: inflowErr } = await sb
+          .from("transactions")
+          .insert({
+            id: inflowTxId,
+            user_id: userId,
+            account_id: debtAccount.id,
+            amount: resolvedAmount,
+            currency_code: entry.currency_code,
+            direction: "INFLOW",
+            transaction_date: today,
+            description: `Pago: ${entry.label}`,
+            merchant_name: entry.label,
+            capture_method: "MANUAL_FORM",
+            category_id: entry.category_id,
+            transfer_group_id: transferGroupId,
+            idempotency_key: `MANUAL_FORM|${inflowTxId}|${today}|${resolvedAmount}|${entry.label}`,
+            is_recurring: !!entry.recurring_template_id,
+          });
+        if (inflowErr) throw new Error(inflowErr.message);
+      }
+
+      // 3. Link to recurring occurrence
+      if (entry.recurring_template_id) {
+        const monthPrefix = toLocalMonthString() + "%";
+        const { data: occurrences } = await sb
+          .from("recurring_occurrences")
+          .select("id")
+          .eq("template_id", entry.recurring_template_id)
+          .eq("user_id", userId)
+          .eq("status", "pending")
+          .like("occurrence_date", monthPrefix)
+          .order("occurrence_date", { ascending: true })
+          .limit(1);
+
+        if (occurrences && occurrences.length > 0) {
+          await sb
+            .from("recurring_occurrences")
+            .update({
+              status: "paid",
+              transaction_id: outflowTxId,
+              paid_at: new Date().toISOString(),
+            })
+            .eq("id", occurrences[0].id)
+            .eq("user_id", userId);
+        }
+      }
+
+      // 4. Mark planning entry COMPLETED
+      await sb
+        .from("planning_entries")
+        .update({ status: "COMPLETED", completed_at: new Date().toISOString() })
+        .eq("id", entry.id)
+        .eq("user_id", userId);
+
+      handleClose();
+      onSuccess();
+    } catch (err: any) {
+      const msg = err?.message ?? "Error al registrar el pago";
+      if (msg.includes("23505") || msg.includes("duplicate")) {
+        handleClose();
+        onSuccess();
+        return;
+      }
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, session?.user?.id, resolvedAmount, selectedSourceId, entry, debtAccount, handleClose, onSuccess]);
+
+  // ── Account name lookup for candidates ──
+  const allAccountMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const a of sourceAccounts) map.set(a.id, a.name);
+    if (debtAccount) map.set(debtAccount.id, debtAccount.name);
+    return map;
+  }, [sourceAccounts, debtAccount]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
+        <View className="flex-1 justify-end bg-black/60">
+          <View className="rounded-t-3xl border-t border-white-6 bg-background">
+            {/* Header */}
+            <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+              <Text className="text-[15px] font-inter-semibold text-foreground">
+                {mode === "link" ? "Vincular pago existente" : "Registrar pago"}
+              </Text>
+              <Pressable onPress={handleClose} className="h-8 w-8 items-center justify-center rounded-full">
+                <X size={16} color={COLORS.sageLight} />
+              </Pressable>
+            </View>
+
+            <ScrollView
+              className="max-h-[80%]"
+              contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40 }}
+              keyboardShouldPersistTaps="handled"
+            >
+              {/* Entry info */}
+              <View className={`${PANEL_INSET_CLASS} p-3 mb-4`}>
+                <Text className="text-sm font-inter-semibold text-foreground">{entry.label}</Text>
+                <Text className="text-[11px] font-inter text-muted-foreground mt-0.5">
+                  {formatDate(entry.expected_date, "dd MMM yyyy")}
+                  {debtAccount ? ` · ${debtAccount.name}` : ""}
+                  {" · "}{formatCurrency(entry.amount, currency)}
+                </Text>
+              </View>
+
+              {/* ── LOADING ── */}
+              {mode === "loading" && (
+                <View className="items-center py-8">
+                  <ActivityIndicator size="small" color={COLORS.brass} />
+                  <Text className="text-xs font-inter text-muted-foreground mt-2">
+                    Buscando transacciones similares...
+                  </Text>
+                </View>
+              )}
+
+              {/* ── LINK MODE: show candidate transactions ── */}
+              {mode === "link" && (
+                <>
+                  <Text className="text-xs font-inter-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                    ¿Ya hiciste este pago?
+                  </Text>
+                  <Text className="text-[11px] font-inter text-muted-fg-50 mb-3">
+                    Encontramos transacciones que podrian ser este pago. Selecciona una para vincularla.
+                  </Text>
+
+                  {candidates.map((tx) => {
+                    const isSelected = selectedCandidateId === tx.id;
+                    return (
+                      <Pressable
+                        key={tx.id}
+                        onPress={() => setSelectedCandidateId(isSelected ? null : tx.id)}
+                        className={`${PANEL_INSET_CLASS} flex-row items-center p-3 mb-2 ${isSelected ? "border-z-brass" : ""}`}
+                        style={isSelected ? { borderColor: COLORS.brass } : undefined}
+                      >
+                        <View className="flex-1">
+                          <Text className="text-xs font-inter-semibold text-foreground">
+                            {tx.merchant_name ?? tx.description}
+                          </Text>
+                          <Text className="text-[10px] font-inter text-muted-foreground">
+                            {formatDate(tx.transaction_date, "dd MMM yyyy")}
+                            {" · "}{allAccountMap.get(tx.account_id) ?? ""}
+                          </Text>
+                        </View>
+                        <Text className={`text-sm font-inter-bold ${tx.direction === "INFLOW" ? "text-z-income" : "text-z-expense"}`}>
+                          {tx.direction === "INFLOW" ? "+" : "-"}{formatCurrency(Math.abs(tx.amount), currency)}
+                        </Text>
+                        {isSelected && (
+                          <View className="ml-2">
+                            <Check size={16} color={COLORS.brass} />
+                          </View>
+                        )}
+                      </Pressable>
+                    );
+                  })}
+
+                  {/* Error */}
+                  {error && (
+                    <View className="rounded-xl bg-z-debt/10 px-3 py-2 mb-2">
+                      <Text className="text-xs font-inter-medium text-z-debt">{error}</Text>
+                    </View>
+                  )}
+
+                  {/* Link button */}
+                  <Pressable
+                    onPress={handleLinkTransaction}
+                    disabled={!selectedCandidateId || submitting}
+                    className={`rounded-xl py-3 items-center mt-2 flex-row justify-center gap-2 ${selectedCandidateId ? "bg-z-brass" : "bg-z-brass/30"}`}
+                  >
+                    {submitting ? (
+                      <ActivityIndicator size="small" color={COLORS.ink} />
+                    ) : (
+                      <>
+                        <Link2 size={14} color={COLORS.ink} />
+                        <Text className={`text-sm font-inter-semibold ${selectedCandidateId ? "text-z-ink" : "text-z-ink/50"}`}>
+                          Vincular transaccion
+                        </Text>
+                      </>
+                    )}
+                  </Pressable>
+
+                  {/* Switch to create mode */}
+                  <Pressable onPress={() => setMode("create")} className="items-center py-3 mt-1">
+                    <Text className="text-sm font-inter-medium text-z-brass">
+                      No, registrar nuevo pago
+                    </Text>
+                  </Pressable>
+                </>
+              )}
+
+              {/* ── CREATE MODE: new payment form ── */}
+              {mode === "create" && (
+                <>
+                  <Text className="text-xs font-inter-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                    Monto a pagar
+                  </Text>
+
+                  <RadioOption
+                    selected={amountOption === "planned"}
+                    onPress={() => setAmountOption("planned")}
+                    label="Cuota planeada"
+                    detail={formatCurrency(entry.amount, currency)}
+                  />
+
+                  {showTotalDebt && debtAccount && (
+                    <RadioOption
+                      selected={amountOption === "total_debt"}
+                      onPress={() => setAmountOption("total_debt")}
+                      label="Pago total deuda"
+                      detail={formatCurrency(Math.abs(debtAccount.current_balance), currency)}
+                    />
+                  )}
+
+                  <RadioOption
+                    selected={amountOption === "custom"}
+                    onPress={() => setAmountOption("custom")}
+                    label="Otro monto"
+                  />
+                  {amountOption === "custom" && (
+                    <View className="ml-8 mb-3">
+                      <TextInput
+                        className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-sm font-inter-medium text-foreground"
+                        placeholderTextColor="#938C7E"
+                        placeholder="Ej: 150.000"
+                        keyboardType="numeric"
+                        value={customAmount}
+                        onChangeText={setCustomAmount}
+                        autoFocus
+                      />
+                    </View>
+                  )}
+
+                  {/* Source account */}
+                  {sourceAccounts.length > 0 && (
+                    <>
+                      <Text className="text-xs font-inter-semibold text-muted-foreground mb-2 mt-3 uppercase tracking-wider">
+                        Cuenta origen
+                      </Text>
+                      <Pressable
+                        onPress={() => setShowSourcePicker(!showSourcePicker)}
+                        className={`${PANEL_INSET_CLASS} flex-row items-center justify-between px-3 py-2.5 mb-1`}
+                      >
+                        <Text className="text-sm font-inter-medium text-foreground">
+                          {selectedSource?.name ?? "Seleccionar cuenta"}
+                        </Text>
+                        <ChevronDown
+                          size={14}
+                          color={COLORS.sageDark}
+                          style={{ transform: [{ rotate: showSourcePicker ? "180deg" : "0deg" }] }}
+                        />
+                      </Pressable>
+
+                      {showSourcePicker && (
+                        <View className={`${PANEL_INSET_CLASS} overflow-hidden mb-3`}>
+                          {sourceAccounts.map((acc, i) => (
+                            <Pressable
+                              key={acc.id}
+                              onPress={() => { setSelectedSourceId(acc.id); setShowSourcePicker(false); }}
+                              className={`flex-row items-center justify-between px-3 py-2.5 active:bg-white/5 ${i > 0 ? "border-t border-white-6" : ""}`}
+                            >
+                              <Text className="text-[13px] font-inter-medium text-foreground">{acc.name}</Text>
+                              {acc.id === selectedSourceId && <Check size={14} color={COLORS.income} />}
+                            </Pressable>
+                          ))}
+                        </View>
+                      )}
+                    </>
+                  )}
+
+                  {/* Summary */}
+                  {resolvedAmount != null && (
+                    <View className="flex-row items-center justify-between mt-4 mb-2">
+                      <Text className="text-xs font-inter text-muted-foreground">Total a pagar</Text>
+                      <Text className="text-base font-inter-bold text-foreground">
+                        {formatCurrency(resolvedAmount, currency)}
+                      </Text>
+                    </View>
+                  )}
+
+                  {/* Error */}
+                  {error && (
+                    <View className="rounded-xl bg-z-debt/10 px-3 py-2 mb-2">
+                      <Text className="text-xs font-inter-medium text-z-debt">{error}</Text>
+                    </View>
+                  )}
+
+                  {/* Confirm */}
+                  <Pressable
+                    onPress={handleCreatePayment}
+                    disabled={!canSubmit}
+                    className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+                  >
+                    {submitting ? (
+                      <ActivityIndicator size="small" color={COLORS.ink} />
+                    ) : (
+                      <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+                        Confirmar pago
+                      </Text>
+                    )}
+                  </Pressable>
+
+                  {/* Back to link mode if candidates exist */}
+                  {candidates.length > 0 && (
+                    <Pressable onPress={() => setMode("link")} className="items-center py-3 mt-1">
+                      <Text className="text-sm font-inter-medium text-z-brass">
+                        Vincular pago existente
+                      </Text>
+                    </Pressable>
+                  )}
+
+                  <Pressable onPress={handleClose} className="items-center py-2">
+                    <Text className="text-sm font-inter-medium text-muted-foreground">Cancelar</Text>
+                  </Pressable>
+                </>
+              )}
+            </ScrollView>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+// ── Radio option row ──
+
+function RadioOption({ selected, onPress, label, detail }: {
+  selected: boolean;
+  onPress: () => void;
+  label: string;
+  detail?: string;
+}) {
+  return (
+    <Pressable onPress={onPress} className="flex-row items-center gap-3 py-2.5 mb-1">
+      <View className={`h-5 w-5 rounded-full border-2 items-center justify-center ${selected ? "border-z-brass" : "border-white/20"}`}>
+        {selected && <View className="h-2.5 w-2.5 rounded-full bg-z-brass" />}
+      </View>
+      <View className="flex-1 flex-row items-center justify-between">
+        <Text className="text-sm font-inter-medium text-foreground">{label}</Text>
+        {detail && <Text className="text-sm font-inter-semibold text-z-brass">{detail}</Text>}
+      </View>
+    </Pressable>
+  );
+}

--- a/mobile/components/plan/PlanDrillCards.tsx
+++ b/mobile/components/plan/PlanDrillCards.tsx
@@ -1,48 +1,97 @@
-import { View } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
-import { PiggyBank, Repeat, Heart } from "lucide-react-native";
-import { formatCurrency, type CurrencyCode } from "@zeta/shared";
-import { HubEntry } from "../ui/HubEntry";
+import { Wallet, CalendarClock, RotateCcw, Heart } from "lucide-react-native";
+import { MCardTight } from "../ui/MCard";
+import { COLORS } from "../../lib/constants/colors";
 import { MobileZone } from "../ui/MobileZone";
 
 interface PlanDrillCardsProps {
-  budgetSpent: number;
-  budgetTarget: number;
-  recurringCount: number;
-  currency: CurrencyCode;
+  budgetOverLimit: number;
+  budgetPct: number;
+  recurringPending: number;
+  wishlistCount: number;
+}
+
+interface CardDef {
+  key: string;
+  title: string;
+  icon: typeof Wallet;
+  hint: string;
+  hintColor: string;
+  route: string;
 }
 
 export function PlanDrillCards({
-  budgetSpent,
-  budgetTarget,
-  recurringCount,
-  currency,
+  budgetOverLimit,
+  budgetPct,
+  recurringPending,
+  wishlistCount,
 }: PlanDrillCardsProps) {
   const router = useRouter();
-  const budgetPct = budgetTarget > 0 ? Math.round((budgetSpent / budgetTarget) * 100) : 0;
+
+  const cards: CardDef[] = [
+    {
+      key: "presupuesto",
+      title: "Presupuesto",
+      icon: Wallet,
+      hint: budgetOverLimit > 0 ? `${budgetOverLimit} sobre limite` : `${budgetPct}%`,
+      hintColor: budgetOverLimit > 0 ? COLORS.debt : COLORS.income,
+      route: "/(tabs)/budgets",
+    },
+    {
+      key: "periodo",
+      title: "Periodo",
+      icon: CalendarClock,
+      hint: `${budgetPct}%`,
+      hintColor: budgetPct > 100 ? COLORS.debt : COLORS.income,
+      route: "/periodo",
+    },
+    {
+      key: "recurrentes",
+      title: "Recurrentes",
+      icon: RotateCcw,
+      hint: `${recurringPending}`,
+      hintColor: recurringPending > 0 ? COLORS.alert : COLORS.income,
+      route: "/recurrentes",
+    },
+    {
+      key: "deseos",
+      title: "Deseos",
+      icon: Heart,
+      hint: `${wishlistCount}`,
+      hintColor: COLORS.sageDark,
+      route: "/deseos",
+    },
+  ];
 
   return (
-    <MobileZone eyebrow="EXPLORAR">
-      <View className="gap-1.5">
-        <HubEntry
-          icon={PiggyBank}
-          title="Presupuesto"
-          hint={budgetTarget > 0 ? `${budgetPct}% usado · ${formatCurrency(budgetSpent, currency)} de ${formatCurrency(budgetTarget, currency)}` : "Sin presupuesto configurado"}
-          onPress={() => router.push("/(tabs)/budgets" as any)}
-        />
-        <HubEntry
-          icon={Repeat}
-          title="Recurrentes"
-          hint={`${recurringCount} obligaciones activas`}
-          onPress={() => router.push("/recurrentes" as any)}
-        />
-        <HubEntry
-          icon={Heart}
-          title="Deseos"
-          hint="Lista de deseos financieros"
-          onPress={() => router.push("/deseos" as any)}
-        />
-      </View>
+    <MobileZone eyebrow="IR A">
+      <MCardTight>
+        <View className="flex-row flex-wrap">
+          {cards.map((card, i) => {
+            const Icon = card.icon;
+            const isRight = i % 2 === 0;
+            const isTop = i < 2;
+            return (
+              <Pressable
+                key={card.key}
+                onPress={() => router.push(card.route as any)}
+                className={`w-1/2 p-3 ${isRight ? "border-r border-white-6" : ""} ${isTop ? "border-b border-white-6" : ""}`}
+              >
+                <View className="flex-row items-center justify-between mb-1">
+                  <Icon size={14} color={COLORS.sageDark} />
+                  <Text className="text-sm font-inter-bold" style={{ color: card.hintColor }}>
+                    {card.hint}
+                  </Text>
+                </View>
+                <Text className="text-[11px] font-inter-semibold text-foreground">
+                  {card.title}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </MCardTight>
     </MobileZone>
   );
 }

--- a/mobile/components/plan/PlanExpandableChips.tsx
+++ b/mobile/components/plan/PlanExpandableChips.tsx
@@ -101,7 +101,7 @@ export function PlanExpandableChips({
       <AnimatedAccordion expanded={active !== null} estimatedHeight={200}>
         {active === "income" && (
           <View className={`${PANEL_INSET_CLASS} p-3`} style={{ borderColor: "rgba(92,184,138,0.2)", backgroundColor: "rgba(92,184,138,0.05)" }}>
-            <Text className="text-[10px] font-inter-bold uppercase tracking-[3px] text-z-income mb-2">
+            <Text className="text-[10px] font-inter-bold uppercase tracking-[0.18em] text-z-income mb-2">
               Ingresos esperados
             </Text>
             {incomes.length > 0 ? (
@@ -137,7 +137,7 @@ export function PlanExpandableChips({
         )}
         {active === "payment" && (
           <View className={`${PANEL_INSET_CLASS} p-3`} style={{ borderColor: "rgba(224,85,69,0.2)", backgroundColor: "rgba(224,85,69,0.05)" }}>
-            <Text className="text-[10px] font-inter-bold uppercase tracking-[3px] text-z-debt mb-2">
+            <Text className="text-[10px] font-inter-bold uppercase tracking-[0.18em] text-z-debt mb-2">
               Pagos programados
             </Text>
             {payments.length > 0 ? (

--- a/mobile/components/plan/PlanExpandableChips.tsx
+++ b/mobile/components/plan/PlanExpandableChips.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { Plus } from "lucide-react-native";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import type { OccurrenceWithTemplate } from "../../lib/repositories/recurring";
+import { AnimatedAccordion } from "../ui/AnimatedAccordion";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { COLORS } from "../../lib/constants/colors";
+
+interface PlanExpandableChipsProps {
+  incomes: OccurrenceWithTemplate[];
+  payments: OccurrenceWithTemplate[];
+  currency: CurrencyCode;
+}
+
+type ChipType = "income" | "payment" | null;
+
+export function PlanExpandableChips({
+  incomes,
+  payments,
+  currency,
+}: PlanExpandableChipsProps) {
+  const [active, setActive] = useState<ChipType>(null);
+
+  const toggle = (type: ChipType) => setActive((prev) => (prev === type ? null : type));
+
+  const nextIncome = incomes[0] ?? null;
+  const nextPayment = payments[0] ?? null;
+
+  return (
+    <View className="gap-2">
+      <View className="flex-row gap-2">
+        {/* Próximo ingreso chip */}
+        <Pressable
+          onPress={() => toggle("income")}
+          className={`${PANEL_INSET_CLASS} flex-1 p-3 ${active === "income" ? "border-z-income/50 bg-z-income/10" : ""} ${active === "payment" ? "opacity-50" : ""}`}
+          style={active === "income" ? { borderColor: "rgba(92,184,138,0.5)", backgroundColor: "rgba(92,184,138,0.1)" } : undefined}
+        >
+          {nextIncome ? (
+            <>
+              <Text className="text-[18px] font-inter-bold text-z-income">
+                {formatCurrency(nextIncome.expected_amount, currency)}
+              </Text>
+              <Text className="text-[10px] font-inter-medium text-z-income mt-0.5">
+                Proximo ingreso
+              </Text>
+              <Text className="text-[9px] font-inter text-muted-foreground">
+                · {formatDate(nextIncome.occurrence_date, "dd MMM")}
+              </Text>
+            </>
+          ) : (
+            <>
+              <View className="flex-row items-center gap-1">
+                <Plus size={14} color={COLORS.income} />
+                <Text className="text-xs font-inter-semibold text-z-income">
+                  Mapear ingreso
+                </Text>
+              </View>
+              <Text className="text-[10px] font-inter text-muted-foreground mt-1">
+                Agrega un ingreso recurrente
+              </Text>
+            </>
+          )}
+        </Pressable>
+
+        {/* Próximo pago chip */}
+        <Pressable
+          onPress={() => toggle("payment")}
+          className={`${PANEL_INSET_CLASS} flex-1 p-3 ${active === "income" ? "opacity-50" : ""}`}
+          style={active === "payment" ? { borderColor: "rgba(224,85,69,0.5)", backgroundColor: "rgba(224,85,69,0.1)" } : undefined}
+        >
+          {nextPayment ? (
+            <>
+              <Text className="text-[18px] font-inter-bold text-z-debt">
+                {formatCurrency(nextPayment.expected_amount, currency)}
+              </Text>
+              <Text className="text-[10px] font-inter-medium text-z-debt mt-0.5">
+                Proximo pago
+              </Text>
+              <Text className="text-[9px] font-inter text-muted-foreground">
+                · {formatDate(nextPayment.occurrence_date, "dd MMM")}
+              </Text>
+            </>
+          ) : (
+            <>
+              <View className="flex-row items-center gap-1">
+                <Plus size={14} color={COLORS.debt} />
+                <Text className="text-xs font-inter-semibold text-z-debt">
+                  Mapear pago
+                </Text>
+              </View>
+              <Text className="text-[10px] font-inter text-muted-foreground mt-1">
+                Agrega un pago recurrente
+              </Text>
+            </>
+          )}
+        </Pressable>
+      </View>
+
+      {/* Expanded list */}
+      <AnimatedAccordion expanded={active !== null} estimatedHeight={200}>
+        {active === "income" && (
+          <View className={`${PANEL_INSET_CLASS} p-3`} style={{ borderColor: "rgba(92,184,138,0.2)", backgroundColor: "rgba(92,184,138,0.05)" }}>
+            <Text className="text-[10px] font-inter-bold uppercase tracking-[3px] text-z-income mb-2">
+              Ingresos esperados
+            </Text>
+            {incomes.length > 0 ? (
+              <>
+                {incomes.map((item) => (
+                  <View key={item.id} className="flex-row items-center justify-between py-2 border-b border-white-6">
+                    <View>
+                      <Text className="text-xs font-inter-medium text-foreground">
+                        {item.merchant_name ?? item.description ?? "Ingreso"}
+                      </Text>
+                      <Text className="text-[10px] font-inter text-muted-foreground">
+                        {formatDate(item.occurrence_date, "dd MMM yyyy")}
+                      </Text>
+                    </View>
+                    <Text className="text-sm font-inter-semibold text-z-income">
+                      {formatCurrency(item.expected_amount, currency)}
+                    </Text>
+                  </View>
+                ))}
+                <View className="flex-row justify-between mt-2 pt-2 border-t border-white-6">
+                  <Text className="text-xs font-inter text-muted-foreground">Total</Text>
+                  <Text className="text-xs font-inter-bold text-z-income">
+                    {formatCurrency(incomes.reduce((s, i) => s + i.expected_amount, 0), currency)}
+                  </Text>
+                </View>
+              </>
+            ) : (
+              <Text className="text-xs font-inter text-muted-foreground text-center py-3">
+                No tienes ingresos recurrentes configurados
+              </Text>
+            )}
+          </View>
+        )}
+        {active === "payment" && (
+          <View className={`${PANEL_INSET_CLASS} p-3`} style={{ borderColor: "rgba(224,85,69,0.2)", backgroundColor: "rgba(224,85,69,0.05)" }}>
+            <Text className="text-[10px] font-inter-bold uppercase tracking-[3px] text-z-debt mb-2">
+              Pagos programados
+            </Text>
+            {payments.length > 0 ? (
+              <>
+                {payments.map((item) => (
+                  <View key={item.id} className="flex-row items-center justify-between py-2 border-b border-white-6">
+                    <View>
+                      <Text className="text-xs font-inter-medium text-foreground">
+                        {item.merchant_name ?? item.description ?? "Pago"}
+                      </Text>
+                      <Text className="text-[10px] font-inter text-muted-foreground">
+                        {formatDate(item.occurrence_date, "dd MMM yyyy")}
+                      </Text>
+                    </View>
+                    <Text className="text-sm font-inter-semibold text-z-debt">
+                      {formatCurrency(item.expected_amount, currency)}
+                    </Text>
+                  </View>
+                ))}
+                <View className="flex-row justify-between mt-2 pt-2 border-t border-white-6">
+                  <Text className="text-xs font-inter text-muted-foreground">Total</Text>
+                  <Text className="text-xs font-inter-bold text-z-debt">
+                    {formatCurrency(payments.reduce((s, i) => s + i.expected_amount, 0), currency)}
+                  </Text>
+                </View>
+              </>
+            ) : (
+              <Text className="text-xs font-inter text-muted-foreground text-center py-3">
+                No tienes pagos recurrentes configurados
+              </Text>
+            )}
+          </View>
+        )}
+      </AnimatedAccordion>
+    </View>
+  );
+}

--- a/mobile/components/plan/PlanFlowChart.tsx
+++ b/mobile/components/plan/PlanFlowChart.tsx
@@ -259,17 +259,17 @@ export function PlanFlowChart({ timelineData, currency }: PlanFlowChartProps) {
         {/* Summary row */}
         <View className="mt-2 flex-row items-center">
           <View className="flex-1 items-center">
-            <Text className="text-[9px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">Ingresos</Text>
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">Ingresos</Text>
             <Text className="mt-0.5 text-[13px] font-inter-semibold text-z-income">{formatCurrency(totalIncome, currency)}</Text>
           </View>
           <View className="h-5 w-px bg-white-6" />
           <View className="flex-1 items-center">
-            <Text className="text-[9px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">Gastos</Text>
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">Gastos</Text>
             <Text className="mt-0.5 text-[13px] font-inter-semibold text-z-debt">{formatCurrency(totalExpense, currency)}</Text>
           </View>
           <View className="h-5 w-px bg-white-6" />
           <View className="flex-1 items-center">
-            <Text className="text-[9px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">Neto</Text>
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">Neto</Text>
             <Text className={`mt-0.5 text-[13px] font-inter-semibold ${net >= 0 ? "text-z-brass" : "text-z-debt"}`}>{formatCurrency(net, currency)}</Text>
           </View>
         </View>

--- a/mobile/components/plan/PlanFlowChart.tsx
+++ b/mobile/components/plan/PlanFlowChart.tsx
@@ -1,0 +1,279 @@
+import React, { useMemo, useState, useCallback } from "react";
+import { View, Text, LayoutChangeEvent } from "react-native";
+import Svg, { Rect, Line, Path, Text as SvgText, Circle } from "react-native-svg";
+import { Gesture, GestureDetector, GestureHandlerRootView } from "react-native-gesture-handler";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import type { TimelineData } from "../../lib/utils/timeline";
+import { MobileZone } from "../ui/MobileZone";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { COLORS } from "../../lib/constants/colors";
+
+interface PlanFlowChartProps {
+  timelineData: TimelineData;
+  currency: CurrencyCode;
+}
+
+// Chart dimensions (viewBox coordinates)
+const VB_W = 360;
+const VB_H = 180;
+const BASELINE_Y = 90;
+const PAD_L = 32;
+const PAD_R = 10;
+const PAD_T = 15;
+const USABLE_W = VB_W - PAD_L - PAD_R;
+
+function dayX(day: number, daysInMonth: number): number {
+  return PAD_L + ((day - 1) / Math.max(daysInMonth - 1, 1)) * USABLE_W;
+}
+
+export function PlanFlowChart({ timelineData, currency }: PlanFlowChartProps) {
+  const { days, cumulativeBalance, totalIncome, totalExpense, daysInMonth, dayOfMonth } = timelineData;
+  const [selectedDay, setSelectedDay] = useState<number | null>(null);
+  const [chartWidth, setChartWidth] = useState(360);
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    setChartWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const chart = useMemo(() => {
+    if (days.length === 0) return null;
+
+    let maxVal = 1;
+    for (const d of days) {
+      maxVal = Math.max(maxVal, d.income, d.expense);
+    }
+
+    let maxAbsBalance = 1;
+    for (const pt of cumulativeBalance) {
+      maxAbsBalance = Math.max(maxAbsBalance, Math.abs(pt.balance));
+    }
+
+    const barW = Math.min(12, USABLE_W / (days.length * 2.5));
+    const scaleUp = (BASELINE_Y - PAD_T) / maxVal;
+    const scaleDown = (VB_H - BASELINE_Y - 30) / maxVal;
+    const balanceRange = Math.min(BASELINE_Y - PAD_T, VB_H - BASELINE_Y - 30);
+    const balanceScale = balanceRange / maxAbsBalance;
+
+    // Balance polyline
+    const pastPoints: string[] = [];
+    const futurePoints: string[] = [];
+    const balanceDots: Array<{ x: number; y: number; day: number; isPast: boolean }> = [];
+
+    for (const pt of cumulativeBalance) {
+      const x = dayX(pt.day, daysInMonth);
+      const y = BASELINE_Y - pt.balance * balanceScale;
+      const isPast = pt.day <= dayOfMonth;
+      if (isPast) pastPoints.push(`${pastPoints.length === 0 ? "M" : "L"}${x},${y}`);
+      else futurePoints.push(`${futurePoints.length === 0 ? "M" : "L"}${x},${y}`);
+      balanceDots.push({ x, y, day: pt.day, isPast });
+    }
+
+    // Bridge past → future
+    if (pastPoints.length > 0 && futurePoints.length > 0) {
+      const lastPast = cumulativeBalance.filter((p) => p.day <= dayOfMonth).slice(-1)[0];
+      if (lastPast) {
+        const x = dayX(lastPast.day, daysInMonth);
+        const y = BASELINE_Y - lastPast.balance * balanceScale;
+        futurePoints.unshift(`M${x},${y}`);
+      }
+    }
+
+    // Day labels
+    const todayX = dayX(dayOfMonth, daysInMonth);
+    const dayLabels: Array<{ day: number; x: number }> = [];
+    for (let d = 1; d <= daysInMonth; d++) {
+      if (d === 1 || d === daysInMonth || d % 5 === 0) {
+        const dx = dayX(d, daysInMonth);
+        if (Math.abs(dx - todayX) > 12 && d !== dayOfMonth) {
+          dayLabels.push({ day: d, x: dx });
+        }
+      }
+    }
+
+    return { barW, scaleUp, scaleDown, pastPath: pastPoints.join(" "), futurePath: futurePoints.join(" "), todayX, dayLabels, maxVal, balanceDots };
+  }, [days, cumulativeBalance, daysInMonth, dayOfMonth]);
+
+  // O(1) algebraic inversion of dayX
+  const findClosestDay = useCallback((touchX: number) => {
+    const svgX = (touchX * VB_W) / chartWidth;
+    const rawDay = Math.round(((svgX - PAD_L) / USABLE_W) * (daysInMonth - 1)) + 1;
+    return Math.max(1, Math.min(daysInMonth, rawDay));
+  }, [chartWidth, daysInMonth]);
+
+  // Touch gesture to select a day
+  const panGesture = Gesture.Pan()
+    .runOnJS(true)
+    .onUpdate((e) => {
+      setSelectedDay(findClosestDay(e.x));
+    })
+    .onEnd(() => setSelectedDay(null))
+    .minDistance(0);
+
+  const tapGesture = Gesture.Tap()
+    .runOnJS(true)
+    .onEnd((e) => {
+      const day = findClosestDay(e.x);
+      setSelectedDay((prev) => (prev === day ? null : day));
+    });
+
+  const gesture = Gesture.Exclusive(panGesture, tapGesture);
+
+  // Selected day tooltip data
+  const selectedData = useMemo(() => {
+    if (selectedDay === null) return null;
+    const dayEntry = days.find((d) => d.day === selectedDay);
+    const balancePt = cumulativeBalance.find((p) => p.day === selectedDay);
+    return {
+      day: selectedDay,
+      income: dayEntry?.income ?? 0,
+      expense: dayEntry?.expense ?? 0,
+      balance: balancePt?.balance ?? 0,
+    };
+  }, [selectedDay, days, cumulativeBalance]);
+
+  const net = totalIncome - totalExpense;
+
+  if (!chart || days.length === 0) {
+    return (
+      <MobileZone eyebrow="FLUJO DEL MES">
+        <View className={`${PANEL_INSET_CLASS} py-8 items-center`}>
+          <Text className="text-xs font-inter text-muted-foreground">
+            Sin pagos o ingresos en este mes
+          </Text>
+        </View>
+      </MobileZone>
+    );
+  }
+
+  return (
+    <MobileZone eyebrow="FLUJO DEL MES">
+      <View className={`${PANEL_INSET_CLASS} p-3`}>
+        {/* Touch tooltip */}
+        {selectedData && (
+          <View className="flex-row justify-between mb-2 px-1">
+            <Text className="text-[10px] font-inter-semibold text-z-brass">
+              Dia {selectedData.day}
+            </Text>
+            <View className="flex-row gap-3">
+              {selectedData.income > 0 && (
+                <Text className="text-[10px] font-inter-semibold text-z-income">
+                  +{formatCurrency(selectedData.income, currency)}
+                </Text>
+              )}
+              {selectedData.expense > 0 && (
+                <Text className="text-[10px] font-inter-semibold text-z-debt">
+                  -{formatCurrency(selectedData.expense, currency)}
+                </Text>
+              )}
+            </View>
+          </View>
+        )}
+
+        {/* SVG Chart */}
+        <GestureHandlerRootView>
+        <GestureDetector gesture={gesture}>
+          <View onLayout={onLayout}>
+            <Svg viewBox={`0 0 ${VB_W} ${VB_H}`} style={{ width: "100%", height: 180 }}>
+              {/* Zero line */}
+              <Line x1={PAD_L} y1={BASELINE_Y} x2={VB_W - PAD_R} y2={BASELINE_Y} stroke={COLORS.brass} strokeWidth={1.5} strokeOpacity={0.4} />
+              <SvgText x={PAD_L - 4} y={BASELINE_Y + 3} fill={COLORS.brass} fontSize={7} textAnchor="end" fontWeight="500">$0</SvgText>
+
+              {/* Y-axis max */}
+              <SvgText x={PAD_L - 4} y={PAD_T + 4} fill={COLORS.sageDark} fontSize={7} textAnchor="end">
+                {formatCurrency(chart.maxVal, currency)}
+              </SvgText>
+
+              {/* Today marker */}
+              <Line x1={chart.todayX} y1={PAD_T - 2} x2={chart.todayX} y2={VB_H - 18} stroke="rgba(255,255,255,0.12)" strokeWidth={1} strokeDasharray="4,3" />
+              <SvgText x={chart.todayX} y={VB_H - 8} fill={COLORS.sageLight} fontSize={7} fontWeight="600" textAnchor="middle">Hoy</SvgText>
+
+              {/* Selected day marker */}
+              {selectedDay !== null && (
+                <Line
+                  x1={dayX(selectedDay, daysInMonth)}
+                  y1={PAD_T - 2}
+                  x2={dayX(selectedDay, daysInMonth)}
+                  y2={VB_H - 18}
+                  stroke={COLORS.brass}
+                  strokeWidth={1.5}
+                  strokeOpacity={0.6}
+                />
+              )}
+
+              {/* Bars */}
+              {days.map((d) => {
+                const x = dayX(d.day, daysInMonth);
+                const isPast = d.isReal || d.day <= dayOfMonth;
+                const isSelected = d.day === selectedDay;
+                return (
+                  <React.Fragment key={d.day}>
+                    {d.income > 0 && (
+                      <Rect
+                        x={x - chart.barW / 2}
+                        y={BASELINE_Y - d.income * chart.scaleUp}
+                        width={chart.barW}
+                        height={d.income * chart.scaleUp}
+                        rx={3}
+                        fill={COLORS.income}
+                        opacity={isSelected ? 1 : isPast ? 0.95 : 0.6}
+                      />
+                    )}
+                    {d.expense > 0 && (
+                      <Rect
+                        x={x - chart.barW / 2}
+                        y={BASELINE_Y}
+                        width={chart.barW}
+                        height={d.expense * chart.scaleDown}
+                        rx={3}
+                        fill={COLORS.debt}
+                        opacity={isSelected ? 1 : isPast ? 0.9 : 0.6}
+                      />
+                    )}
+                  </React.Fragment>
+                );
+              })}
+
+              {/* Balance polyline — past (solid) */}
+              {chart.pastPath && (
+                <Path d={chart.pastPath} fill="none" stroke={COLORS.brass} strokeWidth={2} opacity={0.9} strokeLinecap="round" strokeLinejoin="round" />
+              )}
+              {/* Balance polyline — future (dashed) */}
+              {chart.futurePath && (
+                <Path d={chart.futurePath} fill="none" stroke={COLORS.brass} strokeWidth={2} opacity={0.7} strokeDasharray="4,3" strokeLinecap="round" strokeLinejoin="round" />
+              )}
+
+              {/* Balance dots */}
+              {chart.balanceDots.map((dot) => (
+                <Circle key={dot.day} cx={dot.x} cy={dot.y} r={dot.day === selectedDay ? 4.5 : 3} fill={dot.isPast ? COLORS.income : COLORS.brass} opacity={dot.day === selectedDay ? 1 : 0.8} />
+              ))}
+
+              {/* Day labels */}
+              {chart.dayLabels.map((lbl) => (
+                <SvgText key={lbl.day} x={lbl.x} y={VB_H - 8} fill={COLORS.sageDark} fontSize={7} textAnchor="middle">{lbl.day}</SvgText>
+              ))}
+            </Svg>
+          </View>
+        </GestureDetector>
+        </GestureHandlerRootView>
+
+        {/* Summary row */}
+        <View className="mt-2 flex-row items-center">
+          <View className="flex-1 items-center">
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">Ingresos</Text>
+            <Text className="mt-0.5 text-[13px] font-inter-semibold text-z-income">{formatCurrency(totalIncome, currency)}</Text>
+          </View>
+          <View className="h-5 w-px bg-white-6" />
+          <View className="flex-1 items-center">
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">Gastos</Text>
+            <Text className="mt-0.5 text-[13px] font-inter-semibold text-z-debt">{formatCurrency(totalExpense, currency)}</Text>
+          </View>
+          <View className="h-5 w-px bg-white-6" />
+          <View className="flex-1 items-center">
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">Neto</Text>
+            <Text className={`mt-0.5 text-[13px] font-inter-semibold ${net >= 0 ? "text-z-brass" : "text-z-debt"}`}>{formatCurrency(net, currency)}</Text>
+          </View>
+        </View>
+      </View>
+    </MobileZone>
+  );
+}

--- a/mobile/components/plan/PlanNetHero.tsx
+++ b/mobile/components/plan/PlanNetHero.tsx
@@ -63,7 +63,7 @@ export function PlanNetHero({
         </View>
 
         {/* Main number: disponible */}
-        <Text className={`mt-2 text-[32px] font-inter-bold ${isPositive ? "text-z-income" : "text-z-expense"}`}>
+        <Text className={`mt-2 text-[32px] font-inter-bold tabular-nums ${isPositive ? "text-z-income" : "text-z-expense"}`}>
           {formatCurrency(disponible, currency)}
         </Text>
         <Text className="text-xs font-inter text-muted-foreground">
@@ -103,7 +103,7 @@ export function PlanNetHero({
           <View className="mt-3 gap-3">
             {/* ── INGRESOS section ── */}
             <View className={`${PANEL_INSET_CLASS} p-3 gap-1.5`} style={{ borderColor: "rgba(92,184,138,0.2)" }}>
-              <Text className="text-[9px] font-inter-bold uppercase tracking-[3px] text-z-income">
+              <Text className="text-[9px] font-inter-bold uppercase tracking-[0.18em] text-z-income">
                 Ingresos planeados
               </Text>
               <View className="flex-row justify-between">
@@ -140,7 +140,7 @@ export function PlanNetHero({
 
             {/* ── GASTOS FIJOS section ── */}
             <View className={`${PANEL_INSET_CLASS} p-3 gap-1.5`} style={{ borderColor: "rgba(212,168,67,0.2)" }}>
-              <Text className="text-[9px] font-inter-bold uppercase tracking-[3px] text-z-alert">
+              <Text className="text-[9px] font-inter-bold uppercase tracking-[0.18em] text-z-alert">
                 Gastos fijos planeados
               </Text>
               <View className="flex-row justify-between">
@@ -174,7 +174,7 @@ export function PlanNetHero({
 
             {/* ── GASTO LIBRE ── */}
             <View className={`${PANEL_INSET_CLASS} p-3 gap-1`} style={{ borderColor: "rgba(224,85,69,0.2)" }}>
-              <Text className="text-[9px] font-inter-bold uppercase tracking-[3px] text-z-debt">
+              <Text className="text-[9px] font-inter-bold uppercase tracking-[0.18em] text-z-debt">
                 Gasto libre
               </Text>
               <Text className="text-sm font-inter-bold text-z-expense">

--- a/mobile/components/plan/PlanNetHero.tsx
+++ b/mobile/components/plan/PlanNetHero.tsx
@@ -1,65 +1,216 @@
 import { View, Text, Pressable } from "react-native";
+import { Check, Clock } from "lucide-react-native";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { GradientCard } from "../ui/GradientCard";
 import { AnimatedAccordion } from "../ui/AnimatedAccordion";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { SECTION_EYEBROW_CLASS, PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { COLORS } from "../../lib/constants/colors";
+
+export interface PlanExecution {
+  // Income tracking
+  plannedIncome: number;
+  confirmedIncome: number;
+  pendingIncome: number;
+  // Obligation tracking
+  plannedExpenses: number;
+  paidExpenses: number;
+  pendingExpenses: number;
+  // Discretionary spending (non-recurring outflows)
+  discretionarySpent: number;
+  // Bottom line
+  disponible: number;
+  daysRemaining: number;
+  perDay: number;
+}
 
 interface PlanNetHeroProps {
-  ingresos: number;
-  gastos: number;
+  plan: PlanExecution;
   currency: CurrencyCode;
-  daysRemaining: number;
   expanded: boolean;
   onToggle: () => void;
 }
 
 export function PlanNetHero({
-  ingresos,
-  gastos,
+  plan,
   currency,
-  daysRemaining,
   expanded,
   onToggle,
 }: PlanNetHeroProps) {
-  const net = ingresos - gastos;
-  const isPositive = net >= 0;
+  const {
+    plannedIncome, confirmedIncome, pendingIncome,
+    plannedExpenses, paidExpenses, pendingExpenses,
+    discretionarySpent, disponible, daysRemaining, perDay,
+  } = plan;
+
+  const isPositive = disponible >= 0;
+
+  // Progress: how much of planned income has been confirmed
+  const incomePct = plannedIncome > 0 ? Math.min(100, (confirmedIncome / plannedIncome) * 100) : 0;
+  // How much of planned expenses have been paid
+  const expensePct = plannedExpenses > 0 ? Math.min(100, (paidExpenses / plannedExpenses) * 100) : 0;
+
 
   return (
     <Pressable onPress={onToggle}>
       <GradientCard>
-        <Text className="text-[10px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">
-          Balance del mes
-        </Text>
-
-        <View className="mt-2 flex-row items-baseline gap-1">
-          <Text className={`text-[32px] font-inter-bold ${isPositive ? "text-z-income" : "text-z-expense"}`}>
-            {isPositive ? "+" : ""}{formatCurrency(net, currency)}
+        <View className="flex-row items-center justify-between">
+          <Text className={SECTION_EYEBROW_CLASS}>
+            Plan del mes
+          </Text>
+          <Text className="text-xs font-inter text-muted-foreground">
+            {daysRemaining} dias restantes
           </Text>
         </View>
 
-        <Text className="mt-1 text-xs font-inter text-muted-foreground">
-          {daysRemaining} dias restantes
+        {/* Main number: disponible */}
+        <Text className={`mt-2 text-[32px] font-inter-bold ${isPositive ? "text-z-income" : "text-z-expense"}`}>
+          {formatCurrency(disponible, currency)}
+        </Text>
+        <Text className="text-xs font-inter text-muted-foreground">
+          disponible · {formatCurrency(perDay, currency)}/dia
+        </Text>
+
+        {/* Burn bar — how much of confirmed income has been used */}
+        <View className="mt-3 h-2 flex-row overflow-hidden rounded-full bg-white-6">
+          {/* Paid obligations */}
+          <View className="bg-z-alert" style={{ width: `${plannedExpenses > 0 ? Math.min((paidExpenses / (confirmedIncome || 1)) * 100, 100) : 0}%` }} />
+          {/* Discretionary */}
+          <View className="bg-z-debt" style={{ width: `${Math.min((discretionarySpent / (confirmedIncome || 1)) * 100, 100 - (paidExpenses / (confirmedIncome || 1)) * 100)}%` }} />
+          {/* Remaining = green space (implicit) */}
+        </View>
+        <View className="mt-1.5 flex-row items-center gap-3">
+          <View className="flex-row items-center gap-1">
+            <View className="h-1.5 w-1.5 rounded-full bg-z-alert" />
+            <Text className="text-[9px] font-inter text-muted-foreground">Fijos</Text>
+          </View>
+          <View className="flex-row items-center gap-1">
+            <View className="h-1.5 w-1.5 rounded-full bg-z-debt" />
+            <Text className="text-[9px] font-inter text-muted-foreground">Gasto libre</Text>
+          </View>
+          <View className="flex-row items-center gap-1">
+            <View className="h-1.5 w-1.5 rounded-full bg-white-6" />
+            <Text className="text-[9px] font-inter text-muted-foreground">Disponible</Text>
+          </View>
+        </View>
+
+        {/* Expand CTA */}
+        <Text className="mt-2 text-center text-[10px] font-inter text-muted-fg-50">
+          {expanded ? "Ocultar desglose ↑" : "Ver desglose del plan ↓"}
         </Text>
 
         {/* Expandable breakdown */}
-        <AnimatedAccordion expanded={expanded} estimatedHeight={120}>
-          <View className={`mt-3 ${PANEL_INSET_CLASS} border-white-8 bg-black-20 p-3 gap-2`}>
-            <View className="flex-row justify-between">
-              <Text className="text-[11px] font-inter text-muted-foreground">Ingresos</Text>
-              <Text className="text-sm font-inter-semibold text-z-income">
-                +{formatCurrency(ingresos, currency)}
+        <AnimatedAccordion expanded={expanded} estimatedHeight={320}>
+          <View className="mt-3 gap-3">
+            {/* ── INGRESOS section ── */}
+            <View className={`${PANEL_INSET_CLASS} p-3 gap-1.5`} style={{ borderColor: "rgba(92,184,138,0.2)" }}>
+              <Text className="text-[9px] font-inter-bold uppercase tracking-[3px] text-z-income">
+                Ingresos planeados
+              </Text>
+              <View className="flex-row justify-between">
+                <Text className="text-sm font-inter-bold text-foreground">
+                  {formatCurrency(plannedIncome, currency)}
+                </Text>
+                <Text className="text-[10px] font-inter text-muted-foreground">
+                  {Math.round(incomePct)}% recibido
+                </Text>
+              </View>
+              {/* Progress bar */}
+              <View className="h-1.5 flex-row overflow-hidden rounded-full bg-white-6">
+                <View className="bg-z-income rounded-full" style={{ width: `${incomePct}%` }} />
+              </View>
+              {/* Confirmed line */}
+              {confirmedIncome > 0 && (
+                <View className="flex-row items-center gap-1.5 mt-0.5">
+                  <Check size={10} color={COLORS.income} />
+                  <Text className="text-[10px] font-inter text-z-income">
+                    Recibido {formatCurrency(confirmedIncome, currency)}
+                  </Text>
+                </View>
+              )}
+              {/* Pending line */}
+              {pendingIncome > 0 && (
+                <View className="flex-row items-center gap-1.5">
+                  <Clock size={10} color={COLORS.sageDark} />
+                  <Text className="text-[10px] font-inter text-muted-foreground">
+                    Pendiente {formatCurrency(pendingIncome, currency)}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {/* ── GASTOS FIJOS section ── */}
+            <View className={`${PANEL_INSET_CLASS} p-3 gap-1.5`} style={{ borderColor: "rgba(212,168,67,0.2)" }}>
+              <Text className="text-[9px] font-inter-bold uppercase tracking-[3px] text-z-alert">
+                Gastos fijos planeados
+              </Text>
+              <View className="flex-row justify-between">
+                <Text className="text-sm font-inter-bold text-foreground">
+                  {formatCurrency(plannedExpenses, currency)}
+                </Text>
+                <Text className="text-[10px] font-inter text-muted-foreground">
+                  {Math.round(expensePct)}% pagado
+                </Text>
+              </View>
+              <View className="h-1.5 flex-row overflow-hidden rounded-full bg-white-6">
+                <View className="bg-z-alert rounded-full" style={{ width: `${expensePct}%` }} />
+              </View>
+              {paidExpenses > 0 && (
+                <View className="flex-row items-center gap-1.5 mt-0.5">
+                  <Check size={10} color={COLORS.alert} />
+                  <Text className="text-[10px] font-inter text-z-alert">
+                    Pagado {formatCurrency(paidExpenses, currency)}
+                  </Text>
+                </View>
+              )}
+              {pendingExpenses > 0 && (
+                <View className="flex-row items-center gap-1.5">
+                  <Clock size={10} color={COLORS.sageDark} />
+                  <Text className="text-[10px] font-inter text-muted-foreground">
+                    Pendiente {formatCurrency(pendingExpenses, currency)}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {/* ── GASTO LIBRE ── */}
+            <View className={`${PANEL_INSET_CLASS} p-3 gap-1`} style={{ borderColor: "rgba(224,85,69,0.2)" }}>
+              <Text className="text-[9px] font-inter-bold uppercase tracking-[3px] text-z-debt">
+                Gasto libre
+              </Text>
+              <Text className="text-sm font-inter-bold text-z-expense">
+                -{formatCurrency(discretionarySpent, currency)}
+              </Text>
+              <Text className="text-[9px] font-inter text-muted-foreground">
+                Gastos no recurrentes del mes
               </Text>
             </View>
-            <View className="flex-row justify-between">
-              <Text className="text-[11px] font-inter text-muted-foreground">Gastos</Text>
-              <Text className="text-sm font-inter-semibold text-z-expense">
-                -{formatCurrency(gastos, currency)}
-              </Text>
-            </View>
-            <View className="border-t border-white-8 pt-1.5 flex-row justify-between">
-              <Text className="text-[11px] font-inter-semibold text-foreground">Neto</Text>
-              <Text className={`text-sm font-inter-semibold ${isPositive ? "text-z-income" : "text-z-expense"}`}>
-                {isPositive ? "+" : ""}{formatCurrency(net, currency)}
+
+            {/* ── BOTTOM LINE ── */}
+            <View className="border-t border-white-8 pt-2 gap-0.5">
+              <View className="flex-row justify-between">
+                <Text className="text-xs font-inter text-muted-foreground">Ingreso confirmado</Text>
+                <Text className="text-xs font-inter-semibold text-z-income">+{formatCurrency(confirmedIncome, currency)}</Text>
+              </View>
+              <View className="flex-row justify-between">
+                <Text className="text-xs font-inter text-muted-foreground">- Fijos pagados</Text>
+                <Text className="text-xs font-inter-semibold text-z-alert">-{formatCurrency(paidExpenses, currency)}</Text>
+              </View>
+              <View className="flex-row justify-between">
+                <Text className="text-xs font-inter text-muted-foreground">- Fijos pendientes</Text>
+                <Text className="text-xs font-inter-semibold text-muted-foreground">-{formatCurrency(pendingExpenses, currency)}</Text>
+              </View>
+              <View className="flex-row justify-between">
+                <Text className="text-xs font-inter text-muted-foreground">- Gasto libre</Text>
+                <Text className="text-xs font-inter-semibold text-z-expense">-{formatCurrency(discretionarySpent, currency)}</Text>
+              </View>
+              <View className="border-t border-white-8 mt-1 pt-1.5 flex-row justify-between">
+                <Text className="text-xs font-inter-bold text-foreground">= Disponible</Text>
+                <Text className={`text-sm font-inter-bold ${isPositive ? "text-z-income" : "text-z-expense"}`}>
+                  {formatCurrency(disponible, currency)}
+                </Text>
+              </View>
+              <Text className="text-[9px] font-inter text-muted-foreground">
+                ÷ {daysRemaining} dias = {formatCurrency(perDay, currency)}/dia
               </Text>
             </View>
           </View>

--- a/mobile/components/plan/PlanRecurringSummary.tsx
+++ b/mobile/components/plan/PlanRecurringSummary.tsx
@@ -25,7 +25,7 @@ export function PlanRecurringSummary({
       <MCard>
         <View className="flex-row items-center justify-between">
           <View className="flex-1">
-            <Text className="text-[10px] font-inter-semibold uppercase tracking-[3px] text-z-sage-dark">
+            <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">
               Obligaciones recurrentes
             </Text>
             <Text className="text-[18px] font-inter-bold text-foreground mt-1">

--- a/mobile/components/plan/PlanRoot.tsx
+++ b/mobile/components/plan/PlanRoot.tsx
@@ -6,32 +6,50 @@ import { useSync } from "../../lib/sync/hooks";
 import { getTransactions } from "../../lib/repositories/transactions";
 import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
 import { getBudgetProgress, type BudgetProgressRow } from "../../lib/repositories/budgets";
-import { getRecurringSummary } from "../../lib/repositories/recurring";
-import { computeCashflow } from "../../lib/utils/cashflow";
+import {
+  getActiveTemplates,
+  getOccurrencesForMonth,
+  toMonthlyAmount,
+  type OccurrenceWithTemplate,
+} from "../../lib/repositories/recurring";
+import { getWishlistCount } from "../../lib/repositories/wishlist";
+import { computeTimeline, type TimelineData } from "../../lib/utils/timeline";
+import { toLocalMonthString } from "../../lib/utils/date";
+import { DEBT_ACCOUNT_TYPES, LIQUID_ACCOUNT_TYPES } from "../../lib/constants/accounts";
 import { COLORS } from "../../lib/constants/colors";
 import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
 import { useExpandableZone } from "../ui/useExpandableZone";
 import { MonthSelector } from "../common/MonthSelector";
-import { PlanNetHero } from "./PlanNetHero";
+import { PlanNetHero, type PlanExecution } from "./PlanNetHero";
+import { PlanExpandableChips } from "./PlanExpandableChips";
+import { PlanFlowChart } from "./PlanFlowChart";
 import { PlanDrillCards } from "./PlanDrillCards";
-import { PlanBudgetSection } from "./PlanBudgetSection";
-import { PlanRecurringSummary } from "./PlanRecurringSummary";
 
 interface PlanState {
-  ingresos: number;
-  gastos: number;
+  plan: PlanExecution;
   budgetItems: BudgetProgressRow[];
-  recurringCount: number;
-  daysRemaining: number;
-  recurringTotal: number;
   recurringPending: number;
-  recurringPaid: number;
+  incomeOccs: OccurrenceWithTemplate[];
+  paymentOccs: OccurrenceWithTemplate[];
+  wishlistCount: number;
+  timeline: TimelineData | null;
 }
 
+const EMPTY_PLAN: PlanExecution = {
+  plannedIncome: 0, confirmedIncome: 0, pendingIncome: 0,
+  plannedExpenses: 0, paidExpenses: 0, pendingExpenses: 0,
+  discretionarySpent: 0, disponible: 0, daysRemaining: 0, perDay: 0,
+};
+
 const INITIAL: PlanState = {
-  ingresos: 0, gastos: 0, budgetItems: [], recurringCount: 0, daysRemaining: 0,
-  recurringTotal: 0, recurringPending: 0, recurringPaid: 0,
+  plan: EMPTY_PLAN,
+  budgetItems: [],
+  recurringPending: 0,
+  incomeOccs: [],
+  paymentOccs: [],
+  wishlistCount: 0,
+  timeline: null,
 };
 
 export function PlanRoot() {
@@ -39,9 +57,7 @@ export function PlanRoot() {
   const { activeZone, toggle } = useExpandableZone<string>();
 
   const [refreshing, setRefreshing] = useState(false);
-  const [currentMonth, setCurrentMonth] = useState(
-    () => new Date().toISOString().slice(0, 7)
-  );
+  const [currentMonth, setCurrentMonth] = useState(() => toLocalMonthString());
   const [data, setData] = useState<PlanState>(INITIAL);
 
   const currency: CurrencyCode = "COP";
@@ -50,30 +66,113 @@ export function PlanRoot() {
     try {
       const now = new Date();
       const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-      const daysRemaining = daysInMonth - now.getDate();
+      const daysRemaining = Math.max(1, daysInMonth - now.getDate());
 
-      const [txs, accounts, budgets, recSummary] = await Promise.all([
+      const [txs, accounts, budgets, occurrences, wishCount, templates] = await Promise.all([
         getTransactions({ month: currentMonth, limit: 500 }),
         getAllAccounts(),
         getBudgetProgress(currentMonth),
-        getRecurringSummary(currentMonth),
+        getOccurrencesForMonth(currentMonth),
+        getWishlistCount(),
+        getActiveTemplates(),
       ]);
 
-      const { totalInflow, totalOutflow } = computeCashflow(txs, accounts);
+      const accountMap = new Map<string, AccountRow>(accounts.map((a: AccountRow) => [a.id, a]));
 
-      const recurring = accounts.filter(
-        (a: AccountRow) => a.is_active === 1 && a.payment_day
-      ).length;
+      // ── 1. Planned totals from active templates (liquid accounts only) ──
+      let plannedIncome = 0;
+      let plannedExpenses = 0;
+      for (const t of templates) {
+        const acctType = accountMap.get(t.account_id)?.account_type ?? "";
+        // Only count templates on liquid accounts for the plan
+        if (!LIQUID_ACCOUNT_TYPES.has(acctType) && !DEBT_ACCOUNT_TYPES.has(acctType)) continue;
+        const monthlyAmt = toMonthlyAmount(t.amount, t.frequency);
+        const isDebtPayment = DEBT_ACCOUNT_TYPES.has(acctType);
+        if (t.direction === "OUTFLOW" || isDebtPayment) {
+          plannedExpenses += monthlyAmt;
+        } else {
+          plannedIncome += monthlyAmt;
+        }
+      }
+
+      // ── 2. Execution from occurrences (confirmed vs pending) ──
+      let confirmedIncome = 0;
+      let pendingIncome = 0;
+      let paidExpenses = 0;
+      let pendingExpenses = 0;
+      const pendingIncomeOccs: OccurrenceWithTemplate[] = [];
+      const pendingPaymentOccs: OccurrenceWithTemplate[] = [];
+      let totalRecurringPending = 0;
+
+      for (const occ of occurrences) {
+        const acctType = accountMap.get(occ.account_id)?.account_type ?? "";
+        const isDebtInflow = occ.direction === "INFLOW" && DEBT_ACCOUNT_TYPES.has(acctType);
+        const isIncome = occ.direction === "INFLOW" && !isDebtInflow;
+        const isExpense = occ.direction === "OUTFLOW" || isDebtInflow;
+
+        if (isIncome) {
+          if (occ.status === "paid") {
+            confirmedIncome += occ.expected_amount;
+          } else if (occ.status === "pending") {
+            pendingIncome += occ.expected_amount;
+            pendingIncomeOccs.push(occ);
+            totalRecurringPending++;
+          }
+        } else if (isExpense) {
+          if (occ.status === "paid") {
+            paidExpenses += occ.expected_amount;
+          } else if (occ.status === "pending") {
+            pendingExpenses += occ.expected_amount;
+            pendingPaymentOccs.push(occ);
+            totalRecurringPending++;
+          }
+        }
+      }
+
+      // ── 3. Discretionary spending = non-recurring outflows from liquid accounts ──
+      const recurringTxIds = new Set(
+        occurrences
+          .filter((o) => o.transaction_id)
+          .map((o) => o.transaction_id!)
+      );
+
+      let discretionarySpent = 0;
+      for (const tx of txs as any[]) {
+        if (tx.is_excluded) continue;
+        if (tx.direction !== "OUTFLOW") continue;
+        if (tx.transfer_group_id) continue;
+        if (tx.reconciled_into_transaction_id) continue;
+        if (recurringTxIds.has(tx.id)) continue; // already counted as paid obligation
+        // Only count from liquid accounts
+        const txAcctType = accountMap.get(tx.account_id)?.account_type ?? "";
+        if (!LIQUID_ACCOUNT_TYPES.has(txAcctType)) continue;
+        discretionarySpent += Math.abs(tx.amount);
+      }
+
+      // ── 4. Disponible = confirmed income - paid obligations - pending obligations - discretionary ──
+      const disponible = confirmedIncome - paidExpenses - pendingExpenses - discretionarySpent;
+      const perDay = Math.round(Math.max(0, disponible) / daysRemaining);
+
+      // Liquid balance for chart baseline
+      const liquidBalance = accounts
+        .filter((a: AccountRow) => LIQUID_ACCOUNT_TYPES.has(a.account_type))
+        .reduce((sum: number, a: AccountRow) => sum + a.current_balance, 0);
+
+      // Timeline for chart — start from actual liquid balance
+      const timeline = computeTimeline(txs, accounts, occurrences, now, liquidBalance);
 
       setData({
-        ingresos: totalInflow,
-        gastos: totalOutflow,
+        plan: {
+          plannedIncome, confirmedIncome, pendingIncome,
+          plannedExpenses, paidExpenses, pendingExpenses,
+          discretionarySpent, disponible, daysRemaining, perDay,
+        },
         budgetItems: budgets,
-        recurringCount: recurring + recSummary.pending_count + recSummary.paid_count,
-        daysRemaining,
-        recurringTotal: recSummary.total_expected,
-        recurringPending: recSummary.pending_count,
-        recurringPaid: recSummary.paid_count,
+        recurringPending: totalRecurringPending,
+        incomeOccs: pendingIncomeOccs,
+        paymentOccs: pendingPaymentOccs,
+        wishlistCount: wishCount,
+        timeline,
       });
     } catch (error) {
       console.error("Failed to load plan data:", error);
@@ -96,17 +195,22 @@ export function PlanRoot() {
     }
   }, [sync, loadData]);
 
-  const { budgetSpent, budgetTarget } = useMemo(() => ({
-    budgetSpent: data.budgetItems.reduce((sum, b) => sum + b.spent, 0),
-    budgetTarget: data.budgetItems.reduce((sum, b) => sum + b.amount, 0),
-  }), [data.budgetItems]);
+  const { budgetOverLimit, budgetPct } = useMemo(() => {
+    const spent = data.budgetItems.reduce((sum, b) => sum + b.spent, 0);
+    const target = data.budgetItems.reduce((sum, b) => sum + b.amount, 0);
+    const overLimit = data.budgetItems.filter((b) => b.amount > 0 && b.spent > b.amount).length;
+    return {
+      budgetOverLimit: overLimit,
+      budgetPct: target > 0 ? Math.round((spent / target) * 100) : 0,
+    };
+  }, [data.budgetItems]);
 
   return (
     <View className="flex-1 bg-background">
       <MobileHeader
         variant="main"
         title="Plan"
-        subtitle={`${data.daysRemaining}d restantes`}
+        subtitle={`${currentMonth.split("-")[1] === String(new Date().getMonth() + 1).padStart(2, "0") ? `${data.plan.daysRemaining}d restantes` : currentMonth}`}
         right={<AvatarMenuTrigger />}
       />
       <ScrollView
@@ -120,34 +224,35 @@ export function PlanRoot() {
           <MonthSelector month={currentMonth} onChange={setCurrentMonth} />
         </View>
 
+        {/* Live plan execution hero */}
         <PlanNetHero
-          ingresos={data.ingresos}
-          gastos={data.gastos}
+          plan={data.plan}
           currency={currency}
-          daysRemaining={data.daysRemaining}
           expanded={activeZone === "hero"}
           onToggle={() => toggle("hero")}
         />
 
-        {data.recurringTotal > 0 && (
-          <PlanRecurringSummary
-            totalExpected={data.recurringTotal}
-            pendingCount={data.recurringPending}
-            paidCount={data.recurringPaid}
+        {/* Próximo ingreso / Próximo pago */}
+        <PlanExpandableChips
+          incomes={data.incomeOccs}
+          payments={data.paymentOccs}
+          currency={currency}
+        />
+
+        {/* Cashflow chart */}
+        {data.timeline && (
+          <PlanFlowChart
+            timelineData={data.timeline}
             currency={currency}
           />
         )}
 
-        <PlanBudgetSection
-          budgetItems={data.budgetItems}
-          currency={currency}
-        />
-
+        {/* Navigation grid */}
         <PlanDrillCards
-          budgetSpent={budgetSpent}
-          budgetTarget={budgetTarget}
-          recurringCount={data.recurringCount}
-          currency={currency}
+          budgetOverLimit={budgetOverLimit}
+          budgetPct={budgetPct}
+          recurringPending={data.recurringPending}
+          wishlistCount={data.wishlistCount}
         />
       </ScrollView>
     </View>

--- a/mobile/components/plan/ReassignSheet.tsx
+++ b/mobile/components/plan/ReassignSheet.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Check, X } from "lucide-react-native";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { supabase } from "../../lib/supabase";
+import { useAuth } from "../../lib/auth";
+import { COLORS } from "../../lib/constants/colors";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { parseLocalizedAmount } from "../../lib/amount";
+
+import { ENVELOPE_COLORS } from "../../lib/constants/envelope-colors";
+
+export interface ReassignTarget {
+  assignmentId: string;
+  expenseEntryId: string;
+  expenseLabel: string;
+  currentIncomeEntryId: string;
+  currentAmount: number;
+}
+
+export interface IncomeOption {
+  entryId: string;
+  label: string;
+  remainingAmount: number;
+  colorIndex: number;
+}
+
+interface ReassignSheetProps {
+  visible: boolean;
+  target: ReassignTarget | null;
+  incomeOptions: IncomeOption[];
+  currency: CurrencyCode;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function ReassignSheet({
+  visible,
+  target,
+  incomeOptions,
+  currency,
+  onClose,
+  onSuccess,
+}: ReassignSheetProps) {
+  const { session } = useAuth();
+  const [selectedIncomeId, setSelectedIncomeId] = useState<string | null>(null);
+  const [amountInput, setAmountInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = useCallback(() => {
+    setSelectedIncomeId(null);
+    setAmountInput("");
+    setError(null);
+    onClose();
+  }, [onClose]);
+
+  // When selecting an income, pre-fill amount with min(current assignment, remaining on new envelope)
+  const handleSelectIncome = useCallback((incomeId: string, remaining: number) => {
+    setSelectedIncomeId(incomeId);
+    if (target) {
+      setAmountInput(String(Math.min(target.currentAmount, remaining + (incomeId === target.currentIncomeEntryId ? target.currentAmount : 0))));
+    }
+  }, [target]);
+
+  const handleReassign = useCallback(async () => {
+    if (!target || !selectedIncomeId || !session?.user?.id) return;
+
+    const amount = parseLocalizedAmount(amountInput);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setError("Monto invalido");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const sb = supabase as any;
+      const userId = session.user.id;
+
+      if (selectedIncomeId === target.currentIncomeEntryId) {
+        // Same envelope — just update amount
+        await sb
+          .from("planning_assignments")
+          .update({ assigned_amount: amount, updated_at: new Date().toISOString() })
+          .eq("id", target.assignmentId)
+          .eq("user_id", userId);
+      } else {
+        // Different envelope — delete old, create new
+        await sb
+          .from("planning_assignments")
+          .delete()
+          .eq("id", target.assignmentId)
+          .eq("user_id", userId);
+
+        // Get period_id from the old assignment context
+        const { data: oldAssignment } = await sb
+          .from("planning_assignments")
+          .select("period_id")
+          .eq("expense_entry_id", target.expenseEntryId)
+          .eq("user_id", userId)
+          .limit(1)
+          .maybeSingle();
+
+        // If no other assignment exists, get period from the expense entry
+        let periodId: string;
+        if (oldAssignment?.period_id) {
+          periodId = oldAssignment.period_id;
+        } else {
+          const { data: entry } = await sb
+            .from("planning_entries")
+            .select("period_id")
+            .eq("id", target.expenseEntryId)
+            .eq("user_id", userId)
+            .single();
+          periodId = entry?.period_id;
+        }
+
+        if (!periodId) {
+          setError("No se pudo determinar el periodo");
+          return;
+        }
+
+        await sb
+          .from("planning_assignments")
+          .insert({
+            user_id: userId,
+            period_id: periodId,
+            income_entry_id: selectedIncomeId,
+            expense_entry_id: target.expenseEntryId,
+            assigned_amount: amount,
+          });
+      }
+
+      handleClose();
+      onSuccess();
+    } catch (err: any) {
+      setError(err?.message ?? "Error al reasignar");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [target, selectedIncomeId, amountInput, session?.user?.id, handleClose, onSuccess]);
+
+  if (!target) return null;
+
+  // Available envelopes: include current (to change amount) + others with remaining capacity
+  const options = incomeOptions.filter((opt) =>
+    opt.entryId === target.currentIncomeEntryId || opt.remainingAmount > 0
+  );
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <View className="flex-1 justify-end bg-black/60">
+        <View className="rounded-t-3xl border-t border-white-6 bg-background">
+          {/* Header */}
+          <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+            <Text className="text-[15px] font-inter-semibold text-foreground">Reasignar gasto</Text>
+            <Pressable onPress={handleClose} className="h-8 w-8 items-center justify-center rounded-full">
+              <X size={16} color={COLORS.sageLight} />
+            </Pressable>
+          </View>
+
+          <ScrollView
+            className="max-h-[70%]"
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40 }}
+          >
+            {/* Current assignment info */}
+            <View className={`${PANEL_INSET_CLASS} p-3 mb-4`}>
+              <Text className="text-sm font-inter-semibold text-foreground">{target.expenseLabel}</Text>
+              <Text className="text-[11px] font-inter text-muted-foreground mt-0.5">
+                Asignacion actual: {formatCurrency(target.currentAmount, currency)}
+              </Text>
+            </View>
+
+            {/* Income envelope picker */}
+            <Text className="text-xs font-inter-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+              Asignar a ingreso
+            </Text>
+
+            {options.length === 0 ? (
+              <Text className="text-xs font-inter text-muted-foreground py-4 text-center">
+                No hay ingresos con saldo disponible
+              </Text>
+            ) : (
+              options.map((opt) => {
+                const isSelected = selectedIncomeId === opt.entryId;
+                const isCurrent = opt.entryId === target.currentIncomeEntryId;
+                const color = ENVELOPE_COLORS[opt.colorIndex % ENVELOPE_COLORS.length];
+                const displayRemaining = isCurrent
+                  ? opt.remainingAmount + target.currentAmount
+                  : opt.remainingAmount;
+
+                return (
+                  <Pressable
+                    key={opt.entryId}
+                    onPress={() => handleSelectIncome(opt.entryId, displayRemaining)}
+                    className={`${PANEL_INSET_CLASS} flex-row items-center p-3 mb-2`}
+                    style={isSelected ? { borderColor: color } : undefined}
+                  >
+                    <View className="h-3 w-3 rounded-full mr-3" style={{ backgroundColor: color }} />
+                    <View className="flex-1">
+                      <Text className="text-xs font-inter-semibold text-foreground">
+                        {opt.label} {isCurrent ? "(actual)" : ""}
+                      </Text>
+                      <Text className="text-[10px] font-inter text-muted-foreground">
+                        Disponible: {formatCurrency(displayRemaining, currency)}
+                      </Text>
+                    </View>
+                    {isSelected && <Check size={16} color={color} />}
+                  </Pressable>
+                );
+              })
+            )}
+
+            {/* Amount input */}
+            {selectedIncomeId && (
+              <View className="mt-3">
+                <Text className="text-xs font-inter-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+                  Monto a asignar
+                </Text>
+                <TextInput
+                  className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-sm font-inter-medium text-foreground"
+                  placeholderTextColor="#938C7E"
+                  placeholder="Monto"
+                  keyboardType="numeric"
+                  value={amountInput}
+                  onChangeText={setAmountInput}
+                />
+              </View>
+            )}
+
+            {error && (
+              <View className="rounded-xl bg-z-debt/10 px-3 py-2 mt-2">
+                <Text className="text-xs font-inter-medium text-z-debt">{error}</Text>
+              </View>
+            )}
+
+            {/* Actions */}
+            <Pressable
+              onPress={handleReassign}
+              disabled={!selectedIncomeId || submitting}
+              className={`rounded-xl py-3 items-center mt-4 ${selectedIncomeId ? "bg-z-brass" : "bg-z-brass/30"}`}
+            >
+              {submitting ? (
+                <ActivityIndicator size="small" color={COLORS.ink} />
+              ) : (
+                <Text className={`text-sm font-inter-semibold ${selectedIncomeId ? "text-z-ink" : "text-z-ink/50"}`}>
+                  Reasignar
+                </Text>
+              )}
+            </Pressable>
+
+            <Pressable onPress={handleClose} className="items-center py-3 mt-1">
+              <Text className="text-sm font-inter-medium text-muted-foreground">Cancelar</Text>
+            </Pressable>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/mobile/components/recurrentes/RecurrentesRoot.tsx
+++ b/mobile/components/recurrentes/RecurrentesRoot.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, View, ScrollView, RefreshControl } from "react-native"
 import { useFocusEffect } from "expo-router";
 import { ChevronDown, ChevronUp } from "lucide-react-native";
 import type { CurrencyCode } from "@zeta/shared";
+import { toLocalMonthString } from "../../lib/utils/date";
 import { useSync } from "../../lib/sync/hooks";
 import {
   getOccurrencesForMonth,
@@ -38,7 +39,7 @@ export function RecurrentesRoot() {
 
   const [refreshing, setRefreshing] = useState(false);
   const [currentMonth, setCurrentMonth] = useState(
-    () => new Date().toISOString().slice(0, 7)
+    () => toLocalMonthString()
   );
   const [occurrences, setOccurrences] = useState<OccurrenceWithTemplate[]>([]);
   const [summary, setSummary] = useState<RecurringSummary>(EMPTY_SUMMARY);

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -109,26 +109,26 @@ export function CategoryPicker({
       onRequestClose={handleClose}
     >
       <View className="flex-1 justify-end bg-black/35">
-        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl bg-white">
+        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl bg-z-surface-2-55">
           {/* Header */}
-          <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-gray-100">
-            <Text className="text-gray-900 font-inter-bold text-base">
+          <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
+            <Text className="text-foreground font-inter-bold text-base">
               Categoría
             </Text>
             <Pressable
               onPress={handleClose}
-              className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
             >
-              <X size={18} color="#6B7280" />
+              <X size={18} color="#938C7E" />
             </Pressable>
           </View>
 
           {/* Search */}
-          <View className="px-4 py-3 border-b border-gray-100">
+          <View className="px-4 py-3 border-b border-white-6">
             <TextInput
-              className="bg-gray-100 rounded-xl px-4 py-2.5 text-gray-900 font-inter text-sm"
+              className="bg-black-10 rounded-xl px-4 py-2.5 text-foreground font-inter text-sm"
               placeholder="Buscar categoría..."
-              placeholderTextColor="#9CA3AF"
+              placeholderTextColor="#938C7E"
               value={search}
               onChangeText={setSearch}
               autoCorrect={false}
@@ -139,10 +139,10 @@ export function CategoryPicker({
           {/* "None" option */}
           <Pressable
             onPress={() => handleSelect(null, null)}
-            className="flex-row items-center px-4 py-3.5 border-b border-gray-100 active:bg-gray-50"
+            className="flex-row items-center px-4 py-3.5 border-b border-white-6 active:bg-white/5"
           >
-            <View className="w-3 h-3 rounded-full bg-gray-300 mr-3" />
-            <Text className="text-gray-500 font-inter text-sm flex-1">
+            <View className="w-3 h-3 rounded-full bg-white/15 mr-3" />
+            <Text className="text-muted-foreground font-inter text-sm flex-1">
               Sin categoría
             </Text>
             {selectedId === null && <Check size={16} color="#10B981" />}
@@ -155,8 +155,8 @@ export function CategoryPicker({
             renderItem={({ item }) => {
               if (item.type === "header") {
                 return (
-                  <View className="px-4 pt-4 pb-1.5 bg-gray-50">
-                    <Text className="text-gray-400 font-inter-semibold text-xs uppercase tracking-wide">
+                  <View className="px-4 pt-4 pb-1.5 bg-black-10">
+                    <Text className="text-muted-fg-50 font-inter-semibold text-xs uppercase tracking-wide">
                       {displayName(item.item)}
                     </Text>
                   </View>
@@ -171,7 +171,7 @@ export function CategoryPicker({
                   onPress={() =>
                     handleSelect(item.item.id, displayName(item.item))
                   }
-                  className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-gray-50`}
+                  className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-white/5`}
                 >
                   {item.item.color ? (
                     <View
@@ -179,11 +179,11 @@ export function CategoryPicker({
                       style={{ backgroundColor: item.item.color }}
                     />
                   ) : (
-                    <View className="w-3 h-3 rounded-full bg-gray-200 mr-3" />
+                    <View className="w-3 h-3 rounded-full bg-white/15 mr-3" />
                   )}
                   <Text
                     className={`font-inter text-sm flex-1 ${
-                      isSelected ? "text-primary font-inter-medium" : "text-gray-900"
+                      isSelected ? "text-primary font-inter-medium" : "text-foreground"
                     }`}
                   >
                     {displayName(item.item)}
@@ -193,7 +193,7 @@ export function CategoryPicker({
               );
             }}
             ItemSeparatorComponent={() => (
-              <View className="h-px bg-gray-50 ml-4" />
+              <View className="h-px bg-white-6 ml-4" />
             )}
           />
         </View>

--- a/mobile/components/transactions/TransactionRow.tsx
+++ b/mobile/components/transactions/TransactionRow.tsx
@@ -38,7 +38,7 @@ export function TransactionRow({
 
   return (
     <Pressable
-      className="flex-row items-center px-4 py-3 bg-white active:bg-gray-50"
+      className="flex-row items-center px-4 py-3 bg-z-surface-2-55 active:bg-white/5"
       onPress={() => router.push(`/transaction/${id}`)}
     >
       {/* Category icon circle */}
@@ -57,13 +57,13 @@ export function TransactionRow({
       {/* Center: name + category */}
       <View className="flex-1 mr-2">
         <Text
-          className="text-gray-900 font-inter-semibold text-sm"
+          className="text-foreground font-inter-semibold text-sm"
           numberOfLines={1}
         >
           {displayName}
         </Text>
         {semanticCategory && (
-          <Text className="text-gray-400 font-inter text-xs mt-0.5">
+          <Text className="text-muted-fg-50 font-inter text-xs mt-0.5">
             {semanticCategory}
           </Text>
         )}
@@ -72,7 +72,7 @@ export function TransactionRow({
       {/* Amount */}
       <Text
         className={`font-inter-bold text-sm ${
-          isDebtPayment ? "text-sky-600" : isInflow ? "text-green-600" : "text-gray-900"
+          isDebtPayment ? "text-sky-600" : isInflow ? "text-green-600" : "text-foreground"
         }`}
       >
         {isInflow ? "+" : "-"}

--- a/mobile/lib/constants/accounts.ts
+++ b/mobile/lib/constants/accounts.ts
@@ -15,6 +15,9 @@ export function isDebtAccountType(type: string): boolean {
   return DEBT_ACCOUNT_TYPES.has(type);
 }
 
+/** Liquid account types — CHECKING + SAVINGS. Used for plan calculations and disponible. */
+export const LIQUID_ACCOUNT_TYPES = new Set(["CHECKING", "SAVINGS"]);
+
 export const ACCOUNT_TYPES = [
   {
     value: "CHECKING",

--- a/mobile/lib/constants/envelope-colors.ts
+++ b/mobile/lib/constants/envelope-colors.ts
@@ -1,0 +1,5 @@
+/** Envelope color palette — must stay in sync with webapp/src/lib/constants/envelope-colors.ts */
+export const ENVELOPE_COLORS = [
+  "#3B82F6", "#A855F7", "#F97316", "#06B6D4", "#EC4899",
+  "#10B981", "#EAB308", "#6366F1", "#F43F5E", "#14B8A6",
+] as const;

--- a/mobile/lib/repositories/recurring.ts
+++ b/mobile/lib/repositories/recurring.ts
@@ -1,5 +1,17 @@
 import { getDatabase } from "../db/database";
 
+/** Convert a recurring amount to its monthly equivalent based on frequency. */
+export function toMonthlyAmount(amount: number, frequency: string): number {
+  switch (frequency) {
+    case "WEEKLY": return amount * 4.33;
+    case "BIWEEKLY": return amount * 2.17;
+    case "MONTHLY": return amount;
+    case "QUARTERLY": return amount / 3;
+    case "ANNUAL": return amount / 12;
+    default: return amount;
+  }
+}
+
 export type RecurringTemplateRow = {
   id: string;
   user_id: string;

--- a/mobile/lib/repositories/wishlist.ts
+++ b/mobile/lib/repositories/wishlist.ts
@@ -68,6 +68,14 @@ export async function getBoughtWishlistItems(): Promise<WishlistItemWithCategory
   );
 }
 
+export async function getWishlistCount(): Promise<number> {
+  const db = await getDatabase();
+  const row = await db.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM wishlist_items WHERE status = 'wishlist'"
+  );
+  return row?.count ?? 0;
+}
+
 export async function getWishlistSummary() {
   const db = await getDatabase();
   const row = await db.getFirstAsync<{

--- a/mobile/lib/sync/pull.ts
+++ b/mobile/lib/sync/pull.ts
@@ -58,7 +58,6 @@ const FULL_REPLACE_TABLES = new Set<SyncTable>([
  */
 const WINDOWED_TABLES: Partial<Record<SyncTable, { column: string }>> = {
   transactions: { column: "transaction_date" },
-  statement_snapshots: { column: "statement_date" },
   recurring_occurrences: { column: "occurrence_date" },
 };
 
@@ -79,7 +78,7 @@ async function fetchAllPages(buildQuery: () => any): Promise<any[]> {
     if (error) throw error;
     if (!data || data.length === 0) break;
 
-    allRows = allRows.concat(data);
+    allRows.push(...data);
     if (data.length < PAGE_SIZE) break;
     from += PAGE_SIZE;
   }
@@ -96,8 +95,16 @@ export async function pullAll(): Promise<Record<string, number>> {
   const db = await getDatabase();
   const counts: Record<string, number> = {};
 
-  for (const table of SYNC_TABLES) {
-    counts[table] = await pullTable(db, table);
+  // Disable FK checks during sync — windowed tables (transactions) may not
+  // include rows referenced by junction tables (transaction_tags). Data
+  // integrity is enforced server-side by Supabase.
+  await db.execAsync("PRAGMA foreign_keys = OFF");
+  try {
+    for (const table of SYNC_TABLES) {
+      counts[table] = await pullTable(db, table);
+    }
+  } finally {
+    await db.execAsync("PRAGMA foreign_keys = ON");
   }
 
   return counts;

--- a/mobile/lib/utils/cashflow.ts
+++ b/mobile/lib/utils/cashflow.ts
@@ -5,6 +5,8 @@ interface MinimalTransaction {
   direction: string;
   account_id: string;
   is_excluded: number | boolean;
+  transfer_group_id?: string | null;
+  reconciled_into_transaction_id?: string | null;
 }
 
 interface MinimalAccount {
@@ -35,6 +37,8 @@ export function computeCashflow(
 
   for (const tx of transactions) {
     if (tx.is_excluded) continue;
+    if (tx.transfer_group_id) continue; // exclude internal transfers
+    if (tx.reconciled_into_transaction_id) continue; // exclude reconciled dupes
     const amount = Math.abs(tx.amount);
     if (tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id)) {
       totalInflow += amount;

--- a/mobile/lib/utils/date.ts
+++ b/mobile/lib/utils/date.ts
@@ -1,0 +1,22 @@
+/**
+ * Local-timezone date formatting utilities.
+ *
+ * Never use `new Date().toISOString().slice(0, 10)` — it returns UTC,
+ * which is wrong for Colombia (UTC-5). These helpers use local date
+ * components so "today" means today in the user's timezone.
+ */
+
+/** "YYYY-MM-DD" in local timezone */
+export function toLocalDateString(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/** "YYYY-MM" in local timezone */
+export function toLocalMonthString(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}

--- a/mobile/lib/utils/timeline.ts
+++ b/mobile/lib/utils/timeline.ts
@@ -1,0 +1,159 @@
+/**
+ * Compute daily income/expense bars + cumulative balance for the cashflow chart.
+ * Past data comes from transactions, future projections from recurring occurrences.
+ */
+
+interface MinimalTransaction {
+  amount: number;
+  direction: string;
+  transaction_date: string;
+  is_excluded: number | boolean;
+  account_id: string;
+  transfer_group_id?: string | null;
+  reconciled_into_transaction_id?: string | null;
+}
+
+interface MinimalAccount {
+  id: string;
+  account_type: string;
+}
+
+interface MinimalOccurrence {
+  expected_amount: number;
+  occurrence_date: string;
+  direction: string;
+  account_id: string;
+  status: string;
+}
+
+export interface TimelineDay {
+  day: number;
+  income: number;
+  expense: number;
+  isReal: boolean; // false for projected future days
+}
+
+export interface BalancePoint {
+  day: number;
+  balance: number;
+}
+
+export interface TimelineData {
+  days: TimelineDay[];
+  cumulativeBalance: BalancePoint[];
+  totalIncome: number;
+  totalExpense: number;
+  daysInMonth: number;
+  dayOfMonth: number;
+}
+
+import { DEBT_ACCOUNT_TYPES } from "../constants/accounts";
+
+export function computeTimeline(
+  transactions: MinimalTransaction[],
+  accounts: MinimalAccount[],
+  occurrences: MinimalOccurrence[],
+  now: Date = new Date(),
+  liquidBalance: number = 0
+): TimelineData {
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const dayOfMonth = now.getDate();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const debtAccountIds = new Set(
+    accounts.filter((a) => DEBT_ACCOUNT_TYPES.has(a.account_type)).map((a) => a.id)
+  );
+  const accountTypeMap = new Map(accounts.map((a) => [a.id, a.account_type]));
+
+  // Accumulate real (past) data by day
+  const dailyIncome = new Float64Array(daysInMonth + 1);
+  const dailyExpense = new Float64Array(daysInMonth + 1);
+  const isRealDay = new Uint8Array(daysInMonth + 1); // track which days have real data
+  let totalIncome = 0;
+  let totalExpense = 0;
+
+  for (const tx of transactions) {
+    if (tx.is_excluded) continue;
+    if (tx.transfer_group_id) continue;
+    if (tx.reconciled_into_transaction_id) continue;
+    const amount = Math.abs(tx.amount);
+    const txDay = parseInt(tx.transaction_date.slice(8, 10), 10);
+    if (txDay < 1 || txDay > daysInMonth) continue;
+
+    if (tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id)) {
+      dailyIncome[txDay] += amount;
+      totalIncome += amount;
+    } else if (tx.direction === "OUTFLOW") {
+      dailyExpense[txDay] += amount;
+      totalExpense += amount;
+    }
+    isRealDay[txDay] = 1;
+  }
+
+  // Project future from pending occurrences (days > today)
+  for (const occ of occurrences) {
+    if (occ.status !== "pending") continue;
+    const occDay = parseInt(occ.occurrence_date.slice(8, 10), 10);
+    if (occDay < 1 || occDay > daysInMonth || occDay <= dayOfMonth) continue;
+
+    const acctType = accountTypeMap.get(occ.account_id) ?? "";
+    const isDebtInflow = occ.direction === "INFLOW" && DEBT_ACCOUNT_TYPES.has(acctType);
+    const amount = Math.abs(occ.expected_amount);
+
+    if (occ.direction === "INFLOW" && !isDebtInflow) {
+      dailyIncome[occDay] += amount;
+    } else if (occ.direction === "OUTFLOW" || isDebtInflow) {
+      dailyExpense[occDay] += amount;
+    }
+  }
+
+  // Build day entries — include days with activity + today
+  const days: TimelineDay[] = [];
+  for (let d = 1; d <= daysInMonth; d++) {
+    if (dailyIncome[d] > 0 || dailyExpense[d] > 0 || d === dayOfMonth) {
+      days.push({
+        day: d,
+        income: dailyIncome[d],
+        expense: dailyExpense[d],
+        isReal: d <= dayOfMonth && isRealDay[d] === 1,
+      });
+    }
+  }
+
+  // Reconstruct daily balances from today's known liquid balance.
+  // Walk backwards from today to get historical balances,
+  // then forward from today using projected occurrences.
+  const dailyBalance = new Float64Array(daysInMonth + 1);
+  dailyBalance[dayOfMonth] = liquidBalance;
+
+  // Walk backwards: balance[d-1] = balance[d] - net[d]
+  for (let d = dayOfMonth; d >= 2; d--) {
+    dailyBalance[d - 1] = dailyBalance[d] - (dailyIncome[d] - dailyExpense[d]);
+  }
+  // Day 1: balance before day 1's activity
+  if (dayOfMonth >= 1) {
+    dailyBalance[0] = dailyBalance[1] - (dailyIncome[1] - dailyExpense[1]);
+  }
+
+  // Walk forward from today using projected data
+  for (let d = dayOfMonth + 1; d <= daysInMonth; d++) {
+    dailyBalance[d] = dailyBalance[d - 1] + (dailyIncome[d] - dailyExpense[d]);
+  }
+
+  const cumulativeBalance: BalancePoint[] = [];
+  for (let d = 1; d <= daysInMonth; d++) {
+    if (dailyIncome[d] > 0 || dailyExpense[d] > 0 || d === dayOfMonth) {
+      cumulativeBalance.push({ day: d, balance: dailyBalance[d] });
+    }
+  }
+
+  return {
+    days,
+    cumulativeBalance,
+    totalIncome,
+    totalExpense,
+    daysInMonth,
+    dayOfMonth,
+  };
+}

--- a/webapp/src/actions/attention-items.ts
+++ b/webapp/src/actions/attention-items.ts
@@ -7,6 +7,7 @@ import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { toColombiaDateString } from "@/lib/utils/date";
 import { getPendingOccurrencesCached } from "@/actions/occurrences";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { PAY_CYCLE_LOOKAHEAD_DAYS } from "@/lib/constants/occurrences";
 
 
@@ -137,7 +138,7 @@ async function getAttentionItemsCached(
     .slice(0, 5)
     .map((o) => ({
       templateId: o.template_id,
-      name: o.merchant_name ?? o.description ?? (o.direction === "INFLOW" ? "Ingreso recurrente" : "Pago recurrente"),
+      name: o.merchant_name ?? o.description ?? (o.direction === "INFLOW" && !isDebtAccountType(o.account_type) ? "Ingreso recurrente" : "Pago recurrente"),
       amount: o.expected_amount,
       next_date: o.occurrence_date,
       direction: o.direction,

--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -10,8 +10,10 @@ import {
 } from "@/lib/validators/cashflow-planner";
 import { getExchangeRate } from "@/actions/exchange-rate";
 import { getOccurrencesBetween } from "@zeta/shared";
-import { parseISO } from "date-fns";
+import { parseISO, endOfMonth } from "date-fns";
 import { isDebtAccountType } from "@/lib/utils/account-balance";
+import { toColombiaDateString } from "@/lib/utils/date";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import type { ActionResult } from "@/types/actions";
 import type { TablesInsert } from "@/types/database";
 import type {
@@ -881,4 +883,370 @@ export async function autoAssignExpenses(
 
   updateTag(TAG);
   return { success: true, data: { assigned: assignedCount } };
+}
+
+// ─── Candidate Transactions for Planning Entry ──────────────────────────────
+
+export interface PlanCandidateTransaction {
+  id: string;
+  description: string;
+  merchant_name: string | null;
+  amount: number;
+  currency_code: string;
+  transaction_date: string;
+  account_name: string;
+}
+
+/**
+ * Find candidate transactions for linking to a planning entry's "Pagar" flow.
+ * Searches this month's OUTFLOW transactions (unlinked, not excluded, no transfer group).
+ * Also checks for INFLOW on a debt account if debtAccountId is provided.
+ */
+export async function findCandidateTransactions(params: {
+  entryLabel: string;
+  entryAmount: number;
+  debtAccountId?: string | null;
+  month: string; // YYYY-MM
+}): Promise<ActionResult<PlanCandidateTransaction[]>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const monthDate = parseISO(`${params.month}-01`);
+  const monthStart = `${params.month}-01`;
+  const monthEnd = endOfMonth(monthDate).toISOString().split("T")[0];
+
+  // Fetch OUTFLOW transactions this month
+  const { data: outflows, error: outflowErr } = await supabase
+    .from("transactions")
+    .select(
+      `id, clean_description, merchant_name, raw_description, amount, currency_code,
+       transaction_date, direction, account_id, is_excluded, transfer_group_id,
+       account:accounts!transactions_account_id_fkey(name)`
+    )
+    .eq("user_id", user.id)
+    .eq("direction", "OUTFLOW")
+    .eq("is_excluded", false)
+    .is("transfer_group_id", null)
+    .is("recurrence_group_id", null)
+    .gte("transaction_date", monthStart)
+    .lte("transaction_date", monthEnd)
+    .order("transaction_date", { ascending: false })
+    .limit(100);
+
+  if (outflowErr) return { success: false, error: outflowErr.message };
+
+  let allTxs = outflows ?? [];
+
+  // If there's a debt account, also find INFLOW transactions on it (payments)
+  if (params.debtAccountId) {
+    const { data: debtInflows } = await supabase
+      .from("transactions")
+      .select(
+        `id, clean_description, merchant_name, raw_description, amount, currency_code,
+         transaction_date, direction, account_id, is_excluded, transfer_group_id,
+         account:accounts!transactions_account_id_fkey(name)`
+      )
+      .eq("user_id", user.id)
+      .eq("account_id", params.debtAccountId)
+      .eq("direction", "INFLOW")
+      .eq("is_excluded", false)
+      .is("transfer_group_id", null)
+      .is("recurrence_group_id", null)
+      .gte("transaction_date", monthStart)
+      .lte("transaction_date", monthEnd)
+      .order("transaction_date", { ascending: false })
+      .limit(20);
+
+    if (debtInflows) allTxs = [...allTxs, ...debtInflows];
+  }
+
+  // Score & filter: amount ±50% OR merchant matching label
+  const labelLower = params.entryLabel.toLowerCase();
+  const amountMin = params.entryAmount * 0.5;
+  const amountMax = params.entryAmount * 1.5;
+
+  const scored = allTxs
+    .map((tx) => {
+      const desc = tx.clean_description ?? tx.merchant_name ?? tx.raw_description ?? "";
+      const merchantMatch = desc.toLowerCase().includes(labelLower) ||
+        labelLower.includes((tx.merchant_name ?? "").toLowerCase());
+      const amountMatch = tx.amount >= amountMin && tx.amount <= amountMax;
+      if (!merchantMatch && !amountMatch) return null;
+
+      const accountName = (tx.account as { name: string } | null)?.name ?? "";
+
+      return {
+        id: tx.id,
+        description: tx.clean_description ?? tx.merchant_name ?? tx.raw_description ?? "Sin descripción",
+        merchant_name: tx.merchant_name,
+        amount: tx.amount,
+        currency_code: String(tx.currency_code),
+        transaction_date: tx.transaction_date,
+        account_name: accountName,
+      } satisfies PlanCandidateTransaction;
+    })
+    .filter((x): x is PlanCandidateTransaction => x !== null);
+
+  // Return top 5
+  return { success: true, data: scored.slice(0, 5) };
+}
+
+// ─── Pay Planning Entry ─────────────────────────────────────────────────────
+
+/**
+ * Pay a planning entry by either linking an existing transaction or creating a new one.
+ * Handles recurring occurrence linking when the entry has a recurring_template_id.
+ */
+export async function payPlanningEntry(params: {
+  entryId: string;
+  // Link mode: connect existing transaction
+  existingTransactionId?: string;
+  // Create mode: record a new payment
+  amount?: number;
+  sourceAccountId?: string;
+  debtAccountId?: string;
+  currencyCode?: string;
+  categoryId?: string | null;
+  recurringTemplateId?: string | null;
+  label?: string;
+}): Promise<ActionResult<{ transactionId: string }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  // Fetch the planning entry
+  const { data: entry, error: entryErr } = await supabase
+    .from("planning_entries")
+    .select("*, period:planning_periods!inner(start_date, end_date)")
+    .eq("id", params.entryId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (entryErr || !entry) {
+    return { success: false, error: "Entrada del plan no encontrada" };
+  }
+
+  const period = entry.period as { start_date: string; end_date: string };
+
+  // ── LINK MODE: connect existing transaction ──
+  if (params.existingTransactionId) {
+    // If the entry has a recurring template, delegate to occurrence linking
+    if (entry.recurring_template_id) {
+      // Find the pending occurrence for this template in the period
+      const { data: occurrences } = await supabase
+        .from("recurring_occurrences")
+        .select("id")
+        .eq("template_id", entry.recurring_template_id)
+        .eq("user_id", user.id)
+        .eq("status", "pending")
+        .gte("occurrence_date", period.start_date)
+        .lte("occurrence_date", period.end_date)
+        .limit(1);
+
+      if (occurrences && occurrences.length > 0) {
+        const { linkExistingTransactionToOccurrence } = await import("@/actions/occurrences");
+        const linkResult = await linkExistingTransactionToOccurrence(
+          occurrences[0].id,
+          params.existingTransactionId,
+        );
+        if (!linkResult.success) return { success: false, error: linkResult.error };
+      }
+    }
+
+    // Mark planning entry as completed
+    const { error: updateErr } = await supabase
+      .from("planning_entries")
+      .update({ status: "COMPLETED", completed_at: new Date().toISOString() })
+      .eq("id", params.entryId)
+      .eq("user_id", user.id);
+
+    if (updateErr) return { success: false, error: updateErr.message };
+
+    updateTag(TAG);
+    updateTag("occurrences");
+    revalidateFinancialViews();
+    return { success: true, data: { transactionId: params.existingTransactionId } };
+  }
+
+  // ── CREATE MODE: record a new payment ──
+  if (!params.amount || !params.sourceAccountId) {
+    return { success: false, error: "Monto y cuenta origen son requeridos" };
+  }
+
+  // If the entry has a recurring template, delegate to the full payment infrastructure
+  if (entry.recurring_template_id) {
+    const { recordRecurringOccurrencePayment } = await import("@/actions/recurring-templates");
+    const payResult = await recordRecurringOccurrencePayment({
+      templateId: entry.recurring_template_id,
+      occurrenceDate: entry.expected_date,
+      paymentDate: toColombiaDateString(new Date()),
+      actualAmount: params.amount,
+      sourceAccountId: params.sourceAccountId,
+    });
+
+    if (!payResult.success) return { success: false, error: payResult.error };
+
+    // Mark planning entry as completed
+    const { error: updateErr } = await supabase
+      .from("planning_entries")
+      .update({ status: "COMPLETED", completed_at: new Date().toISOString() })
+      .eq("id", params.entryId)
+      .eq("user_id", user.id);
+
+    if (updateErr) return { success: false, error: updateErr.message };
+
+    // Get the created transaction ID
+    const { data: createdTx } = await supabase
+      .from("transactions")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("amount", params.amount)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    updateTag(TAG);
+    return { success: true, data: { transactionId: createdTx?.id ?? "" } };
+  }
+
+  // Standalone entry (no recurring template) — create a simple transaction
+  const today = toColombiaDateString(new Date());
+  const txId = crypto.randomUUID();
+  const transferGroupId = params.debtAccountId ? crypto.randomUUID() : null;
+  const currencyCode = params.currencyCode ?? entry.currency_code ?? "COP";
+  const idempotencyKey = await (async () => {
+    const { computeIdempotencyKey } = await import("@/lib/utils/idempotency");
+    return computeIdempotencyKey({
+      provider: "MANUAL_FORM",
+      providerTransactionId: txId,
+      transactionDate: today,
+      amount: params.amount!,
+      rawDescription: params.label ?? entry.label,
+    });
+  })();
+
+  // OUTFLOW from source account
+  const { error: txErr } = await supabase
+    .from("transactions")
+    .insert({
+      id: txId,
+      user_id: user.id,
+      account_id: params.sourceAccountId,
+      direction: "OUTFLOW",
+      amount: params.amount,
+      currency_code: currencyCode as any,
+      transaction_date: today,
+      raw_description: params.label ?? entry.label,
+      clean_description: params.label ?? entry.label,
+      capture_method: "MANUAL_FORM",
+      idempotency_key: idempotencyKey,
+      transfer_group_id: transferGroupId,
+      category_id: params.categoryId ?? entry.category_id ?? null,
+    } as any)
+    .single();
+
+  if (txErr) {
+    if (txErr.code === "23505") return { success: false, error: "Este pago ya fue registrado" };
+    return { success: false, error: txErr.message };
+  }
+
+  // Update source account balance
+  const { data: sourceAcct } = await supabase
+    .from("accounts")
+    .select("current_balance, account_type")
+    .eq("id", params.sourceAccountId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (sourceAcct) {
+    const { applyAccountBalanceDelta } = await import("@/lib/utils/account-balance");
+    const newBalance = applyAccountBalanceDelta({
+      currentBalance: sourceAcct.current_balance,
+      accountType: sourceAcct.account_type,
+      direction: "OUTFLOW",
+      amount: params.amount,
+    });
+    await supabase
+      .from("accounts")
+      .update({ current_balance: newBalance })
+      .eq("id", params.sourceAccountId)
+      .eq("user_id", user.id);
+  }
+
+  // If debt account, create INFLOW on the debt account
+  if (params.debtAccountId) {
+    const debtTxId = crypto.randomUUID();
+    const debtIdempotencyKey = await (async () => {
+      const { computeIdempotencyKey } = await import("@/lib/utils/idempotency");
+      return computeIdempotencyKey({
+        provider: "MANUAL_FORM",
+        providerTransactionId: debtTxId,
+        transactionDate: today,
+        amount: params.amount!,
+        rawDescription: `Pago: ${params.label ?? entry.label}`,
+      });
+    })();
+
+    const { error: debtTxErr } = await supabase
+      .from("transactions")
+      .insert({
+        id: debtTxId,
+        user_id: user.id,
+        account_id: params.debtAccountId,
+        direction: "INFLOW",
+        amount: params.amount,
+        currency_code: currencyCode as any,
+        transaction_date: today,
+        raw_description: `Pago: ${params.label ?? entry.label}`,
+        clean_description: `Pago: ${params.label ?? entry.label}`,
+        capture_method: "MANUAL_FORM",
+        idempotency_key: debtIdempotencyKey,
+        transfer_group_id: transferGroupId,
+        category_id: params.categoryId ?? entry.category_id ?? null,
+      } as any)
+      .single();
+
+    if (debtTxErr && debtTxErr.code !== "23505") {
+      console.error("Debt INFLOW insert error:", debtTxErr.message);
+    }
+
+    // Update debt account balance
+    const { data: debtAcct } = await supabase
+      .from("accounts")
+      .select("current_balance, account_type")
+      .eq("id", params.debtAccountId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (debtAcct) {
+      const { applyAccountBalanceDelta } = await import("@/lib/utils/account-balance");
+      const newBalance = applyAccountBalanceDelta({
+        currentBalance: debtAcct.current_balance,
+        accountType: debtAcct.account_type,
+        direction: "INFLOW",
+        amount: params.amount,
+      });
+      await supabase
+        .from("accounts")
+        .update({ current_balance: newBalance })
+        .eq("id", params.debtAccountId)
+        .eq("user_id", user.id);
+    }
+  }
+
+  // Mark planning entry as completed
+  const { error: entryUpdateErr } = await supabase
+    .from("planning_entries")
+    .update({ status: "COMPLETED", completed_at: new Date().toISOString() })
+    .eq("id", params.entryId)
+    .eq("user_id", user.id);
+
+  if (entryUpdateErr) {
+    console.error("Entry update error:", entryUpdateErr.message);
+  }
+
+  updateTag(TAG);
+  updateTag("occurrences");
+  updateTag("recurring");
+  revalidateFinancialViews();
+  return { success: true, data: { transactionId: txId } };
 }

--- a/webapp/src/components/cashflow-planner/pay-expense-dialog.tsx
+++ b/webapp/src/components/cashflow-planner/pay-expense-dialog.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import {
+  findCandidateTransactions,
+  payPlanningEntry,
+} from "@/actions/cashflow-planner";
+import type { PlanCandidateTransaction } from "@/actions/cashflow-planner";
+import { toast } from "sonner";
+import { Check, Link, CreditCard, Loader2 } from "lucide-react";
+import type { PlanningEntryWithRelations } from "@/types/cashflow-planner";
+import type { CurrencyCode } from "@/types/domain";
+import type { PlanAccount } from "@/components/mobile/v2/plan/mobile-periodo-view";
+
+/* ── Amount Mode ── */
+type AmountMode = "planned" | "total_debt" | "custom";
+
+interface PayExpenseDialogProps {
+  entry: PlanningEntryWithRelations | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currency: CurrencyCode;
+  accounts: PlanAccount[];
+  periodMonth: string; // YYYY-MM
+}
+
+export function PayExpenseDialog({
+  entry,
+  open,
+  onOpenChange,
+  currency,
+  accounts,
+  periodMonth,
+}: PayExpenseDialogProps) {
+  const [isPending, startTransition] = useTransition();
+  const [mode, setMode] = useState<"link" | "create">("link");
+  const [candidates, setCandidates] = useState<PlanCandidateTransaction[]>([]);
+  const [loadingCandidates, setLoadingCandidates] = useState(false);
+  const [selectedTxId, setSelectedTxId] = useState<string | null>(null);
+
+  // Create mode state
+  const [amountMode, setAmountMode] = useState<AmountMode>("planned");
+  const [customAmount, setCustomAmount] = useState<string>("");
+  const [sourceAccountId, setSourceAccountId] = useState<string>("");
+
+  // Derive debt account info from the entry's account
+  const entryAccountId = entry?.account_id;
+  const entryAccount = entryAccountId
+    ? accounts.find((a) => a.id === entryAccountId)
+    : null;
+  const isDebtEntry =
+    entryAccount != null && isDebtAccountType(entryAccount.account_type);
+  const debtBalance = isDebtEntry ? Math.abs(Number(entryAccount.current_balance)) : 0;
+
+  // Source accounts = CHECKING + SAVINGS
+  const sourceAccounts = accounts.filter(
+    (a) => a.account_type === "CHECKING" || a.account_type === "SAVINGS",
+  );
+
+  // Load candidates when dialog opens
+  useEffect(() => {
+    if (!open || !entry) return;
+    setMode("link");
+    setSelectedTxId(null);
+    setAmountMode("planned");
+    setCustomAmount("");
+    setSourceAccountId("");
+    setLoadingCandidates(true);
+
+    findCandidateTransactions({
+      entryLabel: entry.label,
+      entryAmount: Number(entry.amount),
+      debtAccountId: isDebtEntry ? entryAccountId : null,
+      month: periodMonth,
+    }).then((result) => {
+      setLoadingCandidates(false);
+      if (result.success) {
+        setCandidates(result.data);
+        // If no candidates found, go straight to create mode
+        if (result.data.length === 0) setMode("create");
+      } else {
+        setCandidates([]);
+        setMode("create");
+      }
+    });
+  }, [open, entry, entryAccountId, isDebtEntry, periodMonth]);
+
+  if (!entry) return null;
+
+  const entryAmount = entry.converted_amount;
+
+  function getEffectiveAmount(): number {
+    switch (amountMode) {
+      case "planned":
+        return entryAmount;
+      case "total_debt":
+        return debtBalance;
+      case "custom":
+        return Number(customAmount) || 0;
+    }
+  }
+
+  function handleLinkTransaction() {
+    if (!selectedTxId || !entry) return;
+    startTransition(async () => {
+      const result = await payPlanningEntry({
+        entryId: entry.id,
+        existingTransactionId: selectedTxId,
+      });
+      if (result.success) {
+        toast.success("Pago vinculado");
+        onOpenChange(false);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  function handleCreatePayment() {
+    if (!entry) return;
+    const amount = getEffectiveAmount();
+    if (amount <= 0) {
+      toast.error("El monto debe ser mayor a cero");
+      return;
+    }
+    if (!sourceAccountId) {
+      toast.error("Selecciona una cuenta origen");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await payPlanningEntry({
+        entryId: entry.id,
+        amount,
+        sourceAccountId,
+        debtAccountId: isDebtEntry ? entryAccountId! : undefined,
+        currencyCode: entry.currency_code ?? currency,
+        categoryId: entry.category_id,
+        recurringTemplateId: entry.recurring_template_id,
+        label: entry.label,
+      });
+      if (result.success) {
+        toast.success("Pago registrado");
+        onOpenChange(false);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Pagar: {entry.label}
+          </DialogTitle>
+          <p className="text-xs text-muted-foreground">
+            {formatCurrency(entryAmount, currency)}
+            {" \u00b7 "}
+            {formatDate(entry.expected_date, "dd MMM yyyy")}
+          </p>
+        </DialogHeader>
+
+        {/* ── LINK MODE ── */}
+        {mode === "link" && (
+          <div className="space-y-4">
+            <p className="text-sm font-medium">
+              Ya hiciste este pago?
+            </p>
+
+            {loadingCandidates && (
+              <div className="flex items-center justify-center py-6 text-muted-foreground">
+                <Loader2 className="size-4 animate-spin mr-2" />
+                <span className="text-xs">Buscando transacciones...</span>
+              </div>
+            )}
+
+            {!loadingCandidates && candidates.length > 0 && (
+              <div className="space-y-2 max-h-60 overflow-y-auto">
+                {candidates.map((tx) => (
+                  <button
+                    key={tx.id}
+                    type="button"
+                    onClick={() => setSelectedTxId(tx.id === selectedTxId ? null : tx.id)}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-xl border p-3 text-left transition-colors",
+                      selectedTxId === tx.id
+                        ? "border-z-brass/50 bg-z-brass/8"
+                        : "border-white/6 bg-black/10 hover:bg-white/[0.03]",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "flex size-5 shrink-0 items-center justify-center rounded-md border",
+                        selectedTxId === tx.id
+                          ? "border-z-brass bg-z-brass text-z-ink"
+                          : "border-white/10 bg-white/5",
+                      )}
+                    >
+                      {selectedTxId === tx.id && <Check className="size-3" />}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs font-medium truncate">
+                        {tx.description}
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        {formatDate(tx.transaction_date, "dd MMM")}
+                        {tx.account_name && ` \u00b7 ${tx.account_name}`}
+                      </p>
+                    </div>
+                    <p className="text-sm font-semibold tabular-nums text-z-debt shrink-0">
+                      {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              <Button
+                className={cn("w-full", BRASS_BUTTON_CLASS)}
+                disabled={!selectedTxId || isPending}
+                onClick={handleLinkTransaction}
+              >
+                {isPending ? (
+                  <Loader2 className="size-4 animate-spin mr-2" />
+                ) : (
+                  <Link className="size-4 mr-2" />
+                )}
+                Vincular transaccion
+              </Button>
+
+              <button
+                type="button"
+                onClick={() => setMode("create")}
+                className="text-xs text-z-brass hover:underline text-center py-1"
+              >
+                No, registrar nuevo pago
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ── CREATE MODE ── */}
+        {mode === "create" && (
+          <div className="space-y-4">
+            {/* Amount options */}
+            <div className="space-y-2">
+              <Label>Monto del pago</Label>
+              <div className="space-y-2">
+                {/* Planned amount */}
+                <button
+                  type="button"
+                  onClick={() => setAmountMode("planned")}
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-xl border px-3 py-2.5 text-left transition-colors",
+                    amountMode === "planned"
+                      ? "border-z-brass/50 bg-z-brass/8"
+                      : "border-white/6 bg-black/10 hover:bg-white/[0.03]",
+                  )}
+                >
+                  <span className="text-xs font-medium">Cuota planeada</span>
+                  <span className="text-sm font-semibold tabular-nums">
+                    {formatCurrency(entryAmount, currency)}
+                  </span>
+                </button>
+
+                {/* Total debt — only for CREDIT_CARD/LOAN */}
+                {isDebtEntry && debtBalance > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setAmountMode("total_debt")}
+                    className={cn(
+                      "flex w-full items-center justify-between rounded-xl border px-3 py-2.5 text-left transition-colors",
+                      amountMode === "total_debt"
+                        ? "border-z-brass/50 bg-z-brass/8"
+                        : "border-white/6 bg-black/10 hover:bg-white/[0.03]",
+                    )}
+                  >
+                    <span className="text-xs font-medium">Pago total deuda</span>
+                    <span className="text-sm font-semibold tabular-nums">
+                      {formatCurrency(debtBalance, entryAccount!.currency_code as CurrencyCode)}
+                    </span>
+                  </button>
+                )}
+
+                {/* Custom amount */}
+                <button
+                  type="button"
+                  onClick={() => setAmountMode("custom")}
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-xl border px-3 py-2.5 text-left transition-colors",
+                    amountMode === "custom"
+                      ? "border-z-brass/50 bg-z-brass/8"
+                      : "border-white/6 bg-black/10 hover:bg-white/[0.03]",
+                  )}
+                >
+                  <span className="text-xs font-medium">Otro monto</span>
+                </button>
+
+                {amountMode === "custom" && (
+                  <CurrencyInput
+                    value={customAmount}
+                    onChange={(e) => setCustomAmount(e.target.value)}
+                    placeholder="Monto"
+                    className="bg-card border-white/6"
+                    disabled={isPending}
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Source account */}
+            <div className="space-y-2">
+              <Label>Cuenta origen</Label>
+              <Select
+                value={sourceAccountId}
+                onValueChange={setSourceAccountId}
+              >
+                <SelectTrigger className="bg-card border-white/6">
+                  <SelectValue placeholder="Seleccionar cuenta" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sourceAccounts.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      <span className="flex items-center gap-2">
+                        {a.name}
+                        <span className="text-[10px] text-muted-foreground">
+                          {formatCurrency(a.current_balance, a.currency_code as CurrencyCode)}
+                        </span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Button
+                className={cn("w-full", BRASS_BUTTON_CLASS)}
+                disabled={isPending || !sourceAccountId || getEffectiveAmount() <= 0}
+                onClick={handleCreatePayment}
+              >
+                {isPending ? (
+                  <Loader2 className="size-4 animate-spin mr-2" />
+                ) : (
+                  <CreditCard className="size-4 mr-2" />
+                )}
+                Confirmar pago
+              </Button>
+
+              {candidates.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setMode("link")}
+                  className="text-xs text-z-brass hover:underline text-center py-1"
+                >
+                  Vincular transaccion existente
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -11,6 +11,7 @@ import { PlanFlowChart } from "./plan-flow-chart";
 import { EntryFormDialog } from "@/components/cashflow-planner/entry-form-dialog";
 import { EditEntryDialog } from "@/components/cashflow-planner/edit-entry-dialog";
 import { AssignmentDialog } from "@/components/cashflow-planner/assignment-dialog";
+import { PayExpenseDialog } from "@/components/cashflow-planner/pay-expense-dialog";
 import { AutoAssignButton } from "@/components/cashflow-planner/auto-assign-button";
 import {
   toggleEntryStatus,
@@ -20,6 +21,7 @@ import {
 import { toast } from "sonner";
 import {
   ArrowRightLeft,
+  Banknote,
   Check,
   ChevronDown,
   Pencil,
@@ -49,10 +51,13 @@ const STATUS_BADGE: Record<
 
 /* ────── Main component ────── */
 
+/** Accounts need account_type + current_balance for the pay dialog */
+export type PlanAccount = Pick<Account, "id" | "name" | "icon" | "color" | "account_type" | "current_balance" | "currency_code">;
+
 interface MobilePeriodoViewProps {
   planData: PeriodPlanData;
   timelineData: PlanTimelineData;
-  accounts: Pick<Account, "id" | "name" | "icon" | "color">[];
+  accounts: PlanAccount[];
   categories: Pick<Category, "id" | "name" | "name_es" | "icon" | "color">[];
 }
 
@@ -82,6 +87,9 @@ export function MobilePeriodoView({
   const [editTarget, setEditTarget] =
     useState<PlanningEntryWithRelations | null>(null);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [payTarget, setPayTarget] =
+    useState<PlanningEntryWithRelations | null>(null);
+  const [payDialogOpen, setPayDialogOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   /* ── Computed data ── */
@@ -131,6 +139,14 @@ export function MobilePeriodoView({
     setEditTarget(entry);
     setEditDialogOpen(true);
   }
+
+  function openPay(entry: PlanningEntryWithRelations) {
+    setPayTarget(entry);
+    setPayDialogOpen(true);
+  }
+
+  // Derive the period month (YYYY-MM) from start_date
+  const periodMonth = period.start_date.slice(0, 7);
 
   return (
     <div className="space-y-4">
@@ -238,6 +254,7 @@ export function MobilePeriodoView({
                 onAssign={() => openAssign(entry)}
                 onEdit={() => openEdit(entry)}
                 onDelete={() => handleDeleteEntry(entry.id)}
+                onPay={() => openPay(entry)}
                 isPending={isPending}
               />
             ))}
@@ -266,6 +283,14 @@ export function MobilePeriodoView({
         currency={currency}
         accounts={accounts}
         categories={categories}
+      />
+      <PayExpenseDialog
+        entry={payTarget}
+        open={payDialogOpen}
+        onOpenChange={setPayDialogOpen}
+        currency={currency}
+        accounts={accounts}
+        periodMonth={periodMonth}
       />
     </div>
   );
@@ -458,6 +483,7 @@ function ExpenseRow({
   onAssign,
   onEdit,
   onDelete,
+  onPay,
   isPending,
 }: {
   entry: PlanningEntryWithRelations;
@@ -469,6 +495,7 @@ function ExpenseRow({
   onAssign: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  onPay: () => void;
   isPending: boolean;
 }) {
   return (
@@ -535,6 +562,16 @@ function ExpenseRow({
       {/* Expanded action bar */}
       {isExpanded && (
         <div className="flex items-center gap-2 px-3.5 py-2 border-t border-white/5 bg-black/20">
+          {entry.status !== "COMPLETED" && (
+            <button
+              type="button"
+              onClick={onPay}
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-semibold text-z-brass transition-colors hover:text-z-brass/80"
+            >
+              <Banknote className="size-3" />
+              Pagar
+            </button>
+          )}
           <button
             type="button"
             onClick={onAssign}

--- a/webapp/src/components/plan/plan-flow-timeline.tsx
+++ b/webapp/src/components/plan/plan-flow-timeline.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { ChevronDown, ArrowDownLeft, ArrowUpRight } from "lucide-react";
 import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import type { CurrencyCode, UpcomingRecurrence } from "@/types/domain";
 
 interface PlanFlowTimelineProps {
@@ -63,7 +64,7 @@ export function PlanFlowTimeline({
         <div className="divide-y divide-white/6">
           {sorted.map((item) => {
             const t = item.template;
-            const isIncome = t.direction === "INFLOW";
+            const isIncome = t.direction === "INFLOW" && !isDebtAccountType(t.account?.account_type);
             return (
               <div
                 key={t.id}

--- a/webapp/src/components/plan/tabs/plan-tab-periodo.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-periodo.tsx
@@ -26,6 +26,9 @@ export async function PlanTabPeriodo() {
         name: a.name,
         icon: a.icon,
         color: a.color,
+        account_type: a.account_type,
+        current_balance: a.current_balance,
+        currency_code: a.currency_code,
       }))
     : [];
   const categories = categoriesResult.success ? categoriesResult.data : [];

--- a/webapp/src/components/recurring/recurring-template-card.tsx
+++ b/webapp/src/components/recurring/recurring-template-card.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { CategoryIcon } from "@/components/categories/category-icon";
 import { getTemplateStats, type TemplateStats } from "@/actions/template-stats";
+import { isDebtAccountType } from "@/lib/utils/account-balance";
 import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
 
 type OccurrenceStatus = "paid" | "pending" | "skipped" | null;
@@ -51,6 +52,8 @@ export function RecurringTemplateCard({
   const [loadingStats, setLoadingStats] = useState(false);
   const amount = Number(template.amount);
   const isOnce = template.frequency === "ONCE";
+  const isDebtPayment = isDebtAccountType(template.account.account_type);
+  const isIncome = template.direction === "INFLOW" && !isDebtPayment;
 
   function handleExpand() {
     onToggleExpand();
@@ -157,7 +160,7 @@ export function RecurringTemplateCard({
           {/* Action buttons */}
           <div className={cn(
             "grid gap-1.5",
-            isOnce ? "grid-cols-2" : template.direction === "INFLOW" ? "grid-cols-2" : "grid-cols-3"
+            isOnce ? "grid-cols-2" : isIncome ? "grid-cols-2" : "grid-cols-3"
           )}>
             <ActionButton
               label="Editar"
@@ -165,7 +168,7 @@ export function RecurringTemplateCard({
               className="bg-z-brass/10 border-z-brass/20 text-z-brass"
               onClick={() => router.push(`/recurrentes/${template.id}/edit`)}
             />
-            {template.direction === "OUTFLOW" && !isOnce && (
+            {!isIncome && !isOnce && (
               <ActionButton
                 label="Pausar"
                 icon={<Pause className="size-3.5" />}


### PR DESCRIPTION
## Summary

Major mobile app overhaul — sync reliability, dashboard accuracy, plan page redesign, dark theme, and new periodo/payment features.

- **Sync fixes**: const reassignment bug, FK constraint handling, timezone UTC→local across 8 files, removed non-existent column from windowed sync
- **Dashboard**: Hero now uses liquid balance + pending obligations (matches webapp), days until next income
- **Plan page redesign**: Live execution tracker (confirmed/pending income & obligations, discretionary spending, disponible/día), cashflow chart with touch scrubbing + projected future, expandable income/payment chips, 2x2 navigation grid
- **Periodo page (new)**: Read-only envelope view, "Pagar" flow with transaction matching or custom amount creation, ReassignSheet for moving expenses between envelopes
- **Webapp**: `payPlanningEntry` + `findCandidateTransactions` server actions, `PayExpenseDialog` component
- **Dark theme**: 17+ files converted from white/light to dark design tokens
- **Code quality**: Extracted shared constants (ENVELOPE_COLORS, LIQUID_ACCOUNT_TYPES), O(1) chart touch detection, removed duplicated Sets/arrays

## Test plan

- [ ] Mobile: Pull-to-refresh on Inicio — verify disponible amount matches webapp
- [ ] Mobile: Plan page — verify Neto del mes uses template totals, chart shows real balance
- [ ] Mobile: Periodo — verify income envelopes, expense assignments, Pagar flow
- [ ] Mobile: Navigate all auth screens — verify dark theme (no white backgrounds)
- [ ] Mobile: Budgets page — verify dark theme
- [ ] Mobile: Transaction detail — verify dark theme
- [ ] Webapp: Plan → Periodo → tap Pagar on expense — verify link + create modes
- [ ] Webapp: `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)