### PR TITLE
fix(mobile): Phase 1 polish — tab clearance, dev-tools gate, month sync, deep-link

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,6 +12,23 @@
 
 ## Features
 
+### Promote transaction → recurring template ("Hacer recurrente" CTA)
+- **Priority:** High
+- **What:** Add a "Hacer recurrente" action on `/transactions/[id]` (and ideally the 3-dot menu on list rows) that opens the existing `RecurringFormDialog` pre-filled with the transaction's merchant, amount, account, category, destinatario, and a monthly-frequency default. On confirm, create a `recurring_templates` row with `start_date` = the transaction's date so the occurrence engine generates this month + future pendings; the source transaction auto-links to the current occurrence via `findMatchingOccurrence()`.
+- **Why:** When a bill (home services, rent, subscription) first shows up from email import, there's no way to promote it to a recurring template without rebuilding it from scratch at `/recurrentes/new`. User shouldn't retype data the app already has.
+- **Touches:** `transactions/[id]/page.tsx`, reuse `RecurringFormDialog`, possibly a new `createRecurringTemplateFromTransaction` helper that wires the link.
+- **Found:** User request during Phase 1 PR session, 2026-04-16
+
+### `is_subscription` toggle is a dead flag — connect or remove
+- **Priority:** High (ship with "Hacer recurrente")
+- **What:** The "Marcar como suscripción" switch in `mobile-transaction-form.tsx`, `transaction-form.tsx`, and `voice-capture-sheet.tsx` writes `is_subscription: boolean` to the transactions row, but **nothing reads that field meaningfully**. Zero filters, zero UI treatment, zero linkage to `recurring_templates`. Email ingest also always writes `is_subscription: false`. The actually meaningful flag for "this is a recurring expense" is `is_recurring`, which is only set by the recurring-template occurrence system (read by `burn-rate.ts` to split discretionary vs recurring spending).
+- **Options:**
+  - **A. Wire up (recommended):** When the toggle is on, also create a `recurring_templates` row with inferred defaults (monthly frequency, same account, same amount, merchant=description) and link the tx to the first generated occurrence. Same helper as the "Hacer recurrente" CTA above — the form becomes another entry point.
+  - **B. Remove:** Delete the toggle from all 3 forms and the `is_subscription` param from the `createTransaction` action path. Drop the column in a follow-up migration (nullable deprecation first, then drop).
+- **Why it matters:** Users see the toggle, expect it to do something, and get no signal that it's inert. Feature disappointment.
+- **Touches:** 3 form components, `transactions.ts` action, possibly a DB migration if we pick B.
+- **Found:** Phase 1 PR session investigation, 2026-04-16
+
 ### Account detail page — deferred items
 - **Priority:** Medium
 - **What:** Statement snapshots visual redesign, auto-populate `card_brand` from PDF parsers, composite `(account_id, user_id, transaction_date)` index, use `useAccounts()` hook instead of server-side `getAccounts()` in QuickActionsBar

--- a/webapp/src/app/(dashboard)/etiquetas/page.tsx
+++ b/webapp/src/app/(dashboard)/etiquetas/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function EtiquetasPage() {
-  redirect("/settings");
+  redirect("/settings#etiquetas");
 }

