### PR TITLE
feat: autofill suppression + PDF password vault

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -60,19 +60,11 @@
 - **Touches:** new server action `addPatternToDestinatario(destinatarioId, pattern)` in `actions/destinatarios.ts` (insert into `destinatario_patterns` with `match_type: "contains"`, `priority: 100`; `updateTag("destinatarios")`); `step-destinatarios.tsx` UI (picker + wiring); `import-wizard.tsx` passes the updated rules so later steps use them.
 - **Found:** User feedback during Nu import session, 2026-04-17
 
-### Disable browser autofill/autocomplete on app inputs
-- **Priority:** Medium
-- **What:** Once upon a time we suppressed autocomplete suggestions across forms; the behaviour has regressed (or never covered the newer inputs). Chrome/Safari happily dump saved addresses, card numbers, and unrelated names on top of transaction amounts, account names, destinatarios, etc. Sweep every `<Input>`/`<input>`/`<Textarea>` in `webapp/src/components/` and add `autoComplete="off"` (+ `autoCorrect`, `spellCheck={false}` where relevant). Where browsers ignore `off` (Chrome does for heuristically-detected fields), use a non-standard sentinel like `autoComplete="new-password"` or a one-off token per field. Consider a shared `<AppInput>` wrapper that defaults these props so future forms stay clean.
-- **Touches:** `webapp/src/components/ui/input.tsx` (add default), every form component, mobile forms.
-- **Found:** User request, 2026-04-17
+### ~~Disable browser autofill/autocomplete on app inputs~~ — DONE 2026-04-17
+- Shipped: `ui/input.tsx` defaults `autoComplete/autoCorrect/spellCheck` to off (overridable). Auth forms keep their semantic `autoComplete` hints. Raw `<textarea>` fields in bug-report and deseos got `autoComplete="off"`. `ui/currency-input.tsx` now hardcodes off since the raw `<input>` in that component bypasses the wrapper.
 
