### PR TITLE
feat(recurring): merge multi-currency templates into one per account

### DIFF
--- a/supabase/migrations/20260416120000_add_sub_payments_to_recurring_templates.sql
+++ b/supabase/migrations/20260416120000_add_sub_payments_to_recurring_templates.sql
@@ -77,95 +77,79 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Step 5: Merge existing duplicate templates (same account, INFLOW, MONTHLY, no category)
--- For each account with multiple currency templates, keep the primary currency one
--- and merge the secondary into it as sub_payments.
-WITH duplicates AS (
-  SELECT
-    t.account_id,
-    t.user_id,
-    a.currency_code AS primary_currency,
-    jsonb_agg(
-      jsonb_build_object(
-        'currency_code', t.currency_code::text,
-        'amount', t.amount
-      )
-      ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END
-    ) AS sub_payments_json,
-    -- Keep the template matching the primary currency (or the first active one)
-    (array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC))[1] AS keep_id,
-    array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC) AS all_ids,
-    sum(t.amount) AS total_amount
-  FROM recurring_transaction_templates_enc t
-  JOIN accounts ON accounts.id = t.account_id
-  -- Unencrypted join: accounts is not encrypted, and we filter on non-encrypted columns
-  CROSS JOIN LATERAL (
-    SELECT accounts.currency_code
-  ) a(currency_code)
-  WHERE t.direction = 'INFLOW'
-    AND t.frequency = 'MONTHLY'
-    AND t.category_id IS NULL
-  GROUP BY t.account_id, t.user_id, a.currency_code
-  HAVING count(*) > 1
-)
--- Update the kept template with sub_payments and summed amount
+-- For each account with multiple currency templates, keep the primary-currency one
+-- and merge the secondary into it as sub_payments (display-only metadata).
+-- template.amount stays as the PRIMARY-currency minimum (not a cross-currency sum).
+
+-- 5a: Identify groups and winners
+CREATE TEMP TABLE _merge_plan AS
+SELECT
+  t.account_id,
+  t.user_id,
+  a.currency_code AS primary_currency,
+  jsonb_agg(
+    jsonb_build_object(
+      'currency_code', t.currency_code::text,
+      'amount', t.amount
+    )
+    ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END
+  ) AS sub_payments_json,
+  -- Keep the primary-currency template (or the first active one if primary is missing)
+  (array_agg(t.id ORDER BY
+    CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END,
+    t.is_active DESC,
+    t.updated_at DESC
+  ))[1] AS keep_id,
+  -- Primary-currency amount (for template.amount — NOT a sum of all currencies)
+  (array_agg(t.amount ORDER BY
+    CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END,
+    t.is_active DESC,
+    t.updated_at DESC
+  ))[1] AS primary_amount,
+  array_agg(t.id) AS all_ids
+FROM recurring_transaction_templates_enc t
+JOIN accounts ON accounts.id = t.account_id
+CROSS JOIN LATERAL (
+  SELECT accounts.currency_code
+) a(currency_code)
+WHERE t.direction = 'INFLOW'
+  AND t.frequency = 'MONTHLY'
+  AND t.category_id IS NULL
+GROUP BY t.account_id, t.user_id, a.currency_code
+HAVING count(*) > 1;
+
+-- 5b: Update the kept template with sub_payments and primary-currency amount
 UPDATE recurring_transaction_templates_enc enc
 SET
-  sub_payments = d.sub_payments_json,
-  amount = d.total_amount,
-  currency_code = d.primary_currency
-FROM duplicates d
-WHERE enc.id = d.keep_id;
+  sub_payments = mp.sub_payments_json,
+  amount = mp.primary_amount,
+  currency_code = mp.primary_currency
+FROM _merge_plan mp
+WHERE enc.id = mp.keep_id;
 
--- Delete the secondary templates (the ones NOT kept)
-WITH duplicates AS (
-  SELECT
-    t.account_id,
-    a.currency_code AS primary_currency,
-    (array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC))[1] AS keep_id,
-    array_agg(t.id) AS all_ids
-  FROM recurring_transaction_templates_enc t
-  JOIN accounts ON accounts.id = t.account_id
-  CROSS JOIN LATERAL (
-    SELECT accounts.currency_code
-  ) a(currency_code)
-  WHERE t.direction = 'INFLOW'
-    AND t.frequency = 'MONTHLY'
-    AND t.category_id IS NULL
-    AND t.sub_payments IS NULL  -- Only not-yet-merged ones (skip if already processed above)
-  GROUP BY t.account_id, a.currency_code
-  HAVING count(*) > 1
-),
-to_delete AS (
-  SELECT unnest(all_ids) AS id, keep_id FROM duplicates
-)
--- Reassign occurrences from deleted templates to the kept one
+-- 5c: Delete conflicting occurrences on losers that share the same date as the winner's
+-- (prevents UNIQUE(template_id, occurrence_date) violation on reassignment)
+DELETE FROM recurring_occurrences occ
+USING _merge_plan mp
+WHERE occ.template_id = ANY(mp.all_ids)
+  AND occ.template_id != mp.keep_id
+  AND EXISTS (
+    SELECT 1 FROM recurring_occurrences kept
+    WHERE kept.template_id = mp.keep_id
+      AND kept.occurrence_date = occ.occurrence_date
+  );
+
+-- 5d: Reassign remaining non-conflicting occurrences from losers to the winner
 UPDATE recurring_occurrences occ
-SET template_id = td.keep_id
-FROM to_delete td
-WHERE occ.template_id = td.id AND td.id != td.keep_id;
+SET template_id = mp.keep_id
+FROM _merge_plan mp
+WHERE occ.template_id = ANY(mp.all_ids)
+  AND occ.template_id != mp.keep_id;
 
--- Now delete the secondary templates
-WITH duplicates AS (
-  SELECT
-    t.account_id,
-    a.currency_code AS primary_currency,
-    (array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC))[1] AS keep_id,
-    array_agg(t.id) AS all_ids
-  FROM recurring_transaction_templates_enc t
-  JOIN accounts ON accounts.id = t.account_id
-  CROSS JOIN LATERAL (
-    SELECT accounts.currency_code
-  ) a(currency_code)
-  WHERE t.direction = 'INFLOW'
-    AND t.frequency = 'MONTHLY'
-    AND t.category_id IS NULL
-    -- sub_payments IS NOT NULL means it was the winner from the UPDATE above
-    -- We want to delete the ones that were NOT updated (losers)
-  GROUP BY t.account_id, a.currency_code
-  HAVING count(*) > 1
-),
-to_delete AS (
-  SELECT unnest(all_ids) AS id, keep_id FROM duplicates
-)
-DELETE FROM recurring_transaction_templates_enc
-WHERE id IN (SELECT id FROM to_delete WHERE id != keep_id);
+-- 5e: Delete the loser templates
+DELETE FROM recurring_transaction_templates_enc enc
+USING _merge_plan mp
+WHERE enc.id = ANY(mp.all_ids)
+  AND enc.id != mp.keep_id;
+
+DROP TABLE _merge_plan;

