### PR TITLE
feat(recurring): manually merge and split recurring templates

### DIFF
--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -1137,7 +1137,8 @@ export async function mergeRecurringTemplates(
 
     if (updateError) throw updateError;
 
-    // 2. Delete conflicting occurrences (same date on both templates)
+    // 2. Delete only PENDING conflicting occurrences (same date on both templates).
+    // Paid/skipped occurrences are preserved by reassigning them.
     const { data: keepOccDates } = await supabase
       .from("recurring_occurrences")
       .select("occurrence_date")
@@ -1151,13 +1152,14 @@ export async function mergeRecurringTemplates(
         .delete()
         .eq("template_id", absorbId)
         .eq("user_id", user.id)
+        .eq("status", "pending")
         .in("occurrence_date", dates);
     }
 
-    // 3. Reassign remaining occurrences from absorb to keep
+    // 3. Reassign remaining occurrences from absorb to keep, updating expected_amount
     await supabase
       .from("recurring_occurrences")
-      .update({ template_id: keepId })
+      .update({ template_id: keepId, expected_amount: primaryAmount })
       .eq("template_id", absorbId)
       .eq("user_id", user.id);
 
@@ -1169,8 +1171,6 @@ export async function mergeRecurringTemplates(
       .eq("user_id", user.id);
 
     revalidateFinancialViews();
-    updateTag("recurring");
-    updateTag("occurrences");
 
     return { success: true, data: updated };
   } catch (error) {
@@ -1244,6 +1244,7 @@ export async function splitSubPayment(
         currency_code: currencyCode as Database["public"]["Enums"]["currency_code"],
         direction: template.direction,
         frequency: template.frequency,
+        is_active: template.is_active,
         merchant_name: template.merchant_name
           ? `${template.merchant_name} (${currencyCode})`
           : null,
@@ -1260,10 +1261,7 @@ export async function splitSubPayment(
     if (insertError) throw insertError;
 
     await ensureCurrentOccurrences();
-
     revalidateFinancialViews();
-    updateTag("recurring");
-    updateTag("occurrences");
 
     return { success: true, data: newTemplate };
   } catch (error) {
@@ -1276,7 +1274,7 @@ export async function splitSubPayment(
  * Get templates eligible for merging with a given template.
  * Returns templates for the same account, same direction, same frequency.
  */
-export async function getMergeablTemplates(
+export async function getMergeableTemplates(
   templateId: string,
 ): Promise<ActionResult<RecurringTemplateWithRelations[]>> {
   const { supabase, user, accessToken } = await getAuthenticatedClient();

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -6,6 +6,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { recurringTemplateSchema } from "@/lib/validators/recurring-template";
+import { parseSubPayments } from "@/lib/utils/sub-payments";
 import { computeIdempotencyKey } from "@/lib/utils/idempotency";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 import { toMonthlyAmount } from "@/lib/utils/recurring";
@@ -25,6 +26,7 @@ import type { Database } from "@/types/database";
 import type {
   RecurringTemplate,
   RecurringTemplateWithRelations,
+  SubPayment,
   UpcomingRecurrence,
 } from "@/types/domain";
 
@@ -1032,6 +1034,279 @@ export async function getRecurringTemplateImpact(
     console.error("Error calculating template impact:", error);
     return { success: false, error: "Error al calcular el impacto de la plantilla." };
   }
+}
+
+// ─── Merge / Split ──────────────────────────────────────────────────────────
+
+/**
+ * Merge two recurring templates into one. The "keep" template absorbs the
+ * "absorb" template. Both must belong to the same account and user.
+ *
+ * - The absorb template's currency+amount becomes a sub_payment entry on the keep template
+ * - The keep template's amount stays as its primary-currency minimum
+ * - Conflicting occurrences (same date) are deleted from the absorb template
+ * - Remaining occurrences are reassigned to the keep template
+ * - The absorb template is deleted
+ */
+export async function mergeRecurringTemplates(
+  keepId: string,
+  absorbId: string,
+): Promise<ActionResult<RecurringTemplate>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const keepCheck = uuidStr("ID de plantilla inválido").safeParse(keepId);
+  const absorbCheck = uuidStr("ID de plantilla inválido").safeParse(absorbId);
+  if (!keepCheck.success) return { success: false, error: keepCheck.error.issues[0].message };
+  if (!absorbCheck.success) return { success: false, error: absorbCheck.error.issues[0].message };
+  if (keepId === absorbId) return { success: false, error: "No puedes combinar una plantilla consigo misma." };
+
+  // Load both templates
+  const [keepRes, absorbRes] = await Promise.all([
+    supabase
+      .from("recurring_transaction_templates")
+      .select("*, account:accounts!recurring_transaction_templates_account_id_fkey(id, currency_code)")
+      .eq("id", keepId)
+      .eq("user_id", user.id)
+      .single(),
+    supabase
+      .from("recurring_transaction_templates")
+      .select("*")
+      .eq("id", absorbId)
+      .eq("user_id", user.id)
+      .single(),
+  ]);
+
+  if (keepRes.error || !keepRes.data) return { success: false, error: "No se encontró la plantilla principal." };
+  if (absorbRes.error || !absorbRes.data) return { success: false, error: "No se encontró la plantilla a combinar." };
+
+  const keep = keepRes.data;
+  const absorb = absorbRes.data;
+
+  if (keep.account_id !== absorb.account_id) {
+    return { success: false, error: "Ambas plantillas deben pertenecer a la misma cuenta." };
+  }
+
+  // Build merged sub_payments
+  const existingSubPayments: SubPayment[] = parseSubPayments(keep.sub_payments) ?? [];
+  const absorbSubPayments: SubPayment[] = parseSubPayments(absorb.sub_payments) ?? [];
+
+  // Start from the keep template's sub_payments (or create entry from its amount/currency)
+  const merged = new Map<string, number>();
+  if (existingSubPayments.length > 0) {
+    for (const sp of existingSubPayments) merged.set(sp.currency_code, sp.amount);
+  } else {
+    merged.set(keep.currency_code, keep.amount);
+  }
+
+  // Add the absorb template's sub_payments (or its amount/currency)
+  if (absorbSubPayments.length > 0) {
+    for (const sp of absorbSubPayments) {
+      merged.set(sp.currency_code, (merged.get(sp.currency_code) ?? 0) + sp.amount);
+    }
+  } else {
+    const existing = merged.get(absorb.currency_code) ?? 0;
+    merged.set(absorb.currency_code, existing + absorb.amount);
+  }
+
+  const primaryCurrency = (keep.account as { currency_code: string } | null)?.currency_code ?? keep.currency_code;
+  const subPayments: SubPayment[] = Array.from(merged.entries())
+    .map(([currency_code, amount]) => ({ currency_code, amount }))
+    .sort((a, b) => {
+      if (a.currency_code === primaryCurrency) return -1;
+      if (b.currency_code === primaryCurrency) return 1;
+      return a.currency_code.localeCompare(b.currency_code);
+    });
+
+  // template.amount = primary-currency entry only
+  const primaryAmount = merged.get(primaryCurrency) ?? keep.amount;
+
+  try {
+    // 1. Update the keep template
+    const { data: updated, error: updateError } = await supabase
+      .from("recurring_transaction_templates")
+      .update({
+        amount: primaryAmount,
+        currency_code: primaryCurrency as Database["public"]["Enums"]["currency_code"],
+        sub_payments: subPayments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"],
+      })
+      .eq("id", keepId)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (updateError) throw updateError;
+
+    // 2. Delete conflicting occurrences (same date on both templates)
+    const { data: keepOccDates } = await supabase
+      .from("recurring_occurrences")
+      .select("occurrence_date")
+      .eq("template_id", keepId)
+      .eq("user_id", user.id);
+
+    if (keepOccDates && keepOccDates.length > 0) {
+      const dates = keepOccDates.map((o) => o.occurrence_date);
+      await supabase
+        .from("recurring_occurrences")
+        .delete()
+        .eq("template_id", absorbId)
+        .eq("user_id", user.id)
+        .in("occurrence_date", dates);
+    }
+
+    // 3. Reassign remaining occurrences from absorb to keep
+    await supabase
+      .from("recurring_occurrences")
+      .update({ template_id: keepId })
+      .eq("template_id", absorbId)
+      .eq("user_id", user.id);
+
+    // 4. Delete the absorbed template
+    await supabase
+      .from("recurring_transaction_templates")
+      .delete()
+      .eq("id", absorbId)
+      .eq("user_id", user.id);
+
+    revalidateFinancialViews();
+    updateTag("recurring");
+    updateTag("occurrences");
+
+    return { success: true, data: updated };
+  } catch (error) {
+    console.error("Error merging templates:", error);
+    return { success: false, error: "Error al combinar las plantillas." };
+  }
+}
+
+/**
+ * Split a sub_payment entry out of a template into its own standalone template.
+ * The original template keeps everything except the split-out currency entry.
+ */
+export async function splitSubPayment(
+  templateId: string,
+  currencyCode: string,
+): Promise<ActionResult<RecurringTemplate>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const idCheck = uuidStr("ID de plantilla inválido").safeParse(templateId);
+  if (!idCheck.success) return { success: false, error: idCheck.error.issues[0].message };
+
+  const { data: template, error: fetchError } = await supabase
+    .from("recurring_transaction_templates")
+    .select("*, account:accounts!recurring_transaction_templates_account_id_fkey(id, currency_code)")
+    .eq("id", templateId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (fetchError || !template) return { success: false, error: "No se encontró la plantilla." };
+
+  const subPayments = parseSubPayments(template.sub_payments);
+  if (!subPayments || subPayments.length < 2) {
+    return { success: false, error: "La plantilla no tiene desglose de monedas para separar." };
+  }
+
+  const splitEntry = subPayments.find((sp) => sp.currency_code === currencyCode);
+  if (!splitEntry) {
+    return { success: false, error: `No se encontró la entrada de ${currencyCode} en el desglose.` };
+  }
+
+  const remainingSubPayments = subPayments.filter((sp) => sp.currency_code !== currencyCode);
+  const primaryCurrency = (template.account as { currency_code: string } | null)?.currency_code ?? template.currency_code;
+
+  // Recalculate the original template's amount (primary-currency entry)
+  const newPrimaryAmount = remainingSubPayments.find((sp) => sp.currency_code === primaryCurrency)?.amount ?? template.amount;
+
+  try {
+    // 1. Update original template — remove the split entry
+    const subPaymentsValue = remainingSubPayments.length > 1
+      ? (remainingSubPayments as unknown as Database["public"]["Tables"]["recurring_transaction_templates"]["Row"]["sub_payments"])
+      : null; // If only one currency left, clear sub_payments
+
+    await supabase
+      .from("recurring_transaction_templates")
+      .update({
+        amount: newPrimaryAmount,
+        sub_payments: subPaymentsValue,
+      })
+      .eq("id", templateId)
+      .eq("user_id", user.id);
+
+    // 2. Create new template for the split-out currency
+    const { data: newTemplate, error: insertError } = await supabase
+      .from("recurring_transaction_templates")
+      .insert({
+        user_id: user.id,
+        account_id: template.account_id,
+        transfer_source_account_id: template.transfer_source_account_id,
+        amount: splitEntry.amount,
+        currency_code: currencyCode as Database["public"]["Enums"]["currency_code"],
+        direction: template.direction,
+        frequency: template.frequency,
+        merchant_name: template.merchant_name
+          ? `${template.merchant_name} (${currencyCode})`
+          : null,
+        description: template.description,
+        category_id: template.category_id,
+        day_of_month: template.day_of_month,
+        day_of_week: template.day_of_week,
+        start_date: template.start_date,
+        end_date: template.end_date,
+      })
+      .select()
+      .single();
+
+    if (insertError) throw insertError;
+
+    await ensureCurrentOccurrences();
+
+    revalidateFinancialViews();
+    updateTag("recurring");
+    updateTag("occurrences");
+
+    return { success: true, data: newTemplate };
+  } catch (error) {
+    console.error("Error splitting sub_payment:", error);
+    return { success: false, error: "Error al separar la moneda de la plantilla." };
+  }
+}
+
+/**
+ * Get templates eligible for merging with a given template.
+ * Returns templates for the same account, same direction, same frequency.
+ */
+export async function getMergeablTemplates(
+  templateId: string,
+): Promise<ActionResult<RecurringTemplateWithRelations[]>> {
+  const { supabase, user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+
+  const idCheck = uuidStr("ID inválido").safeParse(templateId);
+  if (!idCheck.success) return { success: false, error: idCheck.error.issues[0].message };
+
+  const { data: source, error: srcErr } = await supabase
+    .from("recurring_transaction_templates")
+    .select("account_id, direction, frequency")
+    .eq("id", templateId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (srcErr || !source) return { success: false, error: "No se encontró la plantilla." };
+
+  const { data: candidates, error } = await supabase
+    .from("recurring_transaction_templates")
+    .select(TEMPLATE_SELECT)
+    .eq("user_id", user.id)
+    .eq("account_id", source.account_id)
+    .eq("direction", source.direction)
+    .eq("frequency", source.frequency)
+    .neq("id", templateId)
+    .eq("is_active", true);
+
+  if (error) return { success: false, error: error.message };
+
+  return { success: true, data: (candidates ?? []) as RecurringTemplateWithRelations[] };
 }
 
 

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -1156,10 +1156,18 @@ export async function mergeRecurringTemplates(
         .in("occurrence_date", dates);
     }
 
-    // 3. Reassign remaining occurrences from absorb to keep, updating expected_amount
+    // 3. Reassign remaining occurrences from absorb to keep.
+    // Pending occurrences get the merged amount; paid/skipped keep historical amounts.
     await supabase
       .from("recurring_occurrences")
       .update({ template_id: keepId, expected_amount: primaryAmount })
+      .eq("template_id", absorbId)
+      .eq("user_id", user.id)
+      .eq("status", "pending");
+
+    await supabase
+      .from("recurring_occurrences")
+      .update({ template_id: keepId })
       .eq("template_id", absorbId)
       .eq("user_id", user.id);
 
@@ -1213,10 +1221,13 @@ export async function splitSubPayment(
   }
 
   const remainingSubPayments = subPayments.filter((sp) => sp.currency_code !== currencyCode);
-  const primaryCurrency = (template.account as { currency_code: string } | null)?.currency_code ?? template.currency_code;
+  const accountCurrency = (template.account as { currency_code: string } | null)?.currency_code ?? template.currency_code;
 
-  // Recalculate the original template's amount (primary-currency entry)
-  const newPrimaryAmount = remainingSubPayments.find((sp) => sp.currency_code === primaryCurrency)?.amount ?? template.amount;
+  // If splitting the primary currency, switch to the next available currency
+  const nextPrimary = remainingSubPayments.find((sp) => sp.currency_code === accountCurrency)
+    ?? remainingSubPayments[0];
+  const newPrimaryAmount = nextPrimary.amount;
+  const newCurrencyCode = nextPrimary.currency_code;
 
   try {
     // 1. Update original template — remove the split entry
@@ -1228,6 +1239,7 @@ export async function splitSubPayment(
       .from("recurring_transaction_templates")
       .update({
         amount: newPrimaryAmount,
+        currency_code: newCurrencyCode as Database["public"]["Enums"]["currency_code"],
         sub_payments: subPaymentsValue,
       })
       .eq("id", templateId)

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -15,6 +15,7 @@ import { SubPaymentsBreakdown } from "@/components/recurring/sub-payments-breakd
 import { useRecurringMonth, type OccurrenceItem, type DateStatus } from "@/components/recurring/use-recurring-month";
 import type { RecurringOccurrence } from "@/actions/occurrences";
 import { OccurrenceActions } from "@/components/recurring/occurrence-actions";
+import { MergePickerSheet } from "@/components/recurring/merge-picker-sheet";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
 import { RecurringImpactDialog } from "@/components/recurring/recurring-impact-dialog";
 import { useCategories } from "@/components/providers/app-data-provider";
@@ -123,6 +124,9 @@ export function MobileRecurrentesView({
   /* ---- Edit dialog state ---- */
   const [editTemplate, setEditTemplate] = useState<RecurringTemplateWithRelations | null>(null);
 
+  /* ---- Merge template flow ---- */
+  const [mergeTemplate, setMergeTemplate] = useState<RecurringTemplateWithRelations | null>(null);
+
   const handleImpactConfirm = async () => {
     if (!impactAction) return;
     const { template, action } = impactAction;
@@ -196,6 +200,12 @@ export function MobileRecurrentesView({
         ? () => {
             setExpandedKey(null);
             setImpactAction({ item, template, action: "delete" });
+          }
+        : undefined,
+      onMerge: template
+        ? () => {
+            setExpandedKey(null);
+            setMergeTemplate(template);
           }
         : undefined,
     };
@@ -474,6 +484,19 @@ export function MobileRecurrentesView({
       )}
 
       {/* Impact dialog (pause/delete) */}
+      {/* Merge picker sheet */}
+      {mergeTemplate && (
+        <MergePickerSheet
+          open={!!mergeTemplate}
+          onOpenChange={(open) => { if (!open) setMergeTemplate(null); }}
+          sourceTemplate={mergeTemplate}
+          onMerged={() => {
+            setMergeTemplate(null);
+            hook.refreshOccurrences();
+          }}
+        />
+      )}
+
       {impactAction && (
         <RecurringImpactDialog
           templateId={impactAction.template.id}

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -484,18 +484,16 @@ export function MobileRecurrentesView({
       )}
 
       {/* Impact dialog (pause/delete) */}
-      {/* Merge picker sheet */}
-      {mergeTemplate && (
-        <MergePickerSheet
-          open={!!mergeTemplate}
-          onOpenChange={(open) => { if (!open) setMergeTemplate(null); }}
-          sourceTemplate={mergeTemplate}
-          onMerged={() => {
-            setMergeTemplate(null);
-            hook.refreshOccurrences();
-          }}
-        />
-      )}
+      {/* Merge picker sheet (always rendered for close animation) */}
+      <MergePickerSheet
+        open={!!mergeTemplate}
+        onOpenChange={(open) => { if (!open) setMergeTemplate(null); }}
+        sourceTemplate={mergeTemplate}
+        onMerged={() => {
+          setMergeTemplate(null);
+          hook.refreshOccurrences();
+        }}
+      />
 
       {impactAction && (
         <RecurringImpactDialog

--- a/webapp/src/components/recurring/merge-picker-sheet.tsx
+++ b/webapp/src/components/recurring/merge-picker-sheet.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { frequencyLabel } from "@zeta/shared";
+import { BRASS_BUTTON_CLASS, MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import {
+  getMergeablTemplates,
+  mergeRecurringTemplates,
+} from "@/actions/recurring-templates";
+import { toast } from "sonner";
+import type { CurrencyCode, RecurringTemplateWithRelations } from "@/types/domain";
+
+interface MergePickerSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The template that will keep its identity (absorbs the picked one) */
+  sourceTemplate: RecurringTemplateWithRelations;
+  onMerged: () => void;
+}
+
+export function MergePickerSheet({
+  open,
+  onOpenChange,
+  sourceTemplate,
+  onMerged,
+}: MergePickerSheetProps) {
+  const [candidates, setCandidates] = useState<RecurringTemplateWithRelations[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!open) return;
+    setIsLoading(true);
+    getMergeablTemplates(sourceTemplate.id).then((res) => {
+      if (res.success) setCandidates(res.data);
+      setIsLoading(false);
+    });
+  }, [open, sourceTemplate.id]);
+
+  function handleMerge(absorbId: string) {
+    startTransition(async () => {
+      const result = await mergeRecurringTemplates(sourceTemplate.id, absorbId);
+      if (result.success) {
+        toast.success("Plantillas combinadas");
+        onOpenChange(false);
+        onMerged();
+      } else {
+        toast.error(result.error ?? "Error al combinar");
+      }
+    });
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className={cn("max-h-[70vh]", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
+        <SheetHeader>
+          <SheetTitle>Combinar con otra recurrente</SheetTitle>
+        </SheetHeader>
+
+        <p className="mt-1 text-xs text-muted-foreground">
+          Selecciona la plantilla que quieres absorber en{" "}
+          <span className="font-semibold text-foreground">
+            {sourceTemplate.merchant_name}
+          </span>
+          . Sus pagos pendientes se moverán aquí y la otra plantilla se eliminará.
+        </p>
+
+        <div className="mt-4 space-y-2 overflow-y-auto">
+          {isLoading && (
+            <div className="py-8 text-center text-sm text-muted-foreground animate-pulse">
+              Buscando plantillas compatibles...
+            </div>
+          )}
+
+          {!isLoading && candidates.length === 0 && (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              No hay otras plantillas de la misma cuenta para combinar.
+            </div>
+          )}
+
+          {candidates.map((candidate) => (
+            <button
+              key={candidate.id}
+              type="button"
+              disabled={isPending}
+              onClick={() => handleMerge(candidate.id)}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-lg border border-white/6 bg-white/[0.03] px-3 py-3 text-left transition-colors active:bg-white/[0.06]",
+                isPending && "opacity-50 pointer-events-none",
+              )}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">
+                  {candidate.merchant_name}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {candidate.account?.name} · {frequencyLabel(candidate.frequency)}
+                </p>
+              </div>
+              <span className="shrink-0 text-sm font-semibold tabular-nums">
+                {formatCurrency(candidate.amount, candidate.currency_code as CurrencyCode)}
+              </span>
+            </button>
+          ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/webapp/src/components/recurring/merge-picker-sheet.tsx
+++ b/webapp/src/components/recurring/merge-picker-sheet.tsx
@@ -12,7 +12,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { frequencyLabel } from "@zeta/shared";
 import { BRASS_BUTTON_CLASS, MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import {
-  getMergeablTemplates,
+  getMergeableTemplates,
   mergeRecurringTemplates,
 } from "@/actions/recurring-templates";
 import { toast } from "sonner";
@@ -22,7 +22,7 @@ interface MergePickerSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** The template that will keep its identity (absorbs the picked one) */
-  sourceTemplate: RecurringTemplateWithRelations;
+  sourceTemplate: RecurringTemplateWithRelations | null;
   onMerged: () => void;
 }
 
@@ -37,15 +37,16 @@ export function MergePickerSheet({
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !sourceTemplate) return;
     setIsLoading(true);
-    getMergeablTemplates(sourceTemplate.id).then((res) => {
+    getMergeableTemplates(sourceTemplate.id).then((res) => {
       if (res.success) setCandidates(res.data);
       setIsLoading(false);
     });
-  }, [open, sourceTemplate.id]);
+  }, [open, sourceTemplate?.id]);
 
   function handleMerge(absorbId: string) {
+    if (!sourceTemplate) return;
     startTransition(async () => {
       const result = await mergeRecurringTemplates(sourceTemplate.id, absorbId);
       if (result.success) {
@@ -68,7 +69,7 @@ export function MergePickerSheet({
         <p className="mt-1 text-xs text-muted-foreground">
           Selecciona la plantilla que quieres absorber en{" "}
           <span className="font-semibold text-foreground">
-            {sourceTemplate.merchant_name}
+            {sourceTemplate?.merchant_name ?? "Recurrente"}
           </span>
           . Sus pagos pendientes se moverán aquí y la otra plantilla se eliminará.
         </p>

--- a/webapp/src/components/recurring/occurrence-actions.tsx
+++ b/webapp/src/components/recurring/occurrence-actions.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { format } from "date-fns";
-import { Check, CircleSlash, Link2, Pencil, Pause, Play, Trash2 } from "lucide-react";
+import { Check, CircleSlash, Link2, Merge, Pencil, Pause, Play, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { DatePicker } from "@/components/ui/date-picker";
@@ -39,6 +39,7 @@ export interface OccurrenceActionsProps {
   onPause?: () => void;
   onResume?: () => void;
   onDelete?: () => void;
+  onMerge?: () => void;
   isPending: boolean;
   sourceAccounts?: SourceAccount[];
 }
@@ -141,6 +142,7 @@ export function OccurrenceActions({
   onPause,
   onResume,
   onDelete,
+  onMerge,
   isPending,
   sourceAccounts,
 }: OccurrenceActionsProps) {
@@ -224,6 +226,14 @@ export function OccurrenceActions({
                   icon={<Pencil className="size-3" />}
                   label="Editar"
                   onClick={onEdit}
+                  disabled={isPending}
+                />
+              )}
+              {onMerge && (
+                <ActionChip
+                  icon={<Merge className="size-3" />}
+                  label="Combinar"
+                  onClick={onMerge}
                   disabled={isPending}
                 />
               )}

--- a/webapp/src/components/recurring/recurring-list.tsx
+++ b/webapp/src/components/recurring/recurring-list.tsx
@@ -197,12 +197,6 @@ function RecurringCard({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <MergePickerSheet
-            open={mergeOpen}
-            onOpenChange={setMergeOpen}
-            sourceTemplate={template}
-            onMerged={() => { /* page will revalidate via cache tags */ }}
-          />
         </div>
 
         <div className="mt-4 flex items-baseline justify-between">
@@ -245,6 +239,13 @@ function RecurringCard({
             Pausada
           </Badge>
         )}
+
+        <MergePickerSheet
+          open={mergeOpen}
+          onOpenChange={setMergeOpen}
+          sourceTemplate={template}
+          onMerged={() => { /* revalidateFinancialViews() in action expires cache tags */ }}
+        />
       </CardContent>
     </Card>
   );

--- a/webapp/src/components/recurring/recurring-list.tsx
+++ b/webapp/src/components/recurring/recurring-list.tsx
@@ -25,10 +25,12 @@ import {
   Play,
   Pencil,
   Trash2,
+  Merge,
 } from "lucide-react";
 import { RecurringFormDialog } from "./recurring-form-dialog";
 import { RecurringImpactDialog } from "./recurring-impact-dialog";
 import { SubPaymentsBreakdown } from "./sub-payments-breakdown";
+import { MergePickerSheet } from "./merge-picker-sheet";
 import type {
   Account,
   CategoryWithChildren,
@@ -84,6 +86,7 @@ function RecurringCard({
 }) {
   const [isPending, startTransition] = useTransition();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [mergeOpen, setMergeOpen] = useState(false);
   const isDebtPayment =
     template.account.account_type === "CREDIT_CARD" ||
     template.account.account_type === "LOAN";
@@ -171,6 +174,10 @@ function RecurringCard({
                   Activar
                 </DropdownMenuItem>
               )}
+              <DropdownMenuItem onClick={() => { setMenuOpen(false); setMergeOpen(true); }}>
+                <Merge className="h-4 w-4 mr-2" />
+                Combinar con otra
+              </DropdownMenuItem>
               <RecurringImpactDialog
                 templateId={template.id}
                 templateName={template.merchant_name ?? "Recurrente"}
@@ -189,6 +196,13 @@ function RecurringCard({
               />
             </DropdownMenuContent>
           </DropdownMenu>
+
+          <MergePickerSheet
+            open={mergeOpen}
+            onOpenChange={setMergeOpen}
+            sourceTemplate={template}
+            onMerged={() => { /* page will revalidate via cache tags */ }}
+          />
         </div>
 
         <div className="mt-4 flex items-baseline justify-between">


### PR DESCRIPTION
## Summary

- **Merge templates**: users can combine two recurring templates for the same account into one, absorbing the other's sub_payments. Accessible from the card dropdown ("Combinar con otra") on desktop and the "Combinar" chip in the mobile Administrar tab.
- **Split sub_payment**: server action to extract a currency entry from sub_payments back into its own standalone template (reverse of merge). Backend ready, UI trigger deferred.
- **MergePickerSheet**: bottom sheet listing eligible templates (same account, direction, frequency) — one tap to merge.

## Details

Server actions (`recurring-templates.ts`):
- `mergeRecurringTemplates(keepId, absorbId)` — validates same account + user, builds merged sub_payments, only deletes pending conflicting occurrences (paid/skipped preserved), updates expected_amount on reassigned occurrences, deletes absorbed template
- `splitSubPayment(templateId, currencyCode)` — extracts entry into new template, copies is_active, generates occurrences via ensureCurrentOccurrences
- `getMergeableTemplates(templateId)` — lists merge candidates

UI wiring:
- Desktop: dropdown menu item + MergePickerSheet in recurring-list cards
- Mobile: onMerge in OccurrenceActions Administrar tab + MergePickerSheet in mobile-recurrentes-view
- MergePickerSheet always mounted (nullable sourceTemplate) for close animation

## Test plan

- [ ] Desktop: open a recurring template card → dropdown → "Combinar con otra" → pick a template for the same account → verify merge completes, absorbed template disappears, sub_payments breakdown shows
- [ ] Mobile: expand an occurrence → Administrar tab → "Combinar" → pick template → verify merge
- [ ] Merge two templates where both have paid occurrences on the same date → verify paid occurrences are NOT deleted
- [ ] Merge two templates with different currencies → verify sub_payments array has both entries, amount = primary currency only
- [ ] Verify no eligible templates shows "No hay otras plantillas" message

https://claude.ai/code/session_01NzEsU1L22ERKafF6cNogGt