-### PDF password vault — per-bank/per-account passwords with aliases
-- **Priority:** Medium
-- **What:** Today the import flow asks for a password per PDF upload and `accounts.pdf_password` is only auto-saved after the retry-with-password flow on email-ingested statements. Users with multiple banks end up retyping the same 3–4 passwords for each manual upload. Build a password vault UI: a table of `{ alias, password, scope }` rows (scope = "account:<id>" or "bank:<name>" or "global"), editable from `/settings`. During the import Upload step, show a dropdown of saved aliases; selecting one fills the password field. When a new password is entered manually and the PDF parses, prompt to save it with an alias. Sync into existing `accounts.pdf_password` when the scope is account-level so email ingest keeps benefiting.
-- **Storage:** New `pdf_passwords` encrypted table (alias + password) tied to `user_id`, with an optional `account_id` FK. Spawn `supabase-migrator` for the 6-step encrypted-column migration. Decide whether to keep `accounts.pdf_password` as a derived mirror or replace it entirely.
-- **UX:** Dropdown on the upload step, "Guardar contraseña" affordance after a successful parse, manage list from settings. For security, never render the password in plaintext after save — show ••• + copy/edit/delete.
-- **Touches:** new action file `webapp/src/actions/pdf-passwords.ts`, settings UI, upload step, password-retry modal, migration.
-- **Found:** User request, 2026-04-17
+### ~~PDF password vault — per-bank/per-account passwords with aliases~~ — DONE 2026-04-17
+- Shipped: migration `20260417143333_create_pdf_passwords_encrypted.sql` (encrypted `alias` + `password` with scope pairing CHECK). Server actions in `webapp/src/actions/pdf-passwords.ts` — list, suggest, create, update, delete. Settings UI `PdfPasswordsCard`. Upload step: "Usar guardada" dropdown (uses suggestions ranked account > bank > global) + inline "Guardar esta contraseña" checkbox (auto-infers bank scope from parser's `bank` label). `accounts.pdf_password` still mirrored on scope=account so email ingest keeps working. Follow-ups deferred: secure "copy password" affordance in settings list, and account-scope picker on the upload step once the account is known earlier.
 
 ### Promote transaction → recurring template ("Hacer recurrente" CTA)
 - **Priority:** High

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -54,6 +54,12 @@
 
 ## Features
 
+### Import wizard — attach pattern to existing destinatario
+- **Priority:** Medium
+- **What:** Step 3 (Destinatarios) of `/import` only offers "Crear destinatario" on each unmatched suggestion. When the cleaned pattern is actually a spelling variant of a destinatario that already exists (e.g., `Rappi Colombia*Dl` vs existing `rappi colombia`), the only recoverable path today is to skip, finish the import, then edit patterns at `/destinatarios`. Add a second action to every suggestion card: "Asignar a destinatario existente" → opens a picker (reuse the zone-picker pattern), on confirm appends the pattern to that destinatario's `destinatario_patterns`, refreshes the in-memory `destinatarioRules`, re-runs `matchDestinatario`, and collapses the suggestion. Optional polish: sort the picker by match score or by destinatario-spend to surface the likely target first.
+- **Touches:** new server action `addPatternToDestinatario(destinatarioId, pattern)` in `actions/destinatarios.ts` (insert into `destinatario_patterns` with `match_type: "contains"`, `priority: 100`; `updateTag("destinatarios")`); `step-destinatarios.tsx` UI (picker + wiring); `import-wizard.tsx` passes the updated rules so later steps use them.
+- **Found:** User feedback during Nu import session, 2026-04-17
+
 ### Disable browser autofill/autocomplete on app inputs
 - **Priority:** Medium
 - **What:** Once upon a time we suppressed autocomplete suggestions across forms; the behaviour has regressed (or never covered the newer inputs). Chrome/Safari happily dump saved addresses, card numbers, and unrelated names on top of transaction amounts, account names, destinatarios, etc. Sweep every `<Input>`/`<input>`/`<Textarea>` in `webapp/src/components/` and add `autoComplete="off"` (+ `autoCorrect`, `spellCheck={false}` where relevant). Where browsers ignore `off` (Chrome does for heuristically-detected fields), use a non-standard sentinel like `autoComplete="new-password"` or a one-off token per field. Consider a shared `<AppInput>` wrapper that defaults these props so future forms stay clean.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -54,6 +54,20 @@
 
 ## Features
 
+### Disable browser autofill/autocomplete on app inputs
+- **Priority:** Medium
+- **What:** Once upon a time we suppressed autocomplete suggestions across forms; the behaviour has regressed (or never covered the newer inputs). Chrome/Safari happily dump saved addresses, card numbers, and unrelated names on top of transaction amounts, account names, destinatarios, etc. Sweep every `<Input>`/`<input>`/`<Textarea>` in `webapp/src/components/` and add `autoComplete="off"` (+ `autoCorrect`, `spellCheck={false}` where relevant). Where browsers ignore `off` (Chrome does for heuristically-detected fields), use a non-standard sentinel like `autoComplete="new-password"` or a one-off token per field. Consider a shared `<AppInput>` wrapper that defaults these props so future forms stay clean.
+- **Touches:** `webapp/src/components/ui/input.tsx` (add default), every form component, mobile forms.
+- **Found:** User request, 2026-04-17
+
+### PDF password vault — per-bank/per-account passwords with aliases
+- **Priority:** Medium
+- **What:** Today the import flow asks for a password per PDF upload and `accounts.pdf_password` is only auto-saved after the retry-with-password flow on email-ingested statements. Users with multiple banks end up retyping the same 3–4 passwords for each manual upload. Build a password vault UI: a table of `{ alias, password, scope }` rows (scope = "account:<id>" or "bank:<name>" or "global"), editable from `/settings`. During the import Upload step, show a dropdown of saved aliases; selecting one fills the password field. When a new password is entered manually and the PDF parses, prompt to save it with an alias. Sync into existing `accounts.pdf_password` when the scope is account-level so email ingest keeps benefiting.
+- **Storage:** New `pdf_passwords` encrypted table (alias + password) tied to `user_id`, with an optional `account_id` FK. Spawn `supabase-migrator` for the 6-step encrypted-column migration. Decide whether to keep `accounts.pdf_password` as a derived mirror or replace it entirely.
+- **UX:** Dropdown on the upload step, "Guardar contraseña" affordance after a successful parse, manage list from settings. For security, never render the password in plaintext after save — show ••• + copy/edit/delete.
+- **Touches:** new action file `webapp/src/actions/pdf-passwords.ts`, settings UI, upload step, password-retry modal, migration.
+- **Found:** User request, 2026-04-17
+
 ### Promote transaction → recurring template ("Hacer recurrente" CTA)
 - **Priority:** High
 - **What:** Add a "Hacer recurrente" action on `/transactions/[id]` (and ideally the 3-dot menu on list rows) that opens the existing `RecurringFormDialog` pre-filled with the transaction's merchant, amount, account, category, destinatario, and a monthly-frequency default. On confirm, create a `recurring_templates` row with `start_date` = the transaction's date so the occurrence engine generates this month + future pendings; the source transaction auto-links to the current occurrence via `findMatchingOccurrence()`.

--- a/supabase/migrations/20260417143333_create_pdf_passwords_encrypted.sql
+++ b/supabase/migrations/20260417143333_create_pdf_passwords_encrypted.sql
@@ -1,0 +1,179 @@
+-- ============================================================================
+-- Create pdf_passwords (encrypted)
+--
+-- User-owned PDF password vault for the import flow. A user can save
+-- reusable PDF passwords scoped to:
+--   - 'global'  → try for any PDF
+--   - 'bank'    → try for any account under a bank_key
+--   - 'account' → specific to one account
+--
+-- Encrypted columns (BYTEA via envelope encryption):
+--   - alias    (user label, e.g. "Cédula Cristian" — PII)
+--   - password (the actual PDF password)
+--
+-- Plaintext columns:
+--   - scope, bank_key, account_id, timestamps
+--
+-- Follows the same pattern as accounts_enc / destinatarios_enc:
+--   1. Real table `pdf_passwords_enc` with BYTEA columns
+--   2. RLS on _enc using (select auth.uid()) = user_id
+--   3. View `pdf_passwords` with zeta_decrypt(...)
+--   4. INSTEAD OF INSERT/UPDATE/DELETE triggers with admin-client fallback
+--      (zeta_encrypt_as / preserve ciphertext when auth.uid() IS NULL)
+--   5. GRANTs on the view for authenticated
+--   6. Unique indexes + scope pairing CHECK constraint
+-- ============================================================================
+
+-- 1. Real _enc table
+CREATE TABLE pdf_passwords_enc (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  alias       BYTEA NOT NULL,
+  password    BYTEA NOT NULL,
+  scope       TEXT NOT NULL CHECK (scope IN ('global','bank','account')),
+  bank_key    TEXT NULL,
+  account_id  UUID NULL REFERENCES accounts_enc(id) ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT pdf_passwords_scope_pairing CHECK (
+    (scope = 'account' AND account_id IS NOT NULL AND bank_key IS NULL) OR
+    (scope = 'bank'    AND bank_key   IS NOT NULL AND account_id IS NULL) OR
+    (scope = 'global'  AND account_id IS NULL      AND bank_key   IS NULL)
+  )
+);
+
+-- Helpful indexes
+CREATE INDEX idx_pdf_passwords_enc_user
+  ON pdf_passwords_enc (user_id);
+CREATE INDEX idx_pdf_passwords_enc_user_scope
+  ON pdf_passwords_enc (user_id, scope);
+CREATE INDEX idx_pdf_passwords_enc_user_bank
+  ON pdf_passwords_enc (user_id, bank_key)
+  WHERE bank_key IS NOT NULL;
+CREATE INDEX idx_pdf_passwords_enc_user_account
+  ON pdf_passwords_enc (user_id, account_id)
+  WHERE account_id IS NOT NULL;
+
+-- Prevent duplicate scope targets per user (e.g. two 'account' rows for same account)
+CREATE UNIQUE INDEX pdf_passwords_enc_user_scope_target_unique
+  ON pdf_passwords_enc (
+    user_id,
+    scope,
+    COALESCE(account_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(bank_key, '')
+  );
+
+-- 2. RLS on the _enc table
+ALTER TABLE pdf_passwords_enc ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can select own pdf_passwords"
+  ON pdf_passwords_enc FOR SELECT
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert own pdf_passwords"
+  ON pdf_passwords_enc FOR INSERT
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can update own pdf_passwords"
+  ON pdf_passwords_enc FOR UPDATE
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can delete own pdf_passwords"
+  ON pdf_passwords_enc FOR DELETE
+  USING ((select auth.uid()) = user_id);
+
+-- 3. Decrypted view
+CREATE VIEW pdf_passwords WITH (security_invoker = true) AS
+SELECT
+  id,
+  user_id,
+  zeta_decrypt(alias) AS alias,
+  zeta_decrypt(password) AS password,
+  scope,
+  bank_key,
+  account_id,
+  created_at,
+  updated_at
+FROM pdf_passwords_enc;
+
+-- 4a. INSTEAD OF INSERT
+CREATE OR REPLACE FUNCTION pdf_passwords_view_insert() RETURNS TRIGGER AS $$
+DECLARE
+  has_auth BOOLEAN;
+BEGIN
+  has_auth := (SELECT auth.uid()) IS NOT NULL;
+
+  NEW.id         := COALESCE(NEW.id, gen_random_uuid());
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := COALESCE(NEW.updated_at, now());
+
+  INSERT INTO pdf_passwords_enc (
+    id, user_id, alias, password, scope, bank_key, account_id,
+    created_at, updated_at
+  ) VALUES (
+    NEW.id,
+    NEW.user_id,
+    CASE WHEN has_auth THEN zeta_encrypt(NEW.alias)    ELSE zeta_encrypt_as(NEW.alias, NEW.user_id)    END,
+    CASE WHEN has_auth THEN zeta_encrypt(NEW.password) ELSE zeta_encrypt_as(NEW.password, NEW.user_id) END,
+    NEW.scope,
+    NEW.bank_key,
+    NEW.account_id,
+    NEW.created_at,
+    NEW.updated_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pdf_passwords_view_insert_trg
+  INSTEAD OF INSERT ON pdf_passwords
+  FOR EACH ROW EXECUTE FUNCTION pdf_passwords_view_insert();
+
+-- 4b. INSTEAD OF UPDATE
+-- When has_auth is false (admin client), preserve existing ciphertext for
+-- encrypted columns because the view's NEW.alias / NEW.password come from
+-- zeta_decrypt() which returns NULL without an auth session.
+CREATE OR REPLACE FUNCTION pdf_passwords_view_update() RETURNS TRIGGER AS $$
+DECLARE
+  has_auth BOOLEAN;
+BEGIN
+  has_auth := (SELECT auth.uid()) IS NOT NULL;
+
+  UPDATE pdf_passwords_enc SET
+    alias = CASE
+      WHEN has_auth THEN zeta_encrypt(NEW.alias)
+      ELSE (SELECT pe.alias FROM pdf_passwords_enc pe WHERE pe.id = OLD.id)
+    END,
+    password = CASE
+      WHEN has_auth THEN zeta_encrypt(NEW.password)
+      ELSE (SELECT pe.password FROM pdf_passwords_enc pe WHERE pe.id = OLD.id)
+    END,
+    scope       = NEW.scope,
+    bank_key    = NEW.bank_key,
+    account_id  = NEW.account_id,
+    updated_at  = COALESCE(NEW.updated_at, now())
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pdf_passwords_view_update_trg
+  INSTEAD OF UPDATE ON pdf_passwords
+  FOR EACH ROW EXECUTE FUNCTION pdf_passwords_view_update();
+
+-- 4c. INSTEAD OF DELETE
+CREATE OR REPLACE FUNCTION pdf_passwords_view_delete() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM pdf_passwords_enc WHERE id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pdf_passwords_view_delete_trg
+  INSTEAD OF DELETE ON pdf_passwords
+  FOR EACH ROW EXECUTE FUNCTION pdf_passwords_view_delete();
+
+-- 5. Grants on the view
+GRANT SELECT, INSERT, UPDATE, DELETE ON pdf_passwords TO authenticated;
+GRANT ALL ON pdf_passwords TO postgres, service_role;

--- a/webapp/src/actions/pdf-passwords.ts
+++ b/webapp/src/actions/pdf-passwords.ts
@@ -1,0 +1,244 @@
+"use server";
+
+import { cacheTag, cacheLife, updateTag } from "next/cache";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
+import {
+  pdfPasswordSchema,
+  pdfPasswordUpdateSchema,
+} from "@/lib/validators/pdf-password";
+import { uuidStr } from "@/lib/validators/shared";
+import type { ActionResult } from "@/types/actions";
+import type { Database } from "@/types/database";
+
+type PdfPasswordRow = Database["public"]["Tables"]["pdf_passwords"]["Row"];
+
+export type PdfPasswordEntry = {
+  id: string;
+  alias: string;
+  scope: "global" | "bank" | "account";
+  bank_key: string | null;
+  account_id: string | null;
+  account_name?: string | null;
+  has_password: boolean;
+  updated_at: string;
+};
+
+export async function listPdfPasswordsCached(
+  accessToken: string,
+  userId: string
+): Promise<PdfPasswordEntry[]> {
+  "use cache";
+  cacheTag("pdf-passwords");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data, error } = await supabase
+    .from("pdf_passwords")
+    .select(
+      "id, alias, scope, bank_key, account_id, updated_at, accounts!pdf_passwords_enc_account_id_fkey(name)"
+    )
+    .eq("user_id", userId)
+    .order("alias");
+
+  if (error) {
+    console.error("[pdf-passwords] list error:", error);
+    return [];
+  }
+
+  return (data ?? []).map((row) => {
+    const account = (row as { accounts?: { name: string | null } | null })
+      .accounts;
+    return {
+      id: row.id,
+      alias: row.alias,
+      scope: row.scope as "global" | "bank" | "account",
+      bank_key: row.bank_key,
+      account_id: row.account_id,
+      account_name: account?.name ?? null,
+      has_password: true,
+      updated_at: row.updated_at,
+    };
+  });
+}
+
+export async function listPdfPasswords(): Promise<PdfPasswordEntry[]> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
+  return listPdfPasswordsCached(accessToken, user.id);
+}
+
+export type PdfPasswordSuggestion = {
+  id: string;
+  alias: string;
+  password: string;
+  scope: "global" | "bank" | "account";
+  bank_key: string | null;
+  account_id: string | null;
+};
+
+export async function suggestPdfPasswordsForAccount(
+  accountId: string | null,
+  bankKey: string | null
+): Promise<PdfPasswordSuggestion[]> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("pdf_passwords")
+    .select("id, alias, password, scope, bank_key, account_id")
+    .eq("user_id", user.id);
+
+  if (error || !data) return [];
+
+  const noContext = !accountId && !bankKey;
+  const scored = data
+    .map((row) => {
+      let score = 0;
+      if (row.scope === "account" && accountId && row.account_id === accountId)
+        score = 3;
+      else if (row.scope === "bank" && bankKey && row.bank_key === bankKey)
+        score = 2;
+      else if (row.scope === "global") score = 1;
+      else if (noContext) score = 0.5;
+      return { row, score };
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || a.row.alias.localeCompare(b.row.alias));
+
+  return scored.map(({ row }) => ({
+    id: row.id,
+    alias: row.alias,
+    password: row.password,
+    scope: row.scope as "global" | "bank" | "account",
+    bank_key: row.bank_key,
+    account_id: row.account_id,
+  }));
+}
+
+export async function createPdfPassword(
+  _prevState: ActionResult<PdfPasswordRow>,
+  formData: FormData
+): Promise<ActionResult<PdfPasswordRow>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = pdfPasswordSchema.safeParse({
+    alias: formData.get("alias"),
+    password: formData.get("password"),
+    scope: formData.get("scope"),
+    bank_key: formData.get("bank_key") || undefined,
+    account_id: formData.get("account_id") || undefined,
+  });
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const { data, error } = await supabase
+    .from("pdf_passwords")
+    .insert({
+      user_id: user.id,
+      alias: parsed.data.alias,
+      password: parsed.data.password,
+      scope: parsed.data.scope,
+      bank_key: parsed.data.bank_key,
+      account_id: parsed.data.account_id,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return { success: false, error: "Ya existe una contraseña con ese alias o alcance." };
+    }
+    return { success: false, error: error.message };
+  }
+
+  if (parsed.data.scope === "account" && parsed.data.account_id) {
+    await supabase
+      .from("accounts")
+      .update({ pdf_password: parsed.data.password })
+      .eq("id", parsed.data.account_id)
+      .eq("user_id", user.id);
+    updateTag("accounts");
+  }
+
+  updateTag("pdf-passwords");
+  return { success: true, data };
+}
+
+export async function updatePdfPassword(
+  _prevState: ActionResult<PdfPasswordRow>,
+  formData: FormData
+): Promise<ActionResult<PdfPasswordRow>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = pdfPasswordUpdateSchema.safeParse({
+    id: formData.get("id"),
+    alias: formData.get("alias") || undefined,
+    password: formData.get("password") || undefined,
+  });
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const patch: Database["public"]["Tables"]["pdf_passwords"]["Update"] = {
+    updated_at: new Date().toISOString(),
+  };
+  if (parsed.data.alias) patch.alias = parsed.data.alias;
+  if (parsed.data.password) patch.password = parsed.data.password;
+
+  const { data, error } = await supabase
+    .from("pdf_passwords")
+    .update(patch)
+    .eq("id", parsed.data.id)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return { success: false, error: "Ya existe una contraseña con ese alias." };
+    }
+    return { success: false, error: error.message };
+  }
+
+  if (parsed.data.password && data.scope === "account" && data.account_id) {
+    await supabase
+      .from("accounts")
+      .update({ pdf_password: parsed.data.password })
+      .eq("id", data.account_id)
+      .eq("user_id", user.id);
+    updateTag("accounts");
+  }
+
+  updateTag("pdf-passwords");
+  return { success: true, data };
+}
+
+export async function deletePdfPassword(
+  _prevState: ActionResult<{ id: string }>,
+  formData: FormData
+): Promise<ActionResult<{ id: string }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsedId = uuidStr().safeParse(formData.get("id"));
+  if (!parsedId.success) {
+    return { success: false, error: "ID inválido" };
+  }
+
+  const { error } = await supabase
+    .from("pdf_passwords")
+    .delete()
+    .eq("id", parsedId.data)
+    .eq("user_id", user.id);
+
+  if (error) return { success: false, error: error.message };
+
+  updateTag("pdf-passwords");
+  return { success: true, data: { id: parsedId.data } };
+}