--- a/supabase/migrations/20260416120000_add_sub_payments_to_recurring_templates.sql
+++ b/supabase/migrations/20260416120000_add_sub_payments_to_recurring_templates.sql
@@ -1,0 +1,171 @@
+-- ===========================================================================
+-- Add sub_payments JSONB to recurring_transaction_templates
+--
+-- Stores per-currency breakdown for multi-currency debt accounts:
+--   [{currency_code: "COP", amount: 50000}, {currency_code: "USD", amount: 25}]
+--
+-- The template's `amount` is the total in the account's primary currency.
+-- sub_payments is informational — not PII, so stored as plain JSONB (no encryption).
+-- ===========================================================================
+
+-- Step 1: Add column to the _enc table (real table)
+ALTER TABLE recurring_transaction_templates_enc
+  ADD COLUMN sub_payments JSONB DEFAULT NULL;
+
+-- Step 2: Recreate the decrypting view to include the new column
+CREATE OR REPLACE VIEW recurring_transaction_templates WITH (security_invoker = true) AS
+SELECT
+  account_id, amount, category_id, created_at, currency_code,
+  day_of_month, day_of_week,
+  zeta_decrypt(description) AS description,
+  direction, end_date, frequency, id, is_active,
+  zeta_decrypt(merchant_name) AS merchant_name,
+  start_date, sub_payments, transfer_source_account_id, updated_at, user_id
+FROM recurring_transaction_templates_enc;
+
+-- Step 3: Update INSERT trigger to include sub_payments
+CREATE OR REPLACE FUNCTION recurring_templates_view_insert() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.id := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+  NEW.currency_code := COALESCE(NEW.currency_code, 'COP'::currency_code);
+  NEW.is_active := COALESCE(NEW.is_active, true);
+
+  INSERT INTO recurring_transaction_templates_enc (
+    id, user_id, account_id, amount, currency_code, direction,
+    frequency, day_of_month, day_of_week, merchant_name, description,
+    category_id, is_active, start_date, end_date,
+    created_at, updated_at, transfer_source_account_id, sub_payments
+  ) VALUES (
+    NEW.id, NEW.user_id, NEW.account_id, NEW.amount, NEW.currency_code,
+    NEW.direction, NEW.frequency, NEW.day_of_month, NEW.day_of_week,
+    zeta_encrypt(NEW.merchant_name), zeta_encrypt(NEW.description),
+    NEW.category_id, NEW.is_active, NEW.start_date, NEW.end_date,
+    NEW.created_at, NEW.updated_at, NEW.transfer_source_account_id,
+    NEW.sub_payments
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 4: Update UPDATE trigger to include sub_payments
+CREATE OR REPLACE FUNCTION recurring_templates_view_update() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE recurring_transaction_templates_enc SET
+    account_id = NEW.account_id,
+    amount = NEW.amount,
+    category_id = NEW.category_id,
+    created_at = NEW.created_at,
+    currency_code = NEW.currency_code,
+    day_of_month = NEW.day_of_month,
+    day_of_week = NEW.day_of_week,
+    description = zeta_encrypt(NEW.description),
+    direction = NEW.direction,
+    end_date = NEW.end_date,
+    frequency = NEW.frequency,
+    is_active = NEW.is_active,
+    merchant_name = zeta_encrypt(NEW.merchant_name),
+    start_date = NEW.start_date,
+    transfer_source_account_id = NEW.transfer_source_account_id,
+    updated_at = NEW.updated_at,
+    user_id = NEW.user_id,
+    sub_payments = NEW.sub_payments
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 5: Merge existing duplicate templates (same account, INFLOW, MONTHLY, no category)
+-- For each account with multiple currency templates, keep the primary currency one
+-- and merge the secondary into it as sub_payments.
+WITH duplicates AS (
+  SELECT
+    t.account_id,
+    t.user_id,
+    a.currency_code AS primary_currency,
+    jsonb_agg(
+      jsonb_build_object(
+        'currency_code', t.currency_code::text,
+        'amount', t.amount
+      )
+      ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END
+    ) AS sub_payments_json,
+    -- Keep the template matching the primary currency (or the first active one)
+    (array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC))[1] AS keep_id,
+    array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC) AS all_ids,
+    sum(t.amount) AS total_amount
+  FROM recurring_transaction_templates_enc t
+  JOIN accounts ON accounts.id = t.account_id
+  -- Unencrypted join: accounts is not encrypted, and we filter on non-encrypted columns
+  CROSS JOIN LATERAL (
+    SELECT accounts.currency_code
+  ) a(currency_code)
+  WHERE t.direction = 'INFLOW'
+    AND t.frequency = 'MONTHLY'
+    AND t.category_id IS NULL
+  GROUP BY t.account_id, t.user_id, a.currency_code
+  HAVING count(*) > 1
+)
+-- Update the kept template with sub_payments and summed amount
+UPDATE recurring_transaction_templates_enc enc
+SET
+  sub_payments = d.sub_payments_json,
+  amount = d.total_amount,
+  currency_code = d.primary_currency
+FROM duplicates d
+WHERE enc.id = d.keep_id;
+
+-- Delete the secondary templates (the ones NOT kept)
+WITH duplicates AS (
+  SELECT
+    t.account_id,
+    a.currency_code AS primary_currency,
+    (array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC))[1] AS keep_id,
+    array_agg(t.id) AS all_ids
+  FROM recurring_transaction_templates_enc t
+  JOIN accounts ON accounts.id = t.account_id
+  CROSS JOIN LATERAL (
+    SELECT accounts.currency_code
+  ) a(currency_code)
+  WHERE t.direction = 'INFLOW'
+    AND t.frequency = 'MONTHLY'
+    AND t.category_id IS NULL
+    AND t.sub_payments IS NULL  -- Only not-yet-merged ones (skip if already processed above)
+  GROUP BY t.account_id, a.currency_code
+  HAVING count(*) > 1
+),
+to_delete AS (
+  SELECT unnest(all_ids) AS id, keep_id FROM duplicates
+)
+-- Reassign occurrences from deleted templates to the kept one
+UPDATE recurring_occurrences occ
+SET template_id = td.keep_id
+FROM to_delete td
+WHERE occ.template_id = td.id AND td.id != td.keep_id;
+
+-- Now delete the secondary templates
+WITH duplicates AS (
+  SELECT
+    t.account_id,
+    a.currency_code AS primary_currency,
+    (array_agg(t.id ORDER BY CASE WHEN t.currency_code = a.currency_code THEN 0 ELSE 1 END, t.is_active DESC, t.updated_at DESC))[1] AS keep_id,
+    array_agg(t.id) AS all_ids
+  FROM recurring_transaction_templates_enc t
+  JOIN accounts ON accounts.id = t.account_id
+  CROSS JOIN LATERAL (
+    SELECT accounts.currency_code
+  ) a(currency_code)
+  WHERE t.direction = 'INFLOW'
+    AND t.frequency = 'MONTHLY'
+    AND t.category_id IS NULL
+    -- sub_payments IS NOT NULL means it was the winner from the UPDATE above
+    -- We want to delete the ones that were NOT updated (losers)
+  GROUP BY t.account_id, a.currency_code
+  HAVING count(*) > 1
+),
+to_delete AS (
+  SELECT unnest(all_ids) AS id, keep_id FROM duplicates
+)
+DELETE FROM recurring_transaction_templates_enc
+WHERE id IN (SELECT id FROM to_delete WHERE id != keep_id);

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -51,7 +51,13 @@ type RecurringTemplateSyncRow = Pick<
   | "is_active"
   | "start_date"
   | "day_of_month"
+  | "sub_payments"
 >;
