### PR TITLE
fix(pdf-parser): Nu total_payment_due uses Usado, not stale prior-cycle block

### DIFF
--- a/services/pdf_parser/parsers/nu_credit_card.py
+++ b/services/pdf_parser/parsers/nu_credit_card.py
@@ -54,17 +54,9 @@ PAYMENT_DUE_DATE_RE = re.compile(
 # Credit limit: "Tu cupo definido" then $ value on next line
 CREDIT_LIMIT_RE = re.compile(r"\$\s*([\d.,]+)")
 
-# Used credit: appears in the same section as "Usado"
-USED_CREDIT_RE = re.compile(r"Usado\s*\n?\s*\$\s*([\d.,]+)", re.IGNORECASE)
-
 # Available credit: "Disponible" then value
 AVAILABLE_CREDIT_RE = re.compile(
     r"Disponible\s*\n?\s*\$\s*([\d.,]+)", re.IGNORECASE
-)
-
-# Total payment due: "PAGO HASTA EL [date] $[amount]"
-TOTAL_PAYMENT_DUE_RE = re.compile(
-    r"PAGO\s+HASTA\s+EL\s+\d+\s+\w+\s+\d+\s*\$\s*([\d.,]+)", re.IGNORECASE
 )
 
 # Minimum payment: "PAGO MÍNIMO $[amount]"
@@ -443,6 +435,18 @@ def parse_nu_credit_card(
                     except ValueError:
                         pass
 
+    # Used credit: "Usado" followed by $ value on same or next line
+    used_credit: float | None = None
+    used_idx = combined_upper.find("USADO")
+    if used_idx >= 0:
+        search_text = combined_text[used_idx:used_idx + 100]
+        values = AMOUNT_RE.findall(search_text)
+        if values:
+            try:
+                used_credit = parse_co_number(values[0])
+            except ValueError:
+                pass
+
     # Available credit: when "Usado" and "Disponible" are on the same line,
     # their values are on the next line. Need to get the SECOND $ value.
     available_idx = combined_upper.find("DISPONIBLE")
@@ -463,13 +467,14 @@ def parse_nu_credit_card(
             except ValueError:
                 pass
 
-    # Total payment due
-    m = TOTAL_PAYMENT_DUE_RE.search(combined_upper)
-    if m:
-        try:
-            total_payment_due = parse_co_number(m.group(1))
-        except ValueError:
-            pass
+    # Total payment due = current outstanding balance (Usado).
+    # The PDF's "PAGO HASTA EL <date>" block refers to the PRIOR cycle's
+    # minimum (already paid), not the new total. "Usado" is what the user
+    # actually owes right now. Fallback: cupo_total - disponible.
+    if used_credit is not None:
+        total_payment_due = used_credit
+    elif credit_limit is not None and available_credit is not None:
+        total_payment_due = credit_limit - available_credit
 
     # Minimum payment
     m = MINIMUM_PAYMENT_RE.search(combined_upper)

--- a/services/pdf_parser/parsers/nu_credit_card.py
+++ b/services/pdf_parser/parsers/nu_credit_card.py
@@ -435,15 +435,18 @@ def parse_nu_credit_card(
                     except ValueError:
                         pass
 
-    # Used credit: "Usado" followed by $ value on same or next line
+    # Used credit: "Usado" followed by $ value on same or next line.
+    # Allow an optional leading minus sign so a credit balance (overpayment)
+    # is parsed with the correct sign instead of flipping to positive.
     used_credit: float | None = None
     used_idx = combined_upper.find("USADO")
     if used_idx >= 0:
         search_text = combined_text[used_idx:used_idx + 100]
-        values = AMOUNT_RE.findall(search_text)
-        if values:
+        signed_match = re.search(r"(-?)\s*\$\s*([\d.,]+)", search_text)
+        if signed_match:
             try:
-                used_credit = parse_co_number(values[0])
+                magnitude = parse_co_number(signed_match.group(2))
+                used_credit = -magnitude if signed_match.group(1) == "-" else magnitude
             except ValueError:
                 pass
 


### PR DESCRIPTION
## Summary
- Nu credit card PDFs print a `PAGO HASTA EL <old date> $<amount>` block that refers to the **prior** cycle's minimum (already paid via abono). The regex matched that as `total_payment_due`, producing wildly understated balances when the user had prepaid — e.g., app showed `$905k` when real debt was `$3.87M`.
- Parse **`Usado`** (current outstanding balance) directly. Fallback: `credit_limit − available_credit`.
- Dropped the `TOTAL_PAYMENT_DUE_RE` regex and the unused `USED_CREDIT_RE`.

## Verification
Tested against a real April 2026 Nu statement where the user prepaid last cycle:

| Field | Before | After | PDF value |
|---|---|---|---|
| `total_payment_due` | `$905.210` | **`$3.874.325`** | Usado `$3.874.324,57` ✅ |
| `minimum_payment` | `$546.040` | `$546.040` | `$546.040,05` ✅ |
| `available_credit` | `$75.675` | `$75.675` | `$75.675,43` ✅ |
| `credit_limit` | `$3.950.000` | `$3.950.000` | `$3.950.000,00` ✅ |

## Test plan
- [x] Run parser locally against provided Nu PDF — values match
- [x] Manually tested full import flow via webapp — wizard step 2 shows correct totals
- [ ] Monitor production import after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)