--- a/webapp/src/actions/pdf-passwords.ts
+++ b/webapp/src/actions/pdf-passwords.ts
@@ -77,6 +77,10 @@ export type PdfPasswordSuggestion = {
   account_id: string | null;
 };
 
+// Intentionally uncached: returns decrypted passwords. Caching would
+// either risk serializing plaintext into the cache layer, or require a
+// separate no-password index that the caller would have to re-resolve.
+// Freshness per call keeps the blast radius contained to the request.
 export async function suggestPdfPasswordsForAccount(
   accountId: string | null,
   bankKey: string | null
@@ -231,6 +235,13 @@ export async function deletePdfPassword(
     return { success: false, error: "ID inválido" };
   }
 
+  const { data: existing } = await supabase
+    .from("pdf_passwords")
+    .select("scope, account_id")
+    .eq("id", parsedId.data)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
   const { error } = await supabase
     .from("pdf_passwords")
     .delete()
@@ -238,6 +249,15 @@ export async function deletePdfPassword(
     .eq("user_id", user.id);
 
   if (error) return { success: false, error: error.message };
+
+  if (existing?.scope === "account" && existing.account_id) {
+    await supabase
+      .from("accounts")
+      .update({ pdf_password: null })
+      .eq("id", existing.account_id)
+      .eq("user_id", user.id);
+    updateTag("accounts");
+  }
 
   updateTag("pdf-passwords");
   return { success: true, data: { id: parsedId.data } };

--- a/webapp/src/app/(dashboard)/import/page.tsx
+++ b/webapp/src/app/(dashboard)/import/page.tsx
@@ -5,6 +5,7 @@ import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getDestinatarioRules } from "@/actions/destinatarios";
 import { getPendingEmailStatements } from "@/actions/email-pdf-ingest";
+import { suggestPdfPasswordsForAccount } from "@/actions/pdf-passwords";
 import { ImportWizard } from "@/components/import/import-wizard";
 import { PendingEmailStatements } from "@/components/import/pending-email-statements";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
@@ -15,11 +16,12 @@ import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 
 export default async function ImportPage() {
   await connection();
-  const [accountResult, categoryResult, rulesResult, pendingStatementsResult] = await Promise.all([
+  const [accountResult, categoryResult, rulesResult, pendingStatementsResult, vaultSuggestions] = await Promise.all([
     getAccounts(),
     getCategories(),
     getDestinatarioRules(),
     getPendingEmailStatements(),
+    suggestPdfPasswordsForAccount(null, null),
   ]);
   const accounts = accountResult.success ? accountResult.data : [];
   const categories = categoryResult.success ? categoryResult.data : [];
@@ -129,6 +131,7 @@ export default async function ImportPage() {
         accounts={accounts}
         categories={categories}
         destinatarioRules={destinatarioRules}
+        initialVaultSuggestions={vaultSuggestions}
       />
 
       {/* Mobile: collapsible info section */}

--- a/webapp/src/app/(dashboard)/settings/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from "next/server";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Activity, ArrowRight, Bug, Mail, Tag, UserRound } from "lucide-react";
+import { Activity, ArrowRight, Bug, KeyRound, Mail, Tag, UserRound } from "lucide-react";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
@@ -23,6 +23,8 @@ import { SettingsMobileAccordion } from "@/components/settings/settings-mobile-a
 import { DemoModeCard } from "@/components/settings/demo-mode-card";
 import { getCaptureTokens } from "@/actions/capture-tokens";
 import { getEmailIngestAddress, getEmailIngestLogs, getUnrecognizedEmails, getAllowedSenders } from "@/actions/email-ingest";
+import { listPdfPasswords } from "@/actions/pdf-passwords";
+import { PdfPasswordsCard } from "@/components/settings/pdf-passwords-card";
 import { getTagGroups } from "@/actions/tags";
 import { TagManager } from "@/components/tags/tag-manager";
 import type { Account } from "@/types/domain";
@@ -40,7 +42,7 @@ export default async function SettingsPage() {
 
   if (!profile) redirect("/login");
 
-  const [tokensResult, { data: accounts }, emailIngestResult, unrecognizedResult, emailLogsResult, tagGroupsResult, allowedSenders] = await Promise.all([
+  const [tokensResult, { data: accounts }, emailIngestResult, unrecognizedResult, emailLogsResult, tagGroupsResult, allowedSenders, pdfPasswords] = await Promise.all([
     getCaptureTokens(),
     supabase
       .from("accounts")
@@ -53,6 +55,7 @@ export default async function SettingsPage() {
     getEmailIngestLogs(),
     getTagGroups(),
     getAllowedSenders(),
+    listPdfPasswords(),
   ]);
 
   const tokens = tokensResult.success ? tokensResult.data : [];
@@ -90,6 +93,17 @@ export default async function SettingsPage() {
           <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
           <EmailIngestLogsCard initialLogs={emailLogs} />
         </div>
+      ),
+    },
+    {
+      id: "pdf-passwords",
+      title: "Contraseñas de PDF",
+      icon: <KeyRound className="size-4 text-z-brass" />,
+      children: (
+        <PdfPasswordsCard
+          initialEntries={pdfPasswords}
+          accounts={(accounts ?? []) as Account[]}
+        />
       ),
     },
     {
@@ -171,6 +185,11 @@ export default async function SettingsPage() {
         <UnrecognizedEmailsCard initialEmails={unrecognizedEmails} />
 
         <EmailIngestLogsCard initialLogs={emailLogs} />
+
+        <PdfPasswordsCard
+          initialEntries={pdfPasswords}
+          accounts={(accounts ?? []) as Account[]}
+        />
 
         <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
           <CardHeader>

--- a/webapp/src/components/deseos/deseos-enrich-drawer.tsx
+++ b/webapp/src/components/deseos/deseos-enrich-drawer.tsx
@@ -111,6 +111,7 @@ export function DeseosEnrichDrawer({
               rows={2}
               maxLength={500}
               placeholder="Describe tu motivacion..."
+              autoComplete="off"
               className="w-full rounded-md border border-white/10 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-z-brass focus:outline-none"
             />
           </div>

--- a/webapp/src/components/deseos/deseos-reflection-card.tsx
+++ b/webapp/src/components/deseos/deseos-reflection-card.tsx
@@ -135,6 +135,7 @@ export function DeseosReflectionCard({
             rows={2}
             maxLength={500}
             placeholder="Que aprendiste?"
+            autoComplete="off"
             className="w-full rounded-md border border-white/10 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-z-brass focus:outline-none"
           />
         </div>

--- a/webapp/src/components/import/import-wizard.tsx
+++ b/webapp/src/components/import/import-wizard.tsx
@@ -6,6 +6,7 @@ import { Check, ShieldCheck } from "lucide-react";
 import { getPendingScreenshotFile } from "@/components/mobile/mobile-sheet-provider";
 import type { Account, CategoryWithChildren, CurrencyCode } from "@/types/domain";
 import type { DestinatarioRule } from "@zeta/shared";
+import type { PdfPasswordSuggestion } from "@/actions/pdf-passwords";
 import type {
   ParseResponse,
   ReconciliationPreviewResult,
@@ -49,11 +50,13 @@ export function ImportWizard({
   categories,
   destinatarioRules,
   initialFile,
+  initialVaultSuggestions,
 }: {
   accounts: Account[];
   categories: CategoryWithChildren[];
   destinatarioRules: DestinatarioRule[];
   initialFile?: File | null;
+  initialVaultSuggestions?: PdfPasswordSuggestion[];
 }) {
   const [step, setStep] = useState<Step>("upload");
   const [parseResult, setParseResult] = useState<ParseResponse | null>(null);
@@ -286,7 +289,13 @@ export function ImportWizard({
 
       <section className="rounded-[28px] border border-white/6 bg-z-surface-2/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] sm:p-6">
         {/* Step content */}
-        {step === "upload" && <StepUpload onParsed={handleParsed} initialFile={resolvedInitialFile} />}
+        {step === "upload" && (
+          <StepUpload
+            onParsed={handleParsed}
+            initialFile={resolvedInitialFile}
+            initialVaultSuggestions={initialVaultSuggestions}
+          />
+        )}
         {step === "review" && parseResult && (
           <StepReview
             parseResult={parseResult}

--- a/webapp/src/components/import/step-upload.tsx
+++ b/webapp/src/components/import/step-upload.tsx
@@ -1,10 +1,30 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Upload, FileText, Loader2, Lock, HelpCircle, CheckCircle2, ImageIcon } from "lucide-react";
+import { Upload, FileText, Loader2, Lock, HelpCircle, CheckCircle2, ImageIcon, KeyRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { ParseResponse } from "@/types/import";
 import { trackClientEvent } from "@/lib/utils/analytics";
+import {
+  suggestPdfPasswordsForAccount,
+  createPdfPassword,
+  type PdfPasswordSuggestion,
+} from "@/actions/pdf-passwords";
+import { toast } from "sonner";
+
+function normalizeBankToKey(bank: string | undefined | null): string | null {
+  if (!bank) return null;
+  return bank.toLowerCase().replace(/_/g, "-");
+}
 
 const PDF_EXTENSIONS = new Set([".pdf"]);
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
@@ -33,6 +53,10 @@ export function StepUpload({
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [password, setPassword] = useState("");
+  const [passwordFromVault, setPasswordFromVault] = useState(false);
+  const [savePassword, setSavePassword] = useState(false);
+  const [saveAlias, setSaveAlias] = useState("");
+  const [vaultSuggestions, setVaultSuggestions] = useState<PdfPasswordSuggestion[]>([]);
   const [dragging, setDragging] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -41,6 +65,17 @@ export function StepUpload({
   const [savedForSupport, setSavedForSupport] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const initialFileProcessed = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    suggestPdfPasswordsForAccount(null, null).then((suggestions) => {
+      if (cancelled) return;
+      setVaultSuggestions(suggestions);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function handleSaveForSupport() {
     if (!unsupportedFile) return;
@@ -193,6 +228,29 @@ export function StepUpload({
           has_metadata: hasMetadata,
         },
       });
+
+      if (savePassword && password && !passwordFromVault && saveAlias.trim()) {
+        const bankKey = normalizeBankToKey(parsed.statements[0]?.bank);
+        const fd = new FormData();
+        fd.append("alias", saveAlias.trim());
+        fd.append("password", password);
+        if (bankKey) {
+          fd.append("scope", "bank");
+          fd.append("bank_key", bankKey);
+        } else {
+          fd.append("scope", "global");
+        }
+        const saveResult = await createPdfPassword(
+          { success: false, error: "" },
+          fd
+        );
+        if (saveResult.success) {
+          toast.success("Contraseña guardada en tu bóveda");
+        } else {
+          toast.error(saveResult.error ?? "No se pudo guardar la contraseña");
+        }
+      }
+
       onParsed(data as ParseResponse);
     } catch {
       void trackClientEvent({
@@ -291,14 +349,78 @@ export function StepUpload({
                     type="password"
                     placeholder="Contraseña del PDF (opcional)"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      setPasswordFromVault(false);
+                    }}
                     className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                     autoComplete="off"
                   />
                 </div>
+                {vaultSuggestions.length > 0 && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className={cn(GHOST_BUTTON_CLASS, "shrink-0")}
+                      >
+                        <KeyRound className="h-4 w-4" />
+                        Usar guardada
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {vaultSuggestions.map((sug) => (
+                        <DropdownMenuItem
+                          key={sug.id}
+                          onSelect={() => {
+                            setPassword(sug.password);
+                            setPasswordFromVault(true);
+                            setSavePassword(false);
+                          }}
+                        >
+                          <span className="truncate">{sug.alias}</span>
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            {sug.scope === "account"
+                              ? "cuenta"
+                              : sug.scope === "bank"
+                              ? sug.bank_key
+                              : "global"}
+                          </span>
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
               </div>
+              {password && !passwordFromVault && (
+                <div className="rounded-md border border-dashed border-white/10 p-3 space-y-2">
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={savePassword}
+                      onChange={(e) => setSavePassword(e.target.checked)}
+                      className="h-3.5 w-3.5 rounded border border-white/6"
+                    />
+                    Guardar esta contraseña en la bóveda para próximos extractos
+                  </label>
+                  {savePassword && (
+                    <Input
+                      placeholder="Alias (ej: Cédula Cristian)"
+                      value={saveAlias}
+                      onChange={(e) => setSaveAlias(e.target.value)}
+                      maxLength={60}
+                      className="h-8 text-sm"
+                    />
+                  )}
+                </div>
+              )}
               <p className="text-xs text-muted-foreground">
                 Algunos extractos están protegidos con contraseña (ej. número de cédula).
+                {vaultSuggestions.length > 0 && (
+                  <> Tienes {vaultSuggestions.length} guardada{vaultSuggestions.length === 1 ? "" : "s"}.</>
+                )}
               </p>
             </>
           )}

--- a/webapp/src/components/import/step-upload.tsx
+++ b/webapp/src/components/import/step-upload.tsx
@@ -21,9 +21,15 @@ import {
 } from "@/actions/pdf-passwords";
 import { toast } from "sonner";
 
+const BANK_KEY_OVERRIDES: Record<string, string> = {
+  banco_popular: "popular",
+  cooperativa_confiar: "confiar",
+};
+
 function normalizeBankToKey(bank: string | undefined | null): string | null {
   if (!bank) return null;
-  return bank.toLowerCase().replace(/_/g, "-");
+  const lower = bank.toLowerCase();
+  return BANK_KEY_OVERRIDES[lower] ?? lower.replace(/_/g, "-");
 }
 
 const PDF_EXTENSIONS = new Set([".pdf"]);
@@ -47,16 +53,20 @@ function isPdfFile(name: string): boolean {
 export function StepUpload({
   onParsed,
   initialFile,
+  initialVaultSuggestions,
 }: {
   onParsed: (data: ParseResponse) => void;
   initialFile?: File | null;
+  initialVaultSuggestions?: PdfPasswordSuggestion[];
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [password, setPassword] = useState("");
   const [passwordFromVault, setPasswordFromVault] = useState(false);
   const [savePassword, setSavePassword] = useState(false);
   const [saveAlias, setSaveAlias] = useState("");
-  const [vaultSuggestions, setVaultSuggestions] = useState<PdfPasswordSuggestion[]>([]);
+  const [vaultSuggestions, setVaultSuggestions] = useState<PdfPasswordSuggestion[]>(
+    initialVaultSuggestions ?? []
+  );
   const [dragging, setDragging] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -67,6 +77,7 @@ export function StepUpload({
   const initialFileProcessed = useRef(false);
 
   useEffect(() => {
+    if (initialVaultSuggestions) return;
     let cancelled = false;
     suggestPdfPasswordsForAccount(null, null).then((suggestions) => {
       if (cancelled) return;
@@ -75,7 +86,7 @@ export function StepUpload({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [initialVaultSuggestions]);
 
   async function handleSaveForSupport() {
     if (!unsupportedFile) return;
@@ -246,6 +257,11 @@ export function StepUpload({
         );
         if (saveResult.success) {
           toast.success("Contraseña guardada en tu bóveda");
+        } else if (
+          saveResult.error &&
+          /alias|alcance/i.test(saveResult.error)
+        ) {
+          toast.info("Ya tenías esta contraseña guardada");
         } else {
           toast.error(saveResult.error ?? "No se pudo guardar la contraseña");
         }
@@ -461,7 +477,7 @@ export function StepUpload({
               <Button
                 size="sm"
                 variant="ghost"
-                className={cn(GHOST_BUTTON_CLASS, "border-z-alert/30 hover:bg-z-alert/10")}
+                className={cn(GHOST_BUTTON_CLASS, "!border-z-alert/30 hover:!bg-z-alert/10")}
                 onClick={handleSaveForSupport}
                 disabled={savingForSupport}
               >

--- a/webapp/src/components/import/step-upload.tsx
+++ b/webapp/src/components/import/step-upload.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { Upload, FileText, Loader2, Lock, HelpCircle, CheckCircle2, ImageIcon, KeyRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -297,8 +297,9 @@ export function StepUpload({
           </p>
         </div>
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
+          className={GHOST_BUTTON_CLASS}
           onClick={() => inputRef.current?.click()}
         >
           Seleccionar archivo
@@ -329,7 +330,11 @@ export function StepUpload({
                 {(file.size / 1024).toFixed(0)} KB
               </p>
             </div>
-            <Button onClick={handleUpload} disabled={loading}>
+            <Button
+              className={BRASS_BUTTON_CLASS}
+              onClick={handleUpload}
+              disabled={loading}
+            >
               {loading ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -455,8 +460,8 @@ export function StepUpload({
             <div className="flex gap-2">
               <Button
                 size="sm"
-                variant="outline"
-                className="border-z-alert/30 hover:bg-z-alert/10"
+                variant="ghost"
+                className={cn(GHOST_BUTTON_CLASS, "border-z-alert/30 hover:bg-z-alert/10")}
                 onClick={handleSaveForSupport}
                 disabled={savingForSupport}
               >
@@ -472,6 +477,7 @@ export function StepUpload({
               <Button
                 size="sm"
                 variant="ghost"
+                className={GHOST_BUTTON_CLASS}
                 onClick={() => setUnsupportedFile(null)}
                 disabled={savingForSupport}
               >

--- a/webapp/src/components/settings/bug-report-form.tsx
+++ b/webapp/src/components/settings/bug-report-form.tsx
@@ -152,6 +152,7 @@ export function BugReportForm() {
           value={description}
           onChange={(event) => setDescription(event.target.value)}
           placeholder="Qué hiciste, qué esperabas y qué pasó."
+          autoComplete="off"
           minLength={9}
           maxLength={4000}
           required

--- a/webapp/src/components/settings/pdf-passwords-card.tsx
+++ b/webapp/src/components/settings/pdf-passwords-card.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import { KeyRound, Plus, Trash2, Pencil, X, Check } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createPdfPassword,
+  updatePdfPassword,
+  deletePdfPassword,
+  type PdfPasswordEntry,
+} from "@/actions/pdf-passwords";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { BANK_LOGOS } from "@/lib/icons/bank-logos";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import type { Account } from "@/types/domain";
+
+interface PdfPasswordsCardProps {
+  initialEntries: PdfPasswordEntry[];
+  accounts: Account[];
+}
+
+type CreateState = Awaited<ReturnType<typeof createPdfPassword>>;
+type UpdateState = Awaited<ReturnType<typeof updatePdfPassword>>;
+type DeleteState = Awaited<ReturnType<typeof deletePdfPassword>>;
+
+const INITIAL_CREATE: CreateState = { success: false, error: "" };
+const INITIAL_UPDATE: UpdateState = { success: false, error: "" };
+const INITIAL_DELETE: DeleteState = { success: false, error: "" };
+
+const BANK_OPTIONS = Object.keys(BANK_LOGOS);
+
+const SCOPE_LABELS: Record<string, string> = {
+  global: "Cualquier PDF",
+  bank: "Por banco",
+  account: "Por cuenta",
+};
+
+export function PdfPasswordsCard({
+  initialEntries,
+  accounts,
+}: PdfPasswordsCardProps) {
+  const [entries, setEntries] = useState(initialEntries);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const [createState, createAction, createPending] = useActionState(
+    createPdfPassword,
+    INITIAL_CREATE
+  );
+
+  useEffect(() => {
+    if (!createState.success || !createState.data) return;
+    const fresh = createState.data;
+    setEntries((prev) => {
+      if (prev.some((e) => e.id === fresh.id)) return prev;
+      return [
+        ...prev,
+        {
+          id: fresh.id,
+          alias: fresh.alias,
+          scope: fresh.scope as "global" | "bank" | "account",
+          bank_key: fresh.bank_key,
+          account_id: fresh.account_id,
+          account_name:
+            accounts.find((a) => a.id === fresh.account_id)?.name ?? null,
+          has_password: true,
+          updated_at: fresh.updated_at,
+        },
+      ];
+    });
+    setShowForm(false);
+    toast.success("Contraseña guardada");
+  }, [createState, accounts]);
+
+  return (
+    <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
+            <KeyRound className="size-4 text-z-brass" />
+          </div>
+          <div className="flex-1">
+            <CardTitle>Contraseñas de PDF</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Guarda las contraseñas de tus extractos para no reescribirlas.
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {entries.length === 0 && !showForm && (
+          <p className="text-sm text-muted-foreground">
+            Aún no guardaste ninguna contraseña.
+          </p>
+        )}
+
+        {entries.length > 0 && (
+          <ul className="space-y-2">
+            {entries.map((entry) =>
+              editingId === entry.id ? (
+                <EditRow
+                  key={entry.id}
+                  entry={entry}
+                  onCancel={() => setEditingId(null)}
+                  onUpdated={(patch) => {
+                    setEntries((prev) =>
+                      prev.map((e) =>
+                        e.id === entry.id ? { ...e, ...patch } : e
+                      )
+                    );
+                    setEditingId(null);
+                    toast.success("Contraseña actualizada");
+                  }}
+                />
+              ) : (
+                <DisplayRow
+                  key={entry.id}
+                  entry={entry}
+                  accounts={accounts}
+                  onEdit={() => setEditingId(entry.id)}
+                  onDeleted={() => {
+                    setEntries((prev) => prev.filter((e) => e.id !== entry.id));
+                    toast.success("Contraseña eliminada");
+                  }}
+                />
+              )
+            )}
+          </ul>
+        )}
+
+        {showForm ? (
+          <form action={createAction} className="space-y-3 rounded-lg border border-white/6 bg-black/10 p-3">
+            <CreateFormFields accounts={accounts} />
+            {!createState.success && createState.error && (
+              <p className="text-xs text-destructive">{createState.error}</p>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                className={GHOST_BUTTON_CLASS}
+                onClick={() => setShowForm(false)}
+                disabled={createPending}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" className={BRASS_BUTTON_CLASS} disabled={createPending}>
+                {createPending ? "Guardando..." : "Guardar"}
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            className={cn(GHOST_BUTTON_CLASS, "w-full justify-start")}
+            onClick={() => setShowForm(true)}
+          >
+            <Plus className="size-4" />
+            Agregar contraseña
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CreateFormFields({ accounts }: { accounts: Account[] }) {
+  const [scope, setScope] = useState<"global" | "bank" | "account">("account");
+  const [bankKey, setBankKey] = useState<string>(BANK_OPTIONS[0] ?? "");
+  const [accountId, setAccountId] = useState<string>(accounts[0]?.id ?? "");
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="alias">Alias</Label>
+          <Input
+            id="alias"
+            name="alias"
+            required
+            maxLength={60}
+            placeholder="Ej: Cédula Cristian"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="password">Contraseña</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            required
+            maxLength={200}
+            autoComplete="new-password"
+          />
+        </div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label>Aplica a</Label>
+          <Select
+            value={scope}
+            onValueChange={(v) => setScope(v as typeof scope)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="account">Una cuenta</SelectItem>
+              <SelectItem value="bank">Un banco</SelectItem>
+              <SelectItem value="global">Cualquier PDF</SelectItem>
+            </SelectContent>
+          </Select>
+          <input type="hidden" name="scope" value={scope} />
+        </div>
+        {scope === "account" && (
+          <div className="space-y-1.5">
+            <Label>Cuenta</Label>
+            <Select value={accountId} onValueChange={setAccountId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Elegir cuenta" />
+              </SelectTrigger>
+              <SelectContent>
+                {accounts.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    {a.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <input type="hidden" name="account_id" value={accountId} />
+          </div>
+        )}
+        {scope === "bank" && (
+          <div className="space-y-1.5">
+            <Label>Banco</Label>
+            <Select value={bankKey} onValueChange={setBankKey}>
+              <SelectTrigger>
+                <SelectValue placeholder="Elegir banco" />
+              </SelectTrigger>
+              <SelectContent>
+                {BANK_OPTIONS.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {key}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <input type="hidden" name="bank_key" value={bankKey} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DisplayRow({
+  entry,
+  accounts,
+  onEdit,
+  onDeleted,
+}: {
+  entry: PdfPasswordEntry;
+  accounts: Account[];
+  onEdit: () => void;
+  onDeleted: () => void;
+}) {
+  const [deleteState, deleteAction, pending] = useActionState(
+    deletePdfPassword,
+    INITIAL_DELETE
+  );
+
+  useEffect(() => {
+    if (deleteState.success && deleteState.data.id === entry.id) {
+      onDeleted();
+    }
+  }, [deleteState, entry.id, onDeleted]);
+
+  const account = accounts.find((a) => a.id === entry.account_id);
+  const scopeLabel =
+    entry.scope === "account"
+      ? (account?.name ?? entry.account_name ?? "Cuenta")
+      : entry.scope === "bank"
+      ? `Banco: ${entry.bank_key}`
+      : "Cualquier PDF";
+
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-lg border border-white/6 bg-black/10 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{entry.alias}</p>
+        <p className="truncate text-xs text-muted-foreground">
+          {SCOPE_LABELS[entry.scope]} · {scopeLabel}
+        </p>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className={cn(GHOST_BUTTON_CLASS, "size-8 px-0")}
+          onClick={onEdit}
+        >
+          <Pencil className="size-3.5" />
+        </Button>
+        <form action={deleteAction}>
+          <input type="hidden" name="id" value={entry.id} />
+          <Button
+            type="submit"
+            size="sm"
+            variant="ghost"
+            className={cn(GHOST_BUTTON_CLASS, "size-8 px-0 text-destructive")}
+            disabled={pending}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        </form>
+      </div>
+    </li>
+  );
+}
+
+function EditRow({
+  entry,
+  onCancel,
+  onUpdated,
+}: {
+  entry: PdfPasswordEntry;
+  onCancel: () => void;
+  onUpdated: (patch: Partial<PdfPasswordEntry>) => void;
+}) {
+  const [updateState, updateAction, pending] = useActionState(
+    updatePdfPassword,
+    INITIAL_UPDATE
+  );
+
+  useEffect(() => {
+    if (updateState.success && updateState.data && updateState.data.id === entry.id) {
+      onUpdated({
+        alias: updateState.data.alias,
+        updated_at: updateState.data.updated_at,
+      });
+    }
+  }, [updateState, entry.id, onUpdated]);
+
+  return (
+    <li className="rounded-lg border border-white/6 bg-black/10 p-3">
+      <form action={updateAction} className="space-y-3">
+        <input type="hidden" name="id" value={entry.id} />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor={`alias-${entry.id}`}>Alias</Label>
+            <Input
+              id={`alias-${entry.id}`}
+              name="alias"
+              defaultValue={entry.alias}
+              maxLength={60}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`password-${entry.id}`}>Nueva contraseña</Label>
+            <Input
+              id={`password-${entry.id}`}
+              name="password"
+              type="password"
+              placeholder="Dejar vacío para no cambiar"
+              maxLength={200}
+              autoComplete="new-password"
+            />
+          </div>
+        </div>
+        {!updateState.success && updateState.error && (
+          <p className="text-xs text-destructive">{updateState.error}</p>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            className={GHOST_BUTTON_CLASS}
+            onClick={onCancel}
+            disabled={pending}
+          >
+            <X className="size-3.5" />
+            Cancelar
+          </Button>
+          <Button type="submit" className={BRASS_BUTTON_CLASS} disabled={pending}>
+            <Check className="size-3.5" />
+            Guardar
+          </Button>
+        </div>
+      </form>
+    </li>
+  );
+}

--- a/webapp/src/components/ui/currency-input.tsx
+++ b/webapp/src/components/ui/currency-input.tsx
@@ -201,6 +201,9 @@ function CurrencyInput({
         ref={inputRef}
         type="text"
         inputMode="numeric"
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
         data-slot="input"
         className={cn(
           "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",

--- a/webapp/src/components/ui/input.tsx
+++ b/webapp/src/components/ui/input.tsx
@@ -2,11 +2,21 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({
+  className,
+  type,
+  autoComplete,
+  autoCorrect,
+  spellCheck,
+  ...props
+}: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
+      autoComplete={autoComplete ?? "off"}
+      autoCorrect={autoCorrect ?? "off"}
+      spellCheck={spellCheck ?? false}
       className={cn(
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",

--- a/webapp/src/lib/validators/pdf-password.ts
+++ b/webapp/src/lib/validators/pdf-password.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import { uuidStr } from "./shared";
+
+const SCOPES = ["global", "bank", "account"] as const;
+
+export const pdfPasswordSchema = z
+  .object({
+    alias: z.string().min(1, "El alias es requerido").max(60),
+    password: z.string().min(1, "La contraseña es requerida").max(200),
+    scope: z.enum(SCOPES),
+    bank_key: z
+      .string()
+      .max(40)
+      .optional()
+      .nullable()
+      .transform((v) => v || null),
+    account_id: uuidStr()
+      .optional()
+      .nullable()
+      .transform((v) => v || null),
+  })
+  .superRefine((data, ctx) => {
+    if (data.scope === "account" && !data.account_id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["account_id"],
+        message: "Selecciona una cuenta",
+      });
+    }
+    if (data.scope === "bank" && !data.bank_key) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["bank_key"],
+        message: "Selecciona un banco",
+      });
+    }
+    if (data.scope !== "account" && data.account_id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["account_id"],
+        message: "La cuenta solo aplica para alcance por cuenta",
+      });
+    }
+    if (data.scope !== "bank" && data.bank_key) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["bank_key"],
+        message: "El banco solo aplica para alcance por banco",
+      });
+    }
+  });
+
+export const pdfPasswordUpdateSchema = z
+  .object({
+    id: uuidStr(),
+    alias: z.string().min(1).max(60).optional(),
+    password: z.string().min(1).max(200).optional(),
+  })
+  .refine((d) => d.alias || d.password, {
+    message: "Nada que actualizar",
+  });
+
+export type PdfPasswordFormData = z.infer<typeof pdfPasswordSchema>;
+export type PdfPasswordScope = (typeof SCOPES)[number];

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -1449,6 +1449,108 @@ export type Database = {
           },
         ]
       }
+      pdf_passwords_enc: {
+        Row: {
+          account_id: string | null
+          alias: string
+          bank_key: string | null
+          created_at: string
+          id: string
+          password: string
+          scope: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id?: string | null
+          alias: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password: string
+          scope: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string | null
+          alias?: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password?: string
+          scope?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pdf_passwords: {
+        Row: {
+          account_id: string | null
+          alias: string
+          bank_key: string | null
+          created_at: string
+          id: string
+          password: string
+          scope: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id?: string | null
+          alias: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password: string
+          scope: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string | null
+          alias?: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password?: string
+          scope?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       planning_assignments: {
         Row: {
           assigned_amount: number


### PR DESCRIPTION
## Summary
Ship the two follow-ups that the original docs PR logged.

### Autofill suppression
- `ui/input.tsx` now defaults `autoComplete`/`autoCorrect`/`spellCheck` to off, overridable per field so auth forms keep their semantic hints (`email`, `new-password`, `current-password`).
- `ui/currency-input.tsx` hardcodes the same attrs on its raw `<input>` (wrapper bypass).
- Bug-report and deseos `<textarea>`s got `autoComplete="off"`.
- Remaining raw `<input>`s in the tree are all `type="hidden"` or checkboxes — no sweep needed.

### PDF password vault
- New encrypted table `pdf_passwords` (`_enc` + view + INSTEAD OF triggers, standard envelope) with `scope = global | bank | account` and CHECK-enforced scope/FK pairing.
- Server actions (`webapp/src/actions/pdf-passwords.ts`): list, suggest (account > bank > global ranking), create, update (with 23505 alias collision), delete. All gated by `getAuthenticatedClient()` + `.eq("user_id", user.id)`. `updateTag("pdf-passwords")` on writes; `updateTag("accounts")` when mirroring into `accounts.pdf_password` on scope=account.
- Settings UI: `PdfPasswordsCard` inline create/edit/delete with scope picker, shown in both the mobile accordion and desktop flat list.
- Upload step: "Usar guardada" dropdown fills the password input from vault suggestions; a "Guardar esta contraseña" checkbox saves newly typed passwords after a successful parse (scope inferred from parser's `bank` label, falls back to global).
- `accounts.pdf_password` is kept as a derived mirror so email-ingest keeps working unchanged.

## Test plan
- [x] Manual import: upload PDF, pick a saved alias from "Usar guardada", confirm the password field fills and parse succeeds.
- [x] Manual import with a new password: check "Guardar", enter alias, confirm the alias appears in settings after parse.
- [ ] Settings → Contraseñas de PDF: create entries for each scope (global, bank, account); edit alias and password; delete; verify toast feedback.
- [ ] Create a second entry with the same alias — confirm duplicate message surfaces.
- [ ] Create an account-scoped entry and confirm `accounts.pdf_password` reflects the new value (email ingest can still auto-decrypt).
- [ ] Auth forms (login, signup, reset, forgot) still surface Chrome/Safari password-manager prompts.
- [ ] `pnpm build` — ✓
- [ ] `server-action-reviewer` — addressed HIGH (23505 on update) and MEDIUM (no-op update refine).
- [ ] `zetas-front-guy` — fixed `border-white/6`, added `GHOST_BUTTON_CLASS` to new dropdown trigger; pre-existing step-upload button violations left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)