### PR TITLE
fix(email): pass PDF bytes directly to Blob to avoid Buffer pool contamination

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -125,6 +125,16 @@
 
 ## Tech Debt
 
+### Clean up corrupted `pending_email_statements` storage rows (pre-Buffer-pool-fix)
+- **Priority:** Medium
+- **What:** Rows created before the Buffer-pool fix (commit `92555b4`, branch `claude/fix-pdf-email-delivery-Jwhzp`) have 8KB of Node pool garbage stored at `storage_path` in the `email-pdfs` bucket instead of the real PDF. They will never parse — even via `retryPdfParsing` — because the stored blob doesn't start with `%PDF`. One-shot cleanup:
+  1. Find `pending_email_statements` rows with `status IN ('pdf_queued','pdf_parse_failed','parse_failed')` AND `created_at < <deploy-timestamp-of-fix>`.
+  2. `admin.storage.from("email-pdfs").remove([storage_path])` for each.
+  3. Set `status = 'parse_failed'`, `error_message = 'Archivo corrupto — vuelve a reenviar el correo'` so the UI guides users to re-send rather than loop on retry.
+- **Why:** Surfaces the issue cleanly; re-sending the email produces a new row with a correct idempotency hash, so there's no collision with the old broken row.
+- **Touches:** One-shot admin script or migration with a pl/pgsql DO block + storage cleanup via service-role.
+- **Found:** import-flow-doctor review of Buffer-pool fix, 2026-04-17
+
 ### `useRecurringMonth` callbacks use `router.refresh()` instead of `startTransition`
 - **Priority:** Medium
 - **What:** All three callbacks in `use-recurring-month.ts` (`confirmPayment`, `skipPayment`, `linkExisting`) call `router.refresh()` after the server action. Should wrap in `startTransition` instead — `router.refresh()` is a redundant network round-trip.

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -449,12 +449,16 @@ async function processEmail(ctx: {
 
     if (pdfAttachments.length > 0 && pdfImportEnabled) {
       console.log(`[email-ingest][${emailId}] Text parse failed — falling back to ${pdfAttachments.length} PDF attachment(s)`);
-      const insertedPdfRows: Array<{ id: string; buffer: ArrayBuffer; filename: string }> = [];
+      const insertedPdfRows: Array<{ id: string; buffer: Uint8Array; filename: string }> = [];
 
       for (const attachment of pdfAttachments) {
         const filename = attachment.filename || "attachment.pdf";
+        // Buffer.from(..., "base64") may allocate from a shared 8KB pool — so
+        // `bytes.buffer` can reference a larger ArrayBuffer with `bytes` at a
+        // non-zero `byteOffset`. Always pass the Uint8Array itself (Buffer
+        // extends Uint8Array) so downstream consumers see exactly the PDF bytes.
         const bytes = Buffer.from(attachment.content, "base64");
-        const contentHash = await computePdfHash(bytes.buffer);
+        const contentHash = await computePdfHash(bytes);
 
         // Check idempotency: skip if we already have this PDF
         const { data: existing } = await admin
@@ -484,7 +488,7 @@ async function processEmail(ctx: {
 
         const { error: uploadError } = await admin.storage
           .from("email-pdfs")
-          .upload(storagePath, bytes.buffer, {
+          .upload(storagePath, bytes, {
             contentType: "application/pdf",
             upsert: false,
           });
@@ -542,7 +546,7 @@ async function processEmail(ctx: {
           continue;
         }
 
-        insertedPdfRows.push({ id: inserted.id, buffer: bytes.buffer, filename });
+        insertedPdfRows.push({ id: inserted.id, buffer: bytes, filename });
 
         await insertLog({
           userId,

--- a/webapp/src/lib/email-ingest/pdf-handler.ts
+++ b/webapp/src/lib/email-ingest/pdf-handler.ts
@@ -21,19 +21,31 @@ export function filterPdfAttachments(attachments: ResendAttachment[]): ResendAtt
   );
 }
 
+/**
+ * Accepted PDF payload types. We accept both raw ArrayBuffers (e.g. from
+ * Blob.arrayBuffer()) and Uint8Array views (e.g. Node Buffers) so callers
+ * don't have to materialize pool-allocated buffers into fresh ArrayBuffers.
+ * Passing `Buffer.from(..).buffer` would include 8KB of shared-pool bytes
+ * around small payloads — always prefer the Uint8Array itself.
+ */
+export type PdfPayload = ArrayBuffer | Uint8Array;
+
+function toUint8(payload: PdfPayload): Uint8Array<ArrayBuffer> {
+  // Node Buffer / Uint8Array from attachment decode is always backed by a plain
+  // ArrayBuffer, never SharedArrayBuffer, so this cast is safe and avoids a copy.
+  if (payload instanceof Uint8Array) {
+    return payload as Uint8Array<ArrayBuffer>;
+  }
+  return new Uint8Array(payload);
+}
+
 /** Compute SHA-256 hash of raw PDF content (for idempotency) */
-export async function computePdfHash(buffer: ArrayBuffer): Promise<string> {
-  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+export async function computePdfHash(payload: PdfPayload): Promise<string> {
+  const bytes = toUint8(payload);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", bytes);
   return Array.from(new Uint8Array(hashBuffer))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
-}
-
-/** Validate PDF magic bytes (%PDF) */
-function isPdfContent(buffer: ArrayBuffer): boolean {
-  if (buffer.byteLength < 4) return false;
-  const header = new Uint8Array(buffer, 0, 4);
-  return header[0] === 0x25 && header[1] === 0x50 && header[2] === 0x44 && header[3] === 0x46;
 }
 
 /**
@@ -41,8 +53,8 @@ function isPdfContent(buffer: ArrayBuffer): boolean {
  * Checks the last 4KB of the file (where the xref/trailer typically lives)
  * plus the first 2KB (some linearized PDFs put it early).
  */
-export function isPdfEncrypted(buffer: ArrayBuffer): boolean {
-  const bytes = new Uint8Array(buffer);
+export function isPdfEncrypted(payload: PdfPayload): boolean {
+  const bytes = toUint8(payload);
   const needle = "/Encrypt";
 
   // Check last 4KB (trailer area)
@@ -59,7 +71,7 @@ export function isPdfEncrypted(buffer: ArrayBuffer): boolean {
 
 /** Send a PDF buffer to the parser service and return parsed statements */
 export async function parsePdfBuffer(params: {
-  buffer: ArrayBuffer;
+  buffer: PdfPayload;
   filename: string;
   password?: string;
 }): Promise<
@@ -71,9 +83,11 @@ export async function parsePdfBuffer(params: {
   }
 
   const formData = new FormData();
+  // Convert to Uint8Array so Blob sees only the PDF bytes — not any enclosing
+  // pool ArrayBuffer that Node.js may have allocated around a small Buffer.
   formData.append(
     "file",
-    new Blob([params.buffer], { type: "application/pdf" }),
+    new Blob([toUint8(params.buffer)], { type: "application/pdf" }),
     params.filename,
   );
   if (params.password) {


### PR DESCRIPTION
Node.js Buffer.from(str, 'base64') may allocate from a shared 8KB pool, which
makes `bytes.buffer` point to the pool ArrayBuffer with `bytes` at a non-zero
`byteOffset`. The webhook was passing `bytes.buffer` to computePdfHash, to the
storage upload, and to parsePdfBuffer — so for small PDFs the parser received
8KB of mostly-zero pool data with the PDF somewhere inside, failing the
`%PDF` magic-byte check with "El archivo no es un PDF válido".

Pass the Uint8Array (Node Buffer) itself everywhere and widen the helper
signatures to accept ArrayBuffer | Uint8Array so Blob/digest/storage only see
the PDF's bytes.