### PR TITLE
fix(auth): handle token_hash + code flows in recovery callback

### DIFF
--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Confirma tu cuenta de Zeta</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#121412;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#D9CCB9;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#121412;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;">
+
+            <tr>
+              <td align="center" style="padding:8px 0 24px 0;">
+                <span style="font-size:11px;font-weight:600;letter-spacing:3px;text-transform:uppercase;color:#938C7E;">ZETA</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="background-color:#1E221E;border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:32px;">
+
+                <p style="margin:0 0 8px 0;font-size:11px;font-weight:600;letter-spacing:3px;text-transform:uppercase;color:#938C7E;">
+                  Bienvenido
+                </p>
+
+                <h1 style="margin:0 0 16px 0;font-size:22px;font-weight:600;letter-spacing:-0.01em;color:#D9CCB9;line-height:1.3;">
+                  Confirma tu cuenta
+                </h1>
+
+                <p style="margin:0 0 24px 0;font-size:15px;line-height:1.6;color:#D9CCB9;">
+                  Gracias por unirte a Zeta. Confirma tu correo para empezar a organizar tus finanzas con claridad.
+                </p>
+
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px 0;">
+                  <tr>
+                    <td style="border-radius:10px;background-color:#937844;">
+                      <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=signup&next=/dashboard"
+                         style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#121412;text-decoration:none;border-radius:10px;">
+                        Confirmar cuenta
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+
+                <p style="margin:0 0 8px 0;font-size:13px;color:#938C7E;">
+                  Si el botón no funciona, copia y pega este enlace en tu navegador:
+                </p>
+                <p style="margin:0 0 24px 0;font-size:12px;word-break:break-all;color:#937844;">
+                  {{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=signup&next=/dashboard
+                </p>
+
+                <div style="height:1px;background-color:rgba(255,255,255,0.06);margin:24px 0;"></div>
+
+                <p style="margin:0;font-size:13px;line-height:1.6;color:#938C7E;">
+                  Si no creaste esta cuenta, puedes ignorar este correo.
+                </p>
+
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:24px 0 8px 0;">
+                <p style="margin:0;font-size:12px;color:#938C7E;">
+                  Zeta &middot; Controla tu dinero con claridad diaria
+                </p>
+              </td>
+            </tr>
+
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Restablece tu contraseña de Zeta</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#121412;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#D9CCB9;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#121412;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;">
+
+            <tr>
+              <td align="center" style="padding:8px 0 24px 0;">
+                <span style="font-size:11px;font-weight:600;letter-spacing:3px;text-transform:uppercase;color:#938C7E;">ZETA</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="background-color:#1E221E;border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:32px;">
+
+                <p style="margin:0 0 8px 0;font-size:11px;font-weight:600;letter-spacing:3px;text-transform:uppercase;color:#938C7E;">
+                  Recuperar contraseña
+                </p>
+
+                <h1 style="margin:0 0 16px 0;font-size:22px;font-weight:600;letter-spacing:-0.01em;color:#D9CCB9;line-height:1.3;">
+                  Restablece tu contraseña
+                </h1>
+
+                <p style="margin:0 0 24px 0;font-size:15px;line-height:1.6;color:#D9CCB9;">
+                  Recibimos una solicitud para restablecer la contraseña de tu cuenta de Zeta. Haz clic en el botón para crear una nueva.
+                </p>
+
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px 0;">
+                  <tr>
+                    <td style="border-radius:10px;background-color:#937844;">
+                      <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password"
+                         style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#121412;text-decoration:none;border-radius:10px;">
+                        Restablecer contraseña
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+
+                <p style="margin:0 0 8px 0;font-size:13px;color:#938C7E;">
+                  Si el botón no funciona, copia y pega este enlace en tu navegador:
+                </p>
+                <p style="margin:0 0 24px 0;font-size:12px;word-break:break-all;color:#937844;">
+                  {{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password
+                </p>
+
+                <div style="height:1px;background-color:rgba(255,255,255,0.06);margin:24px 0;"></div>
+
+                <p style="margin:0 0 8px 0;font-size:13px;line-height:1.6;color:#938C7E;">
+                  Este enlace expira en 1 hora por tu seguridad.
+                </p>
+                <p style="margin:0;font-size:13px;line-height:1.6;color:#938C7E;">
+                  Si no solicitaste este cambio, puedes ignorar este correo. Tu contraseña no se modificará.
+                </p>
+
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:24px 0 8px 0;">
+                <p style="margin:0;font-size:12px;color:#938C7E;">
+                  Zeta &middot; Controla tu dinero con claridad diaria
+                </p>
+              </td>
+            </tr>
+
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/webapp/src/app/(auth)/login/page.tsx
+++ b/webapp/src/app/(auth)/login/page.tsx
@@ -1,6 +1,20 @@
 import { LoginForm } from "@/components/auth/login-form";
 
-export default function LoginPage() {
+const CALLBACK_ERROR_MESSAGES: Record<string, string> = {
+  auth_callback_failed: "No pudimos validar el enlace. Solicita uno nuevo.",
+  auth_callback_missing_params: "El enlace no es válido. Solicita uno nuevo.",
+};
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; reason?: string }>;
+}) {
+  const { error, reason } = await searchParams;
+  const callbackError = error
+    ? CALLBACK_ERROR_MESSAGES[error] ?? reason ?? "No pudimos iniciar sesión. Intenta nuevamente."
+    : null;
+
   return (
     <div className="space-y-4">
       <div className="space-y-1">
@@ -9,6 +23,11 @@ export default function LoginPage() {
           Ingresa tus credenciales para acceder
         </p>
       </div>
+      {callbackError && (
+        <div className="bg-destructive/10 text-destructive text-sm rounded-md p-3">
+          {callbackError}
+        </div>
+      )}
       <LoginForm />
     </div>
   );

--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -10,7 +10,11 @@ export async function GET(request: Request) {
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const nextParam = searchParams.get("next");
-  const next = nextParam ?? (type === "recovery" ? RECOVERY_REDIRECT : "/dashboard");
+  const safeNext =
+    nextParam && nextParam.startsWith("/") && !nextParam.startsWith("//")
+      ? nextParam
+      : null;
+  const next = safeNext ?? (type === "recovery" ? RECOVERY_REDIRECT : "/dashboard");
 
   const supabase = await createClient();
 

--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -1,18 +1,38 @@
 import { createClient } from "@/lib/supabase/server";
+import { type EmailOtpType } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
+
+const RECOVERY_REDIRECT = "/reset-password";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+  const nextParam = searchParams.get("next");
+  const next = nextParam ?? (type === "recovery" ? RECOVERY_REDIRECT : "/dashboard");
+
+  const supabase = await createClient();
+
+  if (tokenHash && type) {
+    const { error } = await supabase.auth.verifyOtp({ type, token_hash: tokenHash });
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+    return NextResponse.redirect(
+      `${origin}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
+    );
+  }
 
   if (code) {
-    const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
       return NextResponse.redirect(`${origin}${next}`);
     }
+    return NextResponse.redirect(
+      `${origin}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
+    );
   }
 
-  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_missing_params`);
 }


### PR DESCRIPTION
The auth callback only handled PKCE `code` params, so recovery emails
using Supabase's modern `token_hash` + `type` template silently failed.
Now supports both flows, defaults recovery links to /reset-password, and
surfaces callback errors on the login page.