### PR TITLE
chore(tech-debt): wave 1 — tokens + createCachedClient pattern

### DIFF
--- a/webapp/src/actions/categories.ts
+++ b/webapp/src/actions/categories.ts
@@ -3,7 +3,7 @@
 import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createCachedClient } from "@/lib/supabase/cached";
 import { categorySchema } from "@/lib/validators/category";
 import type { ActionResult } from "@/types/actions";
 import { parseMonth, monthStartStr, monthEndStr, monthsBeforeStart } from "@/lib/utils/date";
@@ -68,13 +68,14 @@ function buildCategoryTreeWithBudgets(
 
 async function getCategoriesCached(
   userId: string,
+  accessToken: string,
   direction?: TransactionDirection
 ): Promise<CategoryWithChildren[]> {
   "use cache";
   cacheTag("categories");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   let query = supabase
     .from("categories")
@@ -97,13 +98,14 @@ async function getCategoriesCached(
 
 async function getCategoriesWithBudgetsCached(
   userId: string,
+  accessToken: string,
   direction?: TransactionDirection
 ): Promise<CategoryWithBudget[]> {
   "use cache";
   cacheTag("categories");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   let query = supabase
     .from("categories")
@@ -135,13 +137,14 @@ async function getCategoriesWithBudgetsCached(
 }
 
 async function getAllCategoriesForManagementCached(
-  userId: string
+  userId: string,
+  accessToken: string
 ): Promise<CategoryBudgetData[]> {
   "use cache";
   cacheTag("categories");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   // Fetch ALL parent categories (including inactive) for management
   const { data: parents, error } = await supabase
@@ -196,13 +199,14 @@ async function getAllCategoriesForManagementCached(
 
 async function getCategoryTransactionCountCached(
   userId: string,
+  accessToken: string,
   categoryId: string
 ): Promise<number> {
   "use cache";
   cacheTag("categories");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
 
   const { count, error } = await supabase
     .from("transactions")
@@ -217,6 +221,7 @@ async function getCategoryTransactionCountCached(
 
 async function getCategoriesWithBudgetDataCached(
   userId: string,
+  accessToken: string,
   month?: string,
   currency?: CurrencyCode
 ): Promise<CategoryBudgetData[]> {
@@ -227,7 +232,7 @@ async function getCategoriesWithBudgetDataCached(
   cacheTag("dashboard:budgets");
   cacheLife("zeta");
 
-  const supabase = createAdminClient();
+  const supabase = createCachedClient(accessToken);
   const baseCurrency = currency ?? "COP";
   const target = parseMonth(month);
 
@@ -384,10 +389,10 @@ async function getCategoriesWithBudgetDataCached(
 export async function getCategories(
   direction?: TransactionDirection
 ): Promise<ActionResult<CategoryWithChildren[]>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getCategoriesCached(user.id, direction);
+    const data = await getCategoriesCached(user.id, accessToken, direction);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading categories:", error);
@@ -398,10 +403,10 @@ export async function getCategories(
 export async function getCategoriesWithBudgets(
   direction?: TransactionDirection
 ): Promise<ActionResult<CategoryWithBudget[]>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getCategoriesWithBudgetsCached(user.id, direction);
+    const data = await getCategoriesWithBudgetsCached(user.id, accessToken, direction);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading categories:", error);
@@ -412,10 +417,10 @@ export async function getCategoriesWithBudgets(
 export async function getAllCategoriesForManagement(): Promise<
   ActionResult<CategoryBudgetData[]>
 > {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getAllCategoriesForManagementCached(user.id);
+    const data = await getAllCategoriesForManagementCached(user.id, accessToken);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading categories:", error);
@@ -426,10 +431,10 @@ export async function getAllCategoriesForManagement(): Promise<
 export async function getCategoryTransactionCount(
   categoryId: string
 ): Promise<ActionResult<number>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getCategoryTransactionCountCached(user.id, categoryId);
+    const data = await getCategoryTransactionCountCached(user.id, accessToken, categoryId);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading category count:", error);
@@ -441,10 +446,10 @@ export async function getCategoriesWithBudgetData(
   month?: string,
   currency?: CurrencyCode
 ): Promise<ActionResult<CategoryBudgetData[]>> {
-  const { user } = await getAuthenticatedClient();
-  if (!user) return { success: false, error: "No autenticado" };
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
   try {
-    const data = await getCategoriesWithBudgetDataCached(user.id, month, currency);
+    const data = await getCategoriesWithBudgetDataCached(user.id, accessToken, month, currency);
     return { success: true, data };
   } catch (error) {
     console.error("Error loading budget data:", error);

--- a/webapp/src/actions/categories.ts
+++ b/webapp/src/actions/categories.ts
@@ -103,6 +103,7 @@ async function getCategoriesWithBudgetsCached(
 ): Promise<CategoryWithBudget[]> {
   "use cache";
   cacheTag("categories");
+  cacheTag("budgets");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
@@ -204,6 +205,7 @@ async function getCategoryTransactionCountCached(
 ): Promise<number> {
   "use cache";
   cacheTag("categories");
+  cacheTag("transactions");
   cacheLife("zeta");
 
   const supabase = createCachedClient(accessToken);
@@ -228,6 +230,8 @@ async function getCategoriesWithBudgetDataCached(
   "use cache";
   cacheTag("categories");
   cacheTag("budgets");
+  cacheTag("transactions");
+  cacheTag("recurring");
   cacheTag("dashboard:charts");
   cacheTag("dashboard:budgets");
   cacheLife("zeta");

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -13,7 +13,7 @@ import { TagChip } from "@/components/tags/tag-chip";
 import { LinkPickerSheet } from "@/components/recurring/link-picker-sheet";
 import { useOutflowCategories } from "@/components/providers/app-data-provider";
 import { categorizeTransaction } from "@/actions/categorize";
-import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
 import {
   getCandidateOccurrencesForTransaction,
   linkExistingTransactionToOccurrence,
@@ -151,7 +151,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
 
   return (
     <div>
-      <p className="mb-1.5 text-[9px] font-bold uppercase tracking-[0.18em] text-z-sage-dark">
+      <p className={cn(SECTION_EYEBROW_CLASS, "mb-1.5")}>
         Reciente
       </p>
 

--- a/webapp/src/components/recurring/recurring-confirm-inline.tsx
+++ b/webapp/src/components/recurring/recurring-confirm-inline.tsx
@@ -71,7 +71,7 @@ export function RecurringConfirmInline({
   return (
     <form
       onSubmit={handleSubmit}
-      className="rounded-b-lg border-t bg-muted/50 px-3 py-3"
+      className="rounded-b-lg border-t border-white/6 bg-z-surface-3/60 px-3 py-3"
     >
       <div className="space-y-2">
         {/* Fields row */}


### PR DESCRIPTION
## Summary

First of 3 tech-debt cleanup waves. Three small, independent fixes from BACKLOG:

- **`inicio-activity.tsx` eyebrow**: use `SECTION_EYEBROW_CLASS` instead of hardcoded `text-[9px] font-bold …` so the "Reciente" label matches the app's canonical eyebrow (text-[10px] font-semibold).
- **`recurring-confirm-inline.tsx` surface**: replace shadcn `bg-muted/50` with the Zeta surface tier token `bg-z-surface-3/60` + `border-white/6`.
- **`actions/categories.ts` cached client**: 5 cached fns move from `createAdminClient()` → `createCachedClient(accessToken)`. Matches the established pattern (tags, charts, attention, income, scenarios) and stops bypassing RLS. Public wrappers now thread `accessToken` through.

## Other tech-debt items already shipped
Scanning surfaced that these BACKLOG claims were stale — already fixed on main:
- `useRecurringMonth` callbacks already use `startTransition` (no `router.refresh()` remaining)
- `inicio-activity.tsx` arrow bubbles already use `bg-z-income/12` / `bg-z-expense/12`

## Review
- zetas-front-guy: PASS
- server-action-reviewer: PASS

## Test plan
- [x] `pnpm build` clean
- [x] 73/73 vitest tests pass
- [ ] Manual: hit `/` (dashboard) — verify "Reciente" eyebrow visually unchanged
- [ ] Manual: hit `/recurrentes` → expand a pending item — verify inline confirm form matches neighbor surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)