+
+interface SubPaymentEntry {
+  currency_code: string;
+  amount: number;
+}
 
 const IMPORT_DETAIL_MESSAGES = {
   monthlyToAnnual: (
@@ -84,7 +90,7 @@ const IMPORT_DETAIL_MESSAGES = {
 import { sanitizeInterestRate, mvToEaPercent, MV_THRESHOLD } from "@zeta/shared";
 
 const RECURRING_TEMPLATE_SYNC_SELECT =
-  "id, account_id, currency_code, merchant_name, description, direction, frequency, category_id, transfer_source_account_id, is_active, start_date, day_of_month";
+  "id, account_id, currency_code, merchant_name, description, direction, frequency, category_id, transfer_source_account_id, is_active, start_date, day_of_month, sub_payments";
 
 function sanitizeEaRate(
   rawRate: number | null | undefined,
@@ -128,8 +134,47 @@ function buildDecisionKey(statementIndex: number, transactionIndex: number): str
   return `${statementIndex}:${transactionIndex}`;
 }
 
-function buildRecurringTemplateKey(accountId: string, currency: string): string {
-  return `${accountId}:${currency.toUpperCase()}`;
+/** Template key is per-account (not per-currency). Multi-currency payments merge into one template. */
+function buildRecurringTemplateKey(accountId: string): string {
+  return accountId;
+}
+
+function parseSubPayments(raw: unknown): SubPaymentEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (e): e is SubPaymentEntry =>
+      typeof e === "object" && e !== null &&
+      typeof e.currency_code === "string" &&
+      typeof e.amount === "number" && e.amount > 0,
+  );
+}
+
+function upsertSubPayment(
+  existing: SubPaymentEntry[],
+  currencyCode: string,
+  amount: number,
+): SubPaymentEntry[] {
+  const updated = existing.filter((e) => e.currency_code !== currencyCode);
+  updated.push({ currency_code: currencyCode, amount });
+  // Sort: primary currency first (COP usually), then alphabetical
+  updated.sort((a, b) => a.currency_code.localeCompare(b.currency_code));
+  return updated;
+}
+
+function computeSubPaymentsTotal(
+  subPayments: SubPaymentEntry[],
+  primaryCurrency: string,
+): number {
+  // For now, sum all amounts directly. When sub_payments has multiple currencies,
+  // the non-primary currency amounts have already been converted at import time
+  // by using the bank's own minimum_payment in primary currency.
+  // For credit cards, banks typically report the total minimum in the primary currency statement.
+  // We store the per-currency breakdown for display purposes.
+  let total = 0;
+  for (const sp of subPayments) {
+    total += sp.amount;
+  }
+  return Math.round(total * 100) / 100;
 }
 
 function getDayOfMonth(date: string): number | null {
@@ -199,24 +244,31 @@ async function syncCreditCardRecurringTemplate(params: {
   if (!dayOfMonth) return;
 
   const accountName = params.account?.name ?? "tarjeta";
-  const templateKey = buildRecurringTemplateKey(params.meta.accountId, params.meta.currency);
+  const primaryCurrency = params.account?.currency_code ?? params.meta.currency;
+  const templateKey = buildRecurringTemplateKey(params.meta.accountId);
   const merchantName =
     params.existingTemplate?.merchant_name?.trim() ||
     buildDebtPaymentMerchantName(accountName);
   const description = params.existingTemplate?.description?.trim() || null;
-  const amount = Math.round(cc.minimum_payment * 100) / 100;
+  const currencyAmount = Math.round(cc.minimum_payment * 100) / 100;
+
+  // Build updated sub_payments by merging this currency's payment into existing ones
+  const existingSubPayments = parseSubPayments(params.existingTemplate?.sub_payments);
+  const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount);
+  const totalAmount = computeSubPaymentsTotal(updatedSubPayments, primaryCurrency);
 
   try {
     if (params.existingTemplate) {
       const { data, error } = await params.supabase
         .from("recurring_transaction_templates")
         .update({
-          amount,
-          currency_code: params.meta.currency as CurrencyCode,
+          amount: totalAmount,
+          currency_code: primaryCurrency as CurrencyCode,
           merchant_name: merchantName,
           description,
           start_date: cc.payment_due_date,
           day_of_month: dayOfMonth,
+          sub_payments: updatedSubPayments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"],
         })
         .eq("user_id", params.userId)
         .eq("id", params.existingTemplate.id)
@@ -237,8 +289,8 @@ async function syncCreditCardRecurringTemplate(params: {
         user_id: params.userId,
         account_id: params.meta.accountId,
         transfer_source_account_id: null,
-        amount,
-        currency_code: params.meta.currency as CurrencyCode,
+        amount: totalAmount,
+        currency_code: primaryCurrency as CurrencyCode,
         direction: "INFLOW",
         frequency: "MONTHLY",
         merchant_name: merchantName,
@@ -248,6 +300,7 @@ async function syncCreditCardRecurringTemplate(params: {
         day_of_week: null,
         start_date: cc.payment_due_date,
         end_date: null,
+        sub_payments: updatedSubPayments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"],
       })
       .select(RECURRING_TEMPLATE_SYNC_SELECT)
       .single();
@@ -292,25 +345,32 @@ async function syncLoanRecurringTemplate(params: {
   if (!dayOfMonth) return;
 
   const accountName = params.account?.name ?? "préstamo";
-  const templateKey = buildRecurringTemplateKey(params.meta.accountId, params.meta.currency);
+  const primaryCurrency = params.account?.currency_code ?? params.meta.currency;
+  const templateKey = buildRecurringTemplateKey(params.meta.accountId);
   const merchantName =
     params.existingTemplate?.merchant_name?.trim() ||
     buildDebtPaymentMerchantName(accountName);
   const description = params.existingTemplate?.description?.trim() || null;
   // Prefer minimum_payment (for banks that provide it), fall back to total_payment_due
-  const amount = Math.round((ln.minimum_payment ?? ln.total_payment_due) * 100) / 100;
+  const currencyAmount = Math.round((ln.minimum_payment ?? ln.total_payment_due) * 100) / 100;
+
+  // Build updated sub_payments
+  const existingSubPayments = parseSubPayments(params.existingTemplate?.sub_payments);
+  const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount);
+  const totalAmount = computeSubPaymentsTotal(updatedSubPayments, primaryCurrency);
 
   try {
     if (params.existingTemplate) {
       const { data, error } = await params.supabase
         .from("recurring_transaction_templates")
         .update({
-          amount,
-          currency_code: params.meta.currency as CurrencyCode,
+          amount: totalAmount,
+          currency_code: primaryCurrency as CurrencyCode,
           merchant_name: merchantName,
           description,
           start_date: ln.payment_due_date,
           day_of_month: dayOfMonth,
+          sub_payments: updatedSubPayments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"],
         })
         .eq("user_id", params.userId)
         .eq("id", params.existingTemplate.id)
@@ -331,8 +391,8 @@ async function syncLoanRecurringTemplate(params: {
         user_id: params.userId,
         account_id: params.meta.accountId,
         transfer_source_account_id: null,
-        amount,
-        currency_code: params.meta.currency as CurrencyCode,
+        amount: totalAmount,
+        currency_code: primaryCurrency as CurrencyCode,
         direction: "INFLOW",
         frequency: "MONTHLY",
         merchant_name: merchantName,
@@ -342,6 +402,7 @@ async function syncLoanRecurringTemplate(params: {
         day_of_week: null,
         start_date: ln.payment_due_date,
         end_date: null,
+        sub_payments: updatedSubPayments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"],
       })
       .select(RECURRING_TEMPLATE_SYNC_SELECT)
       .single();
@@ -518,7 +579,7 @@ async function processStatementMeta(params: {
       .order("updated_at", { ascending: false });
 
     for (const template of (recurringTemplates ?? []) as RecurringTemplateSyncRow[]) {
-      const key = buildRecurringTemplateKey(template.account_id, template.currency_code);
+      const key = buildRecurringTemplateKey(template.account_id);
       if (!recurringTemplateMap.has(key)) {
         recurringTemplateMap.set(key, template);
       }
@@ -737,7 +798,7 @@ async function processStatementMeta(params: {
       isFirstImport: !prevSnapshot,
     });
 
-    const templateKey = buildRecurringTemplateKey(meta.accountId, meta.currency);
+    const templateKey = buildRecurringTemplateKey(meta.accountId);
     if (meta.creditCardMetadata) {
       await syncCreditCardRecurringTemplate({
         supabase,

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -25,6 +25,7 @@ import type {
 } from "@/types/import";
 import { trackProductEvent } from "@/actions/product-events";
 import { linkTransactionToOccurrence, ensureCurrentOccurrences } from "@/actions/occurrences";
+import { parseSubPayments as parseSubPaymentsShared } from "@/lib/utils/sub-payments";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 
 type DebtKind = "credit_card" | "loan";
@@ -141,24 +142,24 @@ function buildRecurringTemplateKey(accountId: string): string {
 }
 
 function parseSubPayments(raw: unknown): SubPaymentEntry[] {
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(
-    (e): e is SubPaymentEntry =>
-      typeof e === "object" && e !== null &&
-      typeof e.currency_code === "string" &&
-      typeof e.amount === "number" && e.amount > 0,
-  );
+  return parseSubPaymentsShared(raw) ?? [];
 }
 
 function upsertSubPayment(
   existing: SubPaymentEntry[],
   currencyCode: string,
   amount: number,
+  primaryCurrency: string,
 ): SubPaymentEntry[] {
   const updated = existing.filter((e) => e.currency_code !== currencyCode);
   updated.push({ currency_code: currencyCode, amount });
-  // Sort: primary currency first (COP usually), then alphabetical
-  updated.sort((a, b) => a.currency_code.localeCompare(b.currency_code));
+  // Primary currency first, then alphabetical
+  updated.sort((a, b) => {
+    const aPrimary = a.currency_code === primaryCurrency ? 0 : 1;
+    const bPrimary = b.currency_code === primaryCurrency ? 0 : 1;
+    if (aPrimary !== bPrimary) return aPrimary - bPrimary;
+    return a.currency_code.localeCompare(b.currency_code);
+  });
   return updated;
 }
 
@@ -177,12 +178,10 @@ function getPrimaryCurrencyAmount(
 ): number {
   const primary = subPayments.find((sp) => sp.currency_code === primaryCurrency);
   if (primary) return Math.round(primary.amount * 100) / 100;
-  // If primary currency not yet imported, keep the existing amount
-  if (existingAmount != null && existingAmount > 0) return existingAmount;
-  // First import is a secondary currency — use it as placeholder until primary arrives
-  return subPayments.length > 0
-    ? Math.round(subPayments[0].amount * 100) / 100
-    : 0;
+  // If primary currency not yet imported, keep the existing amount.
+  // Never fall back to a secondary-currency amount — that would store
+  // e.g. a USD value as COP, producing a nonsensical template.amount.
+  return (existingAmount != null && existingAmount > 0) ? existingAmount : 0;
 }
 
 function getDayOfMonth(date: string): number | null {
@@ -262,7 +261,7 @@ async function syncCreditCardRecurringTemplate(params: {
 
   // Build updated sub_payments by merging this currency's payment into existing ones
   const existingSubPayments = parseSubPayments(params.existingTemplate?.sub_payments);
-  const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount);
+  const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount, primaryCurrency);
   // template.amount = primary-currency minimum only (sub_payments is display metadata)
   const totalAmount = getPrimaryCurrencyAmount(
     updatedSubPayments,
@@ -369,7 +368,7 @@ async function syncLoanRecurringTemplate(params: {
 
   // Build updated sub_payments
   const existingSubPayments = parseSubPayments(params.existingTemplate?.sub_payments);
-  const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount);
+  const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount, primaryCurrency);
   // template.amount = primary-currency minimum only (sub_payments is display metadata)
   const totalAmount = getPrimaryCurrencyAmount(
     updatedSubPayments,

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -24,7 +24,7 @@ import type {
   TransactionToImport,
 } from "@/types/import";
 import { trackProductEvent } from "@/actions/product-events";
-import { linkTransactionToOccurrence } from "@/actions/occurrences";
+import { linkTransactionToOccurrence, ensureCurrentOccurrences } from "@/actions/occurrences";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 
 type DebtKind = "credit_card" | "loan";
@@ -41,6 +41,7 @@ type RecurringTemplateSyncRow = Pick<
   Database["public"]["Tables"]["recurring_transaction_templates"]["Row"],
   | "id"
   | "account_id"
+  | "amount"
   | "currency_code"
   | "merchant_name"
   | "description"
@@ -90,7 +91,7 @@ const IMPORT_DETAIL_MESSAGES = {
 import { sanitizeInterestRate, mvToEaPercent, MV_THRESHOLD } from "@zeta/shared";
 
 const RECURRING_TEMPLATE_SYNC_SELECT =
-  "id, account_id, currency_code, merchant_name, description, direction, frequency, category_id, transfer_source_account_id, is_active, start_date, day_of_month, sub_payments";
+  "id, account_id, amount, currency_code, merchant_name, description, direction, frequency, category_id, transfer_source_account_id, is_active, start_date, day_of_month, sub_payments";
 
 function sanitizeEaRate(
   rawRate: number | null | undefined,
@@ -161,20 +162,27 @@ function upsertSubPayment(
   return updated;
 }
 
-function computeSubPaymentsTotal(
+/**
+ * Get the primary-currency amount from sub_payments. Only the primary-currency
+ * entry drives the template.amount (used for occurrence expected_amount and
+ * findMatchingOccurrence tolerance). Non-primary entries are display-only metadata.
+ *
+ * Falls back to the existing template amount if the primary currency isn't
+ * present in sub_payments (e.g., only a secondary currency statement was imported).
+ */
+function getPrimaryCurrencyAmount(
   subPayments: SubPaymentEntry[],
   primaryCurrency: string,
+  existingAmount: number | null,
 ): number {
-  // For now, sum all amounts directly. When sub_payments has multiple currencies,
-  // the non-primary currency amounts have already been converted at import time
-  // by using the bank's own minimum_payment in primary currency.
-  // For credit cards, banks typically report the total minimum in the primary currency statement.
-  // We store the per-currency breakdown for display purposes.
-  let total = 0;
-  for (const sp of subPayments) {
-    total += sp.amount;
-  }
-  return Math.round(total * 100) / 100;
+  const primary = subPayments.find((sp) => sp.currency_code === primaryCurrency);
+  if (primary) return Math.round(primary.amount * 100) / 100;
+  // If primary currency not yet imported, keep the existing amount
+  if (existingAmount != null && existingAmount > 0) return existingAmount;
+  // First import is a secondary currency — use it as placeholder until primary arrives
+  return subPayments.length > 0
+    ? Math.round(subPayments[0].amount * 100) / 100
+    : 0;
 }
 
 function getDayOfMonth(date: string): number | null {
@@ -255,7 +263,12 @@ async function syncCreditCardRecurringTemplate(params: {
   // Build updated sub_payments by merging this currency's payment into existing ones
   const existingSubPayments = parseSubPayments(params.existingTemplate?.sub_payments);
   const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount);
-  const totalAmount = computeSubPaymentsTotal(updatedSubPayments, primaryCurrency);
+  // template.amount = primary-currency minimum only (sub_payments is display metadata)
+  const totalAmount = getPrimaryCurrencyAmount(
+    updatedSubPayments,
+    primaryCurrency,
+    params.existingTemplate ? Number(params.existingTemplate.amount) : null,
+  );
 
   try {
     if (params.existingTemplate) {
@@ -357,7 +370,12 @@ async function syncLoanRecurringTemplate(params: {
   // Build updated sub_payments
   const existingSubPayments = parseSubPayments(params.existingTemplate?.sub_payments);
   const updatedSubPayments = upsertSubPayment(existingSubPayments, params.meta.currency, currencyAmount);
-  const totalAmount = computeSubPaymentsTotal(updatedSubPayments, primaryCurrency);
+  // template.amount = primary-currency minimum only (sub_payments is display metadata)
+  const totalAmount = getPrimaryCurrencyAmount(
+    updatedSubPayments,
+    primaryCurrency,
+    params.existingTemplate ? Number(params.existingTemplate.amount) : null,
+  );
 
   try {
     if (params.existingTemplate) {
@@ -1093,6 +1111,9 @@ export async function importTransactions(
     statementMeta: normalizedStatementMeta,
     details,
   });
+
+  // Ensure occurrence rows are generated for any newly created/updated templates
+  await ensureCurrentOccurrences();
 
   // Screenshot imports lack statement metadata — fall back to per-tx balance deltas.
   if (balanceDeltaTxs.length > 0) {

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -9,6 +9,7 @@ import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { isDebtAccountType, reverseAccountBalanceDelta } from "@/lib/utils/account-balance";
+import { parseSubPayments } from "@/lib/utils/sub-payments";
 import { UUID_RE } from "@/lib/validators/shared";
 import {
   generateOccurrenceRowsBatch,
@@ -53,10 +54,10 @@ export interface NextIncomeInfo {
   daysUntil: number;      // Days from today (1 = today or tomorrow)
 }
 
-export interface OccurrenceSubPayment {
-  currency_code: string;
-  amount: number;
-}
+import type { SubPayment } from "@/types/domain";
+
+/** @deprecated Use SubPayment from @/types/domain */
+export type OccurrenceSubPayment = SubPayment;
 
 export interface RecurringOccurrence {
   id: string;
@@ -144,17 +145,6 @@ function isCrossAccountDebtPayment(
     template.account != null &&
     isDebtAccountType(template.account.account_type)
   );
-}
-
-function parseSubPayments(raw: unknown): OccurrenceSubPayment[] | null {
-  if (!Array.isArray(raw)) return null;
-  const result = raw.filter(
-    (e): e is OccurrenceSubPayment =>
-      typeof e === "object" && e !== null &&
-      typeof e.currency_code === "string" &&
-      typeof e.amount === "number" && e.amount > 0,
-  );
-  return result.length > 0 ? result : null;
 }
 
 function mapOccurrenceRow(row: RawOccurrenceRow): RecurringOccurrence | null {

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -53,6 +53,11 @@ export interface NextIncomeInfo {
   daysUntil: number;      // Days from today (1 = today or tomorrow)
 }
 
+export interface OccurrenceSubPayment {
+  currency_code: string;
+  amount: number;
+}
+
 export interface RecurringOccurrence {
   id: string;
   template_id: string;
@@ -71,6 +76,7 @@ export interface RecurringOccurrence {
   category_icon: string | null;
   category_color: string | null;
   transfer_source_account_id: string | null;
+  sub_payments: OccurrenceSubPayment[] | null;
 }
 
 // ─── Select fragment for occurrence + joined template data ────────────────────
@@ -90,6 +96,7 @@ const OCCURRENCE_SELECT = `
     is_active,
     account_id,
     transfer_source_account_id,
+    sub_payments,
     account:accounts!recurring_transaction_templates_account_id_fkey(name, account_type),
     category:categories!recurring_transaction_templates_category_id_fkey(name_es, icon, color)
   )
@@ -110,6 +117,7 @@ type RawOccurrenceRow = {
     is_active: boolean;
     account_id: string;
     transfer_source_account_id: string | null;
+    sub_payments: unknown;
     account: { name: string; account_type: string } | null;
     category: { name_es: string | null; icon: string | null; color: string | null } | null;
   } | null;
@@ -138,6 +146,17 @@ function isCrossAccountDebtPayment(
   );
 }
 
+function parseSubPayments(raw: unknown): OccurrenceSubPayment[] | null {
+  if (!Array.isArray(raw)) return null;
+  const result = raw.filter(
+    (e): e is OccurrenceSubPayment =>
+      typeof e === "object" && e !== null &&
+      typeof e.currency_code === "string" &&
+      typeof e.amount === "number" && e.amount > 0,
+  );
+  return result.length > 0 ? result : null;
+}
+
 function mapOccurrenceRow(row: RawOccurrenceRow): RecurringOccurrence | null {
   if (!row.template || !row.template.account) return null;
   return {
@@ -158,6 +177,7 @@ function mapOccurrenceRow(row: RawOccurrenceRow): RecurringOccurrence | null {
     category_icon: row.template.category?.icon ?? null,
     category_color: row.template.category?.color ?? null,
     transfer_source_account_id: row.template.transfer_source_account_id,
+    sub_payments: parseSubPayments(row.template.sub_payments),
   };
 }
 

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -254,13 +254,14 @@ export async function createRecurringTemplate(
     day_of_week: formData.get("day_of_week") || undefined,
     start_date: formData.get("start_date"),
     end_date: formData.get("end_date") || undefined,
+    sub_payments: formData.get("sub_payments") || undefined,
   });
 
   if (!parsed.success) {
     return { success: false, error: parsed.error.issues[0].message };
   }
 
-  const payload = { ...parsed.data };
+  const { sub_payments, ...payload } = parsed.data;
   const { data: account, error: accountError } = await supabase
     .from("accounts")
     .select("id, account_type")
@@ -285,11 +286,16 @@ export async function createRecurringTemplate(
     payload.transfer_source_account_id = null;
   }
 
+  const subPaymentsValue = sub_payments && sub_payments.length > 0
+    ? (sub_payments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"])
+    : null;
+
   const { data, error } = await supabase
     .from("recurring_transaction_templates")
     .insert({
       user_id: user.id,
       ...payload,
+      sub_payments: subPaymentsValue,
     })
     .select()
     .single();
@@ -328,13 +334,14 @@ export async function updateRecurringTemplate(
     day_of_week: formData.get("day_of_week") || undefined,
     start_date: formData.get("start_date"),
     end_date: formData.get("end_date") || undefined,
+    sub_payments: formData.get("sub_payments") || undefined,
   });
 
   if (!parsed.success) {
     return { success: false, error: parsed.error.issues[0].message };
   }
 
-  const payload = { ...parsed.data };
+  const { sub_payments, ...payload } = parsed.data;
   const { data: account, error: accountError } = await supabase
     .from("accounts")
     .select("id, account_type")
@@ -359,9 +366,16 @@ export async function updateRecurringTemplate(
     payload.transfer_source_account_id = null;
   }
 
+  const subPaymentsValue = sub_payments && sub_payments.length > 0
+    ? (sub_payments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"])
+    : null;
+
   const { data, error } = await supabase
     .from("recurring_transaction_templates")
-    .update(payload)
+    .update({
+      ...payload,
+      sub_payments: subPaymentsValue,
+    })
     .eq("id", id)
     .eq("user_id", user.id)
     .select()

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -331,7 +331,7 @@ export function MobileRecurrentesView({
 
                         {/* Option A: Inline expand */}
                         {isExpanded && (
-                          <div className="border-t border-white/5 bg-black/20 px-3 py-3">
+                          <div className="border-t border-white/6 bg-black/20 px-3 py-3">
                             <OccurrenceActions
                               item={item}
                               isPending={isBusy}

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -11,6 +11,7 @@ import {
   MOBILE_EYEBROW_CLASS,
   MOBILE_TAB_BAR_CLEARANCE_CLASS,
 } from "@/lib/constants/styles";
+import { SubPaymentsBreakdown } from "@/components/recurring/sub-payments-breakdown";
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
 import type { RecurringOccurrence } from "@/actions/occurrences";
 import { OccurrenceActions } from "@/components/recurring/occurrence-actions";
@@ -314,6 +315,12 @@ export function MobileRecurrentesView({
                             <p className="truncate text-[10px] text-muted-foreground">
                               {item.accountName}
                             </p>
+                            {item.subPayments && item.subPayments.length > 1 && (
+                              <SubPaymentsBreakdown
+                                subPayments={item.subPayments}
+                                className="flex gap-2 text-[10px]"
+                              />
+                            )}
                           </div>
 
                           {/* Amount */}
@@ -376,7 +383,29 @@ export function MobileRecurrentesView({
         />
       )}
 
-      {/* Templates section — admin for non-checklist management */}
+      {/* Create new recurring — always visible */}
+      {hook.isHydrated && (
+        <div className="space-y-2">
+          <RecurringFormDialog
+            accounts={accounts}
+            categories={categories}
+            onClose={hook.refreshOccurrences}
+            trigger={
+              <button
+                type="button"
+                className={cn(
+                  "flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-brass/20 py-3 text-xs font-semibold text-z-brass active:bg-z-brass/5",
+                )}
+              >
+                <Plus className="size-3.5" />
+                Nueva recurrente
+              </button>
+            }
+          />
+        </div>
+      )}
+
+      {/* Templates section — view all, manage paused */}
       {hook.isHydrated && (
         <TemplatesSection
           templates={templates}
@@ -581,24 +610,6 @@ function TemplatesSection({
 
       {show && (
         <div className="space-y-2">
-          {/* Create new */}
-          <RecurringFormDialog
-            accounts={accounts}
-            categories={categories}
-            onClose={onMutate}
-            trigger={
-              <button
-                type="button"
-                className={cn(
-                  "flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-brass/20 py-3 text-xs font-semibold text-z-brass active:bg-z-brass/5",
-                )}
-              >
-                <Plus className="size-3.5" />
-                Nueva plantilla
-              </button>
-            }
-          />
-
           {/* Template list */}
           <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
             {templates.map((t) => (

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -22,6 +22,7 @@ import {
 import { Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BRASS_BUTTON_CLASS, BRASS_GHOST_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { parseSubPayments } from "@/lib/utils/sub-payments";
 import { SUBCATEGORY_PAGO_TARJETA, SUBCATEGORY_CUOTA_CREDITO } from "@zeta/shared";
 import type { ActionResult } from "@/types/actions";
 import type { Account, CategoryWithChildren, RecurringTemplate, SubPayment, TransactionDirection } from "@/types/domain";
@@ -85,26 +86,17 @@ export function RecurringForm({
     template?.transfer_source_account_id ?? ""
   );
   // Multi-currency sub_payments for debt accounts
-  const initialSubPayments: SubPayment[] = (() => {
-    const raw = template?.sub_payments as unknown;
-    if (!Array.isArray(raw)) return [];
-    return raw.filter(
-      (e): e is SubPayment =>
-        typeof e === "object" && e !== null &&
-        typeof (e as Record<string, unknown>).currency_code === "string" &&
-        typeof (e as Record<string, unknown>).amount === "number" &&
-        ((e as Record<string, unknown>).amount as number) > 0,
-    );
-  })();
+  const initialSubPayments: SubPayment[] = parseSubPayments(template?.sub_payments) ?? [];
   const [subPayments, setSubPayments] = useState<SubPayment[]>(initialSubPayments);
   const [useSubPayments, setUseSubPayments] = useState(initialSubPayments.length > 0);
 
-  const subPaymentsTotal = useMemo(
-    () => subPayments.reduce((sum, sp) => sum + (sp.amount || 0), 0),
-    [subPayments],
-  );
-
   const selectedAccount = accounts.find((acc) => acc.id === accountId) ?? null;
+
+  // Primary-currency amount from sub_payments (not a cross-currency sum).
+  // Falls back to 0 if the primary currency entry isn't set yet.
+  const primaryCurrency = selectedAccount?.currency_code ?? template?.currency_code ?? "COP";
+  const subPaymentsPrimaryAmount =
+    subPayments.find((sp) => sp.currency_code === primaryCurrency)?.amount ?? 0;
   const cutoffDay = selectedAccount?.cutoff_day ?? null;
   const paymentDay = selectedAccount?.payment_day ?? null;
   const isDebtAccount =
@@ -217,7 +209,7 @@ export function RecurringForm({
             id="amount"
             name="amount"
             defaultValue={template?.amount}
-            value={useSubPayments ? String(Math.round(subPaymentsTotal * 100) / 100) : undefined}
+            value={useSubPayments ? String(Math.round(subPaymentsPrimaryAmount * 100) / 100) : undefined}
             placeholder="0"
             required
             readOnly={useSubPayments}
@@ -225,7 +217,7 @@ export function RecurringForm({
           />
           <p className="text-xs text-muted-foreground">
             {useSubPayments
-              ? "Calculado desde el desglose por moneda."
+              ? `Pago mínimo en ${primaryCurrency} del desglose por moneda.`
               : isDebtAccount
                 ? "Si importas un extracto con fecha y total a pagar, actualizamos este monto automaticamente. Al confirmar el pago puedes ajustar el monto pagado."
                 : "Este valor es referencia. En el checklist podras registrar el monto pagado."}

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -20,6 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Plus, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { BRASS_BUTTON_CLASS, BRASS_GHOST_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 import { SUBCATEGORY_PAGO_TARJETA, SUBCATEGORY_CUOTA_CREDITO } from "@zeta/shared";
 import type { ActionResult } from "@/types/actions";
 import type { Account, CategoryWithChildren, RecurringTemplate, SubPayment, TransactionDirection } from "@/types/domain";
@@ -239,9 +241,8 @@ export function RecurringForm({
             {!useSubPayments && (
               <Button
                 type="button"
-                variant="outline"
                 size="sm"
-                className="h-6 text-[10px]"
+                className={cn(BRASS_GHOST_BUTTON_CLASS, "h-6 text-[10px]")}
                 onClick={() => {
                   setUseSubPayments(true);
                   if (subPayments.length === 0) {
@@ -293,9 +294,8 @@ export function RecurringForm({
               {subPayments.length < accountCurrencies.length && (
                 <Button
                   type="button"
-                  variant="ghost"
                   size="sm"
-                  className="h-7 text-xs"
+                  className={cn(GHOST_BUTTON_CLASS, "h-7 text-xs")}
                   onClick={() => {
                     const used = new Set(subPayments.map((s) => s.currency_code));
                     const next = accountCurrencies.find((c) => !used.has(c));
@@ -366,11 +366,11 @@ export function RecurringForm({
 
       {isDebtAccount &&
         (cutoffDay != null || paymentDay != null) && (
-          <div className="rounded-md border border-blue-200 bg-blue-50 p-3 space-y-2">
-            <p className="text-sm font-medium text-blue-900">
+          <div className="rounded-md border border-z-alert/20 bg-z-alert/8 p-3 space-y-2">
+            <p className="text-sm font-medium text-z-alert">
               Sugerencias para obligaciones
             </p>
-            <p className="text-xs text-blue-800">
+            <p className="text-xs text-muted-foreground">
               Corte: dia {cutoffDay ?? "--"} · Pago: dia{" "}
               {paymentDay ?? "--"}
             </p>
@@ -378,8 +378,8 @@ export function RecurringForm({
               {cutoffDay != null && (
                 <Button
                   type="button"
-                  variant="outline"
                   size="sm"
+                  className={GHOST_BUTTON_CLASS}
                   onClick={() => setStartDate(nextOccurrenceForDay(cutoffDay))}
                 >
                   Usar dia de corte
@@ -388,8 +388,8 @@ export function RecurringForm({
               {paymentDay != null && (
                 <Button
                   type="button"
-                  variant="outline"
                   size="sm"
+                  className={GHOST_BUTTON_CLASS}
                   onClick={() => setStartDate(nextOccurrenceForDay(paymentDay))}
                 >
                   Usar dia de pago
@@ -486,7 +486,7 @@ export function RecurringForm({
         />
       </div>
 
-      <Button type="submit" className="w-full" disabled={pending}>
+      <Button type="submit" className={cn(BRASS_BUTTON_CLASS, "w-full")} disabled={pending}>
         {pending
           ? "Guardando..."
           : template

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useActionState } from "react";
 import {
   createRecurringTemplate,
@@ -19,9 +19,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Plus, X } from "lucide-react";
 import { SUBCATEGORY_PAGO_TARJETA, SUBCATEGORY_CUOTA_CREDITO } from "@zeta/shared";
 import type { ActionResult } from "@/types/actions";
-import type { Account, CategoryWithChildren, RecurringTemplate, TransactionDirection } from "@/types/domain";
+import type { Account, CategoryWithChildren, RecurringTemplate, SubPayment, TransactionDirection } from "@/types/domain";
 
 const FREQUENCY_OPTIONS = [
   { value: "ONCE", label: "Una vez" },
@@ -81,12 +82,45 @@ export function RecurringForm({
   const [transferSourceAccountId, setTransferSourceAccountId] = useState<string>(
     template?.transfer_source_account_id ?? ""
   );
+  // Multi-currency sub_payments for debt accounts
+  const initialSubPayments: SubPayment[] = (() => {
+    const raw = template?.sub_payments as unknown;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter(
+      (e): e is SubPayment =>
+        typeof e === "object" && e !== null &&
+        typeof (e as Record<string, unknown>).currency_code === "string" &&
+        typeof (e as Record<string, unknown>).amount === "number" &&
+        ((e as Record<string, unknown>).amount as number) > 0,
+    );
+  })();
+  const [subPayments, setSubPayments] = useState<SubPayment[]>(initialSubPayments);
+  const [useSubPayments, setUseSubPayments] = useState(initialSubPayments.length > 0);
+
+  const subPaymentsTotal = useMemo(
+    () => subPayments.reduce((sum, sp) => sum + (sp.amount || 0), 0),
+    [subPayments],
+  );
+
   const selectedAccount = accounts.find((acc) => acc.id === accountId) ?? null;
   const cutoffDay = selectedAccount?.cutoff_day ?? null;
   const paymentDay = selectedAccount?.payment_day ?? null;
   const isDebtAccount =
     selectedAccount?.account_type === "CREDIT_CARD" ||
     selectedAccount?.account_type === "LOAN";
+
+  // Available currencies for the account (from currency_balances)
+  const accountCurrencies = useMemo(() => {
+    const currencies = new Set<string>();
+    if (selectedAccount?.currency_code) currencies.add(selectedAccount.currency_code);
+    const balances = selectedAccount?.currency_balances;
+    if (balances && typeof balances === "object" && !Array.isArray(balances)) {
+      for (const key of Object.keys(balances as Record<string, unknown>)) {
+        currencies.add(key);
+      }
+    }
+    return Array.from(currencies).sort();
+  }, [selectedAccount]);
 
   useEffect(() => {
     if (isDebtAccount && direction !== "INFLOW") {
@@ -174,21 +208,119 @@ export function RecurringForm({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="amount">Monto</Label>
+          <Label htmlFor="amount">
+            {useSubPayments ? "Monto total" : "Monto"}
+          </Label>
           <CurrencyInput
             id="amount"
             name="amount"
             defaultValue={template?.amount}
+            value={useSubPayments ? String(Math.round(subPaymentsTotal * 100) / 100) : undefined}
             placeholder="0"
             required
+            readOnly={useSubPayments}
+            className={useSubPayments ? "opacity-60" : ""}
           />
           <p className="text-xs text-muted-foreground">
-            {isDebtAccount
-              ? "Si importas un extracto con fecha y total a pagar, actualizamos este monto automaticamente. Al confirmar el pago puedes ajustar el monto pagado."
-              : "Este valor es referencia. En el checklist podras registrar el monto pagado."}
+            {useSubPayments
+              ? "Calculado desde el desglose por moneda."
+              : isDebtAccount
+                ? "Si importas un extracto con fecha y total a pagar, actualizamos este monto automaticamente. Al confirmar el pago puedes ajustar el monto pagado."
+                : "Este valor es referencia. En el checklist podras registrar el monto pagado."}
           </p>
         </div>
       </div>
+
+      {/* Multi-currency breakdown for debt accounts */}
+      {isDebtAccount && accountCurrencies.length > 1 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Label>Desglose por moneda</Label>
+            {!useSubPayments && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-6 text-[10px]"
+                onClick={() => {
+                  setUseSubPayments(true);
+                  if (subPayments.length === 0) {
+                    setSubPayments(
+                      accountCurrencies.map((c) => ({ currency_code: c, amount: 0 }))
+                    );
+                  }
+                }}
+              >
+                <Plus className="mr-1 size-3" />
+                Agregar
+              </Button>
+            )}
+          </div>
+
+          {useSubPayments && (
+            <div className="space-y-2 rounded-md border border-white/6 bg-muted/30 p-3">
+              {subPayments.map((sp, idx) => (
+                <div key={sp.currency_code} className="flex items-center gap-2">
+                  <span className="w-10 text-xs font-semibold text-muted-foreground">
+                    {sp.currency_code}
+                  </span>
+                  <CurrencyInput
+                    value={String(sp.amount || "")}
+                    onChange={(e) => {
+                      const val = parseFloat(e.target.value) || 0;
+                      setSubPayments((prev) =>
+                        prev.map((s, i) => (i === idx ? { ...s, amount: val } : s))
+                      );
+                    }}
+                    placeholder="0"
+                    className="h-8 flex-1 text-sm"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const updated = subPayments.filter((_, i) => i !== idx);
+                      setSubPayments(updated);
+                      if (updated.length === 0) setUseSubPayments(false);
+                    }}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                </div>
+              ))}
+
+              {/* Add another currency */}
+              {subPayments.length < accountCurrencies.length && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => {
+                    const used = new Set(subPayments.map((s) => s.currency_code));
+                    const next = accountCurrencies.find((c) => !used.has(c));
+                    if (next) {
+                      setSubPayments((prev) => [...prev, { currency_code: next, amount: 0 }]);
+                    }
+                  }}
+                >
+                  <Plus className="mr-1 size-3" />
+                  Otra moneda
+                </Button>
+              )}
+
+              <p className="text-[10px] text-muted-foreground">
+                El monto total se calcula como la suma de los pagos mínimos de cada moneda.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Hidden field to send sub_payments JSON */}
+      {useSubPayments && subPayments.length > 0 && (
+        <input type="hidden" name="sub_payments" value={JSON.stringify(subPayments)} />
+      )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="space-y-2">

--- a/webapp/src/components/recurring/recurring-list.tsx
+++ b/webapp/src/components/recurring/recurring-list.tsx
@@ -194,7 +194,7 @@ function RecurringCard({
         <div className="mt-4 flex items-baseline justify-between">
           <div>
             <span
-              className={`text-xl font-bold ${
+              className={`text-xl font-bold tabular-nums ${
                 template.direction === "INFLOW" ? "text-z-income" : ""
               }`}
             >

--- a/webapp/src/components/recurring/recurring-list.tsx
+++ b/webapp/src/components/recurring/recurring-list.tsx
@@ -28,10 +28,12 @@ import {
 } from "lucide-react";
 import { RecurringFormDialog } from "./recurring-form-dialog";
 import { RecurringImpactDialog } from "./recurring-impact-dialog";
+import { SubPaymentsBreakdown } from "./sub-payments-breakdown";
 import type {
   Account,
   CategoryWithChildren,
   CurrencyCode,
+  SubPayment,
   RecurringTemplateWithRelations,
 } from "@/types/domain";
 
@@ -190,14 +192,22 @@ function RecurringCard({
         </div>
 
         <div className="mt-4 flex items-baseline justify-between">
-          <span
-            className={`text-xl font-bold ${
-              template.direction === "INFLOW" ? "text-z-income" : ""
-            }`}
-          >
-            {isIncome ? "+" : "-"}
-            {formatCurrency(template.amount, template.currency_code as CurrencyCode)}
-          </span>
+          <div>
+            <span
+              className={`text-xl font-bold ${
+                template.direction === "INFLOW" ? "text-z-income" : ""
+              }`}
+            >
+              {isIncome ? "+" : "-"}
+              {formatCurrency(template.amount, template.currency_code as CurrencyCode)}
+            </span>
+            {Array.isArray(template.sub_payments) && (template.sub_payments as unknown as SubPayment[]).length > 1 && (
+              <SubPaymentsBreakdown
+                subPayments={template.sub_payments as unknown as SubPayment[]}
+                className="mt-0.5 flex gap-2 text-xs"
+              />
+            )}
+          </div>
           <Badge variant="secondary">{frequencyLabel(template.frequency)}</Badge>
         </div>
 

--- a/webapp/src/components/recurring/recurring-payment-timeline.tsx
+++ b/webapp/src/components/recurring/recurring-payment-timeline.tsx
@@ -5,6 +5,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import { cn } from "@/lib/utils";
 import { RecurringConfirmInline } from "./recurring-confirm-inline";
+import { SubPaymentsBreakdown } from "./sub-payments-breakdown";
 import type { OccurrenceItem, DateStatus } from "./use-recurring-month";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -182,12 +183,20 @@ export function PaymentTimeline({
                       </div>
 
                       {/* Amount */}
-                      <span className="shrink-0 text-sm font-medium tabular-nums">
-                        {formatCurrency(
-                          item.plannedAmount,
-                          item.currencyCode as CurrencyCode
+                      <div className="shrink-0 text-right">
+                        <span className="text-sm font-medium tabular-nums">
+                          {formatCurrency(
+                            item.plannedAmount,
+                            item.currencyCode as CurrencyCode
+                          )}
+                        </span>
+                        {item.subPayments && item.subPayments.length > 1 && (
+                          <SubPaymentsBreakdown
+                            subPayments={item.subPayments}
+                            className="flex gap-1.5 text-[10px] justify-end"
+                          />
                         )}
-                      </span>
+                      </div>
 
                       {/* Confirm indicator */}
                       <span className="shrink-0 text-xs text-muted-foreground">

--- a/webapp/src/components/recurring/sub-payments-breakdown.tsx
+++ b/webapp/src/components/recurring/sub-payments-breakdown.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+
+interface SubPaymentEntry {
+  currency_code: string;
+  amount: number;
+}
+
+export function SubPaymentsBreakdown({
+  subPayments,
+  className,
+}: {
+  subPayments: SubPaymentEntry[];
+  className?: string;
+}) {
+  if (subPayments.length <= 1) return null;
+
+  return (
+    <div className={className}>
+      {subPayments.map((sp) => (
+        <span key={sp.currency_code} className="text-muted-foreground">
+          {sp.currency_code}: {formatCurrency(sp.amount, sp.currency_code as CurrencyCode)}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/recurring/sub-payments-breakdown.tsx
+++ b/webapp/src/components/recurring/sub-payments-breakdown.tsx
@@ -20,7 +20,7 @@ export function SubPaymentsBreakdown({
   return (
     <div className={className}>
       {subPayments.map((sp) => (
-        <span key={sp.currency_code} className="text-muted-foreground">
+        <span key={sp.currency_code} className="tabular-nums text-muted-foreground">
           {sp.currency_code}: {formatCurrency(sp.amount, sp.currency_code as CurrencyCode)}
         </span>
       ))}

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -24,7 +24,7 @@ import type {
   Account,
   RecurringTemplateWithRelations,
 } from "@/types/domain";
-import type { RecurringOccurrence } from "@/actions/occurrences";
+import type { RecurringOccurrence, OccurrenceSubPayment } from "@/actions/occurrences";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -49,6 +49,7 @@ export interface OccurrenceItem {
   accountLastFour: string;
   status: "pending" | "paid" | "skipped";
   transactionId: string | null;
+  subPayments: OccurrenceSubPayment[] | null;
 }
 
 export type DateStatus = "today" | "past" | "future";
@@ -82,6 +83,7 @@ function mapToOccurrenceItem(
     accountLastFour: accounts.find((a) => a.id === o.account_id)?.mask ?? "",
     status: o.status as "pending" | "paid" | "skipped",
     transactionId: o.transaction_id,
+    subPayments: o.sub_payments,
   };
 }
 

--- a/webapp/src/lib/utils/sub-payments.ts
+++ b/webapp/src/lib/utils/sub-payments.ts
@@ -1,0 +1,18 @@
+import type { SubPayment } from "@/types/domain";
+
+/**
+ * Parse and validate a raw `sub_payments` JSONB value into typed SubPayment[].
+ * Returns null if the input is not a valid array or has no valid entries.
+ */
+export function parseSubPayments(raw: unknown): SubPayment[] | null {
+  if (!Array.isArray(raw)) return null;
+  const result = raw.filter(
+    (e): e is SubPayment =>
+      typeof e === "object" &&
+      e !== null &&
+      typeof (e as Record<string, unknown>).currency_code === "string" &&
+      typeof (e as Record<string, unknown>).amount === "number" &&
+      ((e as Record<string, unknown>).amount as number) > 0,
+  );
+  return result.length > 0 ? result : null;
+}

--- a/webapp/src/lib/validators/recurring-template.ts
+++ b/webapp/src/lib/validators/recurring-template.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { uuidStr } from "./shared";
 
+const CURRENCY_CODES = ["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"] as const;
+
+export const subPaymentSchema = z.object({
+  currency_code: z.enum(CURRENCY_CODES),
+  amount: z.coerce.number().positive("El monto de cada moneda debe ser mayor a 0"),
+});
+
 export const recurringTemplateSchema = z.object({
   account_id: uuidStr("Cuenta inválida"),
   transfer_source_account_id: z.preprocess(
@@ -8,7 +15,7 @@ export const recurringTemplateSchema = z.object({
     uuidStr().optional().nullable()
   ),
   amount: z.coerce.number().positive("El monto debe ser mayor a 0"),
-  currency_code: z.enum(["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"]),
+  currency_code: z.enum(CURRENCY_CODES),
   direction: z.enum(["INFLOW", "OUTFLOW"]),
   frequency: z.enum(["ONCE", "WEEKLY", "BIWEEKLY", "MONTHLY", "QUARTERLY", "ANNUAL"]),
   merchant_name: z.string().min(1, "El nombre es requerido"),
@@ -29,6 +36,16 @@ export const recurringTemplateSchema = z.object({
   end_date: z.preprocess(
     (val) => (val === "" || val === null ? undefined : val),
     z.string().optional().nullable()
+  ),
+  sub_payments: z.preprocess(
+    (val) => {
+      if (val === "" || val === null || val === undefined) return undefined;
+      if (typeof val === "string") {
+        try { return JSON.parse(val); } catch { return undefined; }
+      }
+      return val;
+    },
+    z.array(subPaymentSchema).optional().nullable()
   ),
 });
 

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -1917,6 +1917,7 @@ export type Database = {
           is_active: boolean
           merchant_name: string | null
           start_date: string
+          sub_payments: Json | null
           transfer_source_account_id: string | null
           updated_at: string
           user_id: string
@@ -1937,6 +1938,7 @@ export type Database = {
           is_active?: boolean
           merchant_name?: string | null
           start_date: string
+          sub_payments?: Json | null
           transfer_source_account_id?: string | null
           updated_at?: string
           user_id: string
@@ -1957,6 +1959,7 @@ export type Database = {
           is_active?: boolean
           merchant_name?: string | null
           start_date?: string
+          sub_payments?: Json | null
           transfer_source_account_id?: string | null
           updated_at?: string
           user_id?: string
@@ -2030,6 +2033,7 @@ export type Database = {
           is_active: boolean
           merchant_name: string | null
           start_date: string
+          sub_payments: Json | null
           transfer_source_account_id: string | null
           updated_at: string
           user_id: string
@@ -2050,6 +2054,7 @@ export type Database = {
           is_active?: boolean
           merchant_name?: string | null
           start_date: string
+          sub_payments?: Json | null
           transfer_source_account_id?: string | null
           updated_at?: string
           user_id: string
@@ -2070,6 +2075,7 @@ export type Database = {
           is_active?: boolean
           merchant_name?: string | null
           start_date?: string
+          sub_payments?: Json | null
           transfer_source_account_id?: string | null
           updated_at?: string
           user_id?: string

--- a/webapp/src/types/domain.ts
+++ b/webapp/src/types/domain.ts
@@ -10,6 +10,13 @@ export type Category = Tables<"categories">;
 export type Budget = Tables<"budgets">;
 
 export type RecurringTemplate = Tables<"recurring_transaction_templates">;
+
+/** Per-currency entry within a multi-currency recurring template */
+export interface SubPayment {
+  currency_code: string;
+  amount: number;
+}
+
 export type EmailIngestAddress = Tables<"email_ingest_addresses">;
 export type PendingEmailTransaction = Tables<"pending_email_transactions">;
 export type EmailIngestLog = Tables<"email_ingest_logs">;


### PR DESCRIPTION
When a credit card has multiple currencies (e.g. COP + USD), the import
flow now creates a single recurring template per account instead of one
per currency. A new `sub_payments` JSONB column stores the per-currency
breakdown for display purposes while the template amount holds the total.

Changes:
- Migration: add sub_payments to _enc table, view, and triggers + data
  migration to merge existing duplicates
- Import: template key changed from accountId:currency to accountId;
  each currency statement upserts its entry into sub_payments
- Form: debt accounts with multiple currencies show a "desglose por
  moneda" section to manually configure sub_payments
- UI: currency breakdown shown on occurrence rows in both desktop
  timeline and mobile views
- Mobile: "Nueva recurrente" button moved to top level for easier access

https://claude.ai/code/session_01NzEsU1L22ERKafF6cNogGt