--- a/webapp/src/app/(dashboard)/layout.tsx
+++ b/webapp/src/app/(dashboard)/layout.tsx
@@ -18,6 +18,8 @@ import { MobileSheetProvider } from "@/components/mobile/mobile-sheet-provider";
 import { PageTransition } from "@/components/ui/page-transition";
 import { KeyboardInsetProvider } from "@/hooks/use-keyboard-inset";
 import { DemoBanner } from "@/components/dashboard/demo-banner";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 
 const DevOverlay = dynamic(
   () => import("@/components/dev/dev-overlay").then((m) => ({ default: m.DevOverlay })),
@@ -104,7 +106,7 @@ export default async function DashboardLayout({
           >
             <AppDataProvider data={appData}>
               <MobileSheetProvider>
-                <main className="flex-1 overflow-x-hidden p-4 pb-20 lg:p-6 lg:pb-6">
+                <main className={cn("flex-1 overflow-x-hidden p-4 lg:p-6 lg:pb-6", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
                   {profile.demo_mode && <DemoBanner />}
                   <PageTransition>
                     {children}

--- a/webapp/src/app/(dashboard)/settings/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/page.tsx
@@ -232,14 +232,16 @@ export default async function SettingsPage() {
 
       <BuildInfo />
 
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <CardTitle className="text-base">Herramientas de Desarrollo</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ReviewModeToggle />
-        </CardContent>
-      </Card>
+      {process.env.NODE_ENV === "development" && (
+        <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+          <CardHeader>
+            <CardTitle className="text-base">Herramientas de Desarrollo</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ReviewModeToggle />
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/webapp/src/components/recurring/use-recurring-month.ts
+++ b/webapp/src/components/recurring/use-recurring-month.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   addMonths,
   endOfMonth,
@@ -9,6 +10,7 @@ import {
   subMonths,
 } from "date-fns";
 import { es } from "date-fns/locale";
+import { formatMonthParam, isCurrentMonth, parseMonth } from "@/lib/utils/date";
 import {
   recordRecurringOccurrencePayment,
 } from "@/actions/recurring-templates";
@@ -98,8 +100,11 @@ export function useRecurringMonth(
 ) {
   const [, startTransition] = useTransition();
 
-  /* ---- month cursor ---- */
-  const [monthCursor, setMonthCursor] = useState(() => new Date());
+  /* ---- month cursor — synced with ?month= URL param (shared with <MonthSelector />) ---- */
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const monthCursor = parseMonth(searchParams.get("month"));
   const monthStart = startOfMonth(monthCursor);
   const monthEnd = endOfMonth(monthCursor);
   const monthKey = format(monthCursor, "yyyy-MM");
@@ -107,13 +112,27 @@ export function useRecurringMonth(
 
   const monthLabel = format(monthCursor, "MMMM yyyy", { locale: es });
 
+  const navigateToMonth = useCallback(
+    (date: Date) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (isCurrentMonth(date)) {
+        params.delete("month");
+      } else {
+        params.set("month", formatMonthParam(date));
+      }
+      const qs = params.toString();
+      router.push(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [router, pathname, searchParams],
+  );
+
   const goNextMonth = useCallback(
-    () => setMonthCursor((prev) => addMonths(prev, 1)),
-    []
+    () => navigateToMonth(addMonths(monthCursor, 1)),
+    [monthCursor, navigateToMonth],
   );
   const goPrevMonth = useCallback(
-    () => setMonthCursor((prev) => subMonths(prev, 1)),
-    []
+    () => navigateToMonth(subMonths(monthCursor, 1)),
+    [monthCursor, navigateToMonth],
   );
 
   /* ---- DB-backed occurrences state ---- */

--- a/webapp/src/components/settings/settings-mobile-accordion.tsx
+++ b/webapp/src/components/settings/settings-mobile-accordion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
@@ -14,6 +14,19 @@ interface SettingsSection {
 
 export function SettingsMobileAccordion({ sections }: { sections: SettingsSection[] }) {
   const [openId, setOpenId] = useState<string>(sections[0]?.id ?? "");
+  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    const hash = window.location.hash.replace(/^#/, "");
+    if (!hash) return;
+    const match = sections.find((s) => s.id === hash);
+    if (!match) return;
+    setOpenId(match.id);
+    // Defer scroll so the accordion has expanded before we scroll into view.
+    requestAnimationFrame(() => {
+      sectionRefs.current[match.id]?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }, [sections]);
 
   return (
     <div className="space-y-2">
@@ -25,7 +38,13 @@ export function SettingsMobileAccordion({ sections }: { sections: SettingsSectio
             open={isOpen}
             onOpenChange={(open) => setOpenId(open ? section.id : "")}
           >
-            <div className="rounded-xl border border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+            <div
+              id={section.id}
+              ref={(el) => {
+                sectionRefs.current[section.id] = el;
+              }}
+              className="scroll-mt-16 rounded-xl border border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+            >
               <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 p-4">
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">


### PR DESCRIPTION
## Summary

Five surgical fixes surfaced by the mobile UX audit (captured in `audit/MOBILE_AUDIT_2026-04-16.md`, not included in this PR). Phase 1 is the structural floor — fixes the "wrong" things so subsequent polish work lands on a stable base. No token, palette, or visual-grammar changes.

- **Production leak fixed** — `Herramientas de Desarrollo` card in `/settings` is now wrapped in `{process.env.NODE_ENV === 'development' && (...)}`. Previously rendered unconditionally for real users.
- **Tab-bar clearance** — `(dashboard)/layout.tsx` swaps `pb-20` (80px) for `MOBILE_TAB_BAR_CLEARANCE_CLASS` which resolves to `calc(var(--z-mobile-tab-bar-h) + env(safe-area-inset-bottom))`. On iPhones with home indicator, tab bar sits ~90px from viewport bottom; previous 80px padding left the last list row clipped behind the tab bar on `/transactions`, `/accounts/[id]`, `/plan?tab=periodo`, etc.
- **Recurrentes month pager sync** — `useRecurringMonth` previously held its own `useState(() => new Date())`, independent from the global `?month=` URL param driven by `<MonthSelector />`. Changing the outer pager left the inner view stuck on today's month. Rewired the hook to read/write the same URL param so both pagers share one source of truth.
- **`/etiquetas` deep-link** — previously `redirect("/settings")` landed the user at the top of their profile with no affordance that the Etiquetas tools were buried 2–3 screens below. Now redirects to `/settings#etiquetas`; `SettingsMobileAccordion` reads `window.location.hash` on mount, auto-opens the matching section and scrolls to it with a `scroll-mt-16` offset for the mobile header.

## Files

- `webapp/src/app/(dashboard)/settings/page.tsx` — NODE_ENV gate around dev tools Card
- `webapp/src/app/(dashboard)/layout.tsx` — global tab-bar clearance via `MOBILE_TAB_BAR_CLEARANCE_CLASS`
- `webapp/src/app/(dashboard)/etiquetas/page.tsx` — redirect target now `#etiquetas`
- `webapp/src/components/settings/settings-mobile-accordion.tsx` — hash-driven auto-open + scroll-into-view
- `webapp/src/components/recurring/use-recurring-month.ts` — URL-param month cursor

## Out of scope (deferred)

- Dual-back navigation on `/transactions/[id]` and `/deudas/planificador` — kept as PWA back-nav insurance per product call. Will revisit in Phase 2 as a redesign (breadcrumb tag vs back chip), not a removal.
- Per-screen hierarchy polish, "label the signals", editorial voice extension, empty-state audit, light-mode audit, RN parity — Phase 2+.

## Test plan

- [x] `pnpm build` passes clean on the new branch base (origin/main head = c9240ad at time of writing).
- [x] Verified in browser at 390×844: `/transactions` scrolled to end → last row ("Youtube Premium") sits comfortably above the tab bar (previously half-clipped).
- [x] Verified at `/plan?tab=recurrentes`: clicking inner pager prev-button changes URL to `?month=2026-03`, outer pager follows instantly, Compromiso mensual recalculates (April $4.386.606 → March $1.331.276).
- [x] Verified `/etiquetas` → `/settings#etiquetas` lands with the Etiquetas accordion pre-opened and scrolled into view; TagManager content visible without further interaction.
- [ ] Reviewer to smoke-test `/settings` on a prod-built preview to confirm `Herramientas de Desarrollo` card is absent.
- [ ] Reviewer to spot-check that changing month from the outer pager while on the Recurrentes tab no longer leaves the inner hero out of sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)