### PR TITLE
feat(mobile): polish Dashboard RECIENTE row + transaction detail page

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -200,6 +200,21 @@
 
 ## Tech Debt
 
+### Tx detail — `router.refresh()` on tag picker close
+- **Priority:** Low
+- **What:** `transaction-detail-client.tsx` calls `router.refresh()` after the TagZonePicker drawer closes to sync `initialTags` from the server. Could be avoided by lifting `setTags` into a `onTagsChanged` callback that TagZonePicker invokes on add/remove, so the parent updates its local `tags` state optimistically and skips the round-trip.
+- **Found:** perf-auditor review on tx detail redesign, 2026-04-18
+
+### Tx detail — zone pickers always mounted (hidden trigger)
+- **Priority:** Low
+- **What:** CategoryZonePicker + DestinatarioZonePicker + TagZonePicker all render on mount with `hideTrigger + controlledOpen`. They pull from context so fetches are gated, but the Radix Dialog/Drawer portals register on mount. Mount-once-on-first-open pattern would save 3 portal registrations per detail page load. Not measurable today, revisit if picker count grows.
+- **Found:** perf-auditor review on tx detail redesign, 2026-04-18
+
+### Tx detail — delete confirm dialog uses raw `<button>` instead of shadcn `<Button>`
+- **Priority:** Low
+- **What:** `transaction-detail-client.tsx` DialogFooter uses two raw `<button>` elements with `cn(GHOST_BUTTON_CLASS, ...)` + `cn(DESTRUCTIVE_BUTTON_CLASS, ...)`. Consolidating to `<Button variant="outline" className={...}>` would inherit shadcn sizing primitives + keep consistency with other Dialogs.
+- **Found:** zetas-front-guy review on tx detail redesign, 2026-04-18
+
 ### `useRecurringMonth` callbacks use `router.refresh()` instead of `startTransition`
 - **Priority:** Medium
 - **What:** All three callbacks in `use-recurring-month.ts` (`confirmPayment`, `skipPayment`, `linkExisting`) call `router.refresh()` after the server action. Should wrap in `startTransition` instead — `router.refresh()` is a redundant network round-trip.

--- a/docs/visual-companions/inicio-reciente-expanded-row-2026-04-18.html
+++ b/docs/visual-companions/inicio-reciente-expanded-row-2026-04-18.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zeta — Dashboard RECIENTE · Expanded Row Redesign</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
+  :root {
+    --z-ink: #1a1d1a;
+    --z-obsidian: #121412;
+    --z-surface-1: #151815;
+    --z-surface-2: rgba(26,29,26,0.80);
+    --z-brass: #c8b560;
+    --z-brass-10: rgba(200,181,96,0.10);
+    --z-brass-20: rgba(200,181,96,0.20);
+    --z-sage-light: #b0b89c;
+    --z-sage-dark: #7a8068;
+    --z-sage: #8ea882;
+    --z-income: #10b981;
+    --z-expense: #f59e0b;
+    --z-debt: #ef4444;
+    --z-border: rgba(255,255,255,0.06);
+    --z-muted: rgba(255,255,255,0.50);
+    --radius-xl: 12px;
+    --radius-2xl: 16px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Inter', -apple-system, sans-serif;
+    background: var(--z-obsidian);
+    color: #e0e0e0;
+    line-height: 1.5;
+    padding: 40px 24px 80px;
+  }
+  .page-wrapper { max-width: 1180px; margin: 0 auto; }
+  .page-header { text-align: center; margin-bottom: 48px; }
+  .page-header .date {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.18em; color: var(--z-brass); margin-bottom: 12px;
+  }
+  .page-header h1 { font-size: 32px; font-weight: 800; color: #fff; margin-bottom: 10px; letter-spacing: -0.02em; }
+  .page-header .subtitle { font-size: 14px; color: var(--z-sage-dark); max-width: 640px; margin: 0 auto; }
+
+  .section { margin-bottom: 64px; }
+  .section-number { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.18em; color: var(--z-brass); margin-bottom: 6px; }
+  .section-title { font-size: 22px; font-weight: 700; color: #fff; margin-bottom: 6px; }
+  .section-desc { font-size: 13px; color: var(--z-sage-dark); max-width: 680px; margin-bottom: 24px; }
+
+  .phones-row { display: flex; gap: 24px; flex-wrap: wrap; justify-content: center; }
+  .phone {
+    width: 320px;
+    border-radius: 28px;
+    border: 2px solid rgba(255,255,255,0.08);
+    background: var(--z-obsidian);
+    overflow: hidden;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+    flex-shrink: 0;
+  }
+  .phone.before { opacity: 0.85; }
+  .phone-label {
+    padding: 8px 16px;
+    font-size: 10px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.18em;
+    text-align: center;
+  }
+  .phone-label.before-l { background: rgba(239,68,68,0.06); color: #f87171; }
+  .phone-label.after-l { background: rgba(16,185,129,0.06); color: #34d399; }
+  .phone-label.after-l2 { background: rgba(200,181,96,0.08); color: var(--z-brass); }
+
+  .status-bar { height: 24px; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 600; color: #fff; }
+  .phone-content { padding: 12px 14px 16px; min-height: 520px; }
+
+  .m-eyebrow { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.22em; color: var(--z-sage-dark); margin-bottom: 6px; }
+
+  /* Tx row */
+  .m-tx-row {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 8px 4px;
+    border-radius: 0;
+    cursor: pointer;
+  }
+  .m-tx-row.open {
+    border-left: 2px solid var(--z-brass);
+    padding-left: 8px;
+    background: rgba(255,255,255,0.02);
+  }
+  .m-tx-icon {
+    width: 22px; height: 22px; border-radius: 6px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 9px; flex-shrink: 0; margin-top: 2px;
+  }
+  .m-tx-icon.inflow { background: rgba(16,185,129,0.12); color: var(--z-income); }
+  .m-tx-icon.outflow { background: rgba(245,158,11,0.12); color: var(--z-expense); }
+
+  .m-tx-body { flex: 1; min-width: 0; }
+  .m-tx-name { font-size: 12px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .m-tx-meta { font-size: 10px; color: var(--z-muted); display: flex; align-items: center; gap: 3px; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .m-tx-amount { font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; flex-shrink: 0; }
+  .m-tx-amount.inflow { color: var(--z-income); }
+  .sep { color: rgba(255,255,255,0.15); padding: 0 2px; }
+  .acc-dot { width: 5px; height: 5px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+
+  /* Panel inset (expanded body) */
+  .panel-inset {
+    margin: 2px 0 10px;
+    border: 1px solid var(--z-border);
+    border-radius: 14px;
+    background: rgba(0,0,0,0.18);
+  }
+  .panel-pad { padding: 12px; }
+
+  /* === CURRENT (BEFORE) — cramped, auto-picker === */
+  .before-panel { padding: 10px; }
+  .before-meta {
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 11px; color: var(--z-muted);
+    margin-bottom: 8px;
+  }
+  .before-meta .actions { display: flex; gap: 8px; }
+  .before-meta .actions a { color: var(--z-brass); font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; gap: 3px; }
+  .before-eyebrow {
+    font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.18em;
+    color: var(--z-muted); border-top: 1px solid var(--z-border); padding-top: 8px; margin-bottom: 6px;
+  }
+  .before-picker {
+    border: 1px solid var(--z-border); border-radius: 8px;
+    background: rgba(0,0,0,0.3);
+  }
+  .before-picker-search {
+    padding: 6px 8px; font-size: 11px; color: var(--z-muted);
+    border-bottom: 1px solid var(--z-border);
+  }
+  .before-picker-list { max-height: 180px; overflow: auto; }
+  .before-cat-row {
+    display: flex; align-items: center; gap: 6px;
+    padding: 6px 8px; font-size: 11px; color: #e0e0e0;
+    border-bottom: 1px solid rgba(255,255,255,0.03);
+  }
+  .before-cat-row .cat-ic { width: 16px; height: 16px; border-radius: 4px; background: var(--z-brass-10); display: flex; align-items: center; justify-content: center; font-size: 9px; color: var(--z-brass); }
+
+  /* === NEW (AFTER) — action chips === */
+  .chips-row { display: flex; gap: 6px; }
+  .chip {
+    flex: 1;
+    display: flex; align-items: center; justify-content: center; gap: 5px;
+    padding: 9px 8px;
+    border: 1px solid var(--z-border);
+    border-radius: 10px;
+    background: rgba(255,255,255,0.03);
+    font-size: 11px; font-weight: 600;
+    color: #e6e6e6;
+    white-space: nowrap;
+  }
+  .chip.primary {
+    background: var(--z-brass-10);
+    border-color: rgba(200,181,96,0.25);
+    color: var(--z-brass);
+  }
+  .chip.danger {
+    background: rgba(239,68,68,0.08);
+    border-color: rgba(239,68,68,0.20);
+    color: #fca5a5;
+  }
+  .chip .ic { font-size: 11px; opacity: 0.85; }
+  .chip.more { flex: 0.8; }
+
+  /* Inline picker (after phase 2) */
+  .picker-head {
+    display: flex; align-items: center; gap: 8px;
+    padding-bottom: 8px; margin-bottom: 8px;
+    border-bottom: 1px solid var(--z-border);
+  }
+  .picker-back {
+    width: 20px; height: 20px; border-radius: 6px;
+    background: rgba(255,255,255,0.05);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 11px; color: var(--z-muted);
+  }
+  .picker-title { font-size: 11px; font-weight: 700; letter-spacing: 0.04em; color: #fff; }
+
+  .cat-picker-search {
+    padding: 6px 10px;
+    border: 1px solid var(--z-border);
+    border-radius: 8px;
+    background: rgba(0,0,0,0.3);
+    font-size: 11px; color: var(--z-muted);
+    margin-bottom: 8px;
+  }
+  .cat-picker-list { max-height: 210px; overflow: auto; }
+  .cat-parent {
+    padding: 6px 6px; font-size: 10px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.18em; color: var(--z-sage-dark);
+  }
+  .cat-row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 6px;
+    font-size: 12px; color: #e0e0e0;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .cat-row:hover, .cat-row.selected { background: rgba(200,181,96,0.06); }
+  .cat-ic {
+    width: 22px; height: 22px; border-radius: 6px;
+    background: var(--z-brass-10);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 11px; color: var(--z-brass);
+  }
+
+  /* === Sheet (Más) === */
+  .sheet {
+    background: var(--z-surface-1);
+    border-radius: 18px 18px 0 0;
+    border: 1px solid var(--z-border);
+    border-bottom: none;
+    padding: 10px 14px 18px;
+    margin-top: 4px;
+    box-shadow: 0 -10px 40px rgba(0,0,0,0.4);
+  }
+  .sheet-handle {
+    width: 36px; height: 4px; border-radius: 2px;
+    background: rgba(255,255,255,0.12);
+    margin: 0 auto 10px;
+  }
+  .sheet-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.18em; color: var(--z-sage-dark); margin-bottom: 10px; }
+  .sheet-sub { font-size: 11px; color: var(--z-muted); margin-top: -6px; margin-bottom: 12px; }
+  .sheet-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 4px;
+    border-top: 1px solid var(--z-border);
+    font-size: 13px; color: #e6e6e6;
+  }
+  .sheet-row:first-of-type { border-top: none; }
+  .sheet-row.danger { color: #fca5a5; }
+  .sheet-icon {
+    width: 28px; height: 28px; border-radius: 8px;
+    background: rgba(255,255,255,0.04);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; color: var(--z-muted);
+  }
+  .sheet-row.danger .sheet-icon { color: #fca5a5; background: rgba(239,68,68,0.08); }
+  .sheet-chev { margin-left: auto; color: var(--z-muted); font-size: 13px; }
+  .dim-backdrop { background: rgba(0,0,0,0.55); padding-top: 140px; }
+
+  /* Annotation */
+  .annotation {
+    margin: 20px auto 0; max-width: 820px;
+    padding: 12px 14px;
+    border-radius: var(--radius-xl);
+    background: rgba(200,181,96,0.05);
+    border-left: 2px solid var(--z-brass);
+    font-size: 12px; color: var(--z-sage-light);
+  }
+  .annotation strong { color: #fff; }
+  .annotation ul { padding-left: 18px; margin-top: 4px; }
+  .annotation li { margin-bottom: 2px; }
+  .legend {
+    font-size: 10px; color: var(--z-sage-dark);
+    margin: 0 auto 20px; max-width: 720px; text-align: center;
+  }
+
+  /* Dim surrounding when sheet open */
+  .phone.sheet-open .phone-content { background: rgba(0,0,0,0.25); }
+</style>
+</head>
+<body>
+<div class="page-wrapper">
+  <div class="page-header">
+    <div class="date">2026 · 04 · 18</div>
+    <h1>Dashboard RECIENTE — Expanded Row Redesign</h1>
+    <div class="subtitle">Fix the auto-open category picker bug and replace the cramped inline panel with a two-phase action-chip layout. Inicio mobile only.</div>
+  </div>
+
+  <!-- ───── BEFORE vs AFTER baseline ───── -->
+  <div class="section">
+    <div class="section-number">01 — Baseline</div>
+    <div class="section-title">Before: auto-mount picker crams every OUTFLOW expand</div>
+    <div class="section-desc">Today, tapping any OUTFLOW tx auto-opens the full CategoryPickerBody tree inside the row. The picker is the only action surface; Vincular and Ver detalle float above it on a single line. Narrow, noisy, and always-on.</div>
+
+    <div class="phones-row">
+      <div class="phone before">
+        <div class="phone-label before-l">Before — current</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-eyebrow">Reciente</div>
+
+          <!-- collapsed row -->
+          <div class="m-tx-row">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Rappi Colombia</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#8ea882"></span> Bancolombia ··1234</div>
+            </div>
+            <div class="m-tx-amount">-$42.900</div>
+          </div>
+
+          <!-- EXPANDED (current behavior) -->
+          <div class="m-tx-row open">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Nu Colombia</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#8a2be2"></span> Nu ··5678</div>
+            </div>
+            <div class="m-tx-amount">-$120.000</div>
+          </div>
+          <div class="panel-inset">
+            <div class="before-panel">
+              <div class="before-meta">
+                <span>Gasto · $120.000</span>
+                <div class="actions">
+                  <a>🔗 Vincular</a>
+                  <a>✎ Ver detalle</a>
+                </div>
+              </div>
+              <div class="before-eyebrow">Asignar categoría</div>
+              <div class="before-picker">
+                <div class="before-picker-search">🔍 Buscar categoría…</div>
+                <div class="before-picker-list">
+                  <div class="before-cat-row"><span class="cat-ic">🍽</span> Comida &amp; Restaurantes</div>
+                  <div class="before-cat-row"><span class="cat-ic">🛒</span> Supermercado</div>
+                  <div class="before-cat-row"><span class="cat-ic">🚗</span> Transporte</div>
+                  <div class="before-cat-row"><span class="cat-ic">🏠</span> Hogar</div>
+                  <div class="before-cat-row"><span class="cat-ic">🎬</span> Entretenimiento</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="m-tx-row">
+            <div class="m-tx-icon inflow">↙</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Nómina Q2</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#c8b560"></span> Bancolombia ··1234</div>
+            </div>
+            <div class="m-tx-amount inflow">+$3.250.000</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Problems we're solving</strong>
+      <ul>
+        <li>Picker opens on every tap — user can't even "peek" at a row without a 200+ LOC picker tree hydrating.</li>
+        <li>Vincular + Ver detalle crammed into one meta line; tap targets are undersized.</li>
+        <li>No path to Destinatario / Etiquetas / Eliminar without navigating off the Dashboard.</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- ───── AFTER Phase 1: Action chips ───── -->
+  <div class="section">
+    <div class="section-number">02 — After · Phase 1</div>
+    <div class="section-title">Expand shows a lean chip row — no heavy picker until requested</div>
+    <div class="section-desc">Three chips only: <strong>Categorizar</strong> (OUTFLOW · brass tint when uncategorized — neutral otherwise), <strong>Vincular</strong> (only when account has a pending occurrence), <strong>Más</strong> (opens bottom sheet with Ver detalle + secondary actions). Nothing auto-mounts. The picker tree stays unhydrated until the user taps Categorizar.</div>
+
+    <div class="phones-row">
+      <div class="phone">
+        <div class="phone-label after-l">After · Phase 1 — uncategorized</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-eyebrow">Reciente</div>
+
+          <div class="m-tx-row open">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Nu Colombia</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#8a2be2"></span> Nu ··5678</div>
+            </div>
+            <div class="m-tx-amount">-$120.000</div>
+          </div>
+          <div class="panel-inset">
+            <div class="panel-pad">
+              <div class="chips-row">
+                <div class="chip primary"><span class="ic">🏷</span> Categorizar</div>
+                <div class="chip"><span class="ic">🔗</span> Vincular</div>
+                <div class="chip more"><span class="ic">⋯</span> Más</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="m-tx-row">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Rappi Colombia</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#8ea882"></span> Bancolombia ··1234 <span class="sep">·</span> 🍽 Comida</div>
+            </div>
+            <div class="m-tx-amount">-$42.900</div>
+          </div>
+          <div class="m-tx-row">
+            <div class="m-tx-icon inflow">↙</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Nómina Q2</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#c8b560"></span> Bancolombia ··1234</div>
+            </div>
+            <div class="m-tx-amount inflow">+$3.250.000</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="phone">
+        <div class="phone-label after-l">After · Phase 1 — already categorized</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-eyebrow">Reciente</div>
+          <div class="m-tx-row open">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Rappi Colombia</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#8ea882"></span> Bancolombia ··1234 <span class="sep">·</span> 🍽 Comida</div>
+            </div>
+            <div class="m-tx-amount">-$42.900</div>
+          </div>
+          <div class="panel-inset">
+            <div class="panel-pad">
+              <div class="chips-row">
+                <div class="chip"><span class="ic">🏷</span> Categorizar</div>
+                <div class="chip more" style="flex:1;"><span class="ic">⋯</span> Más</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="m-tx-row">
+            <div class="m-tx-icon inflow">↙</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Nómina Q2</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#c8b560"></span> Bancolombia ··1234</div>
+            </div>
+            <div class="m-tx-amount inflow">+$3.250.000</div>
+          </div>
+          <div class="m-tx-row">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Netflix</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#c8b560"></span> Amex ··0404 <span class="sep">·</span> 🎬 Entretenimiento</div>
+            </div>
+            <div class="m-tx-amount">-$38.900</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Rules</strong>
+      <ul>
+        <li><strong>Categorizar</strong> — only on OUTFLOW. Brass-tinted when <code>category_id == null</code>, neutral otherwise.</li>
+        <li><strong>Vincular</strong> — only shown when the account has pending recurring occurrences AND the tx is not already linked.</li>
+        <li><strong>Más</strong> — always shown. Its flex expands to fill when Vincular isn't present.</li>
+        <li>INFLOW rows show a 2-chip layout (Vincular when applicable + Más); no Categorizar.</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- ───── AFTER Phase 2a: Inline category picker ───── -->
+  <div class="section">
+    <div class="section-number">03 — After · Phase 2a</div>
+    <div class="section-title">Categorizar swaps the panel body with the picker (back arrow returns)</div>
+    <div class="section-desc">Stays <strong>inline</strong> — no sheet, no navigation. <code>CategoryPickerBody</code> mounts the first time Categorizar is tapped (lazy). Selecting a category optimistically updates the row and collapses the panel.</div>
+
+    <div class="phones-row">
+      <div class="phone">
+        <div class="phone-label after-l2">After · Phase 2a — inline picker</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="m-eyebrow">Reciente</div>
+
+          <div class="m-tx-row open">
+            <div class="m-tx-icon outflow">↗</div>
+            <div class="m-tx-body">
+              <div class="m-tx-name">Nu Colombia</div>
+              <div class="m-tx-meta"><span class="acc-dot" style="background:#8a2be2"></span> Nu ··5678</div>
+            </div>
+            <div class="m-tx-amount">-$120.000</div>
+          </div>
+          <div class="panel-inset">
+            <div class="panel-pad">
+              <div class="picker-head">
+                <div class="picker-back">←</div>
+                <div class="picker-title">ASIGNAR CATEGORÍA</div>
+              </div>
+              <div class="cat-picker-search">🔍 Buscar categoría…</div>
+              <div class="cat-picker-list">
+                <div class="cat-parent">Comida &amp; Alimentación</div>
+                <div class="cat-row selected"><span class="cat-ic">🍽</span> Restaurantes</div>
+                <div class="cat-row"><span class="cat-ic">🛒</span> Supermercado</div>
+                <div class="cat-row"><span class="cat-ic">🥤</span> Café &amp; Snacks</div>
+                <div class="cat-parent">Transporte</div>
+                <div class="cat-row"><span class="cat-ic">⛽</span> Combustible</div>
+                <div class="cat-row"><span class="cat-ic">🚕</span> Apps de transporte</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ───── AFTER Phase 2b: Más sheet ───── -->
+  <div class="section">
+    <div class="section-number">04 — After · Phase 2b</div>
+    <div class="section-title">Más opens a bottom sheet — secondary actions, not inline</div>
+    <div class="section-desc">Sheet keeps secondary actions out of the cramped row. Ver detalle navigates; the rest are in-place mutations (Destinatario, Etiquetas, Eliminar). Destinatario + Etiquetas could open their own pickers (existing zone-picker sheets) from inside this sheet — standard stacked-sheet pattern.</div>
+
+    <div class="phones-row">
+      <div class="phone sheet-open">
+        <div class="phone-label after-l">After · Phase 2b — Más sheet</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content dim-backdrop">
+          <div class="sheet">
+            <div class="sheet-handle"></div>
+            <div class="sheet-title">Nu Colombia</div>
+            <div class="sheet-sub">Gasto · $120.000 · Hoy</div>
+            <div class="sheet-row">
+              <div class="sheet-icon">✎</div>
+              <div>Ver detalle</div>
+              <div class="sheet-chev">›</div>
+            </div>
+            <div class="sheet-row">
+              <div class="sheet-icon">👤</div>
+              <div>Asignar destinatario</div>
+              <div class="sheet-chev">›</div>
+            </div>
+            <div class="sheet-row">
+              <div class="sheet-icon">🏷</div>
+              <div>Etiquetas</div>
+              <div class="sheet-chev">›</div>
+            </div>
+            <div class="sheet-row danger">
+              <div class="sheet-icon">🗑</div>
+              <div>Eliminar transacción</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Implementation notes</strong>
+      <ul>
+        <li>Reuse existing <code>DestinatarioZonePicker</code> + <code>TagZonePicker</code> components — don't build new surfaces. They already handle their own Sheet/Popover variants.</li>
+        <li>Delete → reuse existing <code>DeleteTransactionButton</code> confirm flow.</li>
+        <li>Sheet uses <code>MOBILE_TAB_BAR_CLEARANCE_CLASS</code> on <code>SheetContent</code> bottom padding per UI Rules.</li>
+        <li>Phase state is row-local: <code>{ phase: "actions" | "categorize", rowId }</code>. Collapsing the row resets phase to "actions".</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="legend">
+    Tokens · z-brass <code>#c8b560</code> · z-income <code>#10b981</code> · z-expense <code>#f59e0b</code> · z-debt <code>#ef4444</code> · border <code>rgba(255,255,255,0.06)</code>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/visual-companions/transaction-detail-redesign-2026-04-18.html
+++ b/docs/visual-companions/transaction-detail-redesign-2026-04-18.html
@@ -1,0 +1,583 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zeta — Transaction Detail · Mobile-first Redesign</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
+  :root {
+    --z-ink: #1a1d1a;
+    --z-obsidian: #121412;
+    --z-surface: #171A17;
+    --z-surface-2: #1E221E;
+    --z-surface-3: #262B26;
+    --z-brass: #c8b560;
+    --z-brass-10: rgba(200,181,96,0.10);
+    --z-brass-20: rgba(200,181,96,0.20);
+    --z-sage-light: #b0b89c;
+    --z-sage-dark: #7a8068;
+    --z-sage: #8ea882;
+    --z-income: #10b981;
+    --z-expense: #f59e0b;
+    --z-debt: #ef4444;
+    --z-indigo: #7c68ee;
+    --z-border: rgba(255,255,255,0.06);
+    --z-muted: rgba(255,255,255,0.50);
+    --z-white: #F6F0E3;
+    --radius-xl: 12px;
+    --radius-2xl: 16px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Inter', -apple-system, sans-serif;
+    background: var(--z-obsidian);
+    color: #e0e0e0;
+    line-height: 1.5;
+    padding: 40px 24px 80px;
+  }
+  .page-wrapper { max-width: 1200px; margin: 0 auto; }
+  .page-header { text-align: center; margin-bottom: 48px; }
+  .page-header .date { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.18em; color: var(--z-brass); margin-bottom: 12px; }
+  .page-header h1 { font-size: 32px; font-weight: 800; color: #fff; margin-bottom: 10px; letter-spacing: -0.02em; }
+  .page-header .subtitle { font-size: 14px; color: var(--z-sage-dark); max-width: 720px; margin: 0 auto; }
+
+  .section { margin-bottom: 64px; }
+  .section-number { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.18em; color: var(--z-brass); margin-bottom: 6px; }
+  .section-title { font-size: 22px; font-weight: 700; color: #fff; margin-bottom: 6px; }
+  .section-desc { font-size: 13px; color: var(--z-sage-dark); max-width: 780px; margin-bottom: 24px; }
+
+  .phones-row { display: flex; gap: 24px; flex-wrap: wrap; justify-content: center; }
+  .phone {
+    width: 320px; border-radius: 28px; border: 2px solid rgba(255,255,255,0.08);
+    background: var(--z-obsidian); overflow: hidden; box-shadow: 0 20px 60px rgba(0,0,0,0.5); flex-shrink: 0;
+  }
+  .phone.before { opacity: 0.85; }
+  .phone-label { padding: 8px 16px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.18em; text-align: center; }
+  .phone-label.before-l { background: rgba(239,68,68,0.06); color: #f87171; }
+  .phone-label.after-l { background: rgba(16,185,129,0.06); color: #34d399; }
+  .phone-label.alt-l { background: rgba(200,181,96,0.08); color: var(--z-brass); }
+  .status-bar { height: 24px; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 600; color: #fff; }
+  .phone-content { padding: 0; min-height: 620px; position: relative; }
+
+  /* Mobile sub-header */
+  .sub-header { padding: 10px 14px 8px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--z-border); }
+  .back-btn { width: 24px; height: 24px; border-radius: 8px; background: rgba(255,255,255,0.05); display: inline-flex; align-items: center; justify-content: center; font-size: 13px; color: var(--z-muted); }
+  .sub-header-title { font-size: 13px; font-weight: 600; color: #fff; }
+
+  /* Hero */
+  .hero {
+    padding: 16px 16px 14px;
+    background: radial-gradient(circle at top left, rgba(200,181,96,0.08), transparent 45%), linear-gradient(180deg, rgba(26,29,26,0.9), rgba(18,20,18,0.95));
+    border-bottom: 1px solid var(--z-border);
+  }
+  .hero-pill-row { display: flex; gap: 6px; margin-bottom: 10px; }
+  .hero-pill {
+    font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em;
+    padding: 3px 8px; border-radius: 999px;
+  }
+  .hero-pill.income { background: rgba(16,185,129,0.14); color: var(--z-income); }
+  .hero-pill.expense { background: rgba(245,158,11,0.14); color: var(--z-expense); }
+  .hero-pill.pending { background: rgba(200,181,96,0.12); color: var(--z-brass); }
+  .hero-title { font-size: 17px; font-weight: 700; color: #fff; margin-bottom: 2px; }
+  .hero-amount { font-size: 32px; font-weight: 700; letter-spacing: -0.01em; font-variant-numeric: tabular-nums; margin-top: 8px; margin-bottom: 6px; }
+  .hero-amount.income { color: var(--z-income); }
+  .hero-amount.expense { color: var(--z-white); }
+  .hero-meta { font-size: 11px; color: var(--z-muted); display: flex; align-items: center; gap: 3px; }
+  .sep { color: rgba(255,255,255,0.18); padding: 0 4px; }
+
+  .section-block { padding: 14px 14px 2px; }
+  .section-eyebrow { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.22em; color: var(--z-sage-dark); margin-bottom: 8px; }
+
+  /* Field row */
+  .field { padding: 10px 0; border-top: 1px solid var(--z-border); }
+  .field:first-child { border-top: none; }
+  .field-label {
+    font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.22em;
+    color: var(--z-sage-dark); margin-bottom: 6px;
+  }
+
+  /* Inline category / destinatario pill */
+  .select-pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 6px 10px 6px 8px;
+    border-radius: 999px;
+    font-size: 12px; font-weight: 600;
+    border: 1px solid transparent;
+  }
+  .select-pill .ic {
+    width: 18px; height: 18px; border-radius: 999px;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 11px;
+  }
+  .select-pill .chev { margin-left: 2px; opacity: 0.5; font-size: 12px; }
+  .select-pill.cat-filled { background: rgba(124,104,238,0.15); color: #9d8dff; }
+  .select-pill.cat-filled .ic { background: rgba(124,104,238,0.2); color: #b3a6ff; }
+  .select-pill.dest-filled { background: rgba(200,181,96,0.12); color: var(--z-brass); }
+  .select-pill.dest-filled .ic { background: rgba(200,181,96,0.18); color: var(--z-brass); }
+  .select-pill.empty {
+    background: rgba(255,255,255,0.03);
+    border-color: rgba(255,255,255,0.08);
+    color: var(--z-muted);
+  }
+  .select-pill.empty .ic { background: rgba(255,255,255,0.05); color: var(--z-muted); }
+
+  /* Tag chips */
+  .tag-row { display: flex; flex-wrap: wrap; gap: 6px; }
+  .tag-chip {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 3px 8px; border-radius: 999px;
+    font-size: 11px; font-weight: 500;
+    background: rgba(200,181,96,0.12);
+    color: var(--z-brass);
+    border: 1px solid rgba(200,181,96,0.25);
+  }
+  .tag-chip .x { opacity: 0.55; font-size: 10px; }
+  .tag-chip.add {
+    background: rgba(255,255,255,0.03);
+    color: var(--z-muted);
+    border-color: rgba(255,255,255,0.08);
+  }
+
+  /* Notes inline */
+  .notes {
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--z-border);
+    border-radius: 12px;
+    padding: 10px 12px;
+    margin-top: 2px;
+    font-size: 12px; color: #eee; min-height: 30px;
+  }
+  .notes.placeholder { color: var(--z-muted); font-style: italic; }
+
+  /* Disclosure */
+  .disclosure {
+    font-size: 11px; color: var(--z-muted);
+    display: inline-flex; align-items: center; gap: 4px;
+    margin-top: 10px;
+  }
+  .disclosure-body {
+    margin-top: 6px;
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--z-border);
+    border-radius: 10px;
+    padding: 8px 10px;
+    font-family: 'SF Mono', Menlo, monospace;
+    font-size: 10px;
+    color: #ccc;
+    word-break: break-all;
+  }
+
+  /* Action chip trio */
+  .action-chips { display: flex; gap: 8px; }
+  .action-chip {
+    flex: 1;
+    display: flex; align-items: center; justify-content: center; gap: 5px;
+    padding: 10px 10px;
+    border-radius: 10px;
+    font-size: 11px; font-weight: 600;
+    border: 1px solid var(--z-border);
+    background: rgba(255,255,255,0.04);
+    color: #eee;
+    white-space: nowrap;
+  }
+  .action-chip.brass-ghost {
+    background: rgba(200,181,96,0.08);
+    border-color: rgba(200,181,96,0.2);
+    color: var(--z-brass);
+  }
+  .action-chip.icon-only { flex: 0 0 44px; padding: 10px 0; }
+
+  /* Sticky Guardar bar */
+  .savebar {
+    position: sticky; bottom: 0;
+    background: rgba(18,20,18,0.95);
+    border-top: 1px solid var(--z-border);
+    padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+    backdrop-filter: blur(8px);
+  }
+  .save-btn {
+    width: 100%;
+    background: var(--z-brass); color: var(--z-ink);
+    border: none; border-radius: 10px;
+    padding: 12px 14px;
+    font-size: 14px; font-weight: 700;
+    display: flex; align-items: center; justify-content: center; gap: 6px;
+  }
+  .save-btn.dirty-indicator::before {
+    content: ""; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--z-ink); opacity: 0.8;
+    display: inline-block; margin-right: 4px;
+  }
+  .save-btn.ghost {
+    background: rgba(255,255,255,0.06);
+    color: var(--z-muted);
+  }
+
+  /* Picker preview */
+  .picker-pop {
+    position: absolute;
+    background: var(--z-surface-2);
+    border: 1px solid var(--z-border);
+    border-radius: 12px;
+    padding: 6px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+  }
+  .picker-pop .item {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 10px; font-size: 12px;
+    border-radius: 8px;
+  }
+  .picker-pop .item.selected { background: rgba(124,104,238,0.12); color: #b3a6ff; }
+  .picker-pop .item .ic {
+    width: 22px; height: 22px; border-radius: 6px;
+    background: rgba(124,104,238,0.15); color: #b3a6ff;
+    display: inline-flex; align-items: center; justify-content: center; font-size: 11px;
+  }
+
+  /* Before blocks */
+  .before-hero { padding: 14px; }
+  .before-pill-row { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
+  .before-pill { font-size: 10px; font-weight: 600; padding: 4px 10px; border-radius: 999px; border: 1px solid var(--z-border); color: var(--z-sage-light); background: rgba(0,0,0,0.2); }
+  .before-pill.income { background: rgba(16,185,129,0.15); color: var(--z-income); border-color: transparent; }
+  .before-pill.confirm { background: rgba(255,255,255,0.05); color: #ccc; border-color: transparent; }
+  .before-title { font-size: 18px; font-weight: 700; margin-bottom: 4px; }
+  .before-meta-line { font-size: 11px; color: var(--z-muted); margin-bottom: 12px; }
+  .before-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 14px; }
+  .before-action { font-size: 11px; font-weight: 600; padding: 6px 12px; border-radius: 8px; background: var(--z-brass); color: var(--z-ink); border: none; }
+  .before-action.ghost { background: rgba(255,255,255,0.06); color: #eee; }
+  .before-action.icon { padding: 6px 8px; }
+  .before-stats { display: grid; grid-template-columns: 1fr; gap: 8px; margin-bottom: 14px; }
+  .before-stat { background: rgba(0,0,0,0.2); border: 1px solid var(--z-border); border-radius: 12px; padding: 12px; }
+  .before-stat-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.18em; color: var(--z-sage-dark); margin-bottom: 4px; }
+  .before-stat-value { font-size: 20px; font-weight: 680; }
+  .before-stat-desc { font-size: 10px; color: var(--z-muted); margin-top: 3px; }
+  .before-card { background: rgba(30,34,30,0.7); border: 1px solid var(--z-border); border-radius: 14px; padding: 14px; margin-bottom: 12px; }
+  .before-card-title { font-size: 13px; font-weight: 700; margin-bottom: 4px; }
+  .before-card-desc { font-size: 10px; color: var(--z-muted); margin-bottom: 12px; }
+  .before-picker-slot { background: rgba(0,0,0,0.2); border: 1px dashed rgba(255,255,255,0.1); border-radius: 10px; padding: 14px; font-size: 11px; color: var(--z-muted); text-align: center; }
+  .before-card-icon { width: 32px; height: 32px; border-radius: 10px; background: rgba(0,0,0,0.2); border: 1px solid var(--z-border); display: inline-flex; align-items: center; justify-content: center; color: var(--z-brass); font-size: 14px; margin-right: 8px; }
+  .before-card-head { display: flex; align-items: flex-start; margin-bottom: 10px; }
+
+  /* Annotation / verdict */
+  .annotation {
+    margin: 20px auto 0; max-width: 820px;
+    padding: 12px 14px;
+    border-radius: var(--radius-xl);
+    background: rgba(200,181,96,0.05);
+    border-left: 2px solid var(--z-brass);
+    font-size: 12px; color: var(--z-sage-light);
+  }
+  .annotation strong { color: #fff; }
+  .annotation ul { padding-left: 18px; margin-top: 4px; }
+  .annotation li { margin-bottom: 3px; }
+
+  .verdict {
+    margin: 28px auto; max-width: 820px;
+    padding: 14px 16px;
+    border: 1px solid var(--z-border);
+    border-radius: var(--radius-xl);
+    background: rgba(30,34,30,0.5);
+  }
+  .verdict h3 { font-size: 14px; color: var(--z-brass); margin-bottom: 8px; }
+  .verdict p { font-size: 12px; color: var(--z-sage-light); line-height: 1.6; }
+
+  .legend { font-size: 10px; color: var(--z-sage-dark); margin: 0 auto 20px; max-width: 720px; text-align: center; }
+</style>
+</head>
+<body>
+<div class="page-wrapper">
+  <div class="page-header">
+    <div class="date">2026 · 04 · 18 · final</div>
+    <h1>Transaction Detail — Inline pills + Chip trio</h1>
+    <div class="subtitle">
+      Final direction: inline pill selectors for Categoría + Destinatario, brass tag chips with
+      <code>× remove</code> + <code>+ etiqueta</code>, inline Notas (autosave on blur), chip trio for
+      Vincular / Hacer recurrente / Eliminar. Fully optimistic — no save button.
+    </div>
+  </div>
+
+  <!-- ───── Jobs-to-be-done ───── -->
+  <div class="section">
+    <div class="section-number">00 — Jobs-to-be-done</div>
+    <div class="section-title">What a user is here to do, ranked</div>
+    <ol style="font-size:14px; color:#ddd; padding-left:20px; line-height:1.8; max-width:720px;">
+      <li><strong>Verify</strong> — amount, date, merchant, account. Read-only at a glance.</li>
+      <li><strong>Fix classification</strong> — category, destinatario, tags. Dominant active job.</li>
+      <li><strong>Annotate or manage</strong> — note, promote to recurring, link, or delete.</li>
+    </ol>
+    <div class="annotation" style="margin-top:16px;">
+      <strong>Cut as ceremony:</strong> raw_description (technical — behind a disclosure), "Qué hacer aquí" copy, duplicate back pill, Estado + Fuente as full stat cards, two full cards for two pickers.
+    </div>
+  </div>
+
+  <!-- ───── BEFORE ───── -->
+  <div class="section">
+    <div class="section-number">01 — Baseline</div>
+    <div class="section-title">Before: desktop layout reflowed</div>
+    <div class="section-desc">On 390px wide: ~2600px of scroll. 4 stat cards stacked vertically. 2 full-chrome picker cards. Actions wrap onto 2 rows in the hero. "Qué hacer aquí" occupies a data slot with prose.</div>
+
+    <div class="phones-row">
+      <div class="phone before">
+        <div class="phone-label before-l">Before — current</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content">
+          <div class="sub-header">
+            <div class="back-btn">←</div>
+            <div class="sub-header-title">Detalle</div>
+          </div>
+          <div class="before-hero">
+            <div class="before-pill-row">
+              <span class="before-pill">← Volver a Movimientos</span>
+              <span class="before-pill income">Ingreso</span>
+              <span class="before-pill confirm">Confirmada</span>
+            </div>
+            <div class="before-title">Nómina Q2</div>
+            <div class="before-meta-line">15 abr 2026 · manual</div>
+            <div class="before-actions">
+              <button class="before-action">✎ Editar</button>
+              <button class="before-action ghost">↻ Hacer recurrente</button>
+              <button class="before-action ghost icon">🗑</button>
+            </div>
+            <div class="before-stats">
+              <div class="before-stat">
+                <div class="before-stat-label">↙ Monto</div>
+                <div class="before-stat-value" style="color:var(--z-income)">+$3.250.000</div>
+                <div class="before-stat-desc">Valor que realmente movió esta transacción.</div>
+              </div>
+              <div class="before-stat">
+                <div class="before-stat-label">Estado</div>
+                <div class="before-stat-value" style="font-size:16px;">Confirmada</div>
+                <div class="before-stat-desc">Contexto actual del movimiento.</div>
+              </div>
+              <div class="before-stat">
+                <div class="before-stat-label">Fuente</div>
+                <div class="before-stat-value" style="font-size:16px;">manual</div>
+                <div class="before-stat-desc">Origen con el que entró.</div>
+              </div>
+              <div class="before-stat">
+                <div class="before-stat-label">✓ Qué hacer aquí</div>
+                <div class="before-stat-desc">Editar, borrar o reasignar sin salir del flujo.</div>
+              </div>
+            </div>
+            <div class="before-card">
+              <div class="before-card-head">
+                <div class="before-card-icon">👤</div>
+                <div>
+                  <div class="before-card-title">Destinatario</div>
+                  <div class="before-card-desc">Ajusta la asociación comercial…</div>
+                </div>
+              </div>
+              <div class="before-picker-slot">Picker destinatario</div>
+            </div>
+            <div class="before-card">
+              <div class="before-card-head">
+                <div class="before-card-icon">🏷</div>
+                <div>
+                  <div class="before-card-title">Etiquetas</div>
+                  <div class="before-card-desc">Agrega contexto libre.</div>
+                </div>
+              </div>
+              <div class="before-picker-slot">Picker etiquetas</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ───── Final layout ───── -->
+  <div class="section">
+    <div class="section-number">02 — Final layout</div>
+    <div class="section-title">Hero · Clasificación · Notas · Acciones · Guardar</div>
+    <div class="section-desc">
+      Inline pills + chip trio in the body; Guardar pinned at the bottom. Three frames: default
+      (clean state), Categoría popover (picker open), and dirty state (edits made, Guardar turns brass).
+    </div>
+
+    <div class="phones-row">
+      <!-- Frame 1 — default clean state -->
+      <div class="phone">
+        <div class="phone-label after-l">Default view</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-bottom: 0;">
+          <div class="sub-header">
+            <div class="back-btn">←</div>
+            <div class="sub-header-title">Detalle</div>
+          </div>
+
+          <div class="hero">
+            <div class="hero-pill-row">
+              <span class="hero-pill expense">GASTO</span>
+            </div>
+            <div class="hero-title">Nu Colombia</div>
+            <div class="hero-amount expense">-$120.000</div>
+            <div class="hero-meta">
+              15 abr 2026
+              <span class="sep">·</span>
+              Nu ··5678
+              <span class="sep">·</span>
+              PDF
+            </div>
+          </div>
+
+          <div class="section-block">
+            <div class="section-eyebrow">Clasificación</div>
+            <div class="field">
+              <div class="field-label">Categoría</div>
+              <span class="select-pill cat-filled">
+                <span class="ic">⚡</span> Servicios públicos <span class="chev">↕</span>
+              </span>
+            </div>
+            <div class="field">
+              <div class="field-label">Destinatario</div>
+              <span class="select-pill dest-filled">
+                <span class="ic">👤</span> EPM Servicios <span class="chev">↕</span>
+              </span>
+            </div>
+            <div class="field">
+              <div class="field-label">Etiquetas</div>
+              <div class="tag-row">
+                <span class="tag-chip">Fijos <span class="x">×</span></span>
+                <span class="tag-chip">Marzo <span class="x">×</span></span>
+                <span class="tag-chip add">+ etiqueta</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="section-block">
+            <div class="section-eyebrow">Notas</div>
+            <div class="notes placeholder">Toca para agregar una nota…</div>
+            <div class="disclosure">▸ Ver descripción original</div>
+          </div>
+
+          <div class="section-block">
+            <div class="section-eyebrow">Acciones</div>
+            <div class="action-chips">
+              <div class="action-chip brass-ghost">↻ Hacer recurrente</div>
+              <div class="action-chip">🔗 Vincular</div>
+              <div class="action-chip icon-only">⋯</div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- Frame 2 — Categoría picker open -->
+      <div class="phone">
+        <div class="phone-label after-l">Categoría popover</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-bottom: 0; position: relative;">
+          <div class="sub-header">
+            <div class="back-btn">←</div>
+            <div class="sub-header-title">Detalle</div>
+          </div>
+          <div class="hero">
+            <div class="hero-pill-row"><span class="hero-pill expense">GASTO</span></div>
+            <div class="hero-title">Rappi Colombia*DL</div>
+            <div class="hero-amount expense">-$42.900</div>
+            <div class="hero-meta">16 abr 2026 <span class="sep">·</span> Bancolombia ··1234</div>
+          </div>
+          <div class="section-block">
+            <div class="section-eyebrow">Clasificación</div>
+            <div class="field">
+              <div class="field-label">Categoría</div>
+              <span class="select-pill empty" style="opacity:0.6;">
+                <span class="ic">🏷</span> Sin categoría <span class="chev">↕</span>
+              </span>
+            </div>
+          </div>
+
+          <div class="picker-pop" style="top:170px; left:14px; right:14px;">
+            <div style="background:rgba(0,0,0,0.3); border:1px solid var(--z-border); border-radius:8px; padding:6px 10px; font-size:11px; color:var(--z-muted); margin:4px 4px 8px;">🔍 Buscar…</div>
+            <div class="item selected"><span class="ic">🍽</span> Restaurantes</div>
+            <div class="item"><span class="ic">🛒</span> Supermercado</div>
+            <div class="item"><span class="ic">🚕</span> Transporte</div>
+            <div class="item"><span class="ic">🎬</span> Entretenimiento</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Frame 3 — populated state -->
+      <div class="phone">
+        <div class="phone-label after-l">Populated — all fields set</div>
+        <div class="status-bar">9:41</div>
+        <div class="phone-content" style="padding-bottom: 0;">
+          <div class="sub-header">
+            <div class="back-btn">←</div>
+            <div class="sub-header-title">Detalle</div>
+          </div>
+          <div class="hero">
+            <div class="hero-pill-row"><span class="hero-pill expense">GASTO</span></div>
+            <div class="hero-title">Rappi Colombia*DL</div>
+            <div class="hero-amount expense">-$42.900</div>
+            <div class="hero-meta">16 abr 2026 <span class="sep">·</span> Bancolombia ··1234</div>
+          </div>
+          <div class="section-block">
+            <div class="section-eyebrow">Clasificación</div>
+            <div class="field">
+              <div class="field-label">Categoría</div>
+              <span class="select-pill cat-filled">
+                <span class="ic">🍽</span> Restaurantes <span class="chev">↕</span>
+              </span>
+            </div>
+            <div class="field">
+              <div class="field-label">Destinatario</div>
+              <span class="select-pill dest-filled">
+                <span class="ic">👤</span> Rappi <span class="chev">↕</span>
+              </span>
+            </div>
+            <div class="field">
+              <div class="field-label">Etiquetas</div>
+              <div class="tag-row">
+                <span class="tag-chip">Viaje Medellín <span class="x">×</span></span>
+                <span class="tag-chip add">+ etiqueta</span>
+              </div>
+            </div>
+          </div>
+          <div class="section-block">
+            <div class="section-eyebrow">Notas</div>
+            <div class="notes">Almuerzo con equipo en Parque Lleras</div>
+          </div>
+          <div class="section-block">
+            <div class="section-eyebrow">Acciones</div>
+            <div class="action-chips">
+              <div class="action-chip brass-ghost">↻ Hacer recurrente</div>
+              <div class="action-chip">🔗 Vincular</div>
+              <div class="action-chip icon-only">⋯</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="annotation">
+      <strong>Layout rules — fully optimistic, no save button</strong>
+      <ul>
+        <li><strong>Hero</strong> — direction pill, merchant title, signed amount, single meta line (date · account · source). Read-only.</li>
+        <li><strong>Clasificación</strong> — inline pills. <strong>Categoría</strong> indigo-tinted when set, muted outline when empty. <strong>Destinatario</strong> brass-tinted when set, muted outline when empty. Tap pill → Popover (desktop) or Drawer (mobile). Saves optimistically on select + toast.</li>
+        <li><strong>Etiquetas</strong> — brass chips with <code>× remove</code> (optimistic). <code>+ etiqueta</code> opens the tag picker.</li>
+        <li><strong>Notas</strong> — inline-editable textarea. Autosave on blur + toast.</li>
+        <li><strong>Descripción original</strong> — collapsed disclosure. Expands in place.</li>
+        <li><strong>Acciones</strong> — chip trio: Hacer recurrente (brass-ghost, primary intent) · Vincular (neutral, only when the account has pending occurrences) · <code>⋯</code> (opens sheet: Excluir · Eliminar). Fire immediately on tap.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="verdict">
+    <h3>Final direction</h3>
+    <p>
+      Fully optimistic. Every interaction persists immediately — pill select, tag add/remove,
+      notes blur, action tap. Matches the Dashboard row pattern we shipped and avoids the
+      "dirty-state / am-I-saved?" cognitive tax. Toasts confirm each mutation.
+    </p>
+  </div>
+
+  <div class="legend">
+    Tokens · z-brass <code>#c8b560</code> · z-income <code>#10b981</code> · z-expense <code>#f59e0b</code> · z-debt <code>#ef4444</code> · category pill uses indigo <code>#7c68ee</code>
+  </div>
+</div>
+</body>
+</html>

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -531,8 +531,11 @@ export async function updateDestinatario(
 
   if (error) return { success: false, error: error.message };
 
+  // Destinatario name/active state is embedded in several cached financial
+  // reads (e.g. getRecentTransactionsCached). Revalidate the full financial
+  // surface so renames are read-your-own-writes everywhere.
+  revalidateFinancialViews();
   updateTag("destinatarios");
-  updateTag("attention");
   return { success: true, data };
 }
 
@@ -553,8 +556,10 @@ export async function patchDestinatario(
 
   if (error) return { success: false, error: error.message };
 
+  // Same rationale as updateDestinatario — flipping is_active changes which
+  // destinatarios appear in cached pickers/joins.
+  revalidateFinancialViews();
   updateTag("destinatarios");
-  updateTag("attention");
   return { success: true, data: null };
 }
 

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -574,6 +574,7 @@ export type RecentTransaction = {
   direction: "INFLOW" | "OUTFLOW";
   account_id: string;
   category_id: string | null;
+  destinatario_id: string | null;
   recurrence_group_id: string | null;
   merchant_name: string | null;
   clean_description: string | null;
@@ -587,6 +588,7 @@ export type RecentTransaction = {
     bank_key: string | null;
     account_type: Database["public"]["Enums"]["account_type"];
   } | null;
+  destinatario: { id: string; name: string } | null;
   transaction_tags: Array<{
     tag: { id: string; name: string; color: string | null; group: { color: string | null } | null };
   }>;
@@ -608,10 +610,11 @@ async function getRecentTransactionsCached(
   const { data } = await supabase
     .from("transactions")
     .select(`
-      id, amount, direction, account_id, category_id, recurrence_group_id, merchant_name, clean_description,
+      id, amount, direction, account_id, category_id, destinatario_id, recurrence_group_id, merchant_name, clean_description,
       transaction_date, currency_code,
       categories!transactions_category_id_fkey(name_es, name, icon),
       accounts!transactions_account_id_fkey(name, color, mask, bank_key, account_type),
+      destinatario:destinatarios!transactions_destinatario_id_fkey(id, name),
       transaction_tags!transaction_tags_transaction_id_fkey(tag:tags(id, name, color, group:tag_groups(color)))
     `)
     .eq("user_id", userId)

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cacheTag, cacheLife } from "next/cache";
+import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { createCachedClient } from "@/lib/supabase/cached";
 import { autoCategorize, computeIdempotencyKey } from "@zeta/shared";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -857,6 +857,38 @@ export async function updateTransaction(
 
   revalidateFinancialViews();
   return { success: true, data };
+}
+
+/**
+ * Patch the `notes` field on a single transaction. Lightweight counterpart to
+ * `updateTransaction` for inline/autosave flows (detail page textarea).
+ * Notes don't affect balances or categorization, so we skip the balance-change
+ * reconciliation path.
+ */
+export async function updateTransactionNotes(
+  id: string,
+  notes: string | null,
+): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const normalized = notes?.trim() ? notes.trim() : null;
+  if (normalized && normalized.length > 2000) {
+    return { success: false, error: "La nota es demasiado larga (máx 2000 caracteres)" };
+  }
+
+  const { error } = await supabase
+    .from("transactions")
+    .update({ notes: normalized })
+    .eq("user_id", user.id)
+    .eq("id", id);
+
+  if (error) return { success: false, error: error.message };
+
+  // Narrow invalidation — notes don't affect aggregates, so we only bust the
+  // transactions read cache (which serves getTransactionCached + list queries).
+  updateTag("transactions");
+  return { success: true, data: undefined };
 }
 
 export async function deleteTransaction(id: string): Promise<ActionResult> {

--- a/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
@@ -1,156 +1,16 @@
-import { Suspense } from "react";
 import { connection } from "next/server";
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowDownLeft, ArrowLeft, ArrowUpRight, ReceiptText, ShieldCheck, Tags } from "lucide-react";
 import { getTransaction } from "@/actions/transactions";
 import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getDestinatarios } from "@/actions/destinatarios";
-import { getTagGroups, getTagsForEntity } from "@/actions/tags";
-import { isTransactionLinkedToOccurrence } from "@/actions/occurrences";
-import { TransactionFormDialog } from "@/components/transactions/transaction-form-dialog";
-import { DeleteTransactionButton } from "@/components/transactions/delete-transaction-button";
-import { PromoteToRecurringButton } from "@/components/transactions/promote-to-recurring-button";
-import { DestinatarioPicker } from "@/components/transactions/destinatario-picker";
-import { TagPicker } from "@/components/tags/tag-picker";
+import { getTagsForEntity } from "@/actions/tags";
+import {
+  getAccountIdsWithPendingOccurrences,
+  isTransactionLinkedToOccurrence,
+} from "@/actions/occurrences";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
-import { formatCurrency } from "@/lib/utils/currency";
-import { formatDate } from "@/lib/utils/date";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { PageHero } from "@/components/ui/page-hero";
-import { StatCard } from "@/components/ui/stat-card";
-import { Skeleton } from "@/components/ui/skeleton";
-import type { Transaction } from "@/types/domain";
-
-// ─── Deferred: edit button (needs accounts + categories) ─────────────────────
-
-async function TransactionEditAction({ transaction }: { transaction: Transaction }) {
-  const [accountsResult, categoriesResult] = await Promise.all([
-    getAccounts(),
-    getCategories(),
-  ]);
-
-  return (
-    <TransactionFormDialog
-      transaction={transaction}
-      accounts={accountsResult.success ? accountsResult.data : []}
-      categories={categoriesResult.success ? categoriesResult.data : []}
-    />
-  );
-}
-
-// ─── Deferred: promote-to-recurring button ───────────────────────────────────
-
-async function TransactionPromoteAction({ transaction }: { transaction: Transaction }) {
-  const [accountsResult, categoriesResult, isLinked] = await Promise.all([
-    getAccounts(),
-    getCategories(),
-    isTransactionLinkedToOccurrence(transaction.id),
-  ]);
-
-  return (
-    <PromoteToRecurringButton
-      transaction={{
-        id: transaction.id,
-        account_id: transaction.account_id,
-        amount: transaction.amount,
-        currency_code: transaction.currency_code,
-        direction: transaction.direction,
-        merchant_name: transaction.merchant_name,
-        clean_description: transaction.clean_description,
-        category_id: transaction.category_id,
-        destinatario_id: transaction.destinatario_id,
-        transaction_date: transaction.transaction_date,
-      }}
-      isLinkedToOccurrence={isLinked}
-      accounts={accountsResult.success ? accountsResult.data : []}
-      categories={categoriesResult.success ? categoriesResult.data : []}
-    />
-  );
-}
-
-// ─── Deferred: sidebar (needs destinatarios, categories, tags) ───────────────
-
-async function TransactionSidebar({ transaction }: { transaction: Transaction }) {
-  const [destinatariosResult, categoriesResult, tagGroupsResult, transactionTags] = await Promise.all([
-    getDestinatarios(),
-    getCategories(),
-    getTagGroups(),
-    getTagsForEntity("transaction", transaction.id),
-  ]);
-
-  const destinatarios = destinatariosResult.success ? destinatariosResult.data : [];
-  const categories = categoriesResult.success ? categoriesResult.data : [];
-  const tagGroups = tagGroupsResult.success ? tagGroupsResult.data : [];
-
-  return (
-    <div className="space-y-6">
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-              <ReceiptText className="size-4 text-z-brass" />
-            </div>
-            <div className="space-y-1">
-              <CardTitle>Destinatario</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Ajusta la asociación comercial para mejorar contexto y futuras reglas.
-              </p>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <DestinatarioPicker
-            transactionId={transaction.id}
-            currentDestinatarioId={transaction.destinatario_id}
-            destinatarios={destinatarios}
-            rawDescription={transaction.raw_description}
-            categories={categories}
-          />
-        </CardContent>
-      </Card>
-
-      <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/6 bg-black/10">
-              <Tags className="size-4 text-z-brass" />
-            </div>
-            <div className="space-y-1">
-              <CardTitle>Etiquetas</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Agrega contexto libre: viajes, personas, proyectos.
-              </p>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <TagPicker
-            entityType="transaction"
-            entityId={transaction.id}
-            currentTags={transactionTags}
-            allTagGroups={tagGroups}
-          />
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ─── Skeletons ───────────────────────────────────────────────────────────────
-
-function SidebarSkeleton() {
-  return (
-    <div className="space-y-6">
-      <Skeleton className="h-40 rounded-xl" />
-      <Skeleton className="h-40 rounded-xl" />
-    </div>
-  );
-}
-
-// ─── Page ────────────────────────────────────────────────────────────────────
+import { TransactionDetailClient } from "./transaction-detail-client";
 
 export default async function TransactionDetailPage({
   params,
@@ -160,131 +20,50 @@ export default async function TransactionDetailPage({
   await connection();
   const { id } = await params;
 
-  // Only fetch the transaction — everything else streams in via Suspense
+  // Fire the tx-independent list fetches immediately so they don't wait on
+  // `getTransaction`. On cold cache this turns a serial waterfall into
+  // `max(tx, lists)` instead of their sum.
+  const listFetchesPromise = Promise.all([
+    getAccounts(),
+    getCategories(),
+    getDestinatarios(),
+    getAccountIdsWithPendingOccurrences(),
+  ]);
+
   const txResult = await getTransaction(id);
   if (!txResult.success) notFound();
-
   const tx = txResult.data;
-  const isInflow = tx.direction === "INFLOW";
-  const txStatus =
-    tx.status === "POSTED"
-      ? "Confirmada"
-      : tx.status === "PENDING"
-        ? "Pendiente"
-        : "Cancelada";
+
+  const [
+    [accountsResult, categoriesResult, destinatariosResult, linkableAccountIds],
+    initialTags,
+    isLinkedToOccurrence,
+  ] = await Promise.all([
+    listFetchesPromise,
+    getTagsForEntity("transaction", tx.id),
+    isTransactionLinkedToOccurrence(tx.id),
+  ]);
+
+  const accounts = accountsResult.success ? accountsResult.data : [];
+  const categories = categoriesResult.success ? categoriesResult.data : [];
+  const destinatarios = destinatariosResult.success ? destinatariosResult.data : [];
+
+  const currentDestinatarioName = tx.destinatario_id
+    ? destinatarios.find((d) => d.id === tx.destinatario_id)?.name ?? null
+    : null;
 
   return (
-    <div className="max-w-4xl space-y-6 lg:space-y-8">
+    <div className="mx-auto w-full max-w-xl lg:max-w-4xl">
       <MobileHeader variant="sub" title="Detalle" backHref="/transactions" />
-      <PageHero
-        pills={
-          <>
-            <Link
-              href="/transactions"
-              className="inline-flex items-center gap-2 rounded-full border border-white/6 bg-black/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-z-sage-light hover:bg-white/5"
-            >
-              <ArrowLeft className="size-3.5" />
-              Volver a Movimientos
-            </Link>
-            <Badge className={isInflow ? "bg-z-income/15 text-z-income hover:bg-z-income/15" : "bg-z-debt/15 text-z-debt hover:bg-z-debt/15"}>
-              {isInflow ? "Ingreso" : "Gasto"}
-            </Badge>
-            <Badge variant="secondary">{txStatus}</Badge>
-          </>
-        }
-        title={tx.merchant_name || tx.clean_description || "Transacción"}
-        description={`${formatDate(tx.transaction_date, "dd MMMM yyyy")} \u00b7 ${tx.provider}`}
-        actions={
-          <>
-            <Suspense fallback={<Skeleton className="h-9 w-20 rounded-md" />}>
-              <TransactionEditAction transaction={tx} />
-            </Suspense>
-            <Suspense fallback={<Skeleton className="h-9 w-28 rounded-md" />}>
-              <TransactionPromoteAction transaction={tx} />
-            </Suspense>
-            <DeleteTransactionButton transactionId={tx.id} />
-          </>
-        }
-      >
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <StatCard
-            label={
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                {isInflow ? (
-                  <ArrowDownLeft className="size-4 text-z-income" />
-                ) : (
-                  <ArrowUpRight className="size-4 text-z-debt" />
-                )}
-                Monto
-              </div>
-            }
-            value={
-              <span className={isInflow ? "text-z-income" : "text-z-sage-light"}>
-                {isInflow ? "+" : "-"}
-                {formatCurrency(tx.amount, tx.currency_code)}
-              </span>
-            }
-            description="Valor que realmente movió esta transacción."
-          />
-          <StatCard
-            label="Estado"
-            value={<span className="text-lg">{txStatus}</span>}
-            description="Contexto actual del movimiento dentro de la base."
-          />
-          <StatCard
-            label="Fuente"
-            value={<span className="text-lg">{tx.provider}</span>}
-            description="Origen con el que entró o fue registrado este movimiento."
-          />
-          <StatCard
-            label={
-              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                <ShieldCheck className="size-4 text-z-brass" />
-                Qué hacer aquí
-              </div>
-            }
-            value={
-              <span className="text-sm font-normal leading-6 text-muted-foreground">
-                Editar, borrar o reasignar destinatario sin salir del flujo operativo de Movimientos.
-              </span>
-            }
-          />
-        </div>
-      </PageHero>
-
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
-        <Card className="border-white/6 bg-z-surface-2/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-          <CardHeader>
-            <CardTitle>Contexto del movimiento</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Datos base para entender de dónde viene y cómo quedó registrado.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {tx.raw_description && (
-              <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                  Descripción original
-                </p>
-                <p className="mt-2 text-sm font-mono text-z-white">{tx.raw_description}</p>
-              </div>
-            )}
-
-            {tx.notes && (
-              <div className="rounded-2xl border border-white/6 bg-black/10 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-                  Notas
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">{tx.notes}</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Suspense fallback={<SidebarSkeleton />}>
-          <TransactionSidebar transaction={tx} />
-        </Suspense>
-      </div>
+      <TransactionDetailClient
+        transaction={tx}
+        currentDestinatarioName={currentDestinatarioName}
+        accounts={accounts}
+        categories={categories}
+        initialTags={initialTags}
+        isLinkedToOccurrence={isLinkedToOccurrence}
+        linkableAccountIds={linkableAccountIds}
+      />
     </div>
   );
 }

--- a/webapp/src/app/(dashboard)/transactions/[id]/transaction-detail-client.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/transaction-detail-client.tsx
@@ -1,0 +1,660 @@
+"use client";
+
+import { startTransition, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  ChevronDown,
+  ChevronUp,
+  EyeOff,
+  Eye,
+  Link2,
+  Plus,
+  Tag,
+  Trash2,
+  UserRound,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import { chipBackground, zoneTextColor } from "@/lib/utils/zone-colors";
+import {
+  DESTRUCTIVE_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+  SECTION_EYEBROW_CLASS,
+} from "@/lib/constants/styles";
+import { CategoryIcon } from "@/components/categories/category-icon";
+import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import { DestinatarioZonePicker } from "@/components/destinatarios/destinatario-zone-picker";
+import { TagZonePicker } from "@/components/tags/tag-zone-picker";
+import { LinkPickerSheet } from "@/components/recurring/link-picker-sheet";
+import { PromoteToRecurringButton } from "@/components/transactions/promote-to-recurring-button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  categorizeTransaction,
+  uncategorizeTransaction,
+  assignDestinatario,
+} from "@/actions/categorize";
+import {
+  deleteTransaction,
+  toggleExcludeTransaction,
+  updateTransactionNotes,
+} from "@/actions/transactions";
+import { removeTagFromEntity } from "@/actions/tags";
+import {
+  getCandidateOccurrencesForTransaction,
+  linkExistingTransactionToOccurrence,
+  type CandidateOccurrence,
+} from "@/actions/occurrences";
+import type {
+  Account,
+  CategoryWithChildren,
+  CurrencyCode,
+  Tag as TagType,
+  Transaction,
+} from "@/types/domain";
+
+/** Neutral chip button used in the Acciones row. Brass-solid "Hacer recurrente"
+ * is supplied by PromoteToRecurringButton; destructive + toggle chips append
+ * their own color classes on top. */
+const DETAIL_ACTION_CHIP_CLASS =
+  "inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/6 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-foreground transition-colors active:opacity-70 disabled:opacity-50";
+
+/** Fallback category chip color when a category has no `color` set. Hex literal
+ * is intentional — `chipBackground()` / `zoneTextColor()` in `zone-colors.ts`
+ * process raw hex, not CSS variables. Matches --z-sage (#768053). */
+const FALLBACK_CAT_COLOR = "#768053";
+
+interface TransactionDetailClientProps {
+  transaction: Transaction;
+  /** Current destinatario name — fetched alongside the tx to avoid a type extension. */
+  currentDestinatarioName: string | null;
+  accounts: Account[];
+  categories: CategoryWithChildren[];
+  initialTags: TagType[];
+  isLinkedToOccurrence: boolean;
+  /** Account IDs that have at least one pending occurrence — enables "Vincular". */
+  linkableAccountIds: string[];
+}
+
+function findLeafCategory(
+  categories: CategoryWithChildren[],
+  id: string | null,
+): { id: string; name: string; icon: string | null; color: string | null } | null {
+  if (!id) return null;
+  for (const zone of categories) {
+    if (zone.id === id) {
+      return { id: zone.id, name: zone.name_es ?? zone.name ?? "", icon: zone.icon ?? null, color: zone.color ?? null };
+    }
+    const child = zone.children.find((c) => c.id === id);
+    if (child) {
+      // child inherits zone color when it doesn't have its own
+      return {
+        id: child.id,
+        name: child.name_es ?? child.name ?? "",
+        icon: child.icon ?? null,
+        color: child.color ?? zone.color ?? null,
+      };
+    }
+  }
+  return null;
+}
+
+export function TransactionDetailClient({
+  transaction: tx,
+  currentDestinatarioName,
+  accounts,
+  categories,
+  initialTags,
+  isLinkedToOccurrence,
+  linkableAccountIds,
+}: TransactionDetailClientProps) {
+  const router = useRouter();
+  const isInflow = tx.direction === "INFLOW";
+  const account = useMemo(
+    () => accounts.find((a) => a.id === tx.account_id) ?? null,
+    [accounts, tx.account_id],
+  );
+
+  /* ─── Optimistic category ─────────────────────────────────────────── */
+  const [optCategoryId, setOptCategoryId] = useState<string | null>(tx.category_id);
+  const [catOpen, setCatOpen] = useState(false);
+  const [, startCategoryTransition] = useTransition();
+  const selectedCategory = findLeafCategory(categories, optCategoryId);
+
+  function handleCategorySelect(id: string | null) {
+    setOptCategoryId(id);
+    setCatOpen(false);
+    startCategoryTransition(async () => {
+      const result = id
+        ? await categorizeTransaction(tx.id, id)
+        : await uncategorizeTransaction(tx.id);
+      if (!result.success) {
+        setOptCategoryId(tx.category_id);
+        toast.error(result.error ?? "Error al asignar categoría");
+      } else {
+        toast.success(
+          id && selectedCategory
+            ? `Categoría: ${selectedCategory.name}`
+            : "Categoría removida",
+        );
+      }
+    });
+  }
+
+  /* ─── Optimistic destinatario ────────────────────────────────────── */
+  const [optDestId, setOptDestId] = useState<string | null>(tx.destinatario_id);
+  const [optDestName, setOptDestName] = useState<string | null>(currentDestinatarioName);
+  const [destOpen, setDestOpen] = useState(false);
+  const [, startDestTransition] = useTransition();
+
+  function handleDestSelect(id: string | null, name: string | null) {
+    const prevId = optDestId;
+    const prevName = optDestName;
+    setOptDestId(id);
+    setOptDestName(name);
+    setDestOpen(false);
+    if (!id) return;
+    startDestTransition(async () => {
+      const result = await assignDestinatario(tx.id, id);
+      if (result.success) {
+        toast.success(`Destinatario: ${name}`);
+      } else {
+        setOptDestId(prevId);
+        setOptDestName(prevName);
+        toast.error(result.error ?? "No se pudo asignar destinatario");
+      }
+    });
+  }
+
+  /* ─── Tags — optimistic add/remove ────────────────────────────────── */
+  const [tagOpen, setTagOpen] = useState(false);
+  const [tags, setTags] = useState<TagType[]>(initialTags);
+  const [, startTagTransition] = useTransition();
+
+  useEffect(() => {
+    setTags(initialTags);
+  }, [initialTags]);
+
+  function handleRemoveTag(tagId: string) {
+    const prev = tags;
+    setTags((current) => current.filter((t) => t.id !== tagId));
+    startTagTransition(async () => {
+      const result = await removeTagFromEntity(tagId, "transaction", tx.id);
+      if (!result.success) {
+        setTags(prev);
+        toast.error(result.error ?? "No se pudo quitar la etiqueta");
+      }
+    });
+  }
+
+  /* ─── Notes — inline textarea, autosave on blur ───────────────────── */
+  const [notes, setNotes] = useState(tx.notes ?? "");
+  const [notesDirty, setNotesDirty] = useState(false);
+  const [notesSaving, setNotesSaving] = useState(false);
+  const notesTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [notesEditing, setNotesEditing] = useState(false);
+
+  async function handleNotesBlur() {
+    if (!notesDirty) {
+      setNotesEditing(false);
+      return;
+    }
+    setNotesSaving(true);
+    const result = await updateTransactionNotes(tx.id, notes.trim() || null);
+    setNotesSaving(false);
+    setNotesEditing(false);
+    if (result.success) {
+      setNotesDirty(false);
+      toast.success("Nota guardada");
+    } else {
+      // Revert to server value so the UI doesn't silently show unsaved text.
+      setNotes(tx.notes ?? "");
+      setNotesDirty(false);
+      toast.error(result.error ?? "No se pudo guardar la nota");
+    }
+  }
+
+  function handleNotesOpen() {
+    setNotesEditing(true);
+    requestAnimationFrame(() => notesTextareaRef.current?.focus());
+  }
+
+  /* ─── Raw description disclosure ─────────────────────────────────── */
+  const [rawOpen, setRawOpen] = useState(false);
+
+  /* ─── Link to recurring ──────────────────────────────────────────── */
+  const [linking, setLinking] = useState(false);
+  const [occurrenceCandidates, setOccurrenceCandidates] = useState<CandidateOccurrence[]>([]);
+  const [isLinkingPending, startLinkTransition] = useTransition();
+  const vincularEligible =
+    !isLinkedToOccurrence && linkableAccountIds.includes(tx.account_id);
+
+  async function handleOpenLinkPicker() {
+    setLinking(true);
+    const result = await getCandidateOccurrencesForTransaction(tx.id);
+    if (result.success) {
+      setOccurrenceCandidates(result.data);
+    } else {
+      toast.error(result.error ?? "Error al buscar recurrentes");
+      setLinking(false);
+    }
+  }
+
+  function handleConfirmLink(occurrenceId: string) {
+    setLinking(false);
+    startLinkTransition(async () => {
+      const result = await linkExistingTransactionToOccurrence(occurrenceId, tx.id);
+      if (result.success) {
+        toast.success("Transacción vinculada a recurrente");
+        startTransition(() => router.refresh());
+      } else {
+        toast.error(result.error ?? "No se pudo vincular");
+      }
+    });
+  }
+
+  /* ─── Secondary actions ────────────────────────────────────────────── */
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [optExcluded, setOptExcluded] = useState(tx.is_excluded);
+  const [excluding, setExcluding] = useState(false);
+
+  async function handleToggleExclude() {
+    const nextExcluded = !optExcluded;
+    setOptExcluded(nextExcluded);
+    setExcluding(true);
+    const result = await toggleExcludeTransaction(tx.id, nextExcluded);
+    setExcluding(false);
+    if (result.success) {
+      toast.success(nextExcluded ? "Excluida de métricas" : "Incluida en métricas");
+    } else {
+      setOptExcluded(!nextExcluded);
+      toast.error(result.error ?? "No se pudo actualizar");
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true);
+    const result = await deleteTransaction(tx.id);
+    setDeleting(false);
+    if (result.success) {
+      toast.success("Transacción eliminada");
+      setDeleteConfirmOpen(false);
+      router.push("/transactions");
+    } else {
+      toast.error(result.error ?? "No se pudo eliminar");
+    }
+  }
+
+  /* ─── Render ─────────────────────────────────────────────────────── */
+
+  const catChipColor = selectedCategory?.color ?? FALLBACK_CAT_COLOR;
+
+  return (
+    <div className="space-y-0">
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <header
+        className={cn(
+          "relative overflow-hidden border-b border-white/6 px-4 pb-5 pt-4",
+          "bg-[radial-gradient(circle_at_top_left,rgba(200,181,96,0.08),transparent_45%),linear-gradient(180deg,rgba(26,29,26,0.9),rgba(18,20,18,0.95))]",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.18em]",
+              isInflow
+                ? "bg-z-income/14 text-z-income"
+                : "bg-z-expense/14 text-z-expense",
+            )}
+          >
+            {isInflow ? <ArrowDownLeft className="size-3" /> : <ArrowUpRight className="size-3" />}
+            {isInflow ? "Ingreso" : "Gasto"}
+          </span>
+          {tx.status === "PENDING" && (
+            <span className="inline-flex items-center rounded-full bg-z-brass/12 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.18em] text-z-brass">
+              Pendiente
+            </span>
+          )}
+          {tx.status === "CANCELLED" && (
+            <span className="inline-flex items-center rounded-full bg-white/[0.04] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+              Cancelada
+            </span>
+          )}
+          {optExcluded && (
+            <span className="inline-flex items-center rounded-full bg-white/[0.04] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+              Excluida
+            </span>
+          )}
+        </div>
+
+        <h1 className="mt-2 text-lg font-semibold text-z-white">
+          {tx.merchant_name || tx.clean_description || "Transacción"}
+        </h1>
+
+        <p
+          className={cn(
+            "mt-2 text-[28px] font-bold tabular-nums tracking-[-0.01em]",
+            isInflow ? "text-z-income" : "text-z-white",
+          )}
+        >
+          {isInflow ? "+" : "-"}
+          {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+        </p>
+
+        <p className="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground">
+          <span>{formatDate(tx.transaction_date, "dd MMM yyyy")}</span>
+          {account && (
+            <>
+              <span className="text-white/15">·</span>
+              <span>{account.name}</span>
+            </>
+          )}
+          <span className="text-white/15">·</span>
+          <span className="uppercase tracking-wider">{tx.provider}</span>
+        </p>
+      </header>
+
+      {/* ── Clasificación ──────────────────────────────────────────── */}
+      <section className="px-4 pt-4">
+        <p className={cn(SECTION_EYEBROW_CLASS, "mb-3")}>Clasificación</p>
+
+        {/* Categoría */}
+        <div className="border-t border-white/6 py-3 first:border-t-0 first:pt-0">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            Categoría
+          </p>
+          <button
+            type="button"
+            onClick={() => setCatOpen(true)}
+            aria-label="Cambiar categoría"
+            className="inline-flex items-center"
+          >
+            {selectedCategory ? (
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold"
+                style={{
+                  backgroundColor: chipBackground(catChipColor),
+                  color: zoneTextColor(catChipColor),
+                }}
+              >
+                {selectedCategory.icon && (
+                  <CategoryIcon icon={selectedCategory.icon} className="size-3.5" />
+                )}
+                <span>{selectedCategory.name}</span>
+                <ChevronDown className="ml-0.5 size-3 opacity-60" />
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-white/6 bg-white/[0.03] px-2.5 py-1 text-xs text-muted-foreground">
+                <Tag className="size-3" />
+                Sin categoría
+                <ChevronDown className="ml-0.5 size-3 opacity-60" />
+              </span>
+            )}
+          </button>
+          <CategoryZonePicker
+            categories={categories}
+            value={optCategoryId}
+            onValueChange={handleCategorySelect}
+            direction={tx.direction}
+            hideTrigger
+            controlledOpen={catOpen}
+            onControlledOpenChange={setCatOpen}
+          />
+        </div>
+
+        {/* Destinatario */}
+        <div className="border-t border-white/6 py-3">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            Destinatario
+          </p>
+          <button
+            type="button"
+            onClick={() => setDestOpen(true)}
+            aria-label="Cambiar destinatario"
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold",
+              optDestName
+                ? "bg-z-brass/12 text-z-brass"
+                : "border border-white/6 bg-white/[0.03] font-normal text-muted-foreground",
+            )}
+          >
+            <UserRound className="size-3.5" />
+            <span>{optDestName ?? "Sin destinatario"}</span>
+            <ChevronDown className="ml-0.5 size-3 opacity-60" />
+          </button>
+          <DestinatarioZonePicker
+            value={optDestId}
+            selectedName={optDestName}
+            onValueChange={handleDestSelect}
+            hideTrigger
+            controlledOpen={destOpen}
+            onControlledOpenChange={setDestOpen}
+          />
+        </div>
+
+        {/* Etiquetas */}
+        <div className="border-t border-white/6 py-3">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            Etiquetas
+          </p>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {tags.map((t) => (
+              <span
+                key={t.id}
+                className="inline-flex items-center gap-1 rounded-full border border-z-brass/20 bg-z-brass/10 pl-2.5 pr-1 py-0.5 text-[11px] font-medium text-z-brass"
+              >
+                <span className="truncate">{t.name}</span>
+                <button
+                  type="button"
+                  aria-label={`Quitar etiqueta ${t.name}`}
+                  onClick={() => handleRemoveTag(t.id)}
+                  className="ml-0.5 inline-flex size-4 items-center justify-center rounded-full text-z-brass/60 transition-colors hover:bg-z-brass/15 hover:text-z-brass"
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+            <button
+              type="button"
+              onClick={() => setTagOpen(true)}
+              className="inline-flex items-center gap-1 rounded-full border border-white/6 bg-white/[0.03] px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-white/[0.06]"
+            >
+              <Plus className="size-3" />
+              Etiqueta
+            </button>
+          </div>
+          <TagZonePicker
+            entityType="transaction"
+            entityId={tx.id}
+            hideTrigger
+            controlledOpen={tagOpen}
+            onControlledOpenChange={(open) => {
+              setTagOpen(open);
+              if (!open) startTransition(() => router.refresh());
+            }}
+          />
+        </div>
+      </section>
+
+      {/* ── Notas ──────────────────────────────────────────────────── */}
+      <section className="px-4 pt-4">
+        <p className={cn(SECTION_EYEBROW_CLASS, "mb-2")}>Notas</p>
+        {notesEditing ? (
+          <textarea
+            ref={notesTextareaRef}
+            value={notes}
+            onChange={(e) => {
+              setNotes(e.target.value);
+              setNotesDirty(true);
+            }}
+            onBlur={handleNotesBlur}
+            placeholder="Agrega una nota…"
+            rows={3}
+            className="w-full rounded-xl border border-z-brass/20 bg-black/20 px-3 py-2 text-sm text-z-white placeholder:text-muted-foreground focus:border-z-brass/40 focus:outline-none"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={handleNotesOpen}
+            className={cn(
+              "block w-full rounded-xl border border-white/6 bg-black/10 px-3 py-2 text-left text-sm transition-colors hover:bg-white/[0.03]",
+              !notes && "italic text-muted-foreground",
+            )}
+          >
+            {notes || "Toca para agregar una nota…"}
+          </button>
+        )}
+        {notesSaving && (
+          <p className="mt-1 text-[10px] text-muted-foreground">Guardando…</p>
+        )}
+
+        {(() => {
+          const rawDesc = tx.raw_description;
+          if (!rawDesc) return null;
+          return (
+            <div className="mt-3">
+              <button
+                type="button"
+                onClick={() => setRawOpen((prev) => !prev)}
+                className="inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-z-sage-light"
+              >
+                {rawOpen ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+                Ver descripción original
+              </button>
+              {rawOpen && (
+                <p className="mt-2 rounded-lg border border-white/6 bg-black/20 px-3 py-2 font-mono text-[11px] leading-relaxed text-z-sage-light break-all">
+                  {rawDesc}
+                </p>
+              )}
+            </div>
+          );
+        })()}
+      </section>
+
+      {/* ── Acciones ───────────────────────────────────────────────── */}
+      <section className="px-4 py-4">
+        <p className={cn(SECTION_EYEBROW_CLASS, "mb-2")}>Acciones</p>
+        <div className="flex flex-wrap items-stretch gap-2">
+          <PromoteToRecurringButton
+            transaction={{
+              id: tx.id,
+              account_id: tx.account_id,
+              amount: tx.amount,
+              currency_code: tx.currency_code as CurrencyCode,
+              direction: tx.direction,
+              merchant_name: tx.merchant_name,
+              clean_description: tx.clean_description,
+              category_id: tx.category_id,
+              destinatario_id: tx.destinatario_id,
+              transaction_date: tx.transaction_date,
+            }}
+            isLinkedToOccurrence={isLinkedToOccurrence}
+            accounts={accounts}
+            categories={categories}
+          />
+          {vincularEligible && (
+            <button
+              type="button"
+              onClick={handleOpenLinkPicker}
+              disabled={isLinkingPending}
+              className={DETAIL_ACTION_CHIP_CLASS}
+            >
+              <Link2 className="size-3.5" />
+              Vincular
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleToggleExclude}
+            disabled={excluding}
+            className={DETAIL_ACTION_CHIP_CLASS}
+          >
+            {optExcluded ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
+            {optExcluded ? "Incluir en métricas" : "Excluir de métricas"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setDeleteConfirmOpen(true)}
+            className={cn(
+              DETAIL_ACTION_CHIP_CLASS,
+              "border-z-debt/20 bg-z-debt/8 text-z-debt",
+            )}
+          >
+            <Trash2 className="size-3.5" />
+            Eliminar
+          </button>
+        </div>
+      </section>
+
+      {/* ── Link picker sheet ─────────────────────────────────────── */}
+      {linking && (
+        <LinkPickerSheet
+          open={linking}
+          onOpenChange={(open) => {
+            if (!open) setLinking(false);
+          }}
+          title="Vincular a recurrente"
+          subtitle={`${tx.merchant_name || tx.clean_description || ""} · ${formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}`}
+          candidates={occurrenceCandidates.map((o) => ({
+            id: o.id,
+            label: o.merchant,
+            sublabel: `${formatDate(o.occurrenceDate)} · ${formatCurrency(o.expectedAmount, o.currencyCode as CurrencyCode)} esperado`,
+            amount: o.expectedAmount,
+            currencyCode: o.currencyCode,
+            direction: tx.direction,
+            matchScore: o.matchScore,
+          }))}
+          onConfirm={handleConfirmLink}
+          isPending={isLinkingPending}
+        />
+      )}
+
+      {/* ── Delete confirm ────────────────────────────────────────── */}
+      <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Eliminar transacción</DialogTitle>
+            <DialogDescription>
+              ¿Estás seguro? Esta acción no se puede deshacer.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setDeleteConfirmOpen(false)}
+              className={cn(
+                "rounded-md px-4 py-2 text-sm font-medium transition-colors border",
+                GHOST_BUTTON_CLASS,
+              )}
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className={cn(
+                "rounded-md px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50",
+                DESTRUCTIVE_BUTTON_CLASS,
+              )}
+            >
+              {deleting ? "Eliminando…" : "Eliminar"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/webapp/src/components/categories/category-zone-picker.tsx
+++ b/webapp/src/components/categories/category-zone-picker.tsx
@@ -63,6 +63,11 @@ interface CategoryZonePickerProps {
   transactionDescription?: string;
   /** Presentation variant — auto-detects if omitted */
   variant?: "dialog" | "popover" | "drawer";
+  /** External open control — when defined, suppresses internal state. */
+  controlledOpen?: boolean;
+  onControlledOpenChange?: (open: boolean) => void;
+  /** Hide the default trigger button — parent opens via controlledOpen. */
+  hideTrigger?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -111,8 +116,20 @@ export function CategoryZonePicker({
   categoryRules,
   transactionDescription,
   variant: variantProp,
+  controlledOpen,
+  onControlledOpenChange,
+  hideTrigger = false,
 }: CategoryZonePickerProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpenControlled = controlledOpen !== undefined;
+  const open = isOpenControlled ? controlledOpen : internalOpen;
+  const setOpen = (next: boolean) => {
+    if (isOpenControlled) {
+      onControlledOpenChange?.(next);
+    } else {
+      setInternalOpen(next);
+    }
+  };
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
@@ -301,7 +318,7 @@ export function CategoryZonePicker({
       <>
         {name && <input type="hidden" name={name} value={value ?? ""} />}
         <Popover open={open} onOpenChange={handleOpen}>
-          <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+          {!hideTrigger && <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>}
           <PopoverContent
             container={portalContainer}
             className="w-[320px] max-w-[min(22rem,calc(100vw-2rem))] p-0 overscroll-contain touch-pan-y"
@@ -323,7 +340,7 @@ export function CategoryZonePicker({
     return (
       <>
         {name && <input type="hidden" name={name} value={value ?? ""} />}
-        {triggerButton}
+        {!hideTrigger && triggerButton}
         <Dialog open={open} onOpenChange={handleOpen}>
           <DialogContent className="flex max-h-[70vh] w-full max-w-md flex-col gap-0 overflow-hidden p-0">
             <DialogHeader className="border-b px-4 py-3">
@@ -345,7 +362,7 @@ export function CategoryZonePicker({
   return (
     <>
       {name && <input type="hidden" name={name} value={value ?? ""} />}
-      {triggerButton}
+      {!hideTrigger && triggerButton}
       <Drawer open={open} onOpenChange={handleOpen}>
         <DrawerContent>
           <DrawerHeader>

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -50,6 +50,7 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
     amount: tx.amount,
     currency_code: (tx.currency_code ?? "COP") as CurrencyCode,
     direction: tx.direction,
+    transaction_date: tx.transaction_date,
     account_id: tx.account_id,
     account_name: tx.accounts?.name ?? "Sin cuenta",
     account_color: tx.accounts?.color ?? null,
@@ -59,6 +60,8 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
     category_id: tx.category_id ?? null,
     category_name: tx.categories?.name_es ?? tx.categories?.name ?? null,
     category_icon: tx.categories?.icon ?? null,
+    destinatario_id: tx.destinatario_id ?? null,
+    destinatario_name: tx.destinatario?.name ?? null,
     recurrence_group_id: tx.recurrence_group_id ?? null,
     tags: (tx.transaction_tags ?? []).map((tt) => ({
       id: tt.tag.id,

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -43,6 +43,11 @@ interface DestinatarioZonePickerProps {
   /** Render as a small icon button instead of a combobox */
   compact?: boolean;
   variant?: "popover" | "dialog" | "drawer";
+  /** External open control — when defined, suppresses internal state. */
+  controlledOpen?: boolean;
+  onControlledOpenChange?: (open: boolean) => void;
+  /** Hide the default trigger button — parent opens via controlledOpen. */
+  hideTrigger?: boolean;
 }
 
 export function DestinatarioZonePicker({
@@ -53,8 +58,20 @@ export function DestinatarioZonePicker({
   selectedName,
   compact = false,
   variant: variantProp,
+  controlledOpen,
+  onControlledOpenChange,
+  hideTrigger = false,
 }: DestinatarioZonePickerProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = (next: boolean) => {
+    if (isControlled) {
+      onControlledOpenChange?.(next);
+    } else {
+      setInternalOpen(next);
+    }
+  };
   const [creating, setCreating] = useState(false);
   const [, startCreateTransition] = useTransition();
   const createInputRef = useRef<HTMLInputElement>(null);
@@ -284,7 +301,7 @@ export function DestinatarioZonePicker({
   if (variant === "popover") {
     return (
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+        {!hideTrigger && <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>}
         <PopoverContent
           className="w-[280px] p-0"
           align="start"
@@ -299,7 +316,7 @@ export function DestinatarioZonePicker({
   if (variant === "dialog") {
     return (
       <>
-        {triggerButton}
+        {!hideTrigger && triggerButton}
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogContent className="flex max-h-[70vh] w-full max-w-sm flex-col gap-0 overflow-hidden p-0">
             <DialogHeader className="border-b px-4 py-3">
@@ -320,7 +337,7 @@ export function DestinatarioZonePicker({
   // variant === "drawer"
   return (
     <>
-      {triggerButton}
+      {!hideTrigger && triggerButton}
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerContent>
           <DrawerHeader>

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -1,9 +1,22 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { startTransition, useEffect, useRef, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { ArrowDownLeft, ArrowUpRight, ArrowRight, Link2, Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  ArrowRight,
+  ChevronLeft,
+  Eye,
+  Hash,
+  Link2,
+  MoreHorizontal,
+  Tag,
+  Trash2,
+  UserRound,
+} from "lucide-react";
 import { AccountRowIdentity } from "@/components/accounts/account-row-identity";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
@@ -11,13 +24,36 @@ import { formatDate } from "@/lib/utils/date";
 import { CategoryIcon } from "@/components/categories/category-icon";
 import { TagChip } from "@/components/tags/tag-chip";
 import { LinkPickerSheet } from "@/components/recurring/link-picker-sheet";
-import { useOutflowCategories } from "@/components/providers/app-data-provider";
-import { categorizeTransaction } from "@/actions/categorize";
-import { PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
+import { DestinatarioZonePicker } from "@/components/destinatarios/destinatario-zone-picker";
+import { TagZonePicker } from "@/components/tags/tag-zone-picker";
 import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useOutflowCategories } from "@/components/providers/app-data-provider";
+import { categorizeTransaction, assignDestinatario } from "@/actions/categorize";
+import { deleteTransaction } from "@/actions/transactions";
+import {
+  DESTRUCTIVE_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE_CLASS,
+  PANEL_INSET_CLASS,
+  SECTION_EYEBROW_CLASS,
+} from "@/lib/constants/styles";
+import {
+  getAccountIdsWithPendingOccurrences,
   getCandidateOccurrencesForTransaction,
   linkExistingTransactionToOccurrence,
-  getAccountIdsWithPendingOccurrences,
 } from "@/actions/occurrences";
 import type { CandidateOccurrence } from "@/actions/occurrences";
 import { toast } from "sonner";
@@ -32,6 +68,7 @@ const CategoryPickerBody = dynamic(
 );
 
 type AccountTypeEnum = "CHECKING" | "SAVINGS" | "CREDIT_CARD" | "CASH" | "INVESTMENT" | "LOAN" | "OTHER";
+type RowPhase = "actions" | "categorize";
 
 interface RecentTransactionMobile {
   id: string;
@@ -39,6 +76,7 @@ interface RecentTransactionMobile {
   amount: number;
   currency_code: CurrencyCode;
   direction: "INFLOW" | "OUTFLOW";
+  transaction_date: string;
   account_id: string;
   account_name: string;
   account_color: string | null;
@@ -48,6 +86,8 @@ interface RecentTransactionMobile {
   category_id: string | null;
   category_name: string | null;
   category_icon: string | null;
+  destinatario_id: string | null;
+  destinatario_name: string | null;
   recurrence_group_id: string | null;
   tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
 }
@@ -72,11 +112,15 @@ function findCategoryById(
   return null;
 }
 
+const CHIP_BASE_CLASS =
+  "flex flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 py-2.5 text-[11px] font-semibold transition-colors active:opacity-70";
+
 export function InicioActivity({ transactions }: InicioActivityProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [rowPhase, setRowPhase] = useState<Record<string, RowPhase>>({});
   // Track which rows have been opened at least once so we can defer mounting
-  // the heavy CategoryPickerBody until the user actually interacts.
-  const [openedOnceIds, setOpenedOnceIds] = useState<Set<string>>(new Set());
+  // the heavy CategoryPickerBody until the user actually taps Categorizar.
+  const [openedCategorizeIds, setOpenedCategorizeIds] = useState<Set<string>>(new Set());
   const outflowCategories = useOutflowCategories();
   // Refs for each row so we can scroll the expanded panel into view above the tab bar.
   const rowRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -98,6 +142,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
     if (!category) return;
     setOptimisticCategories((prev) => ({ ...prev, [txId]: category }));
     setExpandedId(null);
+    setRowPhase((prev) => ({ ...prev, [txId]: "actions" }));
     startCategoryTransition(async () => {
       const result = await categorizeTransaction(txId, categoryId);
       if (!result.success) {
@@ -137,7 +182,6 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
       const result = await linkExistingTransactionToOccurrence(occurrenceId, txId);
       if (result.success) {
         toast.success("Transacción vinculada a recurrente");
-        // Refresh linkable accounts — some may no longer have pending occurrences
         getAccountIdsWithPendingOccurrences().then((ids) => setLinkableAccountIds(new Set(ids)));
       } else {
         toast.error(result.error ?? "No se pudo vincular");
@@ -145,22 +189,93 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
     });
   };
 
+  /* ---- "Más" sheet + nested-picker state ----
+     Only one surface may be open at a time: the Más bottom-sheet OR one of the
+     nested pickers (destinatario/etiquetas drawer). Opening a picker from the
+     sheet closes the sheet first so they never stack. */
+  const router = useRouter();
+  const [moreSheetTxId, setMoreSheetTxId] = useState<string | null>(null);
+  const [nestedPicker, setNestedPicker] = useState<
+    | { txId: string; kind: "destinatario" | "tags" }
+    | null
+  >(null);
+  const [, startDestinatarioTransition] = useTransition();
+
+  const moreSheetTx = moreSheetTxId
+    ? transactions.find((t) => t.id === moreSheetTxId) ?? null
+    : null;
+  const nestedPickerTx = nestedPicker
+    ? transactions.find((t) => t.id === nestedPicker.txId) ?? null
+    : null;
+
+  function openNestedPicker(txId: string, kind: "destinatario" | "tags") {
+    setMoreSheetTxId(null);
+    setNestedPicker({ txId, kind });
+  }
+
+  function closeNestedPicker() {
+    setNestedPicker(null);
+    startTransition(() => router.refresh());
+  }
+
+  function handleAssignDestinatario(destId: string | null) {
+    const active = nestedPicker;
+    if (!destId || !active) return;
+    startDestinatarioTransition(async () => {
+      const result = await assignDestinatario(active.txId, destId);
+      if (result.success) {
+        toast.success("Destinatario asignado");
+        closeNestedPicker();
+      } else {
+        toast.error(result.error ?? "No se pudo asignar el destinatario");
+      }
+    });
+  }
+
   if (transactions.length === 0) return null;
 
   const visible = transactions.slice(0, 3);
 
+  function toggleExpand(txId: string) {
+    const willOpen = expandedId !== txId;
+    setExpandedId(willOpen ? txId : null);
+    if (willOpen) {
+      setRowPhase((prev) => ({ ...prev, [txId]: "actions" }));
+      requestAnimationFrame(() => {
+        rowRefs.current[txId]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      });
+    }
+  }
+
+  function openCategorizePhase(txId: string) {
+    setRowPhase((prev) => ({ ...prev, [txId]: "categorize" }));
+    setOpenedCategorizeIds((prev) => {
+      if (prev.has(txId)) return prev;
+      const next = new Set(prev);
+      next.add(txId);
+      return next;
+    });
+  }
+
+  function returnToActionsPhase(txId: string) {
+    setRowPhase((prev) => ({ ...prev, [txId]: "actions" }));
+  }
+
   return (
     <div>
-      <p className={cn(SECTION_EYEBROW_CLASS, "mb-1.5")}>
-        Reciente
-      </p>
+      <p className={cn(SECTION_EYEBROW_CLASS, "mb-1.5")}>Reciente</p>
 
       <div>
         {visible.map((tx) => {
           const isOpen = expandedId === tx.id;
+          const phase: RowPhase = rowPhase[tx.id] ?? "actions";
           const optimisticCat = optimisticCategories[tx.id];
           const categoryIcon = optimisticCat?.icon ?? tx.category_icon;
           const categoryName = optimisticCat?.name ?? tx.category_name;
+          const vincularEligible =
+            linkableAccountIds.has(tx.account_id) && !tx.recurrence_group_id;
+          const categoryResolved = Boolean(optimisticCat?.id ?? tx.category_id);
+
           return (
             <div
               key={tx.id}
@@ -172,25 +287,10 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                 type="button"
                 aria-expanded={isOpen}
                 aria-label={isOpen ? `Cerrar detalles de ${tx.description}` : `Ver acciones para ${tx.description}`}
-                onClick={() => {
-                  const willOpen = !isOpen;
-                  setExpandedId(willOpen ? tx.id : null);
-                  if (willOpen) {
-                    setOpenedOnceIds((prev) => {
-                      if (prev.has(tx.id)) return prev;
-                      const next = new Set(prev);
-                      next.add(tx.id);
-                      return next;
-                    });
-                    // Defer to next frame so the expanded panel has mounted before scrolling.
-                    requestAnimationFrame(() => {
-                      rowRefs.current[tx.id]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-                    });
-                  }
-                }}
+                onClick={() => toggleExpand(tx.id)}
                 className={cn(
                   "flex w-full gap-2 px-1 py-2 text-left transition-colors active:bg-white/[0.03]",
-                  isOpen && "border-l-2 border-l-z-brass pl-2"
+                  isOpen && "border-l-2 border-l-z-brass pl-2",
                 )}
               >
                 <div
@@ -198,7 +298,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                     "mt-0.5 flex size-[22px] shrink-0 items-center justify-center rounded-md",
                     tx.direction === "INFLOW"
                       ? "bg-z-income/12 text-z-income"
-                      : "bg-z-expense/12 text-z-expense"
+                      : "bg-z-expense/12 text-z-expense",
                   )}
                 >
                   {tx.direction === "INFLOW" ? (
@@ -249,7 +349,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                 <span
                   className={cn(
                     "shrink-0 text-xs font-medium tabular-nums",
-                    tx.direction === "INFLOW" && "text-z-income"
+                    tx.direction === "INFLOW" && "text-z-income",
                   )}
                 >
                   {tx.direction === "INFLOW" ? "+" : "-"}
@@ -263,51 +363,89 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
               >
                 <div className="overflow-hidden">
                   <div className={cn("py-1.5 transition-opacity duration-150", isOpen ? "opacity-100" : "opacity-0")}>
-                    <div className={cn(PANEL_INSET_CLASS, "space-y-2 border-z-brass/15 bg-black/20 p-2.5")}>
-                      <div className="flex items-center justify-between">
-                        <span className="text-[11px] text-muted-foreground">
-                          {tx.direction === "INFLOW" ? "Ingreso" : "Gasto"} &middot; {formatCurrency(tx.amount, tx.currency_code)}
-                        </span>
-                        <div className="flex items-center gap-2">
-                          {linkableAccountIds.has(tx.account_id) && !tx.recurrence_group_id && (
+                    <div className={cn(PANEL_INSET_CLASS, "border-z-brass/15 bg-black/20 p-3")}>
+                      {phase === "actions" ? (
+                        <div className="flex gap-1.5">
+                          {tx.direction === "OUTFLOW" && (
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                openCategorizePhase(tx.id);
+                              }}
+                              className={cn(
+                                CHIP_BASE_CLASS,
+                                categoryResolved
+                                  ? "border-white/8 bg-white/[0.03] text-foreground"
+                                  : "border-z-brass/25 bg-z-brass/10 text-z-brass",
+                              )}
+                            >
+                              <Tag className="size-3" />
+                              Categorizar
+                            </button>
+                          )}
+                          {vincularEligible && (
                             <button
                               type="button"
                               onClick={(e) => {
                                 e.preventDefault();
                                 handleOpenLinkPicker(tx.id);
                               }}
-                              className="inline-flex items-center gap-1 text-[11px] font-semibold text-z-brass"
+                              className={cn(
+                                CHIP_BASE_CLASS,
+                                "border-white/8 bg-white/[0.03] text-foreground",
+                              )}
                             >
-                              <Link2 className="size-2.5" />
+                              <Link2 className="size-3" />
                               Vincular
                             </button>
                           )}
-                          <Link
-                            href={`/transactions/${tx.id}`}
-                            className="inline-flex items-center gap-1 text-[11px] font-semibold text-z-brass"
-                          >
-                            <Pencil className="size-2.5" />
-                            Ver detalle
-                          </Link>
-                        </div>
-                      </div>
-                      {/* OUTFLOW only; INFLOW txs use Ver detalle for the full form.
-                          Lazy-mounted via openedOnceIds so the picker tree is not hydrated for rows the user never expands. */}
-                      {tx.direction === "OUTFLOW" && openedOnceIds.has(tx.id) && (
-                        <div className="border-t border-white/6 pt-2">
-                          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                            Asignar categoría
-                          </p>
-                          <CategoryPickerBody
-                            categories={outflowCategories}
-                            value={optimisticCat?.id ?? tx.category_id}
-                            onSelect={(id) => {
-                              if (id) handleAssignCategory(tx.id, id);
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setMoreSheetTxId(tx.id);
                             }}
-                            onCategoryCreated={() => { /* no-op inline — user creates via /categories */ }}
-                            suggestion={null}
-                            direction="OUTFLOW"
-                          />
+                            className={cn(
+                              CHIP_BASE_CLASS,
+                              "border-white/8 bg-white/[0.03] text-foreground",
+                              // When 3 chips fit, shrink "Más" slightly so labels stay readable
+                              tx.direction === "OUTFLOW" && vincularEligible && "flex-[0.8]",
+                            )}
+                          >
+                            <MoreHorizontal className="size-3" />
+                            Más
+                          </button>
+                        </div>
+                      ) : (
+                        <div>
+                          <div className="mb-2 flex items-center gap-2 border-b border-white/6 pb-2">
+                            <button
+                              type="button"
+                              onClick={() => returnToActionsPhase(tx.id)}
+                              aria-label="Volver a acciones"
+                              className="inline-flex size-6 items-center justify-center rounded-md bg-white/[0.05] text-muted-foreground transition-colors active:bg-white/[0.08]"
+                            >
+                              <ChevronLeft className="size-3.5" />
+                            </button>
+                            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                              Asignar categoría
+                            </p>
+                          </div>
+                          {openedCategorizeIds.has(tx.id) && (
+                            <CategoryPickerBody
+                              categories={outflowCategories}
+                              value={optimisticCat?.id ?? tx.category_id}
+                              onSelect={(id) => {
+                                if (id) handleAssignCategory(tx.id, id);
+                              }}
+                              onCategoryCreated={() => {
+                                /* no-op inline — user creates via /categories */
+                              }}
+                              suggestion={null}
+                              direction="OUTFLOW"
+                            />
+                          )}
                         </div>
                       )}
                     </div>
@@ -331,7 +469,9 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
       {linkingTxId && (
         <LinkPickerSheet
           open={!!linkingTxId}
-          onOpenChange={(open) => { if (!open) setLinkingTxId(null); }}
+          onOpenChange={(open) => {
+            if (!open) setLinkingTxId(null);
+          }}
           title="Vincular a recurrente"
           subtitle={(() => {
             const tx = transactions.find((t) => t.id === linkingTxId);
@@ -350,6 +490,207 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
           isPending={isLinking}
         />
       )}
+
+      {/* Secondary-actions sheet opened via "Más" chip. On close we refresh the
+          Dashboard segment so any destinatario/tag/delete mutations are
+          reflected in the row immediately (server cache is already invalidated
+          by the underlying actions via updateTag). */}
+      {moreSheetTx && (
+        <MoreActionsSheet
+          tx={moreSheetTx}
+          open={!!moreSheetTxId}
+          onOpenChange={(open) => {
+            if (!open) {
+              setMoreSheetTxId(null);
+              startTransition(() => router.refresh());
+            }
+          }}
+          onOpenNestedPicker={(kind) => openNestedPicker(moreSheetTx.id, kind)}
+        />
+      )}
+
+      {/* Nested pickers — rendered at root so they never stack on the Más sheet.
+          Opening a picker closes Más; picker close refreshes the segment. */}
+      {nestedPickerTx && nestedPicker?.kind === "destinatario" && (
+        <DestinatarioZonePicker
+          hideTrigger
+          controlledOpen
+          onControlledOpenChange={(open) => {
+            if (!open) closeNestedPicker();
+          }}
+          value={nestedPickerTx.destinatario_id}
+          selectedName={nestedPickerTx.destinatario_name}
+          onValueChange={handleAssignDestinatario}
+          variant="drawer"
+        />
+      )}
+      {nestedPickerTx && nestedPicker?.kind === "tags" && (
+        <TagZonePicker
+          hideTrigger
+          controlledOpen
+          onControlledOpenChange={(open) => {
+            if (!open) closeNestedPicker();
+          }}
+          entityType="transaction"
+          entityId={nestedPickerTx.id}
+          variant="drawer"
+        />
+      )}
     </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MoreActionsSheet                                                          */
+/* -------------------------------------------------------------------------- */
+
+interface MoreActionsSheetProps {
+  tx: RecentTransactionMobile;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenNestedPicker: (kind: "destinatario" | "tags") => void;
+}
+
+const SHEET_ROW_CLASS =
+  "flex w-full items-center gap-3 border-t border-white/6 px-1 py-3 text-left text-sm transition-colors active:bg-white/[0.03]";
+const SHEET_ROW_ICON_CLASS =
+  "inline-flex size-8 items-center justify-center rounded-lg bg-white/[0.04] text-muted-foreground";
+
+function MoreActionsSheet({ tx, open, onOpenChange, onOpenNestedPicker }: MoreActionsSheetProps) {
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    const result = await deleteTransaction(tx.id);
+    setDeleting(false);
+    if (result.success) {
+      toast.success("Transacción eliminada");
+      setDeleteConfirmOpen(false);
+      onOpenChange(false);
+    } else {
+      toast.error(result.error ?? "No se pudo eliminar");
+    }
+  }
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          className={cn(
+            "max-h-[85dvh] rounded-t-2xl border-t border-white/6 bg-z-surface-2",
+            MOBILE_TAB_BAR_CLEARANCE_CLASS,
+          )}
+        >
+          <SheetHeader className="gap-1 border-b border-white/6 pb-3">
+            <SheetTitle className="text-sm">{tx.description}</SheetTitle>
+            <p className="text-[11px] text-muted-foreground">
+              {tx.direction === "INFLOW" ? "Ingreso" : "Gasto"} ·{" "}
+              {formatCurrency(tx.amount, tx.currency_code)} · {formatDate(tx.transaction_date)}
+            </p>
+          </SheetHeader>
+
+          <div className="px-4 pb-2">
+            <Link
+              href={`/transactions/${tx.id}`}
+              onClick={() => onOpenChange(false)}
+              className={SHEET_ROW_CLASS}
+            >
+              <span className={SHEET_ROW_ICON_CLASS}>
+                <Eye className="size-4" />
+              </span>
+              <span className="flex-1">Ver detalle</span>
+              <ArrowRight className="size-3.5 text-muted-foreground" />
+            </Link>
+
+            <button
+              type="button"
+              onClick={() => onOpenNestedPicker("destinatario")}
+              className={SHEET_ROW_CLASS}
+            >
+              <span className={SHEET_ROW_ICON_CLASS}>
+                <UserRound className="size-4" />
+              </span>
+              <div className="flex-1 min-w-0 text-left">
+                <p className="text-sm">Destinatario</p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  {tx.destinatario_name ?? "Sin asignar"}
+                </p>
+              </div>
+              <ArrowRight className="size-3.5 text-muted-foreground" />
+            </button>
+
+            <button
+              type="button"
+              onClick={() => onOpenNestedPicker("tags")}
+              className={SHEET_ROW_CLASS}
+            >
+              <span className={SHEET_ROW_ICON_CLASS}>
+                <Hash className="size-4" />
+              </span>
+              <div className="flex-1 min-w-0 text-left">
+                <p className="text-sm">Etiquetas</p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  {tx.tags.length > 0
+                    ? `${tx.tags.length} aplicada${tx.tags.length === 1 ? "" : "s"}`
+                    : "Ninguna"}
+                </p>
+              </div>
+              <ArrowRight className="size-3.5 text-muted-foreground" />
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setDeleteConfirmOpen(true)}
+              className={cn(SHEET_ROW_CLASS, "text-z-debt")}
+            >
+              <span
+                className={cn(
+                  "inline-flex size-8 items-center justify-center rounded-lg bg-z-debt/10 text-z-debt",
+                )}
+              >
+                <Trash2 className="size-4" />
+              </span>
+              <span className="flex-1">Eliminar transacción</span>
+            </button>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Eliminar transacción</DialogTitle>
+            <DialogDescription>
+              ¿Estás seguro? Esta acción no se puede deshacer.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setDeleteConfirmOpen(false)}
+              className={cn(
+                "rounded-md border px-4 py-2 text-sm font-medium transition-colors",
+                GHOST_BUTTON_CLASS,
+              )}
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className={cn(
+                "rounded-md px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50",
+                DESTRUCTIVE_BUTTON_CLASS,
+              )}
+            >
+              {deleting ? "Eliminando…" : "Eliminar"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
@@ -61,6 +61,7 @@ export interface InicioRootProps {
     amount: number;
     currency_code: CurrencyCode;
     direction: "INFLOW" | "OUTFLOW";
+    transaction_date: string;
     account_id: string;
     account_name: string;
     account_color: string | null;
@@ -70,6 +71,8 @@ export interface InicioRootProps {
     category_id: string | null;
     category_name: string | null;
     category_icon: string | null;
+    destinatario_id: string | null;
+    destinatario_name: string | null;
     recurrence_group_id: string | null;
     tags: Array<{ id: string; name: string; color: string | null; group_color: string | null }>;
   }>;

--- a/webapp/src/components/tags/tag-zone-picker.tsx
+++ b/webapp/src/components/tags/tag-zone-picker.tsx
@@ -45,6 +45,11 @@ interface TagZonePickerProps {
   /** Render as a small icon button instead of a combobox */
   compact?: boolean;
   variant?: "popover" | "dialog" | "drawer";
+  /** External open control — when defined, suppresses internal state. */
+  controlledOpen?: boolean;
+  onControlledOpenChange?: (open: boolean) => void;
+  /** Hide the default trigger button — parent opens via controlledOpen. */
+  hideTrigger?: boolean;
 }
 
 export function TagZonePicker({
@@ -54,8 +59,20 @@ export function TagZonePicker({
   triggerClassName,
   compact = false,
   variant: variantProp,
+  controlledOpen,
+  onControlledOpenChange,
+  hideTrigger = false,
 }: TagZonePickerProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = (next: boolean) => {
+    if (isControlled) {
+      onControlledOpenChange?.(next);
+    } else {
+      setInternalOpen(next);
+    }
+  };
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const variant = variantProp ?? (isDesktop ? "popover" : "drawer");
 
@@ -357,7 +374,7 @@ export function TagZonePicker({
   if (variant === "popover") {
     return (
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+        {!hideTrigger && <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>}
         <PopoverContent className="w-[300px] p-0" align="start" sideOffset={8}>
           {body}
         </PopoverContent>
@@ -368,7 +385,7 @@ export function TagZonePicker({
   if (variant === "dialog") {
     return (
       <>
-        {triggerButton}
+        {!hideTrigger && triggerButton}
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogContent className="flex max-h-[70vh] w-full max-w-sm flex-col gap-0 overflow-hidden p-0">
             <DialogHeader className="border-b px-4 py-3">
@@ -389,7 +406,7 @@ export function TagZonePicker({
   // variant === "drawer"
   return (
     <>
-      {triggerButton}
+      {!hideTrigger && triggerButton}
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerContent>
           <DrawerHeader>

--- a/webapp/src/lib/constants/styles.ts
+++ b/webapp/src/lib/constants/styles.ts
@@ -9,6 +9,10 @@ export const GHOST_BUTTON_CLASS =
 export const BRASS_GHOST_BUTTON_CLASS =
   "border-z-brass/20 bg-z-brass/8 text-z-brass hover:bg-z-brass/12";
 
+/** Solid destructive button — for confirm-destroy actions (deletes, unrecoverable ops). */
+export const DESTRUCTIVE_BUTTON_CLASS =
+  "bg-z-debt text-z-white hover:bg-z-debt/90";
+
 /** Shared page shell spacing */
 export const PAGE_STACK_CLASS = "space-y-6 lg:space-y-8";
 

--- a/webapp/src/lib/constants/styles.ts
+++ b/webapp/src/lib/constants/styles.ts
@@ -3,7 +3,7 @@ export const BRASS_BUTTON_CLASS = "bg-z-brass text-z-ink hover:bg-z-brass/90";
 
 /** Obsidian & Brass design token: secondary/ghost button */
 export const GHOST_BUTTON_CLASS =
-  "border-white/8 bg-black/10 text-z-sage-light hover:bg-white/5 hover:text-z-sage-light";
+  "border-white/6 bg-black/10 text-z-sage-light hover:bg-white/5 hover:text-z-sage-light";
 
 /** Obsidian & Brass design token: accent ghost button (brass tint) */
 export const BRASS_GHOST_BUTTON_CLASS =


### PR DESCRIPTION
## Summary

Two mobile polish redesigns in one PR — the Dashboard RECIENTE transaction row and the `/transactions/[id]` detail page. Both move away from reflowed-desktop layouts toward tight mobile-first interactions, share the same zone-picker infrastructure, and use the same optimistic-mutation pattern.

## What changed

### Dashboard RECIENTE expanded-row actions
- Fixes a bug where every OUTFLOW tap auto-mounted the full `CategoryPickerBody` tree in the expanded panel.
- Replaces the cramped inline panel with a two-phase chip layout:
  - **Phase 1 chips** — Categorizar (brass-tinted when uncategorized) · Vincular (when the account has pending occurrences) · Más.
  - **Phase 2 (Categorizar)** — swaps the panel body with inline `CategoryPickerBody` + back arrow, lazy-mounted only when the chip is tapped.
  - **Más bottom sheet** — Ver detalle · Destinatario · Etiquetas · Eliminar. Tapping Destinatario or Etiquetas closes Más first so the nested drawer never stacks on the sheet.
- Extends `DestinatarioZonePicker` + `TagZonePicker` with `controlledOpen` / `hideTrigger` props so the parent can orchestrate the close-Más-then-open-picker handoff.

### Transaction detail page (`/transactions/[id]`)
- Replaces the desktop-style layout (~2600px of scroll, 4 stat cards, 2 full-chrome picker cards, "Qué hacer aquí" filler) with a mobile-first structure:
  - **Hero** — direction pill + status pill + merchant title + signed amount + single meta line (date · account · source).
  - **Clasificación** — inline pills (Categoría in zone color, Destinatario brass-tinted, Etiquetas as brass chips with `× remove` + `+ Etiqueta`).
  - **Notas** — tap-to-edit textarea, autosave on blur, server value restored on failure.
  - **Descripción original** — tucked behind a disclosure.
  - **Acciones** — chip row: Hacer recurrente · Vincular (conditional) · Excluir/Incluir de métricas (optimistic toggle) · Eliminar (destructive confirm).
- All edits fully optimistic — no save button, no dirty state.
- `CategoryZonePicker` gains `hideTrigger` + `controlledOpen` props (same pattern as the other two zone pickers).

### Supporting changes
- `actions/transactions.ts` — `RecentTransaction` + recent-tx query join `destinatario` via FK hint; new `updateTransactionNotes(id, notes)` lightweight action (2000-char cap; narrow `updateTag("transactions")` invalidation).
- `actions/destinatarios.ts` — `updateDestinatario` + `patchDestinatario` now call `revalidateFinancialViews()`. Destinatario name is newly embedded in cached dashboard reads; rename must bust the financial cache surface.
- `styles.ts` — `GHOST_BUTTON_CLASS` border opacity corrected `/8` → `/6`; `DESTRUCTIVE_BUTTON_CLASS` added for the delete-confirm dialog.
- Page-level fetch waterfall in `/transactions/[id]/page.tsx` restructured so tx-independent list fetches fire before `await getTransaction` (collapses cold-cache waterfall).

## Review gates passed

- `pnpm build` clean
- `zetas-front-guy` — token violations resolved across both scopes (`bg-z-surface-1` → `bg-z-surface-2`, `text-white` → `text-z-white`, `tracking-[0.16em]` + `tracking-[0.22em]` → `tracking-[0.18em]`, `border-white/8` → `/6`, hex-literal fallback extracted to named constant)
- `perf-auditor` — HIGH findings resolved (stale rows after Más close, serial fetch waterfall, router.refresh on exclude toggle)
- `server-action-reviewer` — PASS on `updateTransactionNotes` + `updateDestinatario` cache-invalidation widening

## Visual companions

- [`docs/visual-companions/inicio-reciente-expanded-row-2026-04-18.html`](docs/visual-companions/inicio-reciente-expanded-row-2026-04-18.html)
- [`docs/visual-companions/transaction-detail-redesign-2026-04-18.html`](docs/visual-companions/transaction-detail-redesign-2026-04-18.html)

## Test plan

- [ ] Dashboard `/dashboard` mobile viewport — expand an OUTFLOW tx; only chips render, no picker mounts on expand
- [ ] Categorizar inline picker, Vincular (when eligible), Más sheet with Destinatario/Etiquetas nested drawers (single surface at a time)
- [ ] `/transactions/[id]` mobile viewport — hero shows amount + meta in one glance; scroll budget collapsed vs. baseline
- [ ] Inline Categoría pill — tap opens picker; select persists + toasts
- [ ] Inline Destinatario pill — tap opens picker; select persists + toasts
- [ ] Tag row — chips render with × remove (optimistic); `+ Etiqueta` opens picker; add/remove reflect on return
- [ ] Notas — tap opens textarea; blur autosaves; network failure reverts to server value
- [ ] Acciones row — Hacer recurrente, Vincular (conditional), Excluir/Incluir (optimistic toggle), Eliminar (confirm dialog → redirect)
- [ ] Rename a destinatario in `/destinatarios` — dashboard RECIENTE + detail-page pill reflect the new name (no stale 120s window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)