### PR TITLE
fix(import): wire email-ingested statements into import wizard

### DIFF
--- a/webapp/src/actions/email-pdf-ingest.ts
+++ b/webapp/src/actions/email-pdf-ingest.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { updateTag } from "next/cache";
+import { cacheLife, cacheTag, updateTag } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { parsePdfBuffer } from "@/lib/email-ingest/pdf-handler";
 import { parseStatementFilename, matchAccountByLast4 } from "@/lib/email-ingest/statement-filename";
@@ -12,22 +13,39 @@ import type { Json } from "@/types/database";
 
 // ── Read actions ─────────────────────────────────────────────────────────────
 
-export async function getPendingEmailStatements(): Promise<
-  ActionResult<PendingEmailStatement[]>
-> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+async function getPendingEmailStatementsCached(
+  userId: string,
+  accessToken: string,
+): Promise<PendingEmailStatement[]> {
+  "use cache";
+  cacheTag("email-ingest");
+  cacheLife("zeta");
 
+  const supabase = createCachedClient(accessToken);
   const { data, error } = await supabase
     .from("pending_email_statements")
     .select("*")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .in("status", ["pending", "parsing", "parsed", "needs_password", "parse_failed"])
     .order("created_at", { ascending: false })
     .limit(50);
 
-  if (error) return { success: false, error: error.message };
-  return { success: true, data: (data ?? []) as unknown as PendingEmailStatement[] };
+  if (error) throw error;
+  return (data ?? []) as unknown as PendingEmailStatement[];
+}
+
+export async function getPendingEmailStatements(): Promise<
+  ActionResult<PendingEmailStatement[]>
+> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+
+  try {
+    const data = await getPendingEmailStatementsCached(user.id, accessToken);
+    return { success: true, data };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : "Error desconocido" };
+  }
 }
 
 export async function getPendingEmailStatementCount(): Promise<ActionResult<number>> {

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -865,7 +865,7 @@ export async function importTransactions(
     return { success: false, error: "Datos inválidos" };
   }
 
-  const { transactions, statementMeta, reconciliationDecisions = [] } = parsed.data;
+  const { transactions, statementMeta, reconciliationDecisions = [], captureMethod = "PDF_IMPORT" } = parsed.data;
   const normalizedStatementMeta: StatementMetaForImport[] | undefined = statementMeta?.map(
     (meta) => ({
       ...meta,
@@ -950,7 +950,7 @@ export async function importTransactions(
         clean_description: tx.raw_description,
         idempotency_key: idempotencyKey,
         provider: "OCR",
-        capture_method: "PDF_IMPORT",
+        capture_method: captureMethod,
         category_id: tx.category_id ?? null,
         notes: tx.notes ?? null,
         categorization_source: tx.categorization_source ?? "SYSTEM_DEFAULT",
@@ -1027,7 +1027,7 @@ export async function importTransactions(
       category_id: insertedTx.category_id,
       categorization_source: insertedTx.categorization_source,
       notes: insertedTx.notes,
-      capture_method: "PDF_IMPORT",
+      capture_method: captureMethod,
     });
 
     await supabase

--- a/webapp/src/app/(dashboard)/import/page.tsx
+++ b/webapp/src/app/(dashboard)/import/page.tsx
@@ -5,8 +5,7 @@ import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getDestinatarioRules } from "@/actions/destinatarios";
 import { getPendingEmailStatements } from "@/actions/email-pdf-ingest";
-import { ImportWizard } from "@/components/import/import-wizard";
-import { PendingEmailStatements } from "@/components/import/pending-email-statements";
+import { ImportPageClient } from "@/components/import/import-page-client";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { Button } from "@/components/ui/button";
 import { PageHero, HeroPill, HeroAccentPill } from "@/components/ui/page-hero";
@@ -123,12 +122,11 @@ export default async function ImportPage() {
         </p>
       </div>
 
-      <PendingEmailStatements statements={pendingStatements} />
-
-      <ImportWizard
+      <ImportPageClient
         accounts={accounts}
         categories={categories}
         destinatarioRules={destinatarioRules}
+        pendingStatements={pendingStatements}
       />
 
       {/* Mobile: collapsible info section */}

--- a/webapp/src/components/import/import-page-client.tsx
+++ b/webapp/src/components/import/import-page-client.tsx
@@ -51,6 +51,7 @@ export function ImportPageClient({
   return (
     <>
       <PendingEmailStatements
+        key={selectedId ?? "none"}
         statements={visiblePending}
         onReviewStatement={handleReviewStatement}
       />

--- a/webapp/src/components/import/import-page-client.tsx
+++ b/webapp/src/components/import/import-page-client.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { ImportWizard } from "@/components/import/import-wizard";
+import { PendingEmailStatements } from "@/components/import/pending-email-statements";
+import type { Account, CategoryWithChildren, PendingEmailStatement } from "@/types/domain";
+import type { DestinatarioRule } from "@zeta/shared";
+import type { ParsedStatement, ParseResponse } from "@/types/import";
+
+interface Props {
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  destinatarioRules: DestinatarioRule[];
+  pendingStatements: PendingEmailStatement[];
+}
+
+export function ImportPageClient({
+  accounts,
+  categories,
+  destinatarioRules,
+  pendingStatements: initialPending,
+}: Props) {
+  const [pendingStatements, setPendingStatements] = useState(initialPending);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedParseResult, setSelectedParseResult] = useState<ParseResponse | null>(null);
+
+  const handleReviewStatement = useCallback((statement: PendingEmailStatement) => {
+    if (!Array.isArray(statement.parsed_data) || statement.parsed_data.length === 0) return;
+    const statements = statement.parsed_data as unknown as ParsedStatement[];
+    setSelectedId(statement.id);
+    setSelectedParseResult({ statements });
+    // Scroll the wizard into view so the user sees the jump to "Revisar".
+    requestAnimationFrame(() => {
+      const el = document.getElementById("import-wizard");
+      el?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }, []);
+
+  const handleImportedFromEmail = useCallback((id: string) => {
+    setPendingStatements((prev) => prev.filter((s) => s.id !== id));
+    setSelectedId((current) => (current === id ? null : current));
+  }, []);
+
+  // Hide any statement that has been selected for review from the pending list
+  // so the user doesn't see two entry points while the wizard is active.
+  const visiblePending = useMemo(
+    () => pendingStatements.filter((s) => s.id !== selectedId),
+    [pendingStatements, selectedId],
+  );
+
+  return (
+    <>
+      <PendingEmailStatements
+        statements={visiblePending}
+        onReviewStatement={handleReviewStatement}
+      />
+
+      <div id="import-wizard" className="scroll-mt-20">
+        <ImportWizard
+          key={selectedId ?? "fresh"}
+          accounts={accounts}
+          categories={categories}
+          destinatarioRules={destinatarioRules}
+          initialParseResult={selectedParseResult}
+          pendingEmailStatementId={selectedId}
+          onImportedFromEmail={handleImportedFromEmail}
+        />
+      </div>
+    </>
+  );
+}

--- a/webapp/src/components/import/import-page-client.tsx
+++ b/webapp/src/components/import/import-page-client.tsx
@@ -55,7 +55,7 @@ export function ImportPageClient({
         onReviewStatement={handleReviewStatement}
       />
 
-      <div id="import-wizard" className="scroll-mt-20">
+      <div id="import-wizard" className="scroll-mt-16">
         <ImportWizard
           key={selectedId ?? "fresh"}
           accounts={accounts}

--- a/webapp/src/components/import/import-wizard.tsx
+++ b/webapp/src/components/import/import-wizard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { Check, ShieldCheck } from "lucide-react";
 import { getPendingScreenshotFile } from "@/components/mobile/mobile-sheet-provider";
+import { markEmailPdfStatementImported } from "@/actions/email-pdf-ingest";
 import type { Account, CategoryWithChildren, CurrencyCode } from "@/types/domain";
 import type { DestinatarioRule } from "@zeta/shared";
 import type {
@@ -49,14 +50,22 @@ export function ImportWizard({
   categories,
   destinatarioRules,
   initialFile,
+  initialParseResult,
+  pendingEmailStatementId,
+  onImportedFromEmail,
 }: {
   accounts: Account[];
   categories: CategoryWithChildren[];
   destinatarioRules: DestinatarioRule[];
   initialFile?: File | null;
+  initialParseResult?: ParseResponse | null;
+  pendingEmailStatementId?: string | null;
+  onImportedFromEmail?: (id: string) => void;
 }) {
-  const [step, setStep] = useState<Step>("upload");
-  const [parseResult, setParseResult] = useState<ParseResponse | null>(null);
+  const [step, setStep] = useState<Step>(initialParseResult ? "review" : "upload");
+  const [parseResult, setParseResult] = useState<ParseResponse | null>(
+    initialParseResult ?? null,
+  );
   const [mappings, setMappings] = useState<StatementAccountMapping[]>([]);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [accountsList, setAccountsList] = useState<Account[]>(accounts);
@@ -65,6 +74,7 @@ export function ImportWizard({
   const [reconciliationPreview, setReconciliationPreview] =
     useState<ReconciliationPreviewResult | null>(null);
   const [activeDestinatarioRules, setActiveDestinatarioRules] = useState<DestinatarioRule[]>(destinatarioRules);
+  const activeEmailStatementIdRef = useRef<string | null>(pendingEmailStatementId ?? null);
 
   const currentIndex = STEPS.findIndex((s) => s.key === step);
   const currentStep = STEPS[currentIndex];
@@ -96,6 +106,22 @@ export function ImportWizard({
       success: true,
     });
   }, []);
+
+  // Seed the wizard from a pre-parsed email statement when the parent
+  // selects one. Auto-match accounts and jump directly to the review step.
+  useEffect(() => {
+    if (initialParseResult && pendingEmailStatementId) {
+      setParseResult(initialParseResult);
+      setMappings(autoMatchAccounts(initialParseResult, accountsList));
+      setImportResult(null);
+      setPreparedTransactions([]);
+      setPreparedStatementMeta([]);
+      setReconciliationPreview(null);
+      setStep("review");
+      activeEmailStatementIdRef.current = pendingEmailStatementId;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialParseResult, pendingEmailStatementId]);
 
   function autoMatchAccounts(
     result: ParseResponse,
@@ -176,6 +202,16 @@ export function ImportWizard({
   function handleImportComplete(result: ImportResult) {
     setImportResult(result);
     setStep("results");
+
+    const emailId = activeEmailStatementIdRef.current;
+    if (emailId && (result.imported > 0 || result.autoMerged > 0 || result.manualMerged > 0)) {
+      activeEmailStatementIdRef.current = null;
+      void markEmailPdfStatementImported(emailId).then((res) => {
+        if (res.success) {
+          onImportedFromEmail?.(emailId);
+        }
+      });
+    }
   }
 
   function handlePrepared(payload: {
@@ -197,6 +233,7 @@ export function ImportWizard({
     setPreparedTransactions([]);
     setPreparedStatementMeta([]);
     setReconciliationPreview(null);
+    activeEmailStatementIdRef.current = null;
   }
 
   return (

--- a/webapp/src/components/import/import-wizard.tsx
+++ b/webapp/src/components/import/import-wizard.tsx
@@ -204,7 +204,16 @@ export function ImportWizard({
     setStep("results");
 
     const emailId = activeEmailStatementIdRef.current;
-    if (emailId && (result.imported > 0 || result.autoMerged > 0 || result.manualMerged > 0)) {
+    // Also mark imported when everything was skipped: that means the PDF's
+    // transactions already exist in the DB (idempotency-key match). The
+    // pending row is redundant at that point — clean it up.
+    if (
+      emailId &&
+      (result.imported > 0 ||
+        result.autoMerged > 0 ||
+        result.manualMerged > 0 ||
+        result.skipped > 0)
+    ) {
       activeEmailStatementIdRef.current = null;
       void markEmailPdfStatementImported(emailId).then((res) => {
         if (res.success) {

--- a/webapp/src/components/import/import-wizard.tsx
+++ b/webapp/src/components/import/import-wizard.tsx
@@ -360,6 +360,7 @@ export function ImportWizard({
             statementMeta={preparedStatementMeta}
             preview={reconciliationPreview}
             currency={(parseResult?.statements[0]?.currency ?? "COP") as CurrencyCode}
+            captureMethod={pendingEmailStatementId ? "EMAIL_PDF_IMPORT" : "PDF_IMPORT"}
             onComplete={handleImportComplete}
             onBack={() => setStep("confirm")}
           />

--- a/webapp/src/components/import/reconciliation-step.tsx
+++ b/webapp/src/components/import/reconciliation-step.tsx
@@ -73,6 +73,7 @@ export function ReconciliationStep({
   statementMeta,
   preview,
   currency,
+  captureMethod,
   onComplete,
   onBack,
 }: {
@@ -80,6 +81,7 @@ export function ReconciliationStep({
   statementMeta: StatementMetaForImport[];
   preview: ReconciliationPreviewResult;
   currency: CurrencyCode;
+  captureMethod?: "PDF_IMPORT" | "EMAIL_PDF_IMPORT";
   onComplete: (result: ImportResult) => void;
   onBack: () => void;
 }) {
@@ -115,8 +117,9 @@ export function ReconciliationStep({
         transactions,
         statementMeta,
         reconciliationDecisions,
+        captureMethod,
       }),
-    [transactions, statementMeta, reconciliationDecisions]
+    [transactions, statementMeta, reconciliationDecisions, captureMethod]
   );
 
   const [state, formAction, pending] = useActionState<ActionResult<ImportResult>, FormData>(

--- a/webapp/src/lib/validators/import.ts
+++ b/webapp/src/lib/validators/import.ts
@@ -88,4 +88,7 @@ export const importPayloadSchema = z.object({
   transactions: z.array(transactionToImportSchema),
   statementMeta: z.array(statementMetaSchema).optional(),
   reconciliationDecisions: z.array(reconciliationDecisionSchema).optional(),
+  // Source of the import. Defaults to PDF_IMPORT (manual upload); the wizard
+  // sets EMAIL_PDF_IMPORT when seeded from a pending email statement.
+  captureMethod: z.enum(["PDF_IMPORT", "EMAIL_PDF_IMPORT"]).optional(),
 });


### PR DESCRIPTION
## Summary
- The \"Extractos pendientes por correo\" card was rendered without an \`onReviewStatement\` handler, so the **\"Revisar e importar\"** button never appeared. Users with a successfully parsed email PDF had **no UI path to start the import flow** — only \"Descartar\".
- New \`ImportPageClient\` wrapper lifts state between the pending list and the wizard.
- \`ImportWizard\` accepts \`initialParseResult\` + \`pendingEmailStatementId\`, jumps straight to the review step, and auto-matches accounts.
- On successful import, calls \`markEmailPdfStatementImported()\` and prunes the row from the pending list.

## Flow
1. Bancolombia/Nu/etc email arrives → webhook stores the PDF and parses it → row in \`pending_email_statements\` with \`status='parsed'\`.
2. User visits \`/import\` → sees \"Listo para revisar\" badge → clicks **Revisar e importar**.
3. Wizard seeds \`parseResult\` from \`parsed_data\`, auto-matches the account, jumps to step 2 (\"Revisar\").
4. After import completes, \`pending_email_statements\` row is marked \`imported\` and removed from the card.

## Files
- \`webapp/src/components/import/import-page-client.tsx\` — new client wrapper
- \`webapp/src/components/import/import-wizard.tsx\` — accepts pre-parsed result + email id
- \`webapp/src/app/(dashboard)/import/page.tsx\` — uses wrapper

## Test plan
- [x] \`pnpm build\` clean
- [ ] Upload a fresh PDF via normal flow — still works
- [ ] Trigger email ingest → \"Revisar e importar\" button now renders → click → wizard seeded at review step
- [ ] Complete import → card removes the entry + no duplicate rows in transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)