### PR TITLE
feat(plan): page polish — NETO, chips, templates, presupuesto grouping

### DIFF
--- a/docs/superpowers/plans/2026-04-17-plan-page-polish.md
+++ b/docs/superpowers/plans/2026-04-17-plan-page-polish.md
@@ -1,0 +1,1231 @@
+# Plan page polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the mobile `/plan` root + three tabs (periodo, recurrentes, presupuesto) so that "shape of the month" reads at a glance — color-coded NETO, RITMO-proportioned drill chips with brand-brass logos, NETO hero elevated on Periodo, templates promoted on Recurrentes, risk-state grouping on Presupuesto, and a 50/30/20 Meta vs Actual sheet.
+
+**Architecture:** In-place restyling and minor prop additions across `webapp/src/components/mobile/v2/plan/*` plus `webapp/src/components/mobile/mobile-presupuesto.tsx`. One new bottom-sheet component (`plan-5030-20-sheet.tsx`) that consumes the existing `get503020Allocation` server action (already wired into `getPlanPageData`). One server-side shape extension to surface `overdueCount` for the Recurrentes drill chip. No schema changes; `Parcial` occurrence state is deferred to BACKLOG.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind v4, shadcn/ui (Sheet + lucide-react icons), design tokens from `docs/design-system/TOKENS.md`, Playwright MCP for visual verification.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-plan-page-polish-design.md`
+
+---
+
+## File Structure
+
+**New:**
+- `webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx` — bottom sheet component (D7). Consumes `AllocationData` from `@/actions/allocation`. Three buckets (Necesario / Deseos / Ahorro) with Meta labels + bar + meta-position marker.
+- `webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx` — header strip subcomponent for D4. Holds the collapsible template list moved from `TemplatesSection` (today at the footer of `mobile-recurrentes-view.tsx`).
+
+**Modified:**
+- `webapp/src/components/mobile/v2/plan/plan-net-hero.tsx` — D1 (color-code NETO, retokenize emerald/red to z-income/z-expense) + D8 (expand cue: full-brass + Chevron icon).
+- `webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx` — D2 (sort chips by soonest `next_date`; highlight the sooner one with brass border hint).
+- `webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx` — D10 full rebuild: eyebrow → centered `lucide-react` icon (Wallet / CalendarCheck / RefreshCw / Heart) at `text-z-brass/85` → caption line with state-aware color.
+- `webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx` — D3 NETO hero elevation; remove stat-row NETO.
+- `webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx` — D4 (promote templates strip above occurrences list + remove inner month pager + delete footer `TemplatesSection`).
+- `webapp/src/components/mobile/mobile-presupuesto.tsx` — D6 (group categories by risk state, drop `⚠` icon) + D7 (make `Necesario X% · Deseos Y%` row a button that opens the sheet).
+- `webapp/src/actions/plan.ts` — extend `PlanPageData.recurring` with `overdueCount: number` (pending occurrences whose `occurrence_date < today`), used by D10 caption rules.
+- `webapp/src/types/plan.ts` — matching type update.
+- `BACKLOG.md` — append entries for `Parcial` occurrence state and any deferred follow-ups surfaced during implementation.
+
+**Deleted:**
+- None. `TemplatesSection` inline definition inside `mobile-recurrentes-view.tsx` is replaced by the new strip subcomponent; no exported component is removed.
+
+---
+
+## Task ordering rationale
+
+Ordered to minimize risk and maximize reviewable units:
+
+1. **Task 1 — Data layer** (plan.ts + types): unblocks D10 caption and nothing else depends on it visually yet.
+2. **Tasks 2–4 — Plan root tier** (net hero, chips order, drill cards): each independent from the others, commit-per-task.
+3. **Tasks 5–7 — Tab tier** (periodo NETO, recurrentes restructure, presupuesto group + sheet): each touches a different tab.
+4. **Task 8 — `plan-budget-hero.tsx` retokenize**: small cleanup pass.
+5. **Task 9 — Verification pass**: build + Playwright captures.
+6. **Task 10 — Review gate**: zetas-front-guy + perf-auditor → Gemini → frontend-auditor + ux-analyst → /simplify.
+
+Tasks that touch the same file have been collapsed (`plan-net-hero.tsx` D1+D8 in Task 2; `mobile-presupuesto.tsx` D6+D7 in Task 7; `mobile-recurrentes-view.tsx` D4 restructure in Task 6).
+
+---
+
+## Task 1: Extend plan data with `overdueCount`
+
+**Files:**
+- Modify: `webapp/src/types/plan.ts`
+- Modify: `webapp/src/actions/plan.ts`
+
+- [ ] **Step 1.1: Add `overdueCount` to `PlanPageData.recurring`**
+
+Open `webapp/src/types/plan.ts`. Locate the `recurring:` block inside `PlanPageData`. Add a new field:
+
+```ts
+recurring: {
+  upcoming: UpcomingRecurrence[];
+  upcomingIncome: UpcomingRecurrence[];
+  totalMonthlyExpenses: number;
+  totalMonthlyIncome: number;
+  activeCount: number;
+  dueSoonCount: number;
+  dueSoonTotal: number;
+  overdueCount: number; // NEW — pending occurrences with occurrence_date < today
+};
+```
+
+- [ ] **Step 1.2: Compute `overdueCount` inside `getPlanPageData`**
+
+Open `webapp/src/actions/plan.ts`. Inside the `cache`-wrapped `getPlanPageData` body, after the parallel `Promise.all([...])` block (around line 128), add a Supabase query for the overdue count:
+
+```ts
+const { supabase, user } = await getAuthenticatedClient();
+const today = new Date().toISOString().slice(0, 10);
+
+let overdueCount = 0;
+if (user) {
+  const { count } = await supabase
+    .from("recurring_occurrences")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("status", "pending")
+    .lt("occurrence_date", today);
+  overdueCount = count ?? 0;
+}
+```
+
+Then add `overdueCount` to the `recurring` block of the return:
+
+```ts
+recurring: {
+  upcoming: dueSoon,
+  upcomingIncome,
+  totalMonthlyExpenses: recurringSummary.totalMonthlyExpenses,
+  totalMonthlyIncome: recurringSummary.totalMonthlyIncome,
+  activeCount: recurringSummary.activeCount,
+  dueSoonCount: dueSoon.length,
+  dueSoonTotal,
+  overdueCount,
+},
+```
+
+**Notes:**
+- Import `getAuthenticatedClient` from `@/lib/supabase/auth` if not already imported.
+- The `(select auth.uid()) = user_id` RLS pattern applies; also add the `.eq("user_id", user.id)` defense-in-depth per CLAUDE.md.
+- This adds one small query to an already-cached action; `cacheLife("zeta")` handles the SWR.
+
+- [ ] **Step 1.3: Verify build**
+
+```bash
+cd webapp && pnpm build
+```
+Expected: green. No type errors in `plan.ts` or consumers of `PlanPageData`.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add webapp/src/types/plan.ts webapp/src/actions/plan.ts
+git commit -m "feat(plan): surface overdueCount for recurring occurrences
+
+Enables Task 4 (D10 caption rules for Recurrentes drill chip)."
+```
+
+---
+
+## Task 2: Plan root NETO hero (D1 + D8)
+
+**File:**
+- Modify: `webapp/src/components/mobile/v2/plan/plan-net-hero.tsx`
+
+- [ ] **Step 2.1: Read current file to anchor edits**
+
+```bash
+cat webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
+```
+
+Note the key regions to change (lines approximate — locate by content):
+- Line 56: `<p className="text-3xl font-bold text-z-brass">` — NETO number, currently always brass.
+- Line 63: `bg-emerald-500/80` — ingresos bar segment.
+- Line 65: `bg-red-500/80` — gastos bar segment.
+- Line 77 / 81: `bg-emerald-500` / `bg-red-500` — legend dots.
+- Line 91: `text-z-brass/50` — expand cue.
+- Line 92: `Toca para ver flujo ↓` — expand cue copy.
+- Line 100–103: collapse cue (`Ocultar flujo ↑`).
+
+- [ ] **Step 2.2: Import `ChevronDown` and `ChevronUp`**
+
+Add to imports:
+
+```ts
+import { ChevronDown, ChevronUp } from "lucide-react";
+```
+
+- [ ] **Step 2.3: Color-code NETO number (D1)**
+
+Replace the NETO `<p>` block with:
+
+```tsx
+<p
+  className={`text-3xl font-bold ${
+    neto > 0 ? "text-z-income" : neto < 0 ? "text-z-expense" : "text-z-brass"
+  }`}
+>
+  {neto >= 0 ? "+" : ""}
+  {formatCurrency(neto, currency)}
+</p>
+```
+
+- [ ] **Step 2.4: Retokenize bar segment colors (D1)**
+
+Replace the three bar `<div>` class strings inside the stacked progress bar:
+
+```tsx
+<div className="relative mt-3 h-2.5 overflow-hidden rounded-full bg-z-surface-2">
+  <div className="absolute inset-y-0 left-0 w-full rounded-full bg-z-income/80" />
+  <div
+    className="absolute inset-y-0 left-0 rounded-l-full bg-z-expense/80"
+    style={{ width: `${gastosRatio}%` }}
+  />
+  <div
+    className="absolute inset-y-0 right-0 rounded-r-full bg-z-brass/80"
+    style={{ width: `${netoRatio}%` }}
+  />
+</div>
+```
+
+- [ ] **Step 2.5: Retokenize legend dots (D1)**
+
+Swap the two legend dots:
+
+```tsx
+<span className="flex items-center gap-1">
+  <span className="inline-block size-1.5 rounded-full bg-z-income" />
+  Ingresos {formatCurrency(ingresos, currency)}
+</span>
+<span className="flex items-center gap-1">
+  <span className="inline-block size-1.5 rounded-full bg-z-expense" />
+  Gastos {formatCurrency(gastos, currency)}
+</span>
+<span className="flex items-center gap-1">
+  <span className="inline-block size-1.5 rounded-full bg-z-brass" />
+  Neto
+</span>
+```
+
+- [ ] **Step 2.6: Elevate the expand cue (D8)**
+
+Replace the collapsed cue `<p>`:
+
+```tsx
+{!expanded && (
+  <p className="mt-3 flex items-center justify-center gap-1 text-center text-[11px] font-medium text-z-brass">
+    Toca para ver flujo
+    <ChevronDown className="size-3" aria-hidden="true" />
+  </p>
+)}
+```
+
+And the expanded cue:
+
+```tsx
+<p
+  className="mt-2 flex cursor-pointer items-center justify-center gap-1 text-center text-[11px] font-medium text-z-brass"
+  onClick={() => setExpanded(false)}
+>
+  Ocultar flujo
+  <ChevronUp className="size-3" aria-hidden="true" />
+</p>
+```
+
+- [ ] **Step 2.7: Verify build + visual**
+
+```bash
+cd webapp && pnpm build
+```
+Start dev server if not running, navigate to `/plan` on a 390×844 viewport via Playwright MCP (`browser_navigate` + `browser_resize`) and confirm:
+- NETO is green when positive, red when negative (toggle via dev tools if no negative month available; or just verify the class string via inspector).
+- Expand cue is bright brass, not a hint.
+- Tap hero → flow chart renders; tap again → collapses.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
+git commit -m "polish(plan): color-code NETO + brighten expand cue
+
+D1 + D8. Replaces hardcoded emerald/red with z-income/z-expense tokens."
+```
+
+---
+
+## Task 3: Sort Próximo ingreso / pago by soonest date (D2)
+
+**File:**
+- Modify: `webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx`
+
+- [ ] **Step 3.1: Compute the ordered chip list**
+
+Inside the `PlanExpandableChips` function, just before the `return` statement, replace the fixed tuple iteration. Current code (line ~84):
+
+```tsx
+{(["income", "payment"] as const).map((type) => {
+```
+
+Replace the preceding block to derive the order. Add this block above `const expandedList = activeChip ? items[activeChip] : [];`:
+
+```tsx
+// D2: sort by soonest next_date. Tie-breaker: payment first (debt urgency).
+const nextIncomeDate = incomes[0]?.next_date ?? null;
+const nextPaymentDate = payments[0]?.next_date ?? null;
+
+const paymentSooner = (() => {
+  if (!nextIncomeDate && !nextPaymentDate) return false;
+  if (!nextIncomeDate) return true;
+  if (!nextPaymentDate) return false;
+  if (nextPaymentDate === nextIncomeDate) return true; // payment first on tie
+  return nextPaymentDate < nextIncomeDate;
+})();
+
+const orderedTypes = paymentSooner
+  ? (["payment", "income"] as const)
+  : (["income", "payment"] as const);
+const sooner = orderedTypes[0];
+```
+
+- [ ] **Step 3.2: Use `orderedTypes` in the map and highlight the sooner chip**
+
+Replace the chip iteration:
+
+```tsx
+<div className="grid grid-cols-2 gap-2">
+  {orderedTypes.map((type) => {
+    const c = CHIP_CONFIG[type];
+    const next = items[type][0] ?? null;
+    const isSooner = type === sooner && next !== null;
+    return (
+      <button
+        key={type}
+        type="button"
+        onClick={() => toggle(type)}
+        className={cn(
+          "rounded-xl border p-3 text-left transition-all",
+          activeChip === type ? c.borderActive : c.borderInactive,
+          activeChip === OPPOSITE[type] && "opacity-50",
+          isSooner && activeChip !== type && "ring-1 ring-z-brass/30",
+        )}
+      >
+        {/* ...existing content unchanged... */}
+      </button>
+    );
+  })}
+</div>
+```
+
+Keep the inner chip JSX (the `{next ? (...) : (...)}` block) exactly as-is. The only additions are `orderedTypes`, `isSooner`, and the `ring-1 ring-z-brass/30` conditional.
+
+- [ ] **Step 3.3: Verify build + visual**
+
+```bash
+cd webapp && pnpm build
+```
+Visual check at `/plan`: the chip with the sooner `next_date` is on the left and carries a subtle brass ring. If dates are equal (e.g. both `27 abr`), payment wins the left slot.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+git commit -m "polish(plan): order Próximo chips by soonest date
+
+D2. Payment wins the left slot on a date tie."
+```
+
+---
+
+## Task 4: Rebuild "IR A" drill chips (D10)
+
+**Files:**
+- Read first: `webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx` (entirety)
+- Modify: `webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx`
+
+- [ ] **Step 4.1: Inspect current structure**
+
+```bash
+cat webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+```
+
+Identify the card template (likely a shared inner component or 4 inlined blocks). Note the current prop shape (`budget`, `recurring`, `periodoSummary`, `wishlistCount`, `currency`, `expanded`, `onToggle`) and understand how caption data maps to each chip.
+
+- [ ] **Step 4.2: Replace imports with lucide icons needed**
+
+At the top of the file, import the four icons:
+
+```tsx
+import { Wallet, CalendarCheck, RefreshCw, Heart } from "lucide-react";
+import Link from "next/link";
+```
+
+- [ ] **Step 4.3: Define a single `<DrillChip>` subcomponent**
+
+Inside the same file (above the exported `PlanDrillCards`), add:
+
+```tsx
+interface DrillChipProps {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  caption: React.ReactNode;
+}
+
+function DrillChip({ label, href, icon: Icon, caption }: DrillChipProps) {
+  return (
+    <Link
+      href={href}
+      className="flex min-h-[150px] flex-col items-center justify-center gap-3 rounded-2xl border border-white/6 bg-white/[0.02] p-4 transition-colors active:bg-white/[0.04]"
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </span>
+      <Icon className="size-10 text-z-brass/85" aria-hidden />
+      <div className="text-center text-xs font-medium text-muted-foreground">
+        {caption}
+      </div>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4.4: Build caption computations in the parent**
+
+Inside `PlanDrillCards`, after destructuring props, compute:
+
+```tsx
+// Presupuesto caption
+const overLimit = budget?.overLimitCount ?? 0;
+const presupuestoCaption =
+  overLimit > 0
+    ? <span className="font-semibold text-z-brass">{overLimit} sobre límite</span>
+    : "dentro del límite";
+
+// Periodo caption — rely on periodoSummary
+const percentAssigned = periodoSummary?.percentAssigned ?? 0;
+const unassigned = periodoSummary?.unassignedCount ?? 0;
+const periodoCaption =
+  percentAssigned >= 100
+    ? "al día"
+    : unassigned > 0
+      ? <span className="font-semibold text-z-brass">{unassigned} pendientes</span>
+      : `${Math.round(percentAssigned)}%`;
+
+// Recurrentes caption — uses overdueCount from Task 1
+const dueSoonCount = recurring.dueSoonCount;
+const overdueCount = recurring.overdueCount;
+const recurrentesCaption = (
+  <>
+    {dueSoonCount} este mes
+    {overdueCount > 0 && (
+      <>
+        {" · "}
+        <span className="font-semibold text-z-brass">{overdueCount} vencidas</span>
+      </>
+    )}
+  </>
+);
+
+// Deseos caption
+const deseosCaption = `${wishlistCount} activos`;
+```
+
+- [ ] **Step 4.5: Replace the card grid with 4 `<DrillChip>`s**
+
+Render:
+
+```tsx
+<div className="grid grid-cols-2 gap-2">
+  <DrillChip
+    label="Presupuesto"
+    href="/plan?tab=presupuesto"
+    icon={Wallet}
+    caption={presupuestoCaption}
+  />
+  <DrillChip
+    label="Periodo"
+    href="/plan?tab=periodo"
+    icon={CalendarCheck}
+    caption={periodoCaption}
+  />
+  <DrillChip
+    label="Recurrentes"
+    href="/plan?tab=recurrentes"
+    icon={RefreshCw}
+    caption={recurrentesCaption}
+  />
+  <DrillChip
+    label="Deseos"
+    href="/plan?tab=deseos"
+    icon={Heart}
+    caption={deseosCaption}
+  />
+</div>
+```
+
+Remove any prior `expanded` / `onToggle` interaction wiring in this component — these chips are pure `<Link>`s now. Keep the `expanded` / `onToggle` props optional if other callers rely on them (audit: the only caller is `plan-root.tsx`).
+
+- [ ] **Step 4.6: Simplify parent props in `plan-root.tsx` (if needed)**
+
+In `webapp/src/components/mobile/v2/plan/plan-root.tsx`, the `<PlanDrillCards>` invocation passes `expanded` / `onToggle`. If `PlanDrillCards` no longer reads them, remove the two props from the call site. If the prop signature was narrowed, match types. Do not remove the `useExpandableZone` hook — it still powers `PlanExpandableChips`.
+
+- [ ] **Step 4.7: Verify build + visual**
+
+```bash
+cd webapp && pnpm build
+```
+
+Navigate `/plan` via Playwright MCP at 390×844. Verify:
+- 4 chips render in 2×2 grid.
+- Each has brass icon centered.
+- Captions match rules (e.g., `7 sobre límite`, `al día`, `8 este mes · 2 vencidas`, `2 activos`).
+- Tap each → routes to the correct tab.
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx webapp/src/components/mobile/v2/plan/plan-root.tsx
+git commit -m "polish(plan): RITMO-style drill chips with brand icons
+
+D10. Eyebrow → centered lucide icon (brass) → state-aware caption.
+Replaces the corner-icon + bottom-label pattern."
+```
+
+---
+
+## Task 5: Periodo tab NETO elevation (D3)
+
+**File:**
+- Modify: `webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx`
+
+- [ ] **Step 5.1: Locate the existing NETO rendering**
+
+```bash
+cat webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx | head -120
+```
+
+Find the stat-row region that renders NETO today (often a 3-up or 4-up with INGRESOS / GASTOS / NETO). Note the variables used (likely `income`, `expenses`, `net`).
+
+- [ ] **Step 5.2: Build a hero block that replaces the NETO stat row**
+
+Add at the top of the render output (below the header / above the list):
+
+```tsx
+<div className="rounded-2xl border border-white/6 bg-z-surface-2 p-4">
+  <div className="flex items-center justify-between">
+    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+      Neto del mes
+    </p>
+    <span className="text-[10px] text-muted-foreground">{periodLabel}</span>
+  </div>
+  <p
+    className={cn(
+      "mt-1 text-3xl font-bold tabular-nums",
+      net > 0 ? "text-z-income" : net < 0 ? "text-z-expense" : "text-z-brass",
+    )}
+  >
+    {net >= 0 ? "+" : ""}
+    {formatCurrency(net, currency)}
+  </p>
+  <p className="mt-1 text-[11px] text-muted-foreground">
+    +{formatCurrency(income, currency)} · −{formatCurrency(expenses, currency)}
+  </p>
+</div>
+```
+
+- [ ] **Step 5.3: Compute `periodLabel`**
+
+Above the JSX, compute:
+
+```ts
+const dayOfMonth = new Date().getDate();
+const periodLabel =
+  dayOfMonth <= 10
+    ? "Comienzo de mes"
+    : dayOfMonth <= 20
+      ? "Mitad de mes"
+      : "Fin de mes";
+```
+
+If `mobile-periodo-view.tsx` already receives a `dayOfMonth` prop (plan-root passes it down), use that instead of reading `new Date()` client-side.
+
+- [ ] **Step 5.4: Remove the pre-existing NETO stat-row cell**
+
+Delete the old NETO cell from the stat row. Leave `INGRESOS` and `GASTOS` cells intact if they still provide value; otherwise, the simpler pattern is to delete the whole stat row since the hero already surfaces the breakdown. Prefer deletion — two representations of the same number violate density rules.
+
+- [ ] **Step 5.5: Verify build + visual**
+
+```bash
+cd webapp && pnpm build
+```
+
+`/plan?tab=periodo` at 390×844 — confirm NETO is the visual anchor at top and color-codes with its sign.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+git commit -m "polish(plan): elevate NETO to hero on Periodo tab
+
+D3. Removes duplicate NETO stat-row cell."
+```
+
+---
+
+## Task 6: Recurrentes templates strip + drop inner pager (D4)
+
+**Files:**
+- Create: `webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx`
+- Modify: `webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx`
+
+- [ ] **Step 6.1: Create the templates strip subcomponent**
+
+Content for `mobile-recurrentes-templates-strip.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
+import { MOBILE_EYEBROW_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import type {
+  Account,
+  CategoryWithChildren,
+  CurrencyCode,
+  RecurringTemplateWithRelations,
+} from "@/types/domain";
+
+interface TemplatesStripProps {
+  templates: RecurringTemplateWithRelations[];
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  currency: CurrencyCode;
+  onMutate: () => Promise<void>;
+}
+
+export function MobileRecurrentesTemplatesStrip({
+  templates,
+  accounts,
+  categories,
+  currency,
+  onMutate,
+}: TemplatesStripProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  let activeCount = 0;
+  let pausedCount = 0;
+  for (const t of templates) {
+    if (t.is_active) activeCount++;
+    else pausedCount++;
+  }
+
+  return (
+    <div className="rounded-2xl border border-z-brass/18 bg-gradient-to-br from-z-brass/10 to-z-brass/[0.02] px-3.5 py-3">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex w-full items-center justify-between text-left"
+      >
+        <div>
+          <p className={cn(MOBILE_EYEBROW_CLASS, "text-z-brass")}>Mis plantillas</p>
+          <p className="mt-0.5 text-sm font-semibold">
+            {activeCount} activa{activeCount !== 1 ? "s" : ""}
+            {pausedCount > 0 && ` · ${pausedCount} pausada${pausedCount !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+        <span className="text-[11px] font-medium text-z-brass">
+          {expanded ? "Ocultar ↑" : "Ver ↓"}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-2">
+          {templates.length > 0 ? (
+            <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
+              {templates.map((t) => (
+                <div
+                  key={t.id}
+                  className={cn(
+                    "flex items-center gap-2 px-3 py-2.5",
+                    !t.is_active && "opacity-50",
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium">{t.merchant_name}</p>
+                    <p className="text-[10px] text-muted-foreground">
+                      {t.account?.name ?? "—"} · {t.frequency ?? "mensual"}
+                      {!t.is_active && " · Pausada"}
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs font-semibold tabular-nums">
+                    {formatCurrency(Number(t.amount), currency)}
+                  </span>
+                  <RecurringFormDialog
+                    template={t}
+                    accounts={accounts}
+                    categories={categories}
+                    onClose={onMutate}
+                    trigger={
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-md px-2 py-0.5 text-[10px] text-z-brass active:bg-white/5"
+                      >
+                        Editar
+                      </button>
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-xs text-muted-foreground">
+              Aún no tienes plantillas
+            </p>
+          )}
+
+          {/* Always-visible create CTA */}
+          <RecurringFormDialog
+            accounts={accounts}
+            categories={categories}
+            onClose={onMutate}
+            trigger={
+              <button
+                type="button"
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-brass/20 py-2.5 text-xs font-semibold text-z-brass active:bg-z-brass/5"
+              >
+                <Plus className="size-3.5" />
+                Nueva plantilla
+              </button>
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6.2: Import the strip in `mobile-recurrentes-view.tsx`**
+
+Add:
+
+```ts
+import { MobileRecurrentesTemplatesStrip } from "./mobile-recurrentes-templates-strip";
+```
+
+- [ ] **Step 6.3: Drop the inner month pager (audit §17)**
+
+In `mobile-recurrentes-view.tsx`, locate the hero card block (lines ~220-262) and remove the month-navigation `<div>`:
+
+```tsx
+{/* DELETE this block: */}
+<div className="mt-3 flex items-center justify-between">
+  <button type="button" onClick={hook.goPrevMonth} ...>‹</button>
+  <span className="text-xs font-medium capitalize text-muted-foreground">
+    {hook.monthLabel}
+  </span>
+  <button type="button" onClick={hook.goNextMonth} ...>›</button>
+</div>
+```
+
+Keep the `Compromiso mensual` eyebrow + `totalPlanned` number + `Pendientes / Completados` split below.
+
+Also remove the unused `ChevronLeft` / `ChevronRight` imports if no other usage remains in this file.
+
+- [ ] **Step 6.4: Insert the strip above the pending list**
+
+In `mobile-recurrentes-view.tsx`, immediately after the hero card and before the `Loading state` block, add:
+
+```tsx
+{hook.isHydrated && (
+  <MobileRecurrentesTemplatesStrip
+    templates={templates}
+    accounts={accounts}
+    categories={categories}
+    currency={currency}
+    onMutate={hook.refreshOccurrences}
+  />
+)}
+```
+
+- [ ] **Step 6.5: Remove the footer `TemplatesSection` + old `+ Nueva recurrente` CTA**
+
+Locate the two blocks near the end of the `return`:
+
+```tsx
+{/* Create new recurring — always visible */}
+{hook.isHydrated && (
+  <div className="space-y-2">
+    <RecurringFormDialog ... trigger={... "Nueva recurrente" ...} />
+  </div>
+)}
+
+{/* Templates section — view all, manage paused */}
+{hook.isHydrated && (
+  <TemplatesSection ... />
+)}
+```
+
+Delete both. The strip now handles both responsibilities.
+
+Also delete the `TemplatesSection` inner function defined at the bottom of the file (if present) — it's no longer referenced.
+
+- [ ] **Step 6.6: Verify build + visual**
+
+```bash
+cd webapp && pnpm build
+```
+
+`/plan?tab=recurrentes` at 390×844:
+- Strip appears under the hero card.
+- Tap strip → expands inline with template rows + `+ Nueva plantilla` CTA.
+- No second month-pager (audit §17 fix).
+- No footer duplicate.
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+git commit -m "polish(plan): promote templates strip + drop inner month pager
+
+D4. Moves Mis plantillas from a footer link to a header strip.
+Removes the redundant inner-card month pager (audit §17)."
+```
+
+---
+
+## Task 7: Presupuesto group + 50/30/20 sheet (D6 + D7)
+
+**Files:**
+- Create: `webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx`
+- Modify: `webapp/src/components/mobile/mobile-presupuesto.tsx`
+
+- [ ] **Step 7.1: Create the sheet component**
+
+Content for `plan-5030-20-sheet.tsx`:
+
+```tsx
+"use client";
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
+import { formatCurrency } from "@/lib/utils/currency";
+import { cn } from "@/lib/utils";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import type { AllocationData } from "@/actions/allocation";
+
+interface Plan5030Sheet20Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  allocation: AllocationData | null;
+}
+
+interface BucketRowProps {
+  name: string;
+  actual: { amount: number; percent: number };
+  target: number;
+  currency: AllocationData["currency"];
+  variance: "over" | "near" | "under";
+}
+
+function BucketRow({ name, actual, target, currency, variance }: BucketRowProps) {
+  const clampedPercent = Math.max(0, Math.min(100, actual.percent));
+  const fillColor =
+    variance === "over" ? "bg-z-expense" : variance === "near" ? "bg-z-brass" : "bg-z-income";
+  const actualColor =
+    variance === "over" ? "text-z-expense" : variance === "near" ? "text-z-brass" : "text-z-income";
+  const markerLeft = Math.min(100, target);
+
+  return (
+    <div className="py-3">
+      <div className="mb-2 flex items-baseline justify-between">
+        <span className="text-sm font-medium">{name}</span>
+        <div className="flex gap-2 text-[11px]">
+          <span className="text-muted-foreground">Meta {target}%</span>
+          <span className={cn("font-semibold", actualColor)}>
+            Actual {Math.round(actual.percent)}%
+          </span>
+        </div>
+      </div>
+      <div className="relative h-2 overflow-hidden rounded-full bg-white/[0.05]">
+        <div
+          className={cn("h-full rounded-full", fillColor)}
+          style={{ width: `${clampedPercent}%` }}
+        />
+        <div
+          className="absolute inset-y-[-2px] w-0.5 bg-white/60"
+          style={{ left: `${markerLeft}%` }}
+          aria-hidden
+        />
+      </div>
+      <p className="mt-1 text-[10px] text-muted-foreground">
+        {formatCurrency(actual.amount, currency)}
+      </p>
+    </div>
+  );
+}
+
+export function Plan5030Sheet20({ open, onOpenChange, allocation }: Plan5030Sheet20Props) {
+  if (!allocation) return null;
+
+  // Variance rules:
+  // - Necesario: over if >55, near if 45-55, under if <45
+  // - Deseos: over if >35, near if 25-35, under if <25
+  // - Ahorro: over if <15, near if 15-25, under if >25 → invert framing: "over" = worst case (too little saved)
+  const needsVariance =
+    allocation.needs.percent > 55 ? "over" : allocation.needs.percent >= 45 ? "near" : "under";
+  const wantsVariance =
+    allocation.wants.percent > 35 ? "over" : allocation.wants.percent >= 25 ? "near" : "under";
+  const savingsVariance =
+    allocation.savings.percent < 15 ? "over" : allocation.savings.percent <= 25 ? "near" : "under";
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className={cn("rounded-t-2xl", MOBILE_TAB_BAR_CLEARANCE_CLASS)}
+      >
+        <SheetHeader>
+          <SheetTitle>Distribución 50/30/20</SheetTitle>
+          <SheetDescription>Cómo estás repartiendo tus gastos este mes</SheetDescription>
+        </SheetHeader>
+        <div className="mt-2 divide-y divide-white/5">
+          <BucketRow
+            name="Necesario"
+            actual={allocation.needs}
+            target={allocation.needs.target}
+            currency={allocation.currency}
+            variance={needsVariance}
+          />
+          <BucketRow
+            name="Deseos"
+            actual={allocation.wants}
+            target={allocation.wants.target}
+            currency={allocation.currency}
+            variance={wantsVariance}
+          />
+          <BucketRow
+            name="Ahorro"
+            actual={allocation.savings}
+            target={allocation.savings.target}
+            currency={allocation.currency}
+            variance={savingsVariance}
+          />
+        </div>
+        <p className="mt-4 text-center text-[11px] text-muted-foreground">
+          50/30/20 es una guía, no una regla estricta.
+        </p>
+      </SheetContent>
+    </Sheet>
+  );
+}
+```
+
+- [ ] **Step 7.2: Read `mobile-presupuesto.tsx` and identify the category list + `Necesario / Deseos` row**
+
+```bash
+cat webapp/src/components/mobile/mobile-presupuesto.tsx | head -200
+```
+
+Note the variables used for category list, percent-used computation, and the `Necesario X% · Deseos Y%` row location.
+
+- [ ] **Step 7.3: Implement risk-state grouping (D6)**
+
+Inside `mobile-presupuesto.tsx`, after categories are normalized and before rendering:
+
+```ts
+const outflow = categories.filter((c) => c.direction === "OUTFLOW" && (c.budget ?? 0) > 0);
+
+const over = outflow
+  .filter((c) => c.percentUsed > 100)
+  .sort((a, b) => b.percentUsed - a.percentUsed);
+const near = outflow
+  .filter((c) => c.percentUsed >= 85 && c.percentUsed <= 100)
+  .sort((a, b) => b.percentUsed - a.percentUsed);
+const safe = outflow
+  .filter((c) => c.percentUsed < 85)
+  .sort((a, b) => a.percentUsed - b.percentUsed);
+```
+
+In the render, replace the flat category list with three grouped blocks (skip a group if empty):
+
+```tsx
+{over.length > 0 && (
+  <section>
+    <p className="mb-2 mt-4 flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.18em] text-z-expense">
+      <span>Sobre límite</span>
+      <span className="text-muted-foreground">{over.length}</span>
+    </p>
+    {over.map((c) => <CategoryRow key={c.id} category={c} tone="over" />)}
+  </section>
+)}
+{near.length > 0 && (
+  <section>
+    <p className="mb-2 mt-4 flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+      <span>Cerca del límite</span>
+      <span className="text-muted-foreground">{near.length}</span>
+    </p>
+    {near.map((c) => <CategoryRow key={c.id} category={c} tone="near" />)}
+  </section>
+)}
+{safe.length > 0 && (
+  <section>
+    <p className="mb-2 mt-4 flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.18em] text-z-income">
+      <span>Dentro del límite</span>
+      <span className="text-muted-foreground">{safe.length}</span>
+    </p>
+    {safe.map((c) => <CategoryRow key={c.id} category={c} tone="safe" />)}
+  </section>
+)}
+```
+
+If the file already has an inner `CategoryRow` component, extend its API with a `tone` prop that drives the progress-bar fill: `bg-z-expense` (over) / `bg-z-brass` (near) / `bg-z-income` (safe). Otherwise, inline equivalent JSX.
+
+- [ ] **Step 7.4: Drop the ⚠ icon (D6)**
+
+Remove the `<AlertTriangle />` (or equivalent) rendered on rows where `percentUsed > 100`. Color + group label already carry the signal.
+
+- [ ] **Step 7.5: Wire the chip → sheet (D7)**
+
+Locate the `Necesario X% · Deseos Y%` row. Convert it to a `<button>`:
+
+```tsx
+const [allocOpen, setAllocOpen] = useState(false);
+
+// ...in JSX, replace the static Necesario/Deseos row with:
+<button
+  type="button"
+  onClick={() => setAllocOpen(true)}
+  className="flex w-full items-center justify-between rounded-lg border border-white/6 bg-white/[0.02] px-3 py-2 text-left text-xs transition-colors active:bg-white/[0.04]"
+  disabled={!allocation}
+>
+  <span>
+    Necesario {Math.round(allocation?.needs.percent ?? 0)}% · Deseos{" "}
+    {Math.round(allocation?.wants.percent ?? 0)}%
+  </span>
+  <span className="flex items-center gap-1 text-z-brass">
+    50/30/20 <ArrowUpRight className="size-3" aria-hidden />
+  </span>
+</button>
+
+<Plan5030Sheet20
+  open={allocOpen}
+  onOpenChange={setAllocOpen}
+  allocation={allocation ?? null}
+/>
+```
+
+Import `ArrowUpRight` from `lucide-react` and the sheet component from `./v2/plan/plan-5030-20-sheet`.
+
+- [ ] **Step 7.6: Ensure the parent passes `allocation`**
+
+`mobile-presupuesto.tsx` likely already receives `allocation` via `budget.allocation` from `PlanPageData.budget.allocation`. Confirm the prop is threaded from the page shell; if not, pass it through.
+
+- [ ] **Step 7.7: Verify build + visual**
+
+```bash
+cd webapp && pnpm build
+```
+
+`/plan?tab=presupuesto`:
+- Three groups rendered, correct counts.
+- No `⚠` icons.
+- `Necesario X% · Deseos Y%` chip has brass `50/30/20 ↗` on the right.
+- Tap chip → sheet opens.
+- Meta markers visible on each bar.
+- Close on overlay tap.
+
+- [ ] **Step 7.8: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx webapp/src/components/mobile/mobile-presupuesto.tsx
+git commit -m "polish(plan): group presupuesto by risk + add 50/30/20 sheet
+
+D6 + D7. Sheet consumes existing get503020Allocation data — no new action."
+```
+
+---
+
+## Task 8: Retokenize `plan-budget-hero.tsx`
+
+**File:**
+- Modify: `webapp/src/components/mobile/v2/plan/plan-budget-hero.tsx`
+
+- [ ] **Step 8.1: Scan for hardcoded colors**
+
+```bash
+grep -nE "emerald-[0-9]|red-[0-9]|green-[0-9]" webapp/src/components/mobile/v2/plan/plan-budget-hero.tsx
+```
+
+Expected: some matches on bar segments / status colors.
+
+- [ ] **Step 8.2: Swap to tokens**
+
+Replace:
+- `emerald-500` → `z-income`
+- `red-500` → `z-expense`
+- `amber-*` → `z-brass` (case-by-case — only where the intent is "alert", not illustrative)
+- Any `/80`, `/60`, etc. opacity suffixes — keep as is.
+
+If any class usage is illustrative (not semantic), leave a brief comment or swap to the nearest neutral token.
+
+- [ ] **Step 8.3: Verify build**
+
+```bash
+cd webapp && pnpm build
+```
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add webapp/src/components/mobile/v2/plan/plan-budget-hero.tsx
+git commit -m "chore(plan): retokenize plan-budget-hero colors
+
+Aligns with z-income/z-expense/z-brass tokens from design system."
+```
+
+---
+
+## Task 9: Playwright verification pass
+
+- [ ] **Step 9.1: Start dev server if not running**
+
+```bash
+lsof -i :3000 -P -sTCP:LISTEN -t >/dev/null || (cd webapp && pnpm dev &)
+```
+
+Wait ~5s for server startup.
+
+- [ ] **Step 9.2: Capture the 5 canonical screens**
+
+Via Playwright MCP at 390×844:
+1. `/plan` — NETO collapsed, chips ordered, drill chips populated.
+2. `/plan` — NETO expanded (tap hero first).
+3. `/plan?tab=periodo` — NETO elevated.
+4. `/plan?tab=recurrentes` — templates strip visible, no double pager.
+5. `/plan?tab=presupuesto` — groups rendered.
+6. `/plan?tab=presupuesto` with sheet open (tap the `Necesario / Deseos` chip).
+
+Save captures under `audit/2026-04-17/` with semantic filenames.
+
+- [ ] **Step 9.3: Build gate**
+
+```bash
+cd webapp && pnpm build
+```
+
+Expected: green. No new warnings introduced by this PR (legacy `totalBudget` deprecation at `inicio-root.tsx:159` may still appear — pre-existing, not this PR's change).
+
+- [ ] **Step 9.4: Commit captures**
+
+```bash
+git add audit/2026-04-17/
+git commit -m "docs(audit): Plan polish phase 2 step 2 verification captures"
+```
+
+---
+
+## Task 10: Review gate
+
+The same layered pattern that worked on Dashboard Phase 2 (PR #169). Each layer surfaces non-overlapping findings; apply each as a separate commit.
+
+- [ ] **Step 10.1: Parallel — zetas-front-guy + perf-auditor**
+
+Spawn both agents in a single message. Each receives the diff scope and the spec path.
+
+`zetas-front-guy`:
+- Validate that D10 icons use brand-brass tokens correctly (requested explicitly by the user — see spec D10 "logo treatment").
+- Scan for any remaining `emerald-*`, `red-*`, `amber-*` classes in the modified files.
+- Check that `plan-5030-20-sheet.tsx` uses `SheetContent` with `MOBILE_TAB_BAR_CLEARANCE_CLASS`.
+
+`perf-auditor`:
+- Confirm the new `overdueCount` query in `getPlanPageData` is cached (`"use cache"` + `cacheTag("plan")`).
+- Check for any new uncached DB reads on render paths.
+- Review that `plan-drill-cards.tsx` remains a Server Component (or properly marked Client Component) without unnecessary client bundles.
+
+Apply findings as a single `fix(plan): apply zetas-front-guy + perf-auditor feedback` commit.
+
+- [ ] **Step 10.2: Push + wait for Gemini bot review**
+
+```bash
+git push -u origin feat/plan-page-polish
+gh pr create --title "feat(plan): page polish — NETO, chips, templates, presupuesto grouping" \
+  --body "$(cat <<'EOF'
+## Summary
+- NETO hero color-coded (D1) + expand cue brightened (D8)
+- Próximo chips ordered by soonest date (D2)
+- IR A drill chips redesigned with brand brass logos (D10)
+- Periodo NETO elevated to hero (D3)
+- Recurrentes templates promoted + inner month pager removed (D4)
+- Presupuesto grouped by risk state (D6) + 50/30/20 sheet (D7)
+
+## Spec
+`docs/superpowers/specs/2026-04-17-plan-page-polish-design.md`
+
+## Test plan
+- [x] `pnpm build` clean
+- [x] Playwright captures at 390×844 (see `audit/2026-04-17/`)
+- [x] zetas-front-guy — token compliance
+- [x] perf-auditor — cache discipline
+- [ ] Gemini review pending
+- [ ] frontend-auditor + ux-analyst pending
+- [ ] /simplify pending
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Wait 2 minutes, then `gh pr view --comments` to see Gemini's review. Apply any valid findings as `fix(plan): address Gemini review`.
+
+- [ ] **Step 10.3: Parallel — frontend-auditor + ux-analyst**
+
+Spawn both, parallel:
+
+`frontend-auditor`:
+- Full design-system audit on the touched files.
+- Check a11y of the new `<button>` in D7 (has `aria-label` if icon-only, sheet has proper aria).
+- Check responsive behavior on 320w and 414w.
+
+`ux-analyst`:
+- Evaluate overall Plan cohesion post-changes.
+- Confirm the "shape of the month" framing lands at first viewport.
+- Spot any remaining density / hierarchy drift.
+
+Apply findings as `fix(plan): apply frontend-auditor + ux-analyst feedback`.
+
+- [ ] **Step 10.4: Run `/simplify`**
+
+Invoke the `/simplify` skill on the branch. Focus areas:
+- Reuse: are any new helpers duplicating existing utilities? (`formatDate`, `formatCurrency` — confirm consistent use.)
+- Quality: any early returns missed, any effect/deps cleanup needed?
+- Efficiency: drill-chip captions pure; `Plan5030Sheet20` returns null when `allocation` is null (no wasted Sheet mount).
+
+Apply findings as `refactor(plan): apply /simplify review`.
+
+- [ ] **Step 10.5: Final build + final commit**
+
+```bash
+cd webapp && pnpm build
+```
+
+Expected: green. PR ready to merge.
+
+---
+
+## Success criteria (from spec)
+
+- `/plan` root first viewport (390×844): NETO hero + Próximo chips + first chip link row all visible without scroll. ✅
+- NETO number color-coded and ≥ 28px in the collapsed hero. ✅
+- Expand cue legible on the first glance. ✅
+- Periodo NETO anchors the screen; no user scans a stat row to find the sign. ✅
+- Recurrentes `Mis plantillas` visible in the first viewport. ✅
+- Presupuesto never renders a wall of red — grouping separates actionable from safe. ✅
+- 50/30/20 sheet opens on a single tap from Presupuesto. ✅
+- `pnpm build` passes; `zetas-front-guy` reports zero token violations. ✅
+- Icons use brand brass tokens (user-requested, verified by `zetas-front-guy`). ✅

--- a/docs/superpowers/specs/2026-04-17-plan-page-polish-design.md
+++ b/docs/superpowers/specs/2026-04-17-plan-page-polish-design.md
@@ -77,13 +77,9 @@ User's framing from the brainstorm: Plan answers **"What's the shape of this mon
 - The global `<MonthSelector />` at the top of `/plan` is now the single pager (audit §17 findings).
 - The hero's `Compromiso mensual` + total + `Pendientes/Completados` stat split stay.
 
-### D5 — `Recurrentes 8` chip badge: neutral by default, brass when overdue
+### D5 — `Recurrentes` badge semantics → folded into D10
 
-- On the `/plan` root drill-card for Recurrentes, today's `8` badge uses brass/warn colors regardless of context. Rewire:
-  - Badge = **neutral** (`bg-white/6` · `text-muted-foreground`) when the count represents the total month occurrences.
-  - Badge = **brass** (`bg-z-brass/16` · `text-z-brass`) with the text `{count} vencidas` when `overdueCount > 0`.
-  - `overdueCount` comes from the same source the Dashboard Timeline uses (`recurring_occurrences` where `status = 'pending' AND date < today`).
-- Apply the same neutral-by-default / brass-on-state rule to other drill-card badges on `/plan` root where the number is ambiguous (Periodo, Presupuesto, Deseos — audit if needed; only change if the current color carries false urgency).
+Originally this decision locked neutral-by-default / brass-on-overdue colors for the `Recurrentes` top-right badge on the drill card. **D10 replaces the top-right badge entirely with an icon-led layout**, so the brass / neutral signal moves into the caption line (`N este mes · M vencidas`). This decision number is retained for continuity with earlier mockups; its substance is subsumed by D10's caption rules.
 
 ### D6 — Presupuesto tab: grouped by risk state
 
@@ -116,6 +112,38 @@ User's framing from the brainstorm: Plan answers **"What's the shape of this mon
 - On expand: `Ocultar flujo ↑` + `ChevronUp`.
 - Keep center alignment, keep the "button-inside-button" behavior (tap anywhere on the hero toggles).
 
+### D10 — "IR A" chips: icon-led identity (match RITMO proportions)
+
+Today's four drill cards (`Presupuesto`, `Periodo`, `Recurrentes`, `Deseos`) on `/plan` root are compact: a small icon in the top-left corner, a number/badge in the top-right, and the label at the bottom-left. They blend visually because every chip looks the same except for the badge color.
+
+Match the **RITMO** widget rhythm from Dashboard (`inicio-metrics-grid.tsx`):
+
+- **Layout:** eyebrow label at top → **centered logo** (visual anchor) → caption underneath.
+- **Size:** `min-h-[150px]` (RITMO is ~120–130; bump slightly for 4-in-a-2x2 grid balance).
+- **Background:** `bg-z-surface-2` / `bg-white/[0.02]` · `border-white/6` · `rounded-2xl`.
+- **Logo treatment:** single-stroke `lucide-react` icon at ~40px, color `text-muted-foreground` (~78% opacity). **No colored backgrounds, no rings, no donut gauges.** Monochrome identity — the icon alone carries recognition.
+- **Icons:**
+  - `Presupuesto` → `Wallet` (or `WalletCards`)
+  - `Periodo` → `CalendarCheck` (calendar with checkmark)
+  - `Recurrentes` → `RefreshCw` (cycle arrow)
+  - `Deseos` → `Heart`
+- **Caption (`text-xs` · muted):** the only source of dynamic color — brass text when there's something to attend to, neutral otherwise.
+
+**Caption rules per chip:**
+| Chip | Neutral | Attention |
+|---|---|---|
+| Presupuesto | `dentro del límite` | `N sobre límite` (brass) |
+| Periodo | `al día` / `100%` | `N pendientes` (brass) · `N vencidas` (expense red) |
+| Recurrentes | `N este mes` | `N este mes · M vencidas` (brass tail) |
+| Deseos | `N activos` | *(no attention state — wishlist isn't time-critical)* |
+
+**What this replaces:**
+- The current `7 sobre límite`, `100%`, `8`, `2` badges in the top-right corner are gone; that information moves into the caption line with consistent voice.
+- The current `plan-drill-cards.tsx` rendering of `7 sobre límite` as a red pill in the corner becomes `7 sobre límite` as brass caption text under the `Wallet` logo.
+- D5's "neutral-by-default, brass-on-overdue" rule for `Recurrentes` folds into D10's caption rules and is no longer a separate decision.
+
+**Interaction:** entire chip still tappable, still routes to `/plan?tab=*`. No change to navigation.
+
 ### D9 — Out of scope (deferred to BACKLOG.md)
 
 1. **Empty states for `/plan` surfaces** — no income, no budgets, no recurrentes, no wishlist. Minimal template empty state in D4 is the single exception. All other empty states deferred as follow-up to match Dashboard Phase 2 scoping.
@@ -130,7 +158,7 @@ User's framing from the brainstorm: Plan answers **"What's the shape of this mon
 |---|---|---|
 | `webapp/src/components/mobile/v2/plan/plan-net-hero.tsx` | D1 + D8 retoken + restructure | Split collapsed vs expanded; retokenize emerald/red → z-income/z-expense; color-code NETO number; upgrade expand cue to full-opacity + icon. |
 | `webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx` | D2 — sort by soonest date | Accept `incomes[]` + `payments[]`; compute next-date for each; reorder slots; apply brass hint styling to the sooner chip. |
-| `webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx` | D5 — badge color logic | Wire `overdueCount` when available; switch Recurrentes badge to neutral-by-default; audit other drill cards for the same rule. |
+| `webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx` | D10 — icon-led layout, caption rules | Restructure all 4 chips to eyebrow → centered lucide icon (40px, monochrome) → caption. Caption text = the only state-aware color. Remove top-right numeric badges. Replace corner-icon + bottom-label pattern with RITMO-style vertical rhythm. |
 | `webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx` | D3 — NETO elevated + Parcial state | Replace the stat-row NETO with hero treatment; add `Parcial` execution state if schema supports. |
 | `webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx` | D4 — templates strip promoted | Create `mobile-recurrentes-templates-strip.tsx` subcomponent placed above the occurrences list; remove the footer `MIS PLANTILLAS VER ↓`. |
 | `webapp/src/components/mobile/mobile-presupuesto.tsx` | D6 + D7 — group-by-risk + tappable chip | Group transform in render; remove ⚠ JSX; convert `Necesario X% · Deseos Y%` static row to a button that opens the sheet. |

--- a/docs/superpowers/specs/2026-04-17-plan-page-polish-design.md
+++ b/docs/superpowers/specs/2026-04-17-plan-page-polish-design.md
@@ -1,0 +1,189 @@
+# Plan page polish — design
+
+**Date:** 2026-04-17
+**Scope:** Mobile `/plan` root + three tabs (`?tab=periodo`, `?tab=recurrentes`, `?tab=presupuesto`).
+**Predecessor:** Dashboard polish Phase 2 (PR #169, merged 2026-04-16) — horizontal "Por resolver" timeline, widget tiles, inline categorize, `useRecurringMonth` URL-param sync.
+**Source:** Full mobile UX audit at `audit/MOBILE_AUDIT_2026-04-16.md` (sections §06, §10, §11, §17) + captures under `audit/2026-04-16/`.
+
+## Context & motivation
+
+The mobile `/plan` surface carries the four canonical Plan questions of the app: **what's my month shape**, **what's coming up**, **what's left to plan**, and **am I within my envelopes**. Today each tab individually answers its question well, but the hierarchy drifts:
+
+- **Root** shows `PlanNetHero` with a split-bar, small NETO text and a low-contrast `Toca para ver flujo ↓` hint; `Próximo ingreso` and `Próximo pago` chips sit at equal weight; the `Recurrentes 8` chip badge uses brass (warning tone) even when 8 is a neutral total.
+- **Periodo** buries NETO in a stat row at the top of the section, despite NETO being the single most important number on that screen — and the `Pago AMEX BC` style repeating rows could benefit from a `Parcial` state.
+- **Recurrentes** has two pagers still rendered (a global `<MonthSelector />` and an inner `‹ Abril 2026 ›` in the hero card — Phase 1 synchronized them via URL param but did not remove the duplicate); and `MIS PLANTILLAS` (the creation + admin surface) still lives as a collapsible footer below 10+ occurrences, so the create path is not discoverable.
+- **Presupuesto** renders 7 of 11 categories red simultaneously, saturating the alert signal; the `Necesario 86% · Deseos 14%` ratio is displayed without a legend explaining the 50/30/20 target.
+
+User's framing from the brainstorm: Plan answers **"What's the shape of this month — income, fixed obligations, room to breathe?"** Periodo is the canonical drill-down; root is a dashboard overview; Presupuesto + Recurrentes are inputs/audits.
+
+## Decisions locked
+
+### D1 — Root NETO hero: collapsed-simple → expanded-rich
+
+**Collapsed state (default):**
+- Eyebrow row: `NETO DEL MES` (brass, small caps) · right-aligned `N días restantes`
+- Big number: `±$X.XXX.XXX` (30–36px, bold, color-coded — `text-z-income` when ≥0, `text-z-expense` when <0, `text-z-brass` at exactly zero)
+- Single breakdown chip: `+ $A.BBBk · − $C.DDDk` (muted)
+- Expand cue: centered `Toca para ver flujo ↓` in **full-opacity `text-z-brass`** with a `ChevronDown` icon (replaces today's `text-z-brass/50`)
+
+**Expanded state (tap hero anywhere):**
+- Same eyebrow + big NETO number (unchanged)
+- Split-bar (`Ingresos · Gastos · Neto` — existing geometry, retokenized)
+- Three-cell legend: `Ingresos $X / Gastos $X / Neto $X` (amounts, not just names)
+- `PlanFlowChart` renders below (existing component, unchanged)
+- Collapse cue: `Ocultar flujo ↑` with `ChevronUp`, same tone as the expand cue
+- Tap backdrop/overlay behavior preserved via `useChartFocusMode`
+
+**Color tokens (globally in this component):**
+- `bg-emerald-500/80` → `bg-z-income/80`
+- `bg-red-500/80` → `bg-z-expense/80`
+- `text-z-brass` for NETO zero-case (kept)
+- Any other hardcoded `emerald-*` / `red-*` classes in `plan-net-hero.tsx` swapped to tokens.
+
+### D2 — Próximo ingreso / próximo pago ordering
+
+- Sort the two chips by **soonest-date-first**. The item whose date is nearest to today occupies the left slot; the other, the right.
+- When dates tie: payments first (debt outflow is more urgent than income inflow when the user is checking "what hits first").
+- The left (sooner) chip gets a subtle highlight: `bg-z-brass/5` + `border-z-brass/20`. The right chip stays neutral (`bg-white/[0.02]` + `border-white/6`).
+- No change to the content of either chip (amount, date, obligation name).
+
+### D3 — Periodo tab: NETO elevated, `Parcial` state
+
+**NETO elevation:**
+- Replace today's stat-row NETO with the same hero treatment as D1 collapsed (eyebrow + big color-coded number + tiny breakdown chip). No expand on Periodo — the list below *is* the detail.
+- Period-specific subline in the eyebrow right-slot: `Mitad de mes` / `Fin de mes` / `Comienzo de mes` based on `dayOfMonth` (informational, not load-bearing).
+
+**`Parcial` state:**
+- Check the `recurring_occurrences` schema during implementation. If the table has `paid_amount` (or an equivalent field that can be compared against `scheduled_amount`), introduce a `Parcial` execution state rendered with brass foreground + a `{percent}%` mini-chip under the row name.
+- If the schema does not support partial payments yet, **do not** expand the schema for polish. Document the gap in `BACKLOG.md` and ship the other D3 changes.
+- Execution states (assuming schema supports it): `Pagado` (green) · `Pendiente` (brass) · `Parcial` (brass with percent) · `Omitido` (neutral). Reuse existing state-chip tokens; add `Parcial` only if feasible.
+
+### D4 — Recurrentes tab: `Mis plantillas` promoted, inner month pager dropped
+
+**Templates strip at top** — the `TemplatesSection` today lives as a collapsible footer (eyebrow + `Ver ↓/Ocultar ↑`) below the occurrences list and `CompletedSection`. Move it to sit directly under the hero card (above `Pendientes` list):
+
+- Strip visual: `rounded-2xl` · gradient `from-z-brass/10 to-z-brass/2` · border `border-z-brass/18` · padding `px-3.5 py-3`.
+- Contents:
+  - Left: eyebrow `MIS PLANTILLAS` · count line below `N activas · N pausadas` (body text).
+  - Right: `Ver ↓` / `Ocultar ↑` toggle (brass).
+- Expanded body: the existing template list (rows: merchant · account · frequency · amount · `Editar`). No route change — expand inline at the strip location, same markup as today's `TemplatesSection`.
+- The existing `+ Nueva recurrente` dashed-brass CTA **moves from its current location (above the old footer templates section)** into the strip's expanded body (below the template list), so all template admin lives in one place. Alternatively, keep `+ Nueva recurrente` as a sticky CTA at the bottom of the expanded strip list — pick whichever is cleaner at implementation.
+- Remove the original footer `TemplatesSection` + dashed-brass `+ Nueva recurrente` — now duplicated.
+- If there are zero templates, the strip's expanded body shows `Aún no tienes plantillas` + the `+ Nueva recurrente` CTA already. Collapsed state still shows counts (`0 activas`).
+
+**Inner month pager removed** — today `mobile-recurrentes-view.tsx` renders its own `‹ Abril 2026 ›` chevrons inside the hero card (lines 230-248), calling `hook.goPrevMonth` / `hook.goNextMonth`. Phase 1's `useRecurringMonth` rewrite synced this inner pager with the global `<MonthSelector />` via URL param — but the visual duplication persists. Drop the inner chevrons entirely:
+
+- Remove the inner `<button>` chevrons and the centered month label from the hero card.
+- The global `<MonthSelector />` at the top of `/plan` is now the single pager (audit §17 findings).
+- The hero's `Compromiso mensual` + total + `Pendientes/Completados` stat split stay.
+
+### D5 — `Recurrentes 8` chip badge: neutral by default, brass when overdue
+
+- On the `/plan` root drill-card for Recurrentes, today's `8` badge uses brass/warn colors regardless of context. Rewire:
+  - Badge = **neutral** (`bg-white/6` · `text-muted-foreground`) when the count represents the total month occurrences.
+  - Badge = **brass** (`bg-z-brass/16` · `text-z-brass`) with the text `{count} vencidas` when `overdueCount > 0`.
+  - `overdueCount` comes from the same source the Dashboard Timeline uses (`recurring_occurrences` where `status = 'pending' AND date < today`).
+- Apply the same neutral-by-default / brass-on-state rule to other drill-card badges on `/plan` root where the number is ambiguous (Periodo, Presupuesto, Deseos — audit if needed; only change if the current color carries false urgency).
+
+### D6 — Presupuesto tab: grouped by risk state
+
+- Sort categories into three visual groups in this order:
+  1. **`SOBRE LÍMITE`** (`actualSpent > budgetAmount`) — red group label + count pill
+  2. **`CERCA DEL LÍMITE`** (`actualSpent >= 0.85 * budgetAmount && actualSpent <= budgetAmount`) — brass group label + count pill
+  3. **`DENTRO DEL LÍMITE`** (remaining) — green group label + count pill
+- Threshold for "near": `>= 85%`. Configurable as a constant if a different threshold later proves better.
+- Each group has a small uppercase header with its color + a count pill: e.g., `SOBRE LÍMITE 3`.
+- **Remove** the `⚠` icon from every category row — progress-bar color alone carries the state signal.
+- Progress-bar colors follow the group: red fill for over-limit (clipped to 100%, optionally with a tiny `over-indicator` chevron to the right of the bar), brass for near-limit, green for within-limit.
+- Within each group, sort by **highest variance first** (most over for SOBRE, closest to limit for CERCA, smallest for DENTRO).
+
+### D7 — 50/30/20 sheet, entry = tap the chip
+
+- The chip `Necesario X% · Deseos Y%` (today rendered as static text on Presupuesto tab) becomes a **button** that opens a bottom sheet.
+- Add a subtle `↗` glyph to the chip so it reads as tappable. No secondary "Ver 50/30/20 ↗" link — single affordance.
+- Sheet content:
+  - Title: `Distribución 50/30/20`
+  - Subtitle: `Cómo estás repartiendo tus gastos este mes`
+  - Three buckets rendered as rows: `Necesario` · `Deseos` · `Ahorro`.
+  - Each row: name + meta label `Meta X%` + actual label `Actual Y%` · progress bar with the **actual fill** (colored by variance: red when actual overruns meta for Necesario, brass when within ±5pp, green when under for Deseos/Ahorro, inverted for Necesario) · **meta marker** — 2px vertical line positioned at the target percent.
+  - Footer: short helper line `50/30/20 es una guía, no una regla estricta.`
+- Sheet uses `MOBILE_TAB_BAR_CLEARANCE_CLASS` on its content, close-on-overlay-tap, and `SheetContent` from `@/components/ui/sheet`.
+- The `50/30/20` actuals are already computed by the budget summary action (`getBudgetSummary` or equivalent). Confirm during implementation; if the ratios need a new computation, add it to the existing summary action rather than creating a new server action.
+
+### D8 — Expand-cue contrast fix (root hero)
+
+- `Toca para ver flujo ↓` today renders `text-z-brass/50` — too dim. Change to `text-z-brass` + `ChevronDown` icon (from `lucide-react`).
+- On expand: `Ocultar flujo ↑` + `ChevronUp`.
+- Keep center alignment, keep the "button-inside-button" behavior (tap anywhere on the hero toggles).
+
+### D9 — Out of scope (deferred to BACKLOG.md)
+
+1. **Empty states for `/plan` surfaces** — no income, no budgets, no recurrentes, no wishlist. Minimal template empty state in D4 is the single exception. All other empty states deferred as follow-up to match Dashboard Phase 2 scoping.
+2. **`/plan?tab=deseos`** — §14 of the audit (score `48` unlabeled, inconsistent per-item state density, `rapido` spelling) is a separate polish. Not blocked by this spec.
+3. **Dual-back pills on `/deudas/planificador`** — HANDOVER explicit carry-over from Phase 2. Revisit as redesign later.
+4. **Month pager elevation on `/plan` root** — today the page has a small centered `‹ Abril ›`. Working as-is; no change this phase.
+5. **Richer widgets on `/plan` root** — adding burndown, health-score, or attention-count tiles. Out of this polish; user's Q1=B framing keeps root lean.
+
+## Component-level changes
+
+| Component | Change | Notes |
+|---|---|---|
+| `webapp/src/components/mobile/v2/plan/plan-net-hero.tsx` | D1 + D8 retoken + restructure | Split collapsed vs expanded; retokenize emerald/red → z-income/z-expense; color-code NETO number; upgrade expand cue to full-opacity + icon. |
+| `webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx` | D2 — sort by soonest date | Accept `incomes[]` + `payments[]`; compute next-date for each; reorder slots; apply brass hint styling to the sooner chip. |
+| `webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx` | D5 — badge color logic | Wire `overdueCount` when available; switch Recurrentes badge to neutral-by-default; audit other drill cards for the same rule. |
+| `webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx` | D3 — NETO elevated + Parcial state | Replace the stat-row NETO with hero treatment; add `Parcial` execution state if schema supports. |
+| `webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx` | D4 — templates strip promoted | Create `mobile-recurrentes-templates-strip.tsx` subcomponent placed above the occurrences list; remove the footer `MIS PLANTILLAS VER ↓`. |
+| `webapp/src/components/mobile/mobile-presupuesto.tsx` | D6 + D7 — group-by-risk + tappable chip | Group transform in render; remove ⚠ JSX; convert `Necesario X% · Deseos Y%` static row to a button that opens the sheet. |
+| `webapp/src/components/mobile/v2/plan/plan-budget-hero.tsx` | Possible retokenize of progress-bar colors | Audit for hardcoded `emerald-*` / `red-*`; swap to `z-income` / `z-expense`. |
+| **New:** `webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx` | New bottom-sheet component | `Sheet` from `@/components/ui/sheet`, three buckets, meta-marker bars. |
+| **New:** `webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx` | New header strip | Template counts + `Gestionar →` link. Minimal empty state if zero templates. |
+
+## Data flow
+
+No backend changes. All data already flows:
+
+- `getPlanPageData` / `getPendingOccurrences` — root data, Periodo list, Recurrentes occurrences
+- Recurring templates list — existing action (pick `getRecurringTemplatesCached` or equivalent); confirm during implementation which function already returns the active/paused counts used by the footer link today.
+- `getBudgetSummary` — Presupuesto categories + 50/30/20 ratios
+- `overdueCount` for D5 — may require extending the existing plan data action with a small aggregation; prefer computing in SQL rather than client-side JS to avoid a second round-trip.
+
+Risk-state grouping in D6 is a pure client-side sort/partition over the existing category list — no new fetch.
+
+## Testing strategy
+
+- **Visual regression** — Playwright screenshots at 390×844 for:
+  - `/plan` root, collapsed hero, populated state
+  - `/plan` root, expanded hero, populated state
+  - `/plan?tab=periodo` with at least one `Parcial` row (if schema supports)
+  - `/plan?tab=recurrentes` with templates strip + occurrences
+  - `/plan?tab=presupuesto` with categories spanning all three risk groups
+  - Presupuesto 50/30/20 sheet open
+- **Interaction** —
+  - Tap NETO hero → expands to bar + chart, tap again → collapses
+  - Tap `Necesario X% · Deseos Y%` chip → sheet opens; tap overlay → closes
+  - Tap `Gestionar →` on templates strip → routes correctly
+- **Token compliance** — spawn `zetas-front-guy` after TSX changes. No `emerald-*` or `red-500` should remain in `plan-*.tsx` files.
+- **Perf** — `perf-auditor` run to confirm no new server-action queries were added for D5/D6 (both should be client-side).
+- **Type-check + build** — `pnpm build` clean.
+
+## Review gate
+
+Follow the same layered pattern that worked on Dashboard Phase 2 (HANDOVER §7):
+
+1. `zetas-front-guy` + `perf-auditor` (parallel) — immediately after implementation
+2. Push → Gemini bot review
+3. `frontend-auditor` + `ux-analyst` (parallel)
+4. `/simplify` skill — reuse + quality + efficiency pass
+
+Each layer's findings land as a separate commit for clean review history.
+
+## Success criteria
+
+- `/plan` root first viewport (390×844): NETO hero + Próximo chips + first chip link row all visible without scroll.
+- NETO number is color-coded and ≥ 28px in the collapsed hero.
+- Expand cue is legible on the first glance — not a hint.
+- Periodo NETO ties the screen together; no user needs to scan a stat row to find the sign.
+- Recurrentes `Mis plantillas` is visible in the first viewport.
+- Presupuesto never renders a wall of red — grouping makes the actionable 3 distinct from the 6 safe.
+- 50/30/20 sheet opens on a single tap from Presupuesto.
+- `pnpm build` passes; `zetas-front-guy` reports zero token violations.

--- a/webapp/src/actions/plan.ts
+++ b/webapp/src/actions/plan.ts
@@ -196,6 +196,7 @@ export const getPlanPageData = cache(
         activeCount: recurringSummary.activeCount,
         dueSoonCount: dueSoon.length,
         dueSoonTotal,
+        overdueCount: recurringSummary.overdueCount,
       },
       scenarios: {
         savedScenarios: [],

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -168,20 +168,34 @@ async function getRecurringSummaryCached(userId: string, accessToken: string): P
   totalMonthlyExpenses: number;
   totalMonthlyIncome: number;
   activeCount: number;
+  overdueCount: number;
 }> {
   "use cache";
   cacheTag("recurring");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
-  const { data: templates } = await supabase
-    .from("recurring_transaction_templates")
-    .select("amount, direction, frequency, accounts!recurring_transaction_templates_account_id_fkey(account_type)")
-    .eq("user_id", userId)
-    .eq("is_active", true);
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [templatesRes, overdueRes] = await Promise.all([
+    supabase
+      .from("recurring_transaction_templates")
+      .select("amount, direction, frequency, accounts!recurring_transaction_templates_account_id_fkey(account_type)")
+      .eq("user_id", userId)
+      .eq("is_active", true),
+    supabase
+      .from("recurring_occurrences")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("status", "pending")
+      .lt("occurrence_date", today),
+  ]);
+
+  const templates = templatesRes.data;
+  const overdueCount = overdueRes.count ?? 0;
 
   if (!templates)
-    return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
+    return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0, overdueCount };
 
   let totalMonthlyExpenses = 0;
   let totalMonthlyIncome = 0;
@@ -201,6 +215,7 @@ async function getRecurringSummaryCached(userId: string, accessToken: string): P
     totalMonthlyExpenses,
     totalMonthlyIncome,
     activeCount: templates.length,
+    overdueCount,
   };
 }
 
@@ -938,9 +953,11 @@ export async function getRecurringSummary(): Promise<{
   totalMonthlyExpenses: number;
   totalMonthlyIncome: number;
   activeCount: number;
+  overdueCount: number;
 }> {
   const { user, accessToken } = await getAuthenticatedClient();
-  if (!user || !accessToken) return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0 };
+  if (!user || !accessToken)
+    return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0, overdueCount: 0 };
   return getRecurringSummaryCached(user.id, accessToken);
 }
 

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -164,7 +164,11 @@ async function getUpcomingRecurrencesCached(
   return upcoming;
 }
 
-async function getRecurringSummaryCached(userId: string, accessToken: string): Promise<{
+async function getRecurringSummaryCached(
+  userId: string,
+  todayStr: string,
+  accessToken: string,
+): Promise<{
   totalMonthlyExpenses: number;
   totalMonthlyIncome: number;
   activeCount: number;
@@ -175,7 +179,6 @@ async function getRecurringSummaryCached(userId: string, accessToken: string): P
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
-  const today = new Date().toISOString().slice(0, 10);
 
   const [templatesRes, overdueRes] = await Promise.all([
     supabase
@@ -188,7 +191,7 @@ async function getRecurringSummaryCached(userId: string, accessToken: string): P
       .select("id", { count: "exact", head: true })
       .eq("user_id", userId)
       .eq("status", "pending")
-      .lt("occurrence_date", today),
+      .lt("occurrence_date", todayStr),
   ]);
 
   const templates = templatesRes.data;
@@ -958,7 +961,7 @@ export async function getRecurringSummary(): Promise<{
   const { user, accessToken } = await getAuthenticatedClient();
   if (!user || !accessToken)
     return { totalMonthlyExpenses: 0, totalMonthlyIncome: 0, activeCount: 0, overdueCount: 0 };
-  return getRecurringSummaryCached(user.id, accessToken);
+  return getRecurringSummaryCached(user.id, toISODateString(new Date()), accessToken);
 }
 
 // ─── Impact preview ──────────────────────────────────────────────────────────

--- a/webapp/src/app/(dashboard)/plan/page.tsx
+++ b/webapp/src/app/(dashboard)/plan/page.tsx
@@ -64,7 +64,7 @@ export default async function PlanPage({
       case "periodo":
         return <PlanTabPeriodo />;
       case "recurrentes":
-        return <PlanTabRecurrentes />;
+        return <PlanTabRecurrentes month={month} />;
       case "deseos":
         return <PlanTabDeseos />;
       default:

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -105,17 +105,17 @@ export function MobilePeriodoView({
 
   const hasUnassigned = planData.unassigned_expenses.length > 0;
 
-  const totalIncome = income_envelopes.reduce(
-    (sum, env) => sum + env.total_amount,
-    0,
-  );
-  const net = totalIncome - total_expenses;
+  // NETO hero uses timeline (actual tx-based cashflow) so the elevated
+  // number matches the chart's stat row. D3 intent: surface the "real"
+  // monthly net, not the envelope-planning net.
+  const heroIncome = timelineData.totalIncome;
+  const heroExpense = timelineData.totalExpense;
+  const net = heroIncome - heroExpense;
 
-  const dayOfMonth = new Date().getDate();
   const periodLabel =
-    dayOfMonth <= 10
+    timelineData.dayOfMonth <= 10
       ? "Comienzo de mes"
-      : dayOfMonth <= 20
+      : timelineData.dayOfMonth <= 20
         ? "Mitad de mes"
         : "Fin de mes";
 
@@ -186,8 +186,8 @@ export function MobilePeriodoView({
           {formatCurrency(net, currency)}
         </p>
         <p className="mt-1 text-[11px] text-muted-foreground">
-          +{formatCurrency(totalIncome, currency)} · −
-          {formatCurrency(total_expenses, currency)}
+          +{formatCurrency(heroIncome, currency)} · −
+          {formatCurrency(heroExpense, currency)}
         </p>
       </div>
 

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -105,6 +105,20 @@ export function MobilePeriodoView({
 
   const hasUnassigned = planData.unassigned_expenses.length > 0;
 
+  const totalIncome = income_envelopes.reduce(
+    (sum, env) => sum + env.total_amount,
+    0,
+  );
+  const net = totalIncome - total_expenses;
+
+  const dayOfMonth = new Date().getDate();
+  const periodLabel =
+    dayOfMonth <= 10
+      ? "Comienzo de mes"
+      : dayOfMonth <= 20
+        ? "Mitad de mes"
+        : "Fin de mes";
+
   /* ── Handlers ── */
   function cycleExpenseStatus(entry: PlanningEntryWithRelations) {
     startTransition(async () => { await toggleEntryStatus(entry.id, nextExpenseStatus(entry.status)); });
@@ -150,6 +164,33 @@ export function MobilePeriodoView({
 
   return (
     <div className="space-y-4">
+      {/* NETO hero — D3 */}
+      <div className="rounded-2xl border border-white/6 bg-z-surface-2 p-4">
+        <div className="flex items-center justify-between">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+            Neto del mes
+          </p>
+          <span className="text-[10px] text-muted-foreground">{periodLabel}</span>
+        </div>
+        <p
+          className={cn(
+            "mt-1 text-3xl font-bold tabular-nums",
+            net > 0
+              ? "text-z-income"
+              : net < 0
+                ? "text-z-expense"
+                : "text-z-brass",
+          )}
+        >
+          {net >= 0 ? "+" : ""}
+          {formatCurrency(net, currency)}
+        </p>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          +{formatCurrency(totalIncome, currency)} · −
+          {formatCurrency(total_expenses, currency)}
+        </p>
+      </div>
+
       {/* Chart hero */}
       <PlanFlowChart timelineData={timelineData} currency={currency} />
 

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -41,7 +41,7 @@ const STATUS_BADGE: Record<
   PlanningEntryStatus,
   { label: string; className: string }
 > = {
-  PLANNED: { label: "Pendiente", className: "bg-amber-400/10 text-amber-400" },
+  PLANNED: { label: "Pendiente", className: "bg-z-brass/10 text-z-brass" },
   COMPLETED: { label: "Pagado", className: "bg-z-income/10 text-z-income" },
   SKIPPED: {
     label: "Omitido",
@@ -476,7 +476,7 @@ function IncomeCard({
                       type="button"
                       onClick={() => onRemoveAssignment(assignment.id)}
                       disabled={isPending}
-                      className="rounded-md p-1 text-muted-foreground transition-colors hover:text-red-400"
+                      className="rounded-md p-1 text-muted-foreground transition-colors hover:text-z-expense"
                     >
                       <Trash2 className="size-3" />
                     </button>
@@ -500,7 +500,7 @@ function IncomeCard({
               type="button"
               onClick={() => onDelete(entry.id)}
               disabled={isPending}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium text-red-400 transition-colors hover:text-red-300"
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium text-z-expense transition-colors hover:text-z-expense/80"
             >
               <Trash2 className="size-3" />
               Eliminar
@@ -633,7 +633,7 @@ function ExpenseRow({
             type="button"
             onClick={onDelete}
             disabled={isPending}
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium text-red-400 transition-colors hover:text-red-300"
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium text-z-expense transition-colors hover:text-z-expense/80"
           >
             <Trash2 className="size-3" />
             Eliminar

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { Plus } from "lucide-react";
+import { useId, useState } from "react";
+import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
@@ -29,6 +29,7 @@ export function MobileRecurrentesTemplatesStrip({
   onMutate,
 }: TemplatesStripProps) {
   const [expanded, setExpanded] = useState(false);
+  const regionId = useId();
 
   let activeCount = 0;
   let pausedCount = 0;
@@ -44,6 +45,7 @@ export function MobileRecurrentesTemplatesStrip({
         onClick={() => setExpanded((prev) => !prev)}
         className="flex w-full items-center justify-between text-left"
         aria-expanded={expanded}
+        aria-controls={regionId}
       >
         <div>
           <p className={cn(MOBILE_EYEBROW_CLASS, "text-z-brass")}>Mis plantillas</p>
@@ -52,13 +54,18 @@ export function MobileRecurrentesTemplatesStrip({
             {pausedCount > 0 && ` · ${pausedCount} pausada${pausedCount !== 1 ? "s" : ""}`}
           </p>
         </div>
-        <span className="text-[11px] font-medium text-z-brass">
-          {expanded ? "Ocultar ↑" : "Ver ↓"}
+        <span className="flex items-center gap-1 text-[11px] font-medium text-z-brass">
+          {expanded ? "Ocultar" : "Ver"}
+          {expanded ? (
+            <ChevronUp className="size-3" aria-hidden />
+          ) : (
+            <ChevronDown className="size-3" aria-hidden />
+          )}
         </span>
       </button>
 
       {expanded && (
-        <div className="mt-3 space-y-2">
+        <div id={regionId} className="mt-3 space-y-2">
           {templates.length > 0 ? (
             <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
               {templates.map((t) => (

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { RecurringFormDialog } from "@/components/recurring/recurring-form-dialog";
+import { MOBILE_EYEBROW_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import type {
+  Account,
+  CategoryWithChildren,
+  CurrencyCode,
+  RecurringTemplateWithRelations,
+} from "@/types/domain";
+
+interface TemplatesStripProps {
+  templates: RecurringTemplateWithRelations[];
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  currency: CurrencyCode;
+  onMutate: () => Promise<void>;
+}
+
+export function MobileRecurrentesTemplatesStrip({
+  templates,
+  accounts,
+  categories,
+  currency,
+  onMutate,
+}: TemplatesStripProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  let activeCount = 0;
+  let pausedCount = 0;
+  for (const t of templates) {
+    if (t.is_active) activeCount++;
+    else pausedCount++;
+  }
+
+  return (
+    <div className="rounded-2xl border border-z-brass/18 bg-gradient-to-br from-z-brass/10 to-z-brass/[0.02] px-3.5 py-3">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex w-full items-center justify-between text-left"
+        aria-expanded={expanded}
+      >
+        <div>
+          <p className={cn(MOBILE_EYEBROW_CLASS, "text-z-brass")}>Mis plantillas</p>
+          <p className="mt-0.5 text-sm font-semibold">
+            {activeCount} activa{activeCount !== 1 ? "s" : ""}
+            {pausedCount > 0 && ` · ${pausedCount} pausada${pausedCount !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+        <span className="text-[11px] font-medium text-z-brass">
+          {expanded ? "Ocultar ↑" : "Ver ↓"}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-2">
+          {templates.length > 0 ? (
+            <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
+              {templates.map((t) => (
+                <div
+                  key={t.id}
+                  className={cn(
+                    "flex items-center gap-2 px-3 py-2.5",
+                    !t.is_active && "opacity-50",
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium">{t.merchant_name}</p>
+                    <p className="text-[10px] text-muted-foreground">
+                      {t.account?.name ?? "—"} · {t.frequency ?? "mensual"}
+                      {!t.is_active && " · Pausada"}
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs font-semibold tabular-nums">
+                    {formatCurrency(Number(t.amount), currency)}
+                  </span>
+                  <RecurringFormDialog
+                    template={t}
+                    accounts={accounts}
+                    categories={categories}
+                    onClose={onMutate}
+                    trigger={
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-md px-2 py-0.5 text-[10px] text-z-brass active:bg-white/5"
+                      >
+                        Editar
+                      </button>
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-xs text-muted-foreground">
+              Aún no tienes plantillas
+            </p>
+          )}
+
+          <RecurringFormDialog
+            accounts={accounts}
+            categories={categories}
+            onClose={onMutate}
+            trigger={
+              <button
+                type="button"
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-brass/20 py-2.5 text-xs font-semibold text-z-brass active:bg-z-brass/5"
+              >
+                <Plus className="size-3.5" />
+                Nueva plantilla
+              </button>
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-templates-strip.tsx
@@ -38,7 +38,7 @@ export function MobileRecurrentesTemplatesStrip({
   }
 
   return (
-    <div className="rounded-2xl border border-z-brass/18 bg-gradient-to-br from-z-brass/10 to-z-brass/[0.02] px-3.5 py-3">
+    <div className="rounded-2xl border border-z-brass/20 bg-gradient-to-br from-z-brass/10 to-z-brass/[0.02] px-3.5 py-3">
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Check, ChevronLeft, ChevronRight, Plus, Tag } from "lucide-react";
+import { Check, Tag } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { MobileRecurrentesTemplatesStrip } from "./mobile-recurrentes-templates-strip";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
 import {
@@ -28,7 +29,7 @@ import type { CandidateTransaction } from "@/actions/occurrences";
 import { LinkPickerSheet } from "@/components/recurring/link-picker-sheet";
 import { toast } from "sonner";
 import type { ActionResult } from "@/types/actions";
-import type { CategoryWithChildren, CurrencyCode, RecurringTemplateWithRelations, Account } from "@/types/domain";
+import type { CurrencyCode, RecurringTemplateWithRelations, Account } from "@/types/domain";
 
 /* ------------------------------------------------------------------ */
 /*  Props                                                              */
@@ -226,27 +227,6 @@ export function MobileRecurrentesView({
           {formatCurrency(hook.totalPlanned, currency)}
         </p>
 
-        {/* Month navigation */}
-        <div className="mt-3 flex items-center justify-between">
-          <button
-            type="button"
-            onClick={hook.goPrevMonth}
-            className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5"
-          >
-            <ChevronLeft className="size-3.5" />
-          </button>
-          <span className="text-xs font-medium capitalize text-muted-foreground">
-            {hook.monthLabel}
-          </span>
-          <button
-            type="button"
-            onClick={hook.goNextMonth}
-            className="flex size-7 items-center justify-center rounded-full border border-white/6 text-muted-foreground active:bg-white/5"
-          >
-            <ChevronRight className="size-3.5" />
-          </button>
-        </div>
-
         {/* Summary chips */}
         <div className="mt-3 flex gap-3 text-center">
           <div className="flex-1">
@@ -266,6 +246,17 @@ export function MobileRecurrentesView({
         <div className="animate-pulse py-8 text-center text-sm text-muted-foreground">
           Verificando estado de pagos...
         </div>
+      )}
+
+      {/* Templates strip — D4 */}
+      {hook.isHydrated && (
+        <MobileRecurrentesTemplatesStrip
+          templates={templates}
+          accounts={accounts}
+          categories={categories}
+          currency={currency}
+          onMutate={hook.refreshOccurrences}
+        />
       )}
 
       {/* Pending payments grouped by date */}
@@ -390,39 +381,6 @@ export function MobileRecurrentesView({
             }
             return result;
           }}
-        />
-      )}
-
-      {/* Create new recurring — always visible */}
-      {hook.isHydrated && (
-        <div className="space-y-2">
-          <RecurringFormDialog
-            accounts={accounts}
-            categories={categories}
-            onClose={hook.refreshOccurrences}
-            trigger={
-              <button
-                type="button"
-                className={cn(
-                  "flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-brass/20 py-3 text-xs font-semibold text-z-brass active:bg-z-brass/5",
-                )}
-              >
-                <Plus className="size-3.5" />
-                Nueva recurrente
-              </button>
-            }
-          />
-        </div>
-      )}
-
-      {/* Templates section — view all, manage paused */}
-      {hook.isHydrated && (
-        <TemplatesSection
-          templates={templates}
-          accounts={accounts}
-          categories={categories}
-          currency={currency}
-          onMutate={hook.refreshOccurrences}
         />
       )}
 
@@ -591,85 +549,3 @@ function CompletedSection({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Templates section (admin — create, see all, manage paused)         */
-/* ------------------------------------------------------------------ */
-
-function TemplatesSection({
-  templates,
-  accounts,
-  categories,
-  currency,
-  onMutate,
-}: {
-  templates: RecurringTemplateWithRelations[];
-  accounts: Account[];
-  categories: CategoryWithChildren[];
-  currency: CurrencyCode;
-  onMutate: () => Promise<void>;
-}) {
-  const [show, setShow] = useState(false);
-
-  let activeCount = 0;
-  let pausedCount = 0;
-  for (const t of templates) {
-    if (t.is_active) activeCount++;
-    else pausedCount++;
-  }
-
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setShow((prev) => !prev)}
-        className={cn("flex w-full items-center justify-between py-2", MOBILE_EYEBROW_CLASS)}
-      >
-        <span>
-          Mis plantillas ({activeCount} activas{pausedCount > 0 ? ` · ${pausedCount} pausadas` : ""})
-        </span>
-        <span>{show ? "Ocultar ↑" : "Ver ↓"}</span>
-      </button>
-
-      {show && (
-        <div className="space-y-2">
-          {/* Template list */}
-          <div className={cn(PANEL_INSET_CLASS, "divide-y divide-white/5")}>
-            {templates.map((t) => (
-              <div
-                key={t.id}
-                className={cn(
-                  "flex items-center gap-2 px-3 py-2.5",
-                  !t.is_active && "opacity-50",
-                )}
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-xs font-medium">{t.merchant_name}</p>
-                  <p className="text-[10px] text-muted-foreground">
-                    {t.account?.name ?? "—"} · {t.frequency ?? "mensual"}
-                    {!t.is_active && " · Pausada"}
-                  </p>
-                </div>
-                <span className="shrink-0 text-xs font-semibold tabular-nums">
-                  {formatCurrency(Number(t.amount), currency)}
-                </span>
-                <RecurringFormDialog
-                  template={t}
-                  accounts={accounts}
-                  categories={categories}
-                  onClose={onMutate}
-                  trigger={
-                    <button
-                      type="button"
-                      className="shrink-0 rounded-md px-2 py-0.5 text-[10px] text-z-brass active:bg-white/5"
-                    >
-                      Editar
-                    </button>
-                  }
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { formatCurrency } from "@/lib/utils/currency";
+import { cn } from "@/lib/utils";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import type { AllocationData } from "@/actions/allocation";
+import type { CurrencyCode } from "@/types/domain";
+
+interface Plan5030Sheet20Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  allocation: AllocationData | null;
+}
+
+type Variance = "over" | "near" | "under";
+
+interface BucketRowProps {
+  name: string;
+  actual: { amount: number; percent: number };
+  target: number;
+  currency: CurrencyCode;
+  variance: Variance;
+}
+
+function BucketRow({ name, actual, target, currency, variance }: BucketRowProps) {
+  const clampedPercent = Math.max(0, Math.min(100, actual.percent));
+  const fillColor =
+    variance === "over"
+      ? "bg-z-expense"
+      : variance === "near"
+        ? "bg-z-brass"
+        : "bg-z-income";
+  const actualColor =
+    variance === "over"
+      ? "text-z-expense"
+      : variance === "near"
+        ? "text-z-brass"
+        : "text-z-income";
+  const markerLeft = Math.min(100, target);
+
+  return (
+    <div className="py-3">
+      <div className="mb-2 flex items-baseline justify-between">
+        <span className="text-sm font-medium">{name}</span>
+        <div className="flex gap-2 text-[11px]">
+          <span className="text-muted-foreground">Meta {target}%</span>
+          <span className={cn("font-semibold", actualColor)}>
+            Actual {Math.round(actual.percent)}%
+          </span>
+        </div>
+      </div>
+      <div className="relative h-2 overflow-hidden rounded-full bg-white/[0.05]">
+        <div
+          className={cn("h-full rounded-full", fillColor)}
+          style={{ width: `${clampedPercent}%` }}
+        />
+        <div
+          className="absolute inset-y-[-2px] w-0.5 bg-white/60"
+          style={{ left: `${markerLeft}%` }}
+          aria-hidden
+        />
+      </div>
+      <p className="mt-1 text-[10px] text-muted-foreground">
+        {formatCurrency(actual.amount, currency)}
+      </p>
+    </div>
+  );
+}
+
+export function Plan5030Sheet20({
+  open,
+  onOpenChange,
+  allocation,
+}: Plan5030Sheet20Props) {
+  if (!allocation) return null;
+
+  const needsVariance: Variance =
+    allocation.needs.percent > 55
+      ? "over"
+      : allocation.needs.percent >= 45
+        ? "near"
+        : "under";
+  const wantsVariance: Variance =
+    allocation.wants.percent > 35
+      ? "over"
+      : allocation.wants.percent >= 25
+        ? "near"
+        : "under";
+  const savingsVariance: Variance =
+    allocation.savings.percent < 15
+      ? "over"
+      : allocation.savings.percent <= 25
+        ? "near"
+        : "under";
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className={cn("rounded-t-2xl", MOBILE_TAB_BAR_CLEARANCE_CLASS)}
+      >
+        <SheetHeader>
+          <SheetTitle>Distribución 50/30/20</SheetTitle>
+          <SheetDescription>
+            Cómo estás repartiendo tus gastos este mes
+          </SheetDescription>
+        </SheetHeader>
+        <div className="mt-2 divide-y divide-white/5">
+          <BucketRow
+            name="Necesario"
+            actual={allocation.needs}
+            target={allocation.needs.target}
+            currency={allocation.currency}
+            variance={needsVariance}
+          />
+          <BucketRow
+            name="Deseos"
+            actual={allocation.wants}
+            target={allocation.wants.target}
+            currency={allocation.currency}
+            variance={wantsVariance}
+          />
+          <BucketRow
+            name="Ahorro"
+            actual={allocation.savings}
+            target={allocation.savings.target}
+            currency={allocation.currency}
+            variance={savingsVariance}
+          />
+        </div>
+        <p className="mt-4 text-center text-[11px] text-muted-foreground">
+          50/30/20 es una guía, no una regla estricta.
+        </p>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-5030-20-sheet.tsx
@@ -56,7 +56,14 @@ function BucketRow({ name, actual, target, currency, variance }: BucketRowProps)
           </span>
         </div>
       </div>
-      <div className="relative h-2 overflow-hidden rounded-full bg-white/[0.05]">
+      <div
+        className="relative h-2 overflow-hidden rounded-full bg-white/[0.05]"
+        role="progressbar"
+        aria-valuenow={Math.round(actual.percent)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${name}: ${Math.round(actual.percent)}% (meta ${target}%)`}
+      >
         <div
           className={cn("h-full rounded-full", fillColor)}
           style={{ width: `${clampedPercent}%` }}
@@ -104,7 +111,10 @@ export function Plan5030Sheet20({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
-        className={cn("rounded-t-2xl", MOBILE_TAB_BAR_CLEARANCE_CLASS)}
+        className={cn(
+          "max-h-[calc(100vh-1rem)] overflow-y-auto rounded-t-2xl",
+          MOBILE_TAB_BAR_CLEARANCE_CLASS,
+        )}
       >
         <SheetHeader>
           <SheetTitle>Distribución 50/30/20</SheetTitle>

--- a/webapp/src/components/mobile/v2/plan/plan-allocation-chip.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-allocation-chip.tsx
@@ -39,6 +39,7 @@ export function PlanAllocationChip({
         type="button"
         onClick={() => setOpen(true)}
         disabled={!allocation}
+        aria-label="Ver distribución 50/30/20"
         className="flex items-center gap-1.5 text-[10px] text-muted-foreground transition-colors active:text-foreground disabled:cursor-default disabled:opacity-60"
       >
         <span>

--- a/webapp/src/components/mobile/v2/plan/plan-allocation-chip.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-allocation-chip.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUpRight } from "lucide-react";
+import { Plan5030Sheet20 } from "./plan-5030-20-sheet";
+import type { AllocationData } from "@/actions/allocation";
+
+interface PlanAllocationChipProps {
+  allocation: AllocationData | null;
+  needsLabel?: string;
+  wantsLabel?: string;
+  /**
+   * Optional fallback percents if allocation is null. When allocation is
+   * available we prefer allocation.needs.percent / allocation.wants.percent.
+   */
+  fallbackNeedsPct?: number;
+  fallbackWantsPct?: number;
+}
+
+export function PlanAllocationChip({
+  allocation,
+  needsLabel = "Necesario",
+  wantsLabel = "Deseos",
+  fallbackNeedsPct = 0,
+  fallbackWantsPct = 0,
+}: PlanAllocationChipProps) {
+  const [open, setOpen] = useState(false);
+
+  const needsPct = allocation
+    ? Math.round(allocation.needs.percent)
+    : Math.round(fallbackNeedsPct);
+  const wantsPct = allocation
+    ? Math.round(allocation.wants.percent)
+    : Math.round(fallbackWantsPct);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={!allocation}
+        className="flex items-center gap-1.5 text-[10px] text-muted-foreground transition-colors active:text-foreground disabled:cursor-default disabled:opacity-60"
+      >
+        <span>
+          {needsLabel} {needsPct}%
+        </span>
+        <span className="text-white/15">|</span>
+        <span>
+          {wantsLabel} {wantsPct}%
+        </span>
+        {allocation && (
+          <span className="ml-1 flex items-center gap-0.5 text-z-brass">
+            50/30/20 <ArrowUpRight className="size-2.5" aria-hidden />
+          </span>
+        )}
+      </button>
+      <Plan5030Sheet20
+        open={open}
+        onOpenChange={setOpen}
+        allocation={allocation}
+      />
+    </>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -1,23 +1,7 @@
-"use client";
-
 import Link from "next/link";
-import { ArrowRight, Wallet, CalendarClock, RotateCcw, Heart } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { formatCurrency } from "@/lib/utils/currency";
-import { formatDate } from "@/lib/utils/date";
-import { PANEL_INSET_CLASS, MOBILE_ACTION_BUTTON_CLASS } from "@/lib/constants/styles";
+import { Wallet, CalendarCheck, RefreshCw, Heart } from "lucide-react";
 import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
 import type { CurrencyCode } from "@/types/domain";
-
-interface DrillCard {
-  key: string;
-  title: string;
-  hint: string;
-  hintColor: string;
-  href: string;
-  icon: React.ReactNode;
-  expandedContent: React.ReactNode;
-}
 
 interface PlanDrillCardsProps {
   budget: PlanBudgetSummary;
@@ -25,8 +9,28 @@ interface PlanDrillCardsProps {
   periodoSummary: { hasActive: boolean; percentAssigned: number; unassignedCount?: number } | null;
   wishlistCount: number;
   currency: CurrencyCode;
-  expanded?: string | null;
-  onToggle?: (id: string) => void;
+}
+
+interface DrillChipProps {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  caption: React.ReactNode;
+}
+
+function DrillChip({ label, href, icon: Icon, caption }: DrillChipProps) {
+  return (
+    <Link
+      href={href}
+      className="flex min-h-[150px] flex-col items-center justify-center gap-3 rounded-2xl border border-white/6 bg-white/[0.02] p-4 transition-colors active:bg-white/[0.04]"
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </span>
+      <Icon className="size-10 text-z-brass/85" aria-hidden />
+      <div className="text-center text-xs font-medium text-muted-foreground">{caption}</div>
+    </Link>
+  );
 }
 
 export function PlanDrillCards({
@@ -34,187 +38,73 @@ export function PlanDrillCards({
   recurring,
   periodoSummary,
   wishlistCount,
-  currency,
-  expanded,
-  onToggle,
 }: PlanDrillCardsProps) {
-  const budgetPct = budget.totalBudgeted > 0
-    ? Math.round((budget.totalSpent / budget.totalBudgeted) * 100)
-    : 0;
+  const overLimit = budget.overLimitCount ?? 0;
+  const presupuestoCaption =
+    overLimit > 0 ? (
+      <span className="font-semibold text-z-brass">{overLimit} sobre límite</span>
+    ) : (
+      "dentro del límite"
+    );
 
-  const nextPayment = recurring.upcoming?.[0];
-  const pendingCount = (recurring.upcoming?.length ?? 0) + (recurring.upcomingIncome?.length ?? 0);
+  const percentAssigned = periodoSummary?.percentAssigned ?? 0;
+  const unassigned = periodoSummary?.unassignedCount ?? 0;
+  const periodoCaption =
+    percentAssigned >= 100 ? (
+      "al día"
+    ) : unassigned > 0 ? (
+      <span className="font-semibold text-z-brass">{unassigned} pendientes</span>
+    ) : (
+      `${Math.round(percentAssigned)}%`
+    );
 
-  const cards: DrillCard[] = [
-    {
-      key: "drill-presupuesto",
-      title: "Presupuesto",
-      icon: <Wallet className="size-3.5" />,
-      hint: budget.overLimitCount > 0
-        ? `${budget.overLimitCount} sobre límite`
-        : `${budgetPct}%`,
-      hintColor: budget.overLimitCount > 0 ? "text-z-debt" : "text-z-income",
-      href: "/plan?tab=presupuesto",
-      expandedContent: (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Gastado</span>
-            <span className="font-medium tabular-nums">{formatCurrency(budget.totalSpent, currency)} de {formatCurrency(budget.totalBudgeted, currency)}</span>
-          </div>
-          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-            <div
-              className={cn("h-full rounded-full", budgetPct > 100 ? "bg-z-debt" : "bg-z-income")}
-              style={{ width: `${Math.min(budgetPct, 100)}%` }}
-            />
-          </div>
-          {budget.overLimitCount > 0 && (
-            <p className="text-[10px] text-z-debt">{budget.overLimitCount} categoría{budget.overLimitCount !== 1 ? "s" : ""} sobre límite</p>
-          )}
-        </div>
-      ),
-    },
-    {
-      key: "drill-periodo",
-      title: "Periodo",
-      icon: <CalendarClock className="size-3.5" />,
-      hint: periodoSummary?.hasActive
-        ? `${periodoSummary.percentAssigned}%`
-        : "—",
-      hintColor: periodoSummary?.hasActive ? "text-z-income" : "text-muted-foreground",
-      href: "/plan?tab=periodo",
-      expandedContent: periodoSummary?.hasActive ? (
-        <div className="space-y-1.5">
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Asignado</span>
-            <span className="font-medium">{periodoSummary.percentAssigned}%</span>
-          </div>
-          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-            <div className="h-full rounded-full bg-z-income" style={{ width: `${Math.min(periodoSummary.percentAssigned, 100)}%` }} />
-          </div>
-          {(periodoSummary.unassignedCount ?? 0) > 0 && (
-            <p className="text-[10px] text-z-alert">{periodoSummary.unassignedCount} gasto{periodoSummary.unassignedCount !== 1 ? "s" : ""} sin asignar</p>
-          )}
-        </div>
-      ) : (
-        <p className="text-[10px] text-muted-foreground">No hay periodo activo este mes</p>
-      ),
-    },
-    {
-      key: "drill-recurrentes",
-      title: "Recurrentes",
-      icon: <RotateCcw className="size-3.5" />,
-      hint: `${pendingCount}`,
-      hintColor: pendingCount > 0 ? "text-z-alert" : "text-z-income",
-      href: "/plan?tab=recurrentes",
-      expandedContent: (
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">
-            {formatCurrency(recurring.totalMonthlyExpenses, currency)}/mes en gastos
-          </p>
-          {nextPayment && (
-            <div className="flex items-center justify-between text-xs">
-              <span className="truncate text-muted-foreground">{nextPayment.template.merchant_name}</span>
-              <span className="shrink-0 font-medium">{formatDate(nextPayment.next_date, "dd MMM")}</span>
-            </div>
-          )}
-          <p className="text-[10px] text-muted-foreground">
-            {pendingCount} pendiente{pendingCount !== 1 ? "s" : ""} este mes
-          </p>
-        </div>
-      ),
-    },
-    {
-      key: "drill-deseos",
-      title: "Deseos",
-      icon: <Heart className="size-3.5" />,
-      hint: `${wishlistCount}`,
-      hintColor: "text-muted-foreground",
-      href: "/plan?tab=deseos",
-      expandedContent: (
-        <p className="text-xs text-muted-foreground">
-          {wishlistCount} item{wishlistCount !== 1 ? "s" : ""} en tu lista de deseos
-        </p>
-      ),
-    },
-  ];
+  const dueSoonCount = recurring.dueSoonCount;
+  const overdueCount = recurring.overdueCount;
+  const recurrentesCaption = (
+    <>
+      {dueSoonCount} este mes
+      {overdueCount > 0 && (
+        <>
+          {" · "}
+          <span className="font-semibold text-z-brass">{overdueCount} vencidas</span>
+        </>
+      )}
+    </>
+  );
 
-  const toggle = (key: string) => onToggle?.(key);
-  const activeKey = expanded?.startsWith("drill-") ? expanded : null;
-
-  // Group into rows of 2
-  const rows: DrillCard[][] = [];
-  for (let i = 0; i < cards.length; i += 2) {
-    rows.push(cards.slice(i, i + 2));
-  }
+  const deseosCaption = `${wishlistCount} activo${wishlistCount !== 1 ? "s" : ""}`;
 
   return (
     <div className="space-y-1.5">
       <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
         Ir a
       </p>
-
-      {rows.map((row, rowIdx) => {
-        const expandedCard = activeKey ? row.find((c) => c.key === activeKey) : null;
-
-        return (
-          <div key={rowIdx}>
-            {/* Row of 2 cards */}
-            <div className="grid grid-cols-2 gap-1.5">
-              {row.map((card) => (
-                <button
-                  key={card.key}
-                  type="button"
-                  onClick={() => toggle(card.key)}
-                  className={cn(
-                    PANEL_INSET_CLASS,
-                    "flex w-full flex-col items-start gap-1 px-3 py-2.5 text-left transition-colors active:bg-white/[0.03]",
-                    activeKey === card.key && "ring-1 ring-z-brass/30 bg-z-brass/[0.06]",
-                    activeKey && activeKey !== card.key && "opacity-50",
-                  )}
-                  aria-expanded={activeKey === card.key}
-                >
-                  <div className="flex w-full items-center justify-between">
-                    <span className="text-muted-foreground">{card.icon}</span>
-                    <span className={cn("text-sm font-bold tabular-nums", card.hintColor)}>
-                      {card.hint}
-                    </span>
-                  </div>
-                  <p className="text-[11px] font-semibold">{card.title}</p>
-                </button>
-              ))}
-            </div>
-
-            {/* Animated expand panel — same pattern as InicioDiscovery */}
-            <div
-              className="grid transition-[grid-template-rows] duration-200 ease-out"
-              style={{ gridTemplateRows: expandedCard ? "1fr" : "0fr" }}
-            >
-              <div className="overflow-hidden">
-                <div
-                  className={cn(
-                    "mt-1.5 transition-opacity duration-150",
-                    expandedCard ? "opacity-100 delay-75" : "opacity-0",
-                  )}
-                >
-                  {expandedCard && (
-                    <div className={cn(PANEL_INSET_CLASS, "border-z-brass/20 bg-black/20 space-y-3 px-4 py-3")}>
-                      <p className="text-xs font-semibold">{expandedCard.title}</p>
-                      {expandedCard.expandedContent}
-                      <Link
-                        href={expandedCard.href}
-                        className={cn(MOBILE_ACTION_BUTTON_CLASS, "inline-flex items-center gap-1.5")}
-                      >
-                        Ver {expandedCard.title.toLowerCase()}
-                        <ArrowRight className="size-3" />
-                      </Link>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      <div className="grid grid-cols-2 gap-2">
+        <DrillChip
+          label="Presupuesto"
+          href="/plan?tab=presupuesto"
+          icon={Wallet}
+          caption={presupuestoCaption}
+        />
+        <DrillChip
+          label="Periodo"
+          href="/plan?tab=periodo"
+          icon={CalendarCheck}
+          caption={periodoCaption}
+        />
+        <DrillChip
+          label="Recurrentes"
+          href="/plan?tab=recurrentes"
+          icon={RefreshCw}
+          caption={recurrentesCaption}
+        />
+        <DrillChip
+          label="Deseos"
+          href="/plan?tab=deseos"
+          icon={Heart}
+          caption={deseosCaption}
+        />
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { Wallet, CalendarCheck, RefreshCw, Heart } from "lucide-react";
+import { MOBILE_EYEBROW_CLASS, PANEL_INSET_SUBTLE_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -22,11 +24,12 @@ function DrillChip({ label, href, icon: Icon, caption }: DrillChipProps) {
   return (
     <Link
       href={href}
-      className="flex min-h-[150px] flex-col items-center justify-center gap-3 rounded-2xl border border-white/6 bg-white/[0.02] p-4 transition-colors active:bg-white/[0.04]"
+      className={cn(
+        PANEL_INSET_SUBTLE_CLASS,
+        "flex min-h-[150px] flex-col items-center justify-center gap-3 p-4 transition-colors active:bg-white/[0.04]",
+      )}
     >
-      <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-        {label}
-      </span>
+      <span className={MOBILE_EYEBROW_CLASS}>{label}</span>
       <Icon className="size-10 text-z-brass/85" aria-hidden />
       <div className="text-center text-xs font-medium text-muted-foreground">{caption}</div>
     </Link>
@@ -76,9 +79,7 @@ export function PlanDrillCards({
 
   return (
     <div className="space-y-1.5">
-      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-        Ir a
-      </p>
+      <p className={MOBILE_EYEBROW_CLASS}>Ir a</p>
       <div className="grid grid-cols-2 gap-2">
         <DrillChip
           label="Presupuesto"

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -3,14 +3,12 @@ import { Wallet, CalendarCheck, RefreshCw, Heart } from "lucide-react";
 import { MOBILE_EYEBROW_CLASS, PANEL_INSET_SUBTLE_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 import type { PlanBudgetSummary, PlanRecurringSummary } from "@/types/plan";
-import type { CurrencyCode } from "@/types/domain";
 
 interface PlanDrillCardsProps {
   budget: PlanBudgetSummary;
   recurring: PlanRecurringSummary;
   periodoSummary: { hasActive: boolean; percentAssigned: number; unassignedCount?: number } | null;
   wishlistCount: number;
-  currency: CurrencyCode;
 }
 
 interface DrillChipProps {

--- a/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-drill-cards.tsx
@@ -65,7 +65,7 @@ export function PlanDrillCards({
   const overdueCount = recurring.overdueCount;
   const recurrentesCaption = (
     <>
-      {dueSoonCount} este mes
+      {dueSoonCount} próximos
       {overdueCount > 0 && (
         <>
           {" · "}

--- a/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-expandable-chips.tsx
@@ -78,12 +78,28 @@ export function PlanExpandableChips({
   const expandedList = activeChip ? items[activeChip] : [];
   const config = activeChip ? CHIP_CONFIG[activeChip] : null;
 
+  // D2: sort by soonest next_date. Tie-breaker: payment first (debt urgency).
+  const nextIncomeDate = incomes[0]?.next_date ?? null;
+  const nextPaymentDate = payments[0]?.next_date ?? null;
+  const paymentSooner = (() => {
+    if (!nextIncomeDate && !nextPaymentDate) return false;
+    if (!nextIncomeDate) return true;
+    if (!nextPaymentDate) return false;
+    if (nextPaymentDate === nextIncomeDate) return true;
+    return nextPaymentDate < nextIncomeDate;
+  })();
+  const orderedTypes = paymentSooner
+    ? (["payment", "income"] as const)
+    : (["income", "payment"] as const);
+  const sooner = orderedTypes[0];
+
   return (
     <div className="space-y-2">
       <div className="grid grid-cols-2 gap-2">
-        {(["income", "payment"] as const).map((type) => {
+        {orderedTypes.map((type) => {
           const c = CHIP_CONFIG[type];
           const next = items[type][0] ?? null;
+          const isSooner = type === sooner && next !== null;
           return (
             <button
               key={type}
@@ -92,7 +108,8 @@ export function PlanExpandableChips({
               className={cn(
                 "rounded-xl border p-3 text-left transition-all",
                 activeChip === type ? c.borderActive : c.borderInactive,
-                activeChip === OPPOSITE[type] && "opacity-50"
+                activeChip === OPPOSITE[type] && "opacity-50",
+                isSooner && activeChip !== type && "ring-1 ring-z-brass/30"
               )}
             >
               {next ? (

--- a/webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useChartFocusMode } from "@/hooks/use-chart-focus-mode";
 import { PlanFlowChart } from "./plan-flow-chart";
 import { formatCurrency } from "@/lib/utils/currency";
@@ -53,16 +54,20 @@ export function PlanNetHero({
           </span>
         </div>
 
-        <p className="text-3xl font-bold text-z-brass">
+        <p
+          className={`text-3xl font-bold ${
+            neto > 0 ? "text-z-income" : neto < 0 ? "text-z-expense" : "text-z-brass"
+          }`}
+        >
           {neto >= 0 ? "+" : ""}
           {formatCurrency(neto, currency)}
         </p>
 
         {/* Stacked progress bar */}
         <div className="relative mt-3 h-2.5 overflow-hidden rounded-full bg-z-surface-2">
-          <div className="absolute inset-y-0 left-0 w-full rounded-full bg-emerald-500/80" />
+          <div className="absolute inset-y-0 left-0 w-full rounded-full bg-z-income/80" />
           <div
-            className="absolute inset-y-0 left-0 rounded-l-full bg-red-500/80"
+            className="absolute inset-y-0 left-0 rounded-l-full bg-z-expense/80"
             style={{ width: `${gastosRatio}%` }}
           />
           <div
@@ -74,11 +79,11 @@ export function PlanNetHero({
         {/* Legend */}
         <div className="mt-2 flex justify-between text-[10px] text-muted-foreground">
           <span className="flex items-center gap-1">
-            <span className="inline-block size-1.5 rounded-full bg-emerald-500" />
+            <span className="inline-block size-1.5 rounded-full bg-z-income" />
             Ingresos {formatCurrency(ingresos, currency)}
           </span>
           <span className="flex items-center gap-1">
-            <span className="inline-block size-1.5 rounded-full bg-red-500" />
+            <span className="inline-block size-1.5 rounded-full bg-z-expense" />
             Gastos {formatCurrency(gastos, currency)}
           </span>
           <span className="flex items-center gap-1">
@@ -88,8 +93,9 @@ export function PlanNetHero({
         </div>
 
         {!expanded && (
-          <p className="mt-3 text-center text-[11px] text-z-brass/50">
-            Toca para ver flujo ↓
+          <p className="mt-3 flex items-center justify-center gap-1 text-center text-[11px] font-medium text-z-brass">
+            Toca para ver flujo
+            <ChevronDown className="size-3" aria-hidden="true" />
           </p>
         )}
 
@@ -97,10 +103,11 @@ export function PlanNetHero({
           <div className="mt-4" onClick={(e) => e.stopPropagation()}>
             <PlanFlowChart timelineData={timelineData} currency={currency} />
             <p
-              className="mt-2 text-center text-[11px] text-z-brass cursor-pointer"
+              className="mt-2 flex cursor-pointer items-center justify-center gap-1 text-center text-[11px] font-medium text-z-brass"
               onClick={() => setExpanded(false)}
             >
-              Ocultar flujo ↑
+              Ocultar flujo
+              <ChevronUp className="size-3" aria-hidden="true" />
             </p>
           </div>
         )}

--- a/webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-net-hero.tsx
@@ -43,6 +43,8 @@ export function PlanNetHero({
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-label={expanded ? "Ocultar flujo del mes" : "Ver flujo del mes"}
         className={`relative z-50 w-full rounded-2xl border border-white/6 ${HERO_CARD_GRADIENT_CLASS} p-4 text-left transition-all`}
       >
         <div className="flex items-center justify-between mb-1">
@@ -102,10 +104,7 @@ export function PlanNetHero({
         {expanded && (
           <div className="mt-4" onClick={(e) => e.stopPropagation()}>
             <PlanFlowChart timelineData={timelineData} currency={currency} />
-            <p
-              className="mt-2 flex cursor-pointer items-center justify-center gap-1 text-center text-[11px] font-medium text-z-brass"
-              onClick={() => setExpanded(false)}
-            >
+            <p className="mt-2 flex items-center justify-center gap-1 text-center text-[11px] font-medium text-z-brass">
               Ocultar flujo
               <ChevronUp className="size-3" aria-hidden="true" />
             </p>

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -76,7 +76,6 @@ export function PlanRoot({
         recurring={planData.recurring}
         periodoSummary={periodoSummary}
         wishlistCount={wishlistCount}
-        currency={currency}
       />
 
       {/* Scenarios — only when stable */}

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -77,8 +77,6 @@ export function PlanRoot({
         periodoSummary={periodoSummary}
         wishlistCount={wishlistCount}
         currency={currency}
-        expanded={activeZone}
-        onToggle={toggle}
       />
 
       {/* Scenarios — only when stable */}

--- a/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
@@ -16,11 +16,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { StateChip } from "@/components/mobile/v2/state-chip";
 import { CategoryIcon } from "@/components/categories/category-icon";
+import { PlanAllocationChip } from "@/components/mobile/v2/plan/plan-allocation-chip";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { parseMonth, formatMonthLabel, getDaysRemainingInMonth } from "@/lib/utils/date";
 import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
-import { AlertTriangle } from "lucide-react";
 import type { CurrencyCode, CategoryBudgetData } from "@/types/domain";
 
 const BudgetWizard = dynamic(
@@ -100,13 +100,17 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
   const essentialPct = totalSpent > 0 ? Math.round((essentialSpent / totalSpent) * 100) : 0;
   const wantsPct = totalSpent > 0 ? Math.round((wantsSpent / totalSpent) * 100) : 0;
 
-  // Sort: over-budget first, then by percentUsed descending
-  const sortedCategories = [...budgeted].sort((a, b) => {
-    const aOver = a.percentUsed >= 100 ? 1 : 0;
-    const bOver = b.percentUsed >= 100 ? 1 : 0;
-    if (aOver !== bOver) return bOver - aOver;
-    return b.percentUsed - a.percentUsed;
-  });
+  // D6: group categories by risk state — over → near → safe
+  const over = [...budgeted]
+    .filter((c) => c.percentUsed > 100)
+    .sort((a, b) => b.percentUsed - a.percentUsed);
+  const near = [...budgeted]
+    .filter((c) => c.percentUsed >= 85 && c.percentUsed <= 100)
+    .sort((a, b) => b.percentUsed - a.percentUsed);
+  const safe = [...budgeted]
+    .filter((c) => c.percentUsed < 85)
+    .sort((a, b) => a.percentUsed - b.percentUsed);
+  const hasBudgetedCategories = over.length + near.length + safe.length > 0;
 
   const pressure = progress >= 100 ? "critical" : progress >= 80 ? "watch" : "stable";
   const chipConfig = {
@@ -161,28 +165,65 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               />
             </div>
 
-            {/* Status + distribution */}
+            {/* Status + distribution — D7: chip opens 50/30/20 sheet */}
             <div className="mt-3 flex items-center justify-between">
-              <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
-                <span>Necesario {essentialPct}%</span>
-                <span className="text-white/15">|</span>
-                <span>Deseos {wantsPct}%</span>
-              </div>
+              <PlanAllocationChip
+                allocation={allocationData}
+                fallbackNeedsPct={essentialPct}
+                fallbackWantsPct={wantsPct}
+              />
               <StateChip label={chip.label} variant={chip.variant} />
             </div>
           </div>
 
-          {/* Category list */}
-          {sortedCategories.length > 0 && (
-            <div className="space-y-1">
-              <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark mb-2">
-                Por categoría
-              </p>
-              <div className="space-y-3">
-                {sortedCategories.map((cat) => (
-                  <MobileBudgetCategoryRow key={cat.id} category={cat} currency={currency} />
-                ))}
-              </div>
+          {/* Categories grouped by risk state — D6 */}
+          {hasBudgetedCategories && (
+            <div className="space-y-5">
+              {over.length > 0 && (
+                <section>
+                  <div className="mb-2 flex items-center justify-between">
+                    <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-expense">
+                      Sobre límite
+                    </p>
+                    <span className="text-[10px] text-muted-foreground">{over.length}</span>
+                  </div>
+                  <div className="space-y-3">
+                    {over.map((cat) => (
+                      <MobileBudgetCategoryRow key={cat.id} category={cat} currency={currency} />
+                    ))}
+                  </div>
+                </section>
+              )}
+              {near.length > 0 && (
+                <section>
+                  <div className="mb-2 flex items-center justify-between">
+                    <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-brass">
+                      Cerca del límite
+                    </p>
+                    <span className="text-[10px] text-muted-foreground">{near.length}</span>
+                  </div>
+                  <div className="space-y-3">
+                    {near.map((cat) => (
+                      <MobileBudgetCategoryRow key={cat.id} category={cat} currency={currency} />
+                    ))}
+                  </div>
+                </section>
+              )}
+              {safe.length > 0 && (
+                <section>
+                  <div className="mb-2 flex items-center justify-between">
+                    <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-income">
+                      Dentro del límite
+                    </p>
+                    <span className="text-[10px] text-muted-foreground">{safe.length}</span>
+                  </div>
+                  <div className="space-y-3">
+                    {safe.map((cat) => (
+                      <MobileBudgetCategoryRow key={cat.id} category={cat} currency={currency} />
+                    ))}
+                  </div>
+                </section>
+              )}
             </div>
           )}
 
@@ -289,9 +330,6 @@ function MobileBudgetCategoryRow({
           <span className="text-sm font-medium truncate">
             {category.name_es ?? category.name}
           </span>
-          {isOver && (
-            <AlertTriangle className="size-3.5 shrink-0 text-z-debt" />
-          )}
         </div>
 
         {/* Right: amounts */}

--- a/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
@@ -153,7 +153,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
             </div>
 
             {/* Progress bar */}
-            <div className="relative mt-3 h-2.5 rounded-full bg-[#1e221d]">
+            <div className="relative mt-3 h-2.5 rounded-full bg-z-surface-2">
               <div
                 className={cn(
                   "h-full rounded-full",

--- a/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
@@ -129,9 +129,12 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
         <div className="space-y-4 px-4 pt-4">
           {/* Budget hero card */}
           <div className={cn(PANEL_INSET_CLASS, "p-4")}>
-            <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
-              Gastado este mes
-            </p>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+                Gastado este mes
+              </p>
+              <StateChip label={chip.label} variant={chip.variant} />
+            </div>
 
             <div className="mt-2 flex items-center justify-between">
               <span
@@ -165,14 +168,13 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               />
             </div>
 
-            {/* Status + distribution — D7: chip opens 50/30/20 sheet */}
-            <div className="mt-3 flex items-center justify-between">
+            {/* 50/30/20 allocation chip — D7 opens sheet on tap */}
+            <div className="mt-3">
               <PlanAllocationChip
                 allocation={allocationData}
                 fallbackNeedsPct={essentialPct}
                 fallbackWantsPct={wantsPct}
               />
-              <StateChip label={chip.label} variant={chip.variant} />
             </div>
           </div>
 

--- a/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-recurrentes.tsx
@@ -18,7 +18,11 @@ import { getCategories } from "@/actions/categories";
 import { formatCurrency } from "@/lib/utils/currency";
 import type { CurrencyCode } from "@/types/domain";
 
-export async function PlanTabRecurrentes() {
+interface PlanTabRecurrentesProps {
+  month?: string;
+}
+
+export async function PlanTabRecurrentes({ month }: PlanTabRecurrentesProps = {}) {
   const [templatesResult, accountsResult, categoriesResult, summary, currency, attentionSnapshot, occurrencesResult] =
     await Promise.all([
       getRecurringTemplates(),
@@ -27,7 +31,7 @@ export async function PlanTabRecurrentes() {
       getRecurringSummary(),
       getPreferredCurrency(),
       getAttentionSnapshot(),
-      getOccurrencesForMonth(),
+      getOccurrencesForMonth(month),
     ]);
 
   const templates = templatesResult.success ? templatesResult.data : [];

--- a/webapp/src/types/plan.ts
+++ b/webapp/src/types/plan.ts
@@ -48,6 +48,7 @@ export interface PlanRecurringSummary {
   activeCount: number;
   dueSoonCount: number;
   dueSoonTotal: number;
+  overdueCount: number;
 }
 
 export interface PlanScenarioSummary {


### PR DESCRIPTION
## Summary

Mobile `/plan` polish pass — root + three tabs (`periodo`, `recurrentes`, `presupuesto`). Framing: Plan answers "shape of the month". Root is overview; Periodo is canonical drill-down.

**Decisions landed** (see spec for full treatment):

- **D1** · NETO hero color-coded (z-income / z-expense / z-brass by sign); emerald/red hardcoded classes retokenized.
- **D2** · Próximo ingreso/pago chips ordered by soonest-date; payment wins on tie.
- **D3** · NETO elevated to hero on Periodo tab using timeline totals (matches chart stat row — audit -\$229k).
- **D4** · `Mis plantillas` promoted from footer to a top strip above the occurrences list. Inner month-pager removed (audit §17 residual from Phase 1).
- **D6** · Presupuesto grouped by risk: `Sobre límite` → `Cerca del límite` → `Dentro del límite`. ⚠ icon dropped; bar color + group label carry the signal.
- **D7** · New bottom sheet for 50/30/20 Meta vs Actual. Entry point = tappable `Necesario X% · Deseos Y%` chip. Consumes existing `get503020Allocation` — no new server action.
- **D8** · Root hero expand cue upgraded from `text-z-brass/50` hint to full brass + `ChevronDown` icon.
- **D10** · IR A drill chips rebuilt RITMO-style: eyebrow → centered 40px brand-brass lucide icon → state-aware caption. Server Component (moved off client bundle).

**Data layer**

- `getRecurringSummaryCached` extended with `overdueCount` (parallel cached count on `recurring_occurrences`). Threaded through `PlanPageData.recurring` for D10 Recurrentes caption.
- `PlanTabRecurrentes` now takes an optional `month` prop so `initialOccurrences` matches the URL's `?month=` param — fixes the "Verificando estado de pagos…" flash on deep links.

**Review gate applied**

- `zetas-front-guy` — token compliance blockers fixed (`MOBILE_EYEBROW_CLASS`, `PANEL_INSET_SUBTLE_CLASS`, `border-z-brass/20`, `bg-z-surface-2` replacing `bg-[#1e221d]`).
- `perf-auditor` — 0 findings. Drill-cards moved Client → Server, new overdue count query properly cached/parallel.
- User-requested visual fixes applied: presupuesto hero decompressed (StateChip → top row), recurrentes hydration fix.

**Out of scope** (see spec §D9)

- Empty states, `/plan?tab=deseos` polish, dual-back pills on `/deudas/planificador`, `Parcial` occurrence state (schema doesn't support — deferred to BACKLOG).

## Spec & Plan

- Design: `docs/superpowers/specs/2026-04-17-plan-page-polish-design.md`
- Plan: `docs/superpowers/plans/2026-04-17-plan-page-polish.md`

## Test plan

- [x] `pnpm build` clean
- [x] Playwright captures at 390×844 (`audit/2026-04-17/`) — 5 canonical screens + sheet + strip-expanded
- [x] zetas-front-guy token sweep
- [x] perf-auditor cache discipline
- [ ] Gemini bot review pending
- [ ] frontend-auditor + ux-analyst pending
- [ ] /simplify pass pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)