### PR TITLE
fix: honor tx.direction in mobile category pickers

### DIFF
--- a/webapp/src/components/categories/category-zone-picker.tsx
+++ b/webapp/src/components/categories/category-zone-picker.tsx
@@ -398,10 +398,17 @@ export function CategoryPickerBody({
   suggestion,
   direction,
 }: CategoryPickerBodyProps) {
+  const filtered = useMemo(
+    () =>
+      direction
+        ? categories.filter((c) => !c.direction || c.direction === direction)
+        : categories,
+    [categories, direction],
+  );
   const [search, setSearch] = useState("");
   const [expandedZoneId, setExpandedZoneId] = useState<string | null>(() => {
     // Pre-expand zone containing current value
-    const parent = findParentZone(categories, value);
+    const parent = findParentZone(filtered, value);
     return parent?.id ?? null;
   });
   const [showInlineCreate, setShowInlineCreate] = useState(false);
@@ -418,12 +425,12 @@ export function CategoryPickerBody({
 
   // Zones (parents with children) + standalone categories
   const zones = useMemo(
-    () => categories.filter((c) => c.children.length > 0),
-    [categories],
+    () => filtered.filter((c) => c.children.length > 0),
+    [filtered],
   );
   const standalone = useMemo(
-    () => categories.filter((c) => c.children.length === 0),
-    [categories],
+    () => filtered.filter((c) => c.children.length === 0),
+    [filtered],
   );
 
   // -----------------------------------------------------------------------

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -40,7 +40,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useOutflowCategories } from "@/components/providers/app-data-provider";
+import { useCategories } from "@/components/providers/app-data-provider";
 import { categorizeTransaction, assignDestinatario } from "@/actions/categorize";
 import { deleteTransaction } from "@/actions/transactions";
 import {
@@ -121,7 +121,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
   // Track which rows have been opened at least once so we can defer mounting
   // the heavy CategoryPickerBody until the user actually taps Categorizar.
   const [openedCategorizeIds, setOpenedCategorizeIds] = useState<Set<string>>(new Set());
-  const outflowCategories = useOutflowCategories();
+  const categories = useCategories();
   // Refs for each row so we can scroll the expanded panel into view above the tab bar.
   const rowRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
@@ -138,7 +138,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
   const [, startCategoryTransition] = useTransition();
 
   function handleAssignCategory(txId: string, categoryId: string) {
-    const category = findCategoryById(outflowCategories, categoryId);
+    const category = findCategoryById(categories, categoryId);
     if (!category) return;
     setOptimisticCategories((prev) => ({ ...prev, [txId]: category }));
     setExpandedId(null);
@@ -434,7 +434,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                           </div>
                           {openedCategorizeIds.has(tx.id) && (
                             <CategoryPickerBody
-                              categories={outflowCategories}
+                              categories={categories}
                               value={optimisticCat?.id ?? tx.category_id}
                               onSelect={(id) => {
                                 if (id) handleAssignCategory(tx.id, id);
@@ -443,7 +443,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                                 /* no-op inline — user creates via /categories */
                               }}
                               suggestion={null}
-                              direction="OUTFLOW"
+                              direction={tx.direction}
                             />
                           )}
                         </div>

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -366,24 +366,22 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                     <div className={cn(PANEL_INSET_CLASS, "border-z-brass/15 bg-black/20 p-3")}>
                       {phase === "actions" ? (
                         <div className="flex gap-1.5">
-                          {tx.direction === "OUTFLOW" && (
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                openCategorizePhase(tx.id);
-                              }}
-                              className={cn(
-                                CHIP_BASE_CLASS,
-                                categoryResolved
-                                  ? "border-white/8 bg-white/[0.03] text-foreground"
-                                  : "border-z-brass/25 bg-z-brass/10 text-z-brass",
-                              )}
-                            >
-                              <Tag className="size-3" />
-                              Categorizar
-                            </button>
-                          )}
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              openCategorizePhase(tx.id);
+                            }}
+                            className={cn(
+                              CHIP_BASE_CLASS,
+                              categoryResolved
+                                ? "border-white/8 bg-white/[0.03] text-foreground"
+                                : "border-z-brass/25 bg-z-brass/10 text-z-brass",
+                            )}
+                          >
+                            <Tag className="size-3" />
+                            Categorizar
+                          </button>
                           {vincularEligible && (
                             <button
                               type="button"
@@ -410,7 +408,7 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                               CHIP_BASE_CLASS,
                               "border-white/8 bg-white/[0.03] text-foreground",
                               // When 3 chips fit, shrink "Más" slightly so labels stay readable
-                              tx.direction === "OUTFLOW" && vincularEligible && "flex-[0.8]",
+                              vincularEligible && "flex-[0.8]",
                             )}
                           >
                             <MoreHorizontal className="size-3" />

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -398,7 +398,7 @@ function CategorizarDetail({
                     categories={categories}
                     value={null}
                     onValueChange={(catId) => handleCategorize(tx, catId)}
-                    direction="OUTFLOW"
+                    direction={tx.direction}
                     placeholder="Categoría"
                     variant="drawer"
                     triggerClassName="text-[10px] h-auto py-1 px-2.5 rounded-lg border border-white/10 bg-white/[0.03] text-z-brass hover:bg-white/[0.06]"

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -207,27 +207,20 @@ export function MovimientosTransactionRow({
       {/* Expanded: action chips */}
       {expanded && (
         <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2.5 pt-0.5">
-          {/* Category chip or picker */}
-          {categoryName ? (
-            <CategoryZonePicker
-              categories={categories}
-              value={localCategory?.id ?? null}
-              onValueChange={handleCategorize}
-              direction={tx.direction}
-              variant="drawer"
-              triggerClassName="text-[10px] h-auto py-1 px-2.5 rounded-full border border-z-brass/20 bg-z-brass/8 text-z-brass hover:bg-z-brass/12 font-medium"
-            />
-          ) : (
-            <CategoryZonePicker
-              categories={categories}
-              value={null}
-              onValueChange={handleCategorize}
-              direction={tx.direction}
-              placeholder="Categoría"
-              variant="drawer"
-              triggerClassName="text-[10px] h-auto py-1 px-2.5 rounded-full border border-white/8 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]"
-            />
-          )}
+          <CategoryZonePicker
+            categories={categories}
+            value={localCategory?.id ?? null}
+            onValueChange={handleCategorize}
+            direction={tx.direction}
+            placeholder="Categoría"
+            variant="drawer"
+            triggerClassName={cn(
+              "text-[10px] h-auto py-1 px-2.5 rounded-full border font-medium",
+              categoryName
+                ? "border-z-brass/20 bg-z-brass/8 text-z-brass hover:bg-z-brass/12"
+                : "border-white/8 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]",
+            )}
+          />
 
           {/* Destinatario chip */}
           <DestinatarioZonePicker

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -213,7 +213,7 @@ export function MovimientosTransactionRow({
               categories={categories}
               value={localCategory?.id ?? null}
               onValueChange={handleCategorize}
-              direction={tx.direction === "OUTFLOW" ? "OUTFLOW" : undefined}
+              direction={tx.direction}
               variant="drawer"
               triggerClassName="text-[10px] h-auto py-1 px-2.5 rounded-full border border-z-brass/20 bg-z-brass/8 text-z-brass hover:bg-z-brass/12 font-medium"
             />
@@ -222,7 +222,7 @@ export function MovimientosTransactionRow({
               categories={categories}
               value={null}
               onValueChange={handleCategorize}
-              direction={tx.direction === "OUTFLOW" ? "OUTFLOW" : undefined}
+              direction={tx.direction}
               placeholder="Categoría"
               variant="drawer"
               triggerClassName="text-[10px] h-auto py-1 px-2.5 rounded-full border border-white/8 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]"


### PR DESCRIPTION
## Summary

- Fix category picker showing outflow zones for income transactions on the movimientos row — the ternary `tx.direction === "OUTFLOW" ? "OUTFLOW" : undefined` collapsed to `undefined` for INFLOW txs, disabling zone filtering in `CategoryZonePicker`. Now passes `tx.direction` directly, matching the transaction detail page.
- Audit across all 22 `CategoryZonePicker` / `CategoryPickerBody` call sites found two more sites hardcoding `direction="OUTFLOW"` on lists that mix both directions:
  - `mobile/v2/inicio/inicio-activity.tsx` — recent-activity feed categorize panel used `useOutflowCategories()` + `direction="OUTFLOW"`. Switched to `useCategories()` + `direction={tx.direction}`.
  - `mobile/v2/movimientos/movimientos-herramientas.tsx` — uncategorized-tx tool panel had the same hardcode. Now passes `tx.direction`.
- Intentionally hardcoded OUTFLOW in `purchase-decision-card` / `purchase-recommender-drawer` is left as-is (purchases are always outflows). Destinatario default-category pickers remain unfiltered since a destinatario can be either direction.

## Test plan

- [ ] Open movimientos page, expand an income (INFLOW) transaction, tap the Categoría chip → picker should show income zones (not outflow).
- [ ] Open movimientos page, expand an expense (OUTFLOW) transaction, tap the Categoría chip → picker should show outflow zones only.
- [ ] From inicio (home), find a recent INFLOW tx, tap Categorizar → picker body should show income zones.
- [ ] In movimientos tools panel ("Transacciones sin categoría"), expand an uncategorized INFLOW → picker should show income zones.
- [ ] Transaction detail page behavior unchanged for both directions.

https://claude.ai/code/session_018rvrwQcme5fXwWhRmjuHAK