### PR TITLE
feat(transactions): Promote-to-recurring polish — toast + visual weight

### DIFF
--- a/webapp/src/components/recurring/recurring-form-dialog.tsx
+++ b/webapp/src/components/recurring/recurring-form-dialog.tsx
@@ -28,6 +28,7 @@ export function RecurringFormDialog({
   trigger,
   controlledOpen,
   onClose,
+  onSuccess,
 }: {
   template?: RecurringTemplate;
   initialValues?: Partial<RecurringTemplate>;
@@ -38,6 +39,9 @@ export function RecurringFormDialog({
   /** When true, dialog opens immediately without a trigger */
   controlledOpen?: boolean;
   onClose?: () => void;
+  /** Fires after a successful save, before the dialog closes. Gives callers
+   * a place to toast / navigate without wiring a separate observer. */
+  onSuccess?: (template: RecurringTemplate | undefined) => void;
 }) {
   const [internalOpen, setInternalOpen] = useState(false);
   const open = controlledOpen ?? internalOpen;
@@ -70,7 +74,10 @@ export function RecurringFormDialog({
           actionOverride={actionOverride}
           accounts={accounts}
           categories={categories}
-          onSuccess={() => setOpen(false)}
+          onSuccess={(saved) => {
+            onSuccess?.(saved);
+            setOpen(false);
+          }}
         />
       </DialogContent>
     </Dialog>

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -57,7 +57,9 @@ export function RecurringForm({
   actionOverride?: RecurringFormAction;
   accounts: Account[];
   categories: CategoryWithChildren[];
-  onSuccess?: () => void;
+  /** Called with the saved template on success. Receives undefined when the
+   * action succeeded but didn't return the row (legacy actions). */
+  onSuccess?: (template: RecurringTemplate | undefined) => void;
 }) {
   const action = template
     ? updateRecurringTemplate.bind(null, template.id)
@@ -69,7 +71,7 @@ export function RecurringForm({
   >(
     async (prevState, formData) => {
       const result = await action(prevState, formData);
-      if (result.success) onSuccess?.();
+      if (result.success) onSuccess?.(result.data);
       return result;
     },
     { success: false, error: "" }

--- a/webapp/src/components/transactions/promote-to-recurring-button.tsx
+++ b/webapp/src/components/transactions/promote-to-recurring-button.tsx
@@ -10,7 +10,6 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { createRecurringTemplateFromTransaction } from "@/actions/recurring-templates";
 import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
-import { cn } from "@/lib/utils";
 
 // Dialog + form are ~580 lines; defer until the user clicks "Hacer recurrente".
 const RecurringFormDialog = dynamic(
@@ -124,16 +123,15 @@ export function PromoteToRecurringButton({
 
   if (isLinkedToOccurrence) {
     return (
-      <Badge
-        asChild
-        variant="secondary"
-        className="bg-z-surface-3/60 text-z-sage-dark transition-colors hover:bg-z-surface-3/80"
-      >
-        <Link href="/recurrentes">
+      <Link href="/recurrentes" className="contents">
+        <Badge
+          variant="secondary"
+          className="cursor-pointer bg-z-surface-3/60 text-z-sage-dark transition-colors hover:bg-z-surface-3/80"
+        >
           <CalendarClock className="mr-1.5 size-3.5" aria-hidden="true" />
           Ya es recurrente
-        </Link>
-      </Badge>
+        </Badge>
+      </Link>
     );
   }
 
@@ -141,7 +139,7 @@ export function PromoteToRecurringButton({
     <>
       <Button
         type="button"
-        className={cn(BRASS_BUTTON_CLASS)}
+        className={BRASS_BUTTON_CLASS}
         onClick={() => setOpen(true)}
       >
         <CalendarClock className="size-4" aria-hidden="true" />

--- a/webapp/src/components/transactions/promote-to-recurring-button.tsx
+++ b/webapp/src/components/transactions/promote-to-recurring-button.tsx
@@ -128,7 +128,7 @@ export function PromoteToRecurringButton({
           variant="secondary"
           className="cursor-pointer bg-z-surface-3/60 text-z-sage-dark transition-colors hover:bg-z-surface-3/80"
         >
-          <CalendarClock className="mr-1.5 size-3.5" aria-hidden="true" />
+          <CalendarClock className="size-3.5" aria-hidden="true" />
           Ya es recurrente
         </Badge>
       </Link>

--- a/webapp/src/components/transactions/promote-to-recurring-button.tsx
+++ b/webapp/src/components/transactions/promote-to-recurring-button.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { CalendarClock } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { createRecurringTemplateFromTransaction } from "@/actions/recurring-templates";
-import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 
 // Dialog + form are ~580 lines; defer until the user clicks "Hacer recurrente".
 const RecurringFormDialog = dynamic(
@@ -104,14 +107,32 @@ export function PromoteToRecurringButton({
     }
   }, [pathname, router, searchParams]);
 
+  const handleSuccess = useCallback(
+    (saved: RecurringTemplate | undefined) => {
+      toast.success("Recurrente creada", {
+        description: "Se programó el próximo pago en Recurrentes.",
+        action: saved
+          ? {
+              label: "Ver",
+              onClick: () => router.push(`/recurrentes/${saved.id}/edit`),
+            }
+          : undefined,
+      });
+    },
+    [router],
+  );
+
   if (isLinkedToOccurrence) {
     return (
       <Badge
+        asChild
         variant="secondary"
-        className="bg-z-surface-3/60 text-z-sage-dark hover:bg-z-surface-3/60"
+        className="bg-z-surface-3/60 text-z-sage-dark transition-colors hover:bg-z-surface-3/80"
       >
-        <CalendarClock className="mr-1.5 size-3.5" aria-hidden="true" />
-        Ya es recurrente
+        <Link href="/recurrentes">
+          <CalendarClock className="mr-1.5 size-3.5" aria-hidden="true" />
+          Ya es recurrente
+        </Link>
       </Badge>
     );
   }
@@ -120,8 +141,7 @@ export function PromoteToRecurringButton({
     <>
       <Button
         type="button"
-        variant="ghost"
-        className={GHOST_BUTTON_CLASS}
+        className={cn(BRASS_BUTTON_CLASS)}
         onClick={() => setOpen(true)}
       >
         <CalendarClock className="size-4" aria-hidden="true" />
@@ -130,6 +150,7 @@ export function PromoteToRecurringButton({
       <RecurringFormDialog
         controlledOpen={open}
         onClose={handleClose}
+        onSuccess={handleSuccess}
         trigger={null}
         initialValues={initialValues}
         actionOverride={actionOverride}

--- a/webapp/src/components/transactions/transaction-form-dialog.tsx
+++ b/webapp/src/components/transactions/transaction-form-dialog.tsx
@@ -10,7 +10,9 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { TransactionForm } from "./transaction-form";
-import { Plus } from "lucide-react";
+import { Pencil, Plus } from "lucide-react";
+import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 import type { Account, CategoryWithChildren, Tag, Transaction } from "@/types/domain";
 
 export function TransactionFormDialog({
@@ -25,13 +27,21 @@ export function TransactionFormDialog({
   tags?: Tag[];
 }) {
   const [open, setOpen] = useState(false);
+  const isEdit = !!transaction;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus className="h-4 w-4 mr-2" />
-          {transaction ? "Editar" : "Nueva transacción"}
+        <Button
+          variant={isEdit ? "ghost" : "default"}
+          className={isEdit ? cn(GHOST_BUTTON_CLASS) : undefined}
+        >
+          {isEdit ? (
+            <Pencil className="h-4 w-4 mr-2" />
+          ) : (
+            <Plus className="h-4 w-4 mr-2" />
+          )}
+          {isEdit ? "Editar" : "Nueva transacción"}
         </Button>
       </DialogTrigger>
       <DialogContent className="flex max-h-[85svh] flex-col overflow-hidden p-0 sm:max-w-xl">

--- a/webapp/src/components/transactions/transaction-form-dialog.tsx
+++ b/webapp/src/components/transactions/transaction-form-dialog.tsx
@@ -12,7 +12,6 @@ import { Button } from "@/components/ui/button";
 import { TransactionForm } from "./transaction-form";
 import { Pencil, Plus } from "lucide-react";
 import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
-import { cn } from "@/lib/utils";
 import type { Account, CategoryWithChildren, Tag, Transaction } from "@/types/domain";
 
 export function TransactionFormDialog({
@@ -32,10 +31,7 @@ export function TransactionFormDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button
-          variant={isEdit ? "ghost" : "default"}
-          className={isEdit ? cn(GHOST_BUTTON_CLASS) : undefined}
-        >
+        <Button className={isEdit ? GHOST_BUTTON_CLASS : undefined}>
           {isEdit ? (
             <Pencil className="h-4 w-4 mr-2" />
           ) : (

--- a/webapp/src/components/transactions/transaction-form-dialog.tsx
+++ b/webapp/src/components/transactions/transaction-form-dialog.tsx
@@ -32,11 +32,7 @@ export function TransactionFormDialog({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button className={isEdit ? GHOST_BUTTON_CLASS : undefined}>
-          {isEdit ? (
-            <Pencil className="h-4 w-4 mr-2" />
-          ) : (
-            <Plus className="h-4 w-4 mr-2" />
-          )}
+          {isEdit ? <Pencil className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
           {isEdit ? "Editar" : "Nueva transacción"}
         </Button>
       </DialogTrigger>


### PR DESCRIPTION
## Summary

Two small follow-ups on PR #173 flagged by the ux-analyst review.

- **Success state.** `PromoteToRecurringButton` now fires a sonner toast on successful create with a "Ver" action that navigates to the template edit page. The "Ya es recurrente" badge becomes a link to `/recurrentes` for the already-linked case. Plumbed via a new `onSuccess(template)` callback through `RecurringFormDialog` → `RecurringForm` so future callers can observe template creation without a separate observer.
- **Visual weight.** Promote is more consequential than Edit, so on `/transactions/[id]` Promote gets the brass button and Edit demotes to ghost + Pencil icon. `/transactions/new` and other creation entry points still render the brass "Nueva transacción" CTA unchanged (only affects the edit branch of `TransactionFormDialog`).

## Backlog items closed

- Promote-to-recurring — success state undersells the outcome (Medium)
- Tx detail hero — Promote vs Edit visual weight inversion (Low)

## Test plan

- [ ] `/transactions/[id]` for an unlinked tx: "Hacer recurrente" is brass, "Editar" is ghost + Pencil.
- [ ] Click "Hacer recurrente" → submit → dialog closes → toast "Recurrente creada" appears with a "Ver" action that routes to `/recurrentes/<id>/edit`.
- [ ] Revisit the same tx: "Ya es recurrente" badge is a link that navigates to `/recurrentes`.
- [ ] `/transactions/new` still renders the brass "Nueva transacción" button (unaffected by the ghost-in-edit-mode tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)