### PR TITLE
feat(mobile): Claude Design import redesign · slice 1

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -240,6 +240,21 @@
 - **What:** Slice-1 extracted `mobile/components/ui/ExpandableStatTile.tsx` and migrated the import reconcile grid, but `InicioMetricsGrid` "Gasto hoy" was left on its bespoke `PANEL_INSET_CLASS` chip shape (different value size, ring-chart sibling, compact currency formatter). A future pass should either (a) widen `ExpandableStatTile` with a `variant="inset-compact"` option to absorb it, or (b) extract a sibling `CompactStatTile` primitive. Worth doing next time we touch either surface.
 - **Found:** zetas-front-guy follow-up on slice-1, 2026-04-19
 
+### Mobile import wizard — follow-up polish from slice-1 review
+- **Priority:** Low
+- **What:** Non-blocking items deferred from the zetas-front-guy / frontend-auditor / ux-analyst review on PR #193:
+  - `mobile/components/import/CreditCardSummary.tsx:242-270` — private `PeriodTile` duplicates `ExpandableStatTile`. Migrate.
+  - `mobile/components/import/import-theme.tsx` — `themeClasses()` is a diverged copy of `themeSurfaceClasses()` in `lib/theme.tsx`. Remove entirely; consumers should call `themeSurfaceClasses(mode)` directly.
+  - `mobile/lib/constants/colors.ts` — settings theme swatches (`#1E221E`, `#18181b`) should become `COLORS.surface2` / `COLORS.surface2Neutral` tokens so they can't drift silently.
+  - `mobile/app/(tabs)/import.tsx:1355` — `AnimatedAccordion estimatedHeight={1200}` for the Row-2 reconcile panel is a worst-case estimate that produces blank-space flicker on short lists. Switch to dynamic `onLayout`-measured height (or reduce the estimate) once `AnimatedAccordion` grows a measured-mode.
+  - `mobile/app/(tabs)/import.tsx:622-670` — `handlePrepareImport` calls `getReconciliationCandidates` then `getReconciliationCandidateById` per match (two awaits per item). Can be flattened to a single query that returns the full candidate in one pass — highest-latency path in the wizard.
+  - UX: Narrator voice (Kalam) is used for both page-level annotations and in-panel empty states; should be reserved for the page-level summary. Convert in-panel empty states to plain `text-xs italic text-z-sage-dark`.
+  - UX: `CreditCardStackCard` lacks a visible "linked" signal between the per-currency cards (both read as independent). Add an eyebrow header "Tarjeta · N monedas" above the stack.
+  - UX: Step 2 → Step 3 → Step 2 loses scroll position on the review list — preserve offset on back.
+  - UX: `ItemSeparator` uses `ml-12` but the checkbox indent is ~28px; hairline misaligns.
+  - `mobile/app/(tabs)/import.tsx:981-989` etc. — `ImportProgress` + "Paso X de 4" eyebrow are redundant. Drop the eyebrow.
+- **Found:** agent review sweep on PR #193, 2026-04-19
+
 ## Open PRs
 
 | PR | Description | Status |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -235,6 +235,11 @@
 - **When:** Extract when a 4th picker is added or when touching all 3 pickers.
 - **Found:** Code reuse review, 2026-04-13
 
+### Mobile `InicioMetricsGrid` "Gasto hoy" migration to `ExpandableStatTile`
+- **Priority:** Low
+- **What:** Slice-1 extracted `mobile/components/ui/ExpandableStatTile.tsx` and migrated the import reconcile grid, but `InicioMetricsGrid` "Gasto hoy" was left on its bespoke `PANEL_INSET_CLASS` chip shape (different value size, ring-chart sibling, compact currency formatter). A future pass should either (a) widen `ExpandableStatTile` with a `variant="inset-compact"` option to absorb it, or (b) extract a sibling `CompactStatTile` primitive. Worth doing next time we touch either surface.
+- **Found:** zetas-front-guy follow-up on slice-1, 2026-04-19
+
 ## Open PRs
 
 | PR | Description | Status |

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,141 +1,133 @@
-# Session Handover — 2026-04-16 (Mobile Polish — Phase 1 + 2)
+# Session Handover — 2026-04-19 (Mobile Import Redesign · Slice 1 continued)
 
-> Supersedes prior handovers in this file. For the 2026-04-08 performance-audit handover, see git history (`HANDOVER.md@HEAD~N`).
+> Supersedes prior handovers. For earlier handovers see git history (`HANDOVER.md@HEAD~N`).
 
 ## 1. Session Summary
 
-Two-phase mobile polish milestone. Phase 1 shipped structural fixes — production leak of dev tooling, tab-bar clipping on list rows, month-pager desync, `/etiquetas` deep-link. Phase 2 reshaped the mobile `/dashboard` end-to-end via the `brainstorming → writing-plans → executing-plans` superpowers flow. Also performed a full mobile audit (28 screenshots, 30+ findings) before any code landed. Five review passes (zetas-front-guy, perf-auditor, frontend-auditor, ux-analyst, Gemini, `/simplify`) shaped the final implementation.
-
----
+Continued the Claude Design "Zeta Wireframes" implementation in the mobile app. Shipped a working end-to-end Bancolombia CC PDF import (fixed a prod middleware bug that was blocking mobile uploads), redesigned the reconcile step with a 2×2 stat grid + in-place expansion animation, introduced a global "narrator" voice (Kalam handwritten font), added a Sage/Neutral theme selector on Settings with persistence, and laid groundwork for a shared `ExpandableStatTile` primitive. App currently runs against local webapp (`http://192.168.1.6:3000`) for testing; the prod middleware fix is local-only and not yet deployed.
 
 ## 2. Changes Made
 
-### Phase 1 — PR #168 (MERGED → `93f1cf3`)
+### Webapp — prod hotfix (NOT YET DEPLOYED)
+- `webapp/src/lib/supabase/middleware.ts:49-57` — added `/api` to `publicPaths`. Fixes mobile Bearer-token requests being redirected to `/login` (then 500'd as `Failed to find Server Action`).
+- `webapp/src/app/api/parse-statement/route.ts` — top-level `try/catch` so unhandled exceptions return JSON instead of generic `"Internal Server Error"`.
 
-- **`webapp/src/app/(dashboard)/settings/page.tsx:235-244`** — Gate "Herramientas de Desarrollo" card behind `process.env.NODE_ENV === 'development'` (was rendering to prod).
-- **`webapp/src/app/(dashboard)/layout.tsx:107`** — Swap `pb-20` for `MOBILE_TAB_BAR_CLEARANCE_CLASS`. 80px was less than `56px + env(safe-area-inset-bottom)` on iPhones with home indicator, clipping the last list row on `/transactions`, `/accounts/[id]`, `/plan?tab=periodo`, etc.
-- **`webapp/src/components/settings/settings-mobile-accordion.tsx`** — Added `useEffect` hash handler + `scroll-mt-16` + per-section refs so `/settings#etiquetas` auto-opens the matching accordion and scrolls into view.
-- **`webapp/src/app/(dashboard)/etiquetas/page.tsx`** — Redirect target changed to `/settings#etiquetas` (was `/settings` top).
-- **`webapp/src/components/recurring/use-recurring-month.ts`** — Rewired month-cursor from local `useState(() => new Date())` to URL-param source via `useRouter`/`useSearchParams`/`parseMonth`/`formatMonthParam`. Inner Recurrentes pager and global `<MonthSelector />` now share one source of truth.
-- **`~/.claude/rules/pdf-parser.md`** — Personal rule sync: import wizard is 6 steps (`upload | review | destinatarios | confirm | reconcile | results`), not 4.
+### Mobile — import flow
+- `mobile/app/(tabs)/import.tsx`:
+  - iOS upload swapped to `FileSystem.uploadAsync` (`expo-file-system/legacy`) + 30s `Promise.race` timeout. Replaced hanging `fetch`+FormData.
+  - Response parsing made content-type-agnostic (iOS omits `content-type` in `uploadResult.headers`).
+  - Multi-statement CC: `allStatements` state + `switchStatement()` helper.
+  - `useSafeAreaInsets` applied to all 4 step roots so headers clear the Dynamic Island.
+  - Step 3 (reconcile) redesigned as 2×2 stat grid (Nuevos / Destinatarios / Duplicados / Ambiguos) with `AnimatedAccordion` expansion between rows.
+  - `StatTile` component with tones `white | brass | alert | income`. Zero values dim to `z-sage-dark`.
+  - `Narrator` annotation always visible below the grid (removed earlier gate).
+  - Account indicator softened from brass chip → baseline caption + hair-line divider.
+  - Removed local `neutralTheme` state; reads from global `useTheme()`.
+- `mobile/components/import/CreditCardStackCard.tsx` — **new**. Per-currency compact CC card with expandable detail metrics.
+- `mobile/components/import/CreditCardSummary.tsx` — added `useImportTheme` for surface swaps.
+- `mobile/components/import/StatementChip.tsx` — **new** (earlier session). Bank · ••last4 chip with period.
+- `mobile/components/import/SectionDivider.tsx` — **new** (earlier session).
+- `mobile/components/import/ImportProgress.tsx` — **new** (earlier session). 4-segment brass progress.
+- `mobile/components/import/import-theme.tsx` — refactored to delegate to global `useTheme()`. `ImportThemeProvider` is now a no-op shim.
+- `mobile/lib/utils/cc-projection.ts` — **new**. 12-month minimum payment projection math (`r_mo = (1+EA)^(1/12)-1`).
 
-### Phase 2 — PR #169 (OPEN, mergeable CLEAN)
+### Mobile — theme + narrator
+- `mobile/lib/theme.tsx` — **new**. `ZetaThemeProvider` + `useTheme()` with `SecureStore` persistence. Modes: `"sage" | "neutral"` (light later). Key: `zeta.theme-mode`.
+- `mobile/app/_layout.tsx` — wrapped root in `ZetaThemeProvider`. Added `Kalam_700Bold` font. (Earlier: `Inter_*_Italic` variants too.)
+- `mobile/app/(tabs)/settings.tsx` — new "Apariencia" section with `ThemeSelector` (Sage / Neutral pill cards). Settings root respects the theme for instant visual feedback.
+- `mobile/components/common/Narrator.tsx` — **new**. Centered 24px `font-narrator` (Kalam 700) annotation. Tones: `brass | sage`. Spacing: `default | tight`.
+- `mobile/tailwind.config.js` — added tokens: `z-ink-neutral (#0d0d0e)`, `z-surface-neutral (#121214)`, `z-surface-2-neutral (#18181b)`, `z-surface-3-neutral (#1f1f23)`. Added `font-narrator: ["Kalam_700Bold"]`.
+- `mobile/package.json` / `pnpm-lock.yaml` — added `@expo-google-fonts/kalam ^0.4.1`. Tried + removed `@expo-google-fonts/caveat`.
 
-**New files:**
-
-- **`webapp/src/components/mobile/v2/inicio/timeline-model.ts`** — Pure module. `TimelineItem`/`TimelineSources`/`UpcomingIncomeItem` types + `buildTimelineItems()` merger. Consumes `formatDate` + `formatCurrency` from `@/lib/utils/*` (was hand-rolling them; simplified in `/simplify` pass).
-- **`webapp/src/components/mobile/v2/inicio/timeline-model.test.ts`** — 5 Vitest cases (empty, overdue, today-collapsed-emails, date sort, income styling). All passing.
-- **`webapp/src/components/mobile/v2/inicio/inicio-attention-timeline.tsx`** — Replaces `inicio-attention.tsx`. Horizontal "Por resolver" strip + `aria-label` per card + empty-state "Todo tranquilo".
-- **`webapp/src/components/mobile/v2/inicio/inicio-tool-row.tsx`** — Replaces `inicio-discovery.tsx`. Single full-width tile wrapping `PurchaseRecommenderDrawer`.
-- **`webapp/vitest.config.ts`** — Minimal `defineConfig` with `@` → `src` path alias. Required only because `timeline-model.ts` now imports `@/lib/utils/*`; previously tests worked with no config.
-
-**Modified files:**
-
-- **`webapp/src/components/mobile/v2/inicio/inicio-root.tsx`** — Reorder to Hero → ImportStrip → Timeline → Widgets → Tool → Reciente. `space-y-2` → `space-y-4`. Added `upcomingIncome` + `currency` plumbing.
-- **`webapp/src/components/mobile/v2/inicio/inicio-metrics-grid.tsx`** — RITMO + GASTO HOY restyled from chip-style to widget tile (`rounded-2xl`, `min-h-[120px]`, centered col, uses new `PANEL_INSET_SUBTLE_CLASS`). Arc-ring stroke uses `var(--color-z-surface-3)` token.
-- **`webapp/src/components/mobile/v2/inicio/inicio-activity.tsx`** — Major. Dropped "Sin cat." yellow tag. Tap-to-expand with inline `CategoryPickerBody` (OUTFLOW only) + optimistic update via `categorizeTransaction`. `CategoryPickerBody` loaded via `next/dynamic({ssr:false})`. Lazy-mount via `openedOnceIds`. `scrollIntoView` after expand to clear tab bar. `aria-expanded` + `aria-label` on row button. `currency_code` typed as `CurrencyCode`. Direction icons use `bg-z-income/12` + `bg-z-expense/12`.
-- **`webapp/src/components/mobile/v2/inicio/inicio-import-strip.tsx`** — Added `hasPendingEmails: boolean` prop; hides when true (redundant with timeline's email card).
-- **`webapp/src/components/dashboard/zones/mobile-zone.tsx`** — Derive `upcomingIncome` from `heroData.nextIncome*`. Added `category_id` to `mobileRecentTx` mapping. `currency_code` cast to `CurrencyCode`.
-- **`webapp/src/actions/transactions.ts:573-588, 604-619`** — Added `category_id` to `RecentTransaction` type + select columns in `getRecentTransactionsCached`.
-- **`webapp/src/lib/constants/styles.ts`** — Added `PANEL_INSET_SUBTLE_CLASS` export (`rounded-2xl border border-white/6 bg-white/[0.02]`).
-
-**Deleted:** `inicio-attention.tsx`, `inicio-discovery.tsx`.
-
-### Session artifacts committed (not code, but durable)
-
-- **`audit/MOBILE_AUDIT_2026-04-16.md`** — 368-line full mobile audit, top 10 quick wins, per-screen findings, RN parity gaps.
-- **`audit/2026-04-16/*.png`** — 28 original sweep captures + 8 Phase 2 verification captures.
-- **`docs/superpowers/specs/2026-04-16-dashboard-polish-design.md`** — Phase 2 design spec (decisions D1–D7).
-- **`docs/superpowers/plans/2026-04-16-dashboard-polish.md`** — Phase 2 implementation plan (12 tasks, ~50 steps).
-- **`BACKLOG.md`** — Appended 5 entries (see section 5 below).
-
----
+### Mobile env (testing only — revert before ship)
+- `mobile/.env` — `EXPO_PUBLIC_API_URL=http://192.168.1.6:3000`. **Revert to `https://pfm.sanson1911.cloud` before release.**
 
 ## 3. Key Decisions
 
-- **Dashboard job = Status + Triage (co-dominant), habit-reinforcement de-prioritized.** User framing: "Am I on track + what needs attention." Drove every subsequent layout choice.
-- **Hero first, same position always.** Rejected adaptive ordering ("attention leads when urgent") for predictability.
-- **"Por resolver" horizontal timeline** (Option D from mockup round) won over stacked cards, unified attention hero, single next action. Chronological mental model absorbs emails/pagos/ingresos.
-- **Widget tiles (W2 mockup) over chip or single-tool variants.** RITMO kept (track signal, not habit). GASTO HOY restored after user feedback despite de-prioritizing habit metrics.
-- **`Plan del mes` tile removed** — redundant with tab-bar Plan entry. `¿Puedo comprarlo?` kept as single tool row since it has no tab-bar home.
-- **Dual-back pills on `/transactions/[id]` + `/deudas/planificador` NOT removed.** User's explicit call: PWA installs lose browser back-swipe; pills are safety insurance. Deferred to redesign (breadcrumb tag vs back chip), not removal.
-- **Reciente "Sin cat." yellow tag removed.** Signal moved into tap-to-expand inline category picker. `/transactions` already surfaces the uncategorized count prominently; don't duplicate on Dashboard.
-- **Inline execution over subagent-driven** for Phase 2. Reasons: Playwright auth session reuse (agents spawn fresh contexts), shared-file serialization (4 tasks touch `inicio-root.tsx`), visual polish benefits from user-in-the-loop iteration.
-- **`CategoryPickerBody` → dynamic import.** `/simplify` efficiency finding: static import shipped ~800 LOC (Radix Command/Popover + inline form + zone tiles) to Dashboard route even though `openedOnceIds` only lazy-*rendered*. `next/dynamic({ssr:false})` defers mount AND bundle.
-- **Timeline model accepts `currency` via `TimelineSources`.** Original hardcoded `$`; frontend-auditor + Gemini + `/simplify` all flagged. Now multi-currency-ready (caveat: attention types still carry `amount: number` with no currency per item — see Gotchas).
-
----
+- **Prod middleware bug root cause** confirmed via SSH + `docker logs` on the VPS: the `Failed to find Server Action "x"` stack trace pointed at `app-page` chunks, not API chunks. Unauthenticated POST returned `307 → /login?redirect=/api/parse-statement`. iOS `FileSystem.uploadAsync` follows redirects, so the multipart POST hit `/login` and Next.js tried to parse it as a Server Action. Fix: treat `/api` as public in middleware; route handlers self-auth via `getRequestUser()` (supports cookie AND Bearer).
+- **Font is Kalam, not Caveat.** User said the reference looked like "Kammus"-ish — nearest Google Font is Kalam. 700 Bold matches the reference weight; Caveat was too uniform.
+- **Multi-currency CC → V2 stacked cards** (user confirmed). Each currency is its own `CreditCardStackCard` with expandable detail row. Account auto-match + selection swap on currency toggle.
+- **Neutral theme is a palette swap, not a CSS rebuild.** Added `*_neutral` tokens in Tailwind; components decide surface class via `useImportTheme`/`useTheme`. Light theme (future) can reuse the same pattern.
+- **Destinatarios copy changed** from "se crean" to "sugeridos" per user. Mobile import will not auto-create destinatarios; user reviews/approves after. (Creation code is currently not present in mobile import; copy now matches behavior.)
+- **Narrator always visible** under the reconcile grid — hiding it when a panel is open felt jarring.
+- **Shared expansion primitive = `AnimatedAccordion`** (`components/ui/AnimatedAccordion.tsx`). User flagged 3 inconsistent expansion patterns (dashboard, plan, import). Import now uses this primitive. Dashboard and plan already do. `CreditCardStackCard` still has its own state — migrate later.
+- **Theme selector scope: global state, instant feedback.** Settings root now swaps bg by theme so the user sees the change immediately instead of having to navigate to Import.
+- **Tool limitation accepted:** I cannot process video input. User will provide verbal description, key frames, or a video path ffmpeg can split.
 
 ## 4. Current State
 
-- **Branch:** `feat/dashboard-polish-phase-2`
-- **PR #169:** OPEN, `mergeStateStatus=CLEAN`, CI green (`verify-webapp: SUCCESS`; others SKIPPED — non-parser, non-deploy PR).
-- **PR #168:** MERGED via squash as commit `93f1cf3` on `main`.
-- **Build:** `pnpm build` clean. Only diagnostic is pre-existing `totalBudget` deprecation warning at `inicio-root.tsx:159` — not this session's change.
-- **Tests:** `pnpm vitest run` — `timeline-model.test.ts` 5/5 passing. No other test files in scope.
-- **Uncommitted changes:** 0 tracked. 38 untracked files (stale `.png` mockups + a WhatsApp video from earlier audit work — unrelated, leave alone or archive).
-- **Dev server:** Background dev server running on :3000 from bash task `bhf8l4v6e`. Kill with `lsof -i :3000 -P -sTCP:LISTEN -t | xargs kill` if desired.
-- **Visual Companion server:** Auto-exits after 30 min idle. Mockup files persist in `.superpowers/brainstorm/9678-1776362397/` (gitignored).
+- **Typecheck:** `npx tsc --noEmit` clean in import.tsx, theme.tsx, Narrator.tsx. Pre-existing errors remain in `mobile/app/(tabs)/settings.tsx` (missing COLORS) and `mobile/lib/demo-data.ts` (missing `@zeta/shared` exports) — untouched, not from this session's edits.
+- **Mobile build:** iOS debug build succeeded (0 errors, 1165 warnings). App installed on sim `AFBA8440-2959-4DC9-8B8D-ABD7CFE5B14A` (iPhone 17 Pro, iOS 26.2). Metro re-bundles fine after `--clear` reset.
+- **End-to-end import verified:** 200 / `statementCount: 2` from real Bancolombia CC PDF (multi-currency) in 1.17 s.
+- **Local services running:**
+  - Webapp dev on `:3000` (needed for current mobile testing).
+  - PDF parser on `:8000` (`uv run python main.py`).
+- **Git:** branch `feat/planner-drag-drop` — **NOT a clean slice-1 branch**. Still stacked on planner work.
 
----
+```
+ M HANDOVER.md
+ M mobile/app/(tabs)/import.tsx
+ M mobile/app/(tabs)/settings.tsx
+ M mobile/app/_layout.tsx
+ M mobile/package.json
+ M mobile/tailwind.config.js
+ M pnpm-lock.yaml
+ M webapp/src/app/api/parse-statement/route.ts
+ M webapp/src/lib/supabase/middleware.ts
+?? mobile/components/common/Narrator.tsx
+?? mobile/components/import/ (StatementChip, SectionDivider, ImportProgress, CreditCardSummary, CreditCardStackCard, import-theme)
+?? mobile/lib/theme.tsx
+?? mobile/lib/utils/cc-projection.ts
+ M mobile/.env (EXPO_PUBLIC_API_URL pointed at local)
+```
 
 ## 5. Open Issues & Gotchas
 
-- **`inicio-root.tsx:159`** — pre-existing `totalBudget` deprecation. Not this session's change.
-- **Timeline `Ver todo →` destination** is `/gestionar`. `ux-analyst` flagged this isn't strictly a time-ordered attention list today. Revisit if Bandeja gets a "Por resolver" section that mirrors the Dashboard timeline.
-- **Category picker is a grid, not chip row** — spec D6 said "horizontal scroll chip row"; implementation uses `CategoryPickerBody` (richer, searchable). `ux-analyst` noted density. Acceptable tradeoff; revisit if real-device feedback shows overflow.
-- **`formatCurrency` on attention items uses a single dashboard currency.** Attention types carry `amount: number` with no per-item currency_code. Timeline receives a single `currency: CurrencyCode` prop. Means a USD obligation would render with `$` (COP's symbol in `es-CO` locale) instead of the correct symbol. Out of scope for polish; track if multi-currency obligations become real.
-- **Reciente INFLOW rows have no inline picker.** Expanded panel shows only "Vincular" + "Ver detalle". Deliberate — INFLOW categorization is rare on Dashboard and rich forms live at `/transactions/[id]`.
-- **Turbopack dev-cache staleness** bit me once when adding a cross-file export. If HMR gets stuck: `lsof -i :3000 -t | xargs kill && rm -rf webapp/.next && cd webapp && pnpm dev`. Codified in CLAUDE.md.
-- **Two pre-existing `as CurrencyCode` casts** at `inicio-activity.tsx:331` on `o.currencyCode` from `occurrenceCandidates`. Not touched — from a different type not owned by this feature.
-
-### BACKLOG entries added this session
-
-1. **Promote transaction → recurring template ("Hacer recurrente" CTA)** — HIGH priority. Add action on `/transactions/[id]` that opens prefilled `RecurringFormDialog`. Closes the "I just paid this, mark it recurring" loop.
-2. **`is_subscription` toggle is dead flag** — HIGH. The mobile + web transaction forms write `is_subscription` to the tx row, but nothing reads it. Connect to template-creation OR remove.
-3. **Link Destinatario ↔ Recurring Template** — HIGH. Add `destinatario_id` column to `recurring_templates`. When destinatario matcher hits a recipient linked to a template, prompt user to link the tx to the pending occurrence.
-4. **Account aliases + mini icons** — HIGH (unblocks density gains). `Bancolombia Ahorros ****4398` → `<alias> · ****<mask>` + 16×16 icon. Requires encrypted-table migration (spawn `supabase-migrator`).
-5. **Dashboard RECIENTE inline category assignment** — Shipped as part of this PR. (Originally backlogged mid-session, then scoped into Phase 2.)
-
----
+- **`zetas-front-guy` agent review findings not yet fixed:**
+  - `settings.tsx:325,343,426,428,444,446` — hardcoded hex (`#EF4444`, `#C5BFAE`, `#3A3A3A`). Use `COLORS.debt`, `COLORS.sageLight`, and add a `switchTrack` token.
+  - `import.tsx:1427,1449` — "Fusionar" / "Mantener ambas" buttons bypass `BRASS_BUTTON_CLASS`/`GHOST_BUTTON_CLASS`. Missing `accessibilityRole`/`accessibilityLabel`.
+  - `import.tsx:1549,1561` — result-step buttons same issue.
+  - `import.tsx:1275,1350` — English loanword "fresh" in user-facing Spanish copy. Replace ("limpios"/"sin duplicados").
+  - `import.tsx:1122,1195` — `paddingBottom: 120` magic number. Extract `MOBILE_TAB_BAR_CLEARANCE` constant in `lib/constants/styles.ts`.
+  - **Neutral theme gap:** fixed action bar uses `bg-background-92` (sage-only token). Add `z-ink-neutral-92` / a semantic `bg-action-bar` token.
+  - **Pattern duplication:** `CreditCardStackCard` has its own `expanded` state. Migrate to `AnimatedAccordion`.
+  - **Reuse gap:** `StatTile` (import) and "Gasto hoy" (`InicioMetricsGrid`) are the same pattern. Extract `components/ui/ExpandableStatTile.tsx`.
+- **Mobile `/api/parse-statement` points at local webapp** — revert `mobile/.env` before shipping.
+- **Prod middleware fix NOT deployed.** Mobile uploads in prod will still 500 until the middleware PR lands + deploys.
+- **Video input not possible** from the agent side. Closing-animation feedback needs description, frames, or ffmpeg path.
+- **`AnimatedAccordion` `estimatedHeight` is hardcoded** in import (`700` row1, `1200` row2). Long transaction lists may clip.
+- **Expansion happens between rows**, not directly under the clicked tile. Acceptable but not identical to dashboard's "Gasto hoy" (accordion inside the tile itself). Shared `ExpandableStatTile` would unify this.
+- **Pre-existing TS errors** (settings COLORS, demo-data exports) still present — untouched.
 
 ## 6. Suggested Next Steps
 
-**Immediate:** merge PR #169 when workflows pass (user said they'll handle this).
-
-**Phase 2 step 2 — Plan page polish:**
-
-1. Re-read `audit/MOBILE_AUDIT_2026-04-16.md` — sections `10` (Plan), `11` (plan-periodo), `17` (recurrentes), and `06` (plan?tab=presupuesto). Key findings:
-   - `/plan` — `Recurrentes 8` badge ambiguous yellow color
-   - `/plan?tab=periodo` — NETO value buried in stat row, list clips behind tab bar (hopefully now fixed by Phase 1 layout change)
-   - `/plan?tab=recurrentes` — `MIS PLANTILLAS` footer buried; discoverability low
-   - `/plan?tab=presupuesto` — all-red category saturation, group by risk state
-2. Invoke `superpowers:brainstorming`. Visual Companion files persist in `.superpowers/brainstorm/` from this session — reference prior mockups if useful.
-3. Produce `docs/superpowers/specs/2026-04-17-plan-page-polish-design.md`.
-4. Produce `docs/superpowers/plans/2026-04-17-plan-page-polish.md`.
-5. Execute inline using `superpowers:executing-plans`.
-6. Same review-gate pattern: zetas-front-guy + perf-auditor → Gemini → frontend-auditor + ux-analyst → `/simplify`.
-
-**Cross-cutting work worth prioritizing:**
-
-- **Account aliases** — unblocks density in many row surfaces (Reciente, Plan occurrences, Deudas accounts). High backlog priority.
-- **"Hacer recurrente" + Destinatario↔Recurring link** — paired features. High backlog priority.
-
----
+1. **Fix `zetas-front-guy` blockers** (§5 above).
+2. **Extract `ExpandableStatTile`** in `components/ui/ExpandableStatTile.tsx`. Use in import reconcile grid and `InicioMetricsGrid` "Gasto hoy". Migrate `CreditCardStackCard` expansion to `AnimatedAccordion` too.
+3. **Revert `mobile/.env`** to `https://pfm.sanson1911.cloud`.
+4. **Cut a new branch off `main`** for slice-1 PR. Don't stack on `feat/planner-drag-drop`. Split commits logically:
+   - Webapp: middleware fix + route try/catch.
+   - Mobile: import-flow components + theme system + narrator + Kalam font + safe-area + reconcile grid.
+5. **Deploy webapp hotfix first.** Mobile slice-1 depends on it to work against prod.
+6. **Move `ParsedStatement` / `ParsedTransaction` to `packages/shared`** — duplicated between mobile and webapp.
+7. **Slice 2 (ranked):** onboarding redesign (6 frames), dashboard Variant B + widgets, Settings visual polish, Afford + "add to wishlist" CTA, Loan Step 2 variant.
+8. **Wire up light theme mode** (user mentioned as future). `lib/theme.tsx` is ready to extend — need light palette tokens + accent decisions.
 
 ## 7. Context for Claude
 
-- **Mobile dashboard tree:** `webapp/src/app/(dashboard)/dashboard/page.tsx` → `<MobileZone>` (`webapp/src/components/dashboard/zones/mobile-zone.tsx`) → `<InicioRoot>` → 5 `inicio-*` children. The Server Component page renders both desktop and mobile branches; desktop is gated to `lg:block`, mobile to `lg:hidden`.
-- **`useLiveDashboard`** hook refreshes hero + metrics + attention silently after mount. Treat the props it derives as the source of truth in client components that receive it.
-- **`categorizeTransaction(txId, categoryId)`** in `@/actions/categorize` — lightweight server action for category assignment. Not `updateTransaction` (full-shape action for form submissions).
-- **`useOutflowCategories()`** in `AppDataProvider` context — cached, no DB call on render. Prefer over `useCategories()` when scope is outflow-only.
-- **`<MonthSelector />`** at `webapp/src/components/month-selector.tsx` — canonical `?month=` URL-param navigation pattern. Any month-aware view should read/write it the same way. This session's `useRecurringMonth` rewrite now follows this pattern.
-- **Review-gate pattern that worked well this session** (recommend for future phases):
-  1. Spawn `zetas-front-guy` + `perf-auditor` in parallel after implementation.
-  2. Push + let Gemini's bot review (usually within 2 min).
-  3. Spawn `frontend-auditor` + `ux-analyst` for deeper a11y + cohesion.
-  4. Run `/simplify` skill (reuse + quality + efficiency).
-
-  Each layer surfaces non-overlapping findings. Apply each as a separate commit for clean review history.
-- **CLAUDE.md rules most relevant to mobile dashboard work:** Performance Rules (`"use cache"` + `cacheTag()`), UI Rules (token palette, `MOBILE_TAB_BAR_CLEARANCE_CLASS`, BRASS/GHOST button variants), Cache API (`updateTag` not `revalidateTag`), Debt account direction rule (INFLOW to CREDIT_CARD ≠ income).
-- **Superpowers skill flow for polish milestones:** audit → brainstorm (with Visual Companion) → write-spec → write-plan → execute. Each artifact lives under `audit/` + `docs/superpowers/{specs,plans}/`. This session's docs are reusable templates.
+- **Global theme hook:** `mobile/lib/theme.tsx` exports `useTheme()` (`{ mode, setMode }`) + `themeSurfaceClasses(mode)` helper. Persistence: `SecureStore`, key `zeta.theme-mode`. Wrap new themed screens:
+  ```ts
+  const { mode } = useTheme();
+  const inkCls = mode === "neutral" ? "bg-z-ink-neutral" : "bg-background";
+  ```
+- **`ImportThemeProvider` is a no-op shim.** `useImportTheme()` delegates to `useTheme()`. Safe to delete once all import components are migrated.
+- **Narrator rules:** only for conversational, low-stakes guidance. Never for errors / critical copy. Centered, `font-narrator` (Kalam 700), `text-z-brass`. Use `tone="sage"` for zero-state "nothing-to-see-here" messages.
+- **Kalam font** — `Kalam_700Bold`. Available weights: 300 / 400 / 700. Caveat was tried and removed.
+- **`AnimatedAccordion`** at `mobile/components/ui/AnimatedAccordion.tsx`. Props: `expanded: boolean`, `estimatedHeight: number`, `duration?: number`. Uses `react-native-reanimated`. Always mounts children; clips to 0 when collapsed.
+- **iOS sim UDID:** `AFBA8440-2959-4DC9-8B8D-ABD7CFE5B14A` (iPhone 17 Pro, iOS 26.2).
+- **Local API for sim:** `http://192.168.1.6:3000` (Mac LAN IP). Simulator reaches this.
+- **Logs:** `tail -F /tmp/zeta-ios.log`.
+- **Mobile upload path:** `mobile/app/(tabs)/import.tsx:handleParse` → `FileSystem.uploadAsync` from `"expo-file-system/legacy"`. Main namespace doesn't export the legacy API in expo-file-system v55.
+- **VPS access:** `ssh root@147.93.41.103`. Webapp container: `personal-finance-manager-webapp-1`. Parser: `personal-finance-manager-pdf-parser-1`. Use `docker logs <container> --tail N`. Reverse-proxy config read is blocked by sandbox permission.
+- **Reconcile state:** `reconExpanded` union is `"none" | "duplicates" | "review" | "unmatched" | "merchants"`. Toggle helper is inline inside the IIFE at ~`import.tsx:1186`.
+- **`StatTile` location:** bottom of `mobile/app/(tabs)/import.tsx`. When extracting the shared component, generalize signature (`tone` union, `hint`, `active`, `onPress`).
+- **BACKLOG.md** at repo root is the canonical backlog. Update it with slice-1 PR status and the unfixed `zetas-front-guy` items.

--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -34,7 +34,7 @@ import { CreditCardSummary } from "../../components/import/CreditCardSummary";
 import { CreditCardStackCard } from "../../components/import/CreditCardStackCard";
 import { ImportThemeProvider } from "../../components/import/import-theme";
 import { Narrator } from "../../components/common/Narrator";
-import { useTheme } from "../../lib/theme";
+import { useTheme, themeSurfaceClasses } from "../../lib/theme";
 import { useAuth } from "../../lib/auth";
 import { supabase } from "../../lib/supabase";
 import {
@@ -53,7 +53,9 @@ import { COLORS } from "../../lib/constants/colors";
 import {
   BRASS_BUTTON_CLASS,
   GHOST_BUTTON_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE,
 } from "../../lib/constants/styles";
+import { ExpandableStatTile } from "../../components/ui/ExpandableStatTile";
 import {
   applyReconciliationMerge,
   createTransaction,
@@ -306,6 +308,7 @@ export default function ImportScreen() {
   const { mode: themeMode } = useTheme();
   const neutralTheme = themeMode === "neutral";
   const inkCls = neutralTheme ? "bg-z-ink-neutral" : "bg-z-ink";
+  const actionBarCls = themeSurfaceClasses(themeMode).actionBar;
   const insets = useSafeAreaInsets();
   const topInset = Math.max(insets.top, 12);
   const [reconExpanded, setReconExpanded] = useState<
@@ -1119,14 +1122,14 @@ export default function ImportScreen() {
         <FlatList
           data={transactions}
           keyExtractor={txnKeyExtractor}
-          contentContainerStyle={{ paddingBottom: 120 }}
+          contentContainerStyle={{ paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
           ListHeaderComponent={reviewHeader}
           renderItem={renderTxnRow}
           ItemSeparatorComponent={ItemSeparator}
         />
 
         {/* Bottom buttons */}
-        <View className="absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 bg-background-92 p-4">
+        <View className={`absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 ${actionBarCls} p-4`}>
           <Pressable
             accessibilityLabel="Cancelar importación"
             className={`flex-1 items-center rounded-xl py-3 ${GHOST_BUTTON_CLASS}`}
@@ -1191,7 +1194,7 @@ export default function ImportScreen() {
       <View className={`flex-1 ${inkCls}`} style={{ paddingTop: topInset }}>
         <ScrollView
           className="flex-1"
-          contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+          contentContainerStyle={{ padding: 16, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         >
           <Text className="text-[11px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
             Paso 3 de 4
@@ -1234,7 +1237,7 @@ export default function ImportScreen() {
               <>
                 <View className="mt-4 flex-row gap-3">
                   <View className="flex-1">
-                    <StatTile
+                    <ExpandableStatTile
                       label="Nuevos"
                       hint="se agregan"
                       value={preview.unmatched.length}
@@ -1245,7 +1248,7 @@ export default function ImportScreen() {
                     />
                   </View>
                   <View className="flex-1">
-                    <StatTile
+                    <ExpandableStatTile
                       label="Destinatarios"
                       hint="sugeridos"
                       value={newMerchantNames.length}
@@ -1271,7 +1274,7 @@ export default function ImportScreen() {
                             Movimientos nuevos
                           </Text>
                           <Text className="mt-1 font-inter-italic text-xs text-z-sage-dark">
-                            No coinciden con nada existente — se importan fresh.
+                            No coinciden con nada existente — se importan limpios.
                           </Text>
                           <View className="mt-3 gap-1.5">
                             {preview.unmatched.map((item) => (
@@ -1318,7 +1321,7 @@ export default function ImportScreen() {
 
                 <View className="mt-3 flex-row gap-3">
                   <View className="flex-1">
-                    <StatTile
+                    <ExpandableStatTile
                       label="Duplicados"
                       hint="se omiten"
                       value={preview.autoMerge.length}
@@ -1329,7 +1332,7 @@ export default function ImportScreen() {
                     />
                   </View>
                   <View className="flex-1">
-                    <StatTile
+                    <ExpandableStatTile
                       label="Ambiguos"
                       hint="tú eliges"
                       value={preview.review.length}
@@ -1346,7 +1349,7 @@ export default function ImportScreen() {
                     {reconExpanded === "duplicates" ? (
                       preview.autoMerge.length === 0 ? (
                         <Narrator tone="sage">
-                          Cero duplicados. Todo entra fresh, sin pisarse.
+                          Cero duplicados. Nada se pisa.
                         </Narrator>
                       ) : (
                         <>
@@ -1423,9 +1426,12 @@ export default function ImportScreen() {
                                         [item.importIndex]: "MERGE",
                                       }))
                                     }
+                                    accessibilityRole="radio"
+                                    accessibilityState={{ selected: choice === "MERGE" }}
+                                    accessibilityLabel="Fusionar con movimiento existente"
                                     className={`flex-1 rounded-xl px-3 py-2 ${
                                       choice === "MERGE"
-                                        ? "bg-z-brass"
+                                        ? BRASS_BUTTON_CLASS
                                         : "bg-z-surface-3"
                                     }`}
                                   >
@@ -1446,6 +1452,9 @@ export default function ImportScreen() {
                                         [item.importIndex]: "KEEP_BOTH",
                                       }))
                                     }
+                                    accessibilityRole="radio"
+                                    accessibilityState={{ selected: choice === "KEEP_BOTH" }}
+                                    accessibilityLabel="Mantener ambos movimientos"
                                     className={`flex-1 rounded-xl px-3 py-2 ${
                                       choice === "KEEP_BOTH"
                                         ? "bg-z-sage-dark"
@@ -1478,7 +1487,7 @@ export default function ImportScreen() {
           <Narrator>{narratorLine}</Narrator>
         </ScrollView>
 
-        <View className="absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 bg-background-92 p-4">
+        <View className={`absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 ${actionBarCls} p-4`}>
           <Pressable
             accessibilityLabel="Volver al paso anterior"
             className={`flex-1 items-center rounded-xl py-3 ${GHOST_BUTTON_CLASS}`}
@@ -1546,7 +1555,9 @@ export default function ImportScreen() {
       )}
 
       <Pressable
-        className="mt-8 rounded-xl bg-z-brass px-8 py-3.5 active:opacity-90"
+        accessibilityRole="button"
+        accessibilityLabel="Ver transacciones importadas"
+        className={`mt-8 rounded-xl ${BRASS_BUTTON_CLASS} px-8 py-3.5 active:opacity-90`}
         onPress={() => {
           resetFlow();
           router.navigate("/(tabs)/transactions");
@@ -1557,7 +1568,12 @@ export default function ImportScreen() {
         </Text>
       </Pressable>
 
-      <Pressable className="mt-4 py-2" onPress={resetFlow}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Importar otro extracto"
+        className="mt-4 py-2"
+        onPress={resetFlow}
+      >
         <Text className="font-inter-medium text-sm text-z-sage-dark">
           Importar otro extracto
         </Text>
@@ -1567,62 +1583,3 @@ export default function ImportScreen() {
   );
 }
 
-function StatTile({
-  label,
-  value,
-  tone,
-  hint,
-  neutral,
-  active,
-  onPress,
-}: {
-  label: string;
-  value: number;
-  tone: "white" | "brass" | "alert" | "income";
-  hint?: string;
-  neutral: boolean;
-  active?: boolean;
-  onPress?: () => void;
-}) {
-  const surfaceCls = neutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2";
-  const isZero = value === 0;
-  const valueColor = isZero
-    ? "text-z-sage-dark"
-    : tone === "brass"
-      ? "text-z-brass"
-      : tone === "alert"
-        ? "text-z-debt"
-        : tone === "income"
-          ? "text-z-income"
-          : "text-z-white";
-  const borderCls = active ? "border-z-brass" : "border-white-6";
-  const interactive = typeof onPress === "function";
-  const Wrapper: typeof Pressable | typeof View = interactive ? Pressable : View;
-  return (
-    <Wrapper
-      {...(interactive
-        ? {
-            onPress,
-            accessibilityRole: "button" as const,
-            accessibilityState: { expanded: !!active },
-            accessibilityLabel: `Ver ${label.toLowerCase()}`,
-          }
-        : {})}
-      className={`rounded-2xl border ${borderCls} ${surfaceCls} px-4 pt-3.5 pb-4`}
-    >
-      <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
-        {label}
-      </Text>
-      <Text
-        className={`mt-1.5 text-[34px] font-inter-bold tabular-nums tracking-tight ${valueColor}`}
-      >
-        {value}
-      </Text>
-      {hint && (
-        <Text className="mt-1 font-inter text-[12px] text-z-sage-dark">
-          {hint}
-        </Text>
-      )}
-    </Wrapper>
-  );
-}

--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -8,9 +8,12 @@ import {
   ScrollView,
   TextInput,
 } from "react-native";
+import { AnimatedAccordion } from "../../components/ui/AnimatedAccordion";
 import { useRouter, useFocusEffect } from "expo-router";
-import { useState, useCallback } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useCallback, useMemo, useState } from "react";
 import * as DocumentPicker from "expo-document-picker";
+import * as FileSystem from "expo-file-system/legacy";
 import {
   Upload,
   FileText,
@@ -19,7 +22,19 @@ import {
   CheckSquare,
   ChevronDown,
 } from "lucide-react-native";
-import { formatCurrency, type ReconciliationCandidate } from "@zeta/shared";
+import {
+  formatCurrency,
+  type CurrencyCode,
+  type ReconciliationCandidate,
+} from "@zeta/shared";
+import { ImportProgress } from "../../components/import/ImportProgress";
+import { StatementChip } from "../../components/import/StatementChip";
+import { SectionDivider } from "../../components/import/SectionDivider";
+import { CreditCardSummary } from "../../components/import/CreditCardSummary";
+import { CreditCardStackCard } from "../../components/import/CreditCardStackCard";
+import { ImportThemeProvider } from "../../components/import/import-theme";
+import { Narrator } from "../../components/common/Narrator";
+import { useTheme } from "../../lib/theme";
 import { useAuth } from "../../lib/auth";
 import { supabase } from "../../lib/supabase";
 import {
@@ -34,6 +49,11 @@ import {
   setPdfPasswordForAccount,
 } from "../../lib/pdf-passwords";
 import { ACCOUNT_TYPES } from "../../lib/constants/accounts";
+import { COLORS } from "../../lib/constants/colors";
+import {
+  BRASS_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+} from "../../lib/constants/styles";
 import {
   applyReconciliationMerge,
   createTransaction,
@@ -99,12 +119,52 @@ type ParsedTransaction = {
   currency?: string;
 };
 
+type StatementSummary = {
+  previous_balance: number | null;
+  total_credits: number | null;
+  total_debits: number | null;
+  final_balance: number | null;
+  purchases_and_charges: number | null;
+  interest_charged: number | null;
+};
+
+type CreditCardMetadata = {
+  credit_limit: number | null;
+  available_credit: number | null;
+  interest_rate: number | null;
+  late_interest_rate: number | null;
+  total_payment_due: number | null;
+  minimum_payment: number | null;
+  payment_due_date: string | null;
+};
+
+type LoanMetadata = {
+  loan_number: string | null;
+  loan_type: string | null;
+  initial_amount: number | null;
+  disbursement_date: string | null;
+  remaining_balance: number | null;
+  interest_rate: number | null;
+  late_interest_rate: number | null;
+  total_payment_due: number | null;
+  minimum_payment: number | null;
+  payment_due_date: string | null;
+  installments_in_default: number | null;
+  statement_cut_date: string | null;
+  last_payment_date: string | null;
+};
+
 type ParsedStatement = {
   bank: string;
-  statement_type: string;
+  statement_type: "savings" | "credit_card" | "loan" | string;
   account_number?: string | null;
   card_last_four?: string | null;
+  period_from?: string | null;
+  period_to?: string | null;
   currency: string;
+  summary?: StatementSummary | null;
+  credit_card_metadata?: CreditCardMetadata | null;
+  loan_metadata?: LoanMetadata | null;
   transactions: ParsedTransaction[];
 };
 
@@ -128,6 +188,10 @@ type ReconciliationPreview = {
   }>;
 };
 
+function ItemSeparator() {
+  return <View className="ml-12 h-px bg-white-6" />;
+}
+
 function AccountSelector({
   accounts,
   selected,
@@ -141,12 +205,12 @@ function AccountSelector({
 
   if (accounts.length === 0) {
     return (
-      <View className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4">
-        <Text className="text-amber-800 font-inter-medium text-sm">
+      <View className="mb-4 rounded-xl border border-z-alert-25 bg-z-alert-12 p-4">
+        <Text className="font-inter-medium text-sm text-z-alert">
           No tienes cuentas registradas.
         </Text>
-        <Text className="text-amber-700 font-inter text-xs mt-1">
-          Crea una cuenta primero en la pestana Cuentas.
+        <Text className="mt-1 font-inter text-xs text-z-sage-light">
+          Crea una cuenta primero en la pestaña Cuentas.
         </Text>
       </View>
     );
@@ -156,50 +220,52 @@ function AccountSelector({
     ? ACCOUNT_TYPES.find((t) => t.value === selected.account_type)
     : null;
   const Icon = typeDef?.icon;
-  const color = selected?.color ?? "#6B7280";
+  const color = selected?.color ?? COLORS.sageDark;
 
   return (
     <View className="mb-4">
-      <Text className="text-gray-700 font-inter-medium text-sm mb-1.5">
-        Cuenta de destino <Text className="text-red-500">*</Text>
+      <Text className="mb-1.5 font-inter-medium text-sm text-z-sage-light">
+        Cuenta de destino <Text className="text-z-debt">*</Text>
       </Text>
       <Pressable
-        className="bg-white border border-gray-200 rounded-xl px-4 py-3 flex-row items-center active:bg-gray-100"
+        accessibilityLabel="Seleccionar cuenta de destino"
+        accessibilityRole="button"
+        className="flex-row items-center rounded-xl border border-z-sage-10 bg-z-surface-2 px-4 py-3 active:bg-z-surface-3"
         onPress={() => setOpen(!open)}
       >
         {selected && Icon ? (
           <>
             <View
-              className="w-7 h-7 rounded-full items-center justify-center mr-3"
+              className="mr-3 h-7 w-7 items-center justify-center rounded-full"
               style={{ backgroundColor: color + "20" }}
             >
               <Icon size={14} color={color} />
             </View>
-            <Text className="flex-1 text-gray-900 font-inter-medium text-sm">
+            <Text className="flex-1 font-inter-medium text-sm text-z-white">
               {selected.name}
             </Text>
           </>
         ) : (
-          <Text className="flex-1 text-gray-400 font-inter text-sm">
+          <Text className="flex-1 font-inter text-sm text-z-sage-dark">
             Seleccionar cuenta...
           </Text>
         )}
-        <ChevronDown size={16} color="#9CA3AF" />
+        <ChevronDown size={16} color="#938C7E" />
       </Pressable>
 
       {open && (
-        <View className="bg-white border border-gray-200 rounded-xl mt-1 overflow-hidden">
+        <View className="mt-1 overflow-hidden rounded-xl border border-z-sage-10 bg-z-surface-2">
           {accounts.map((account, index) => {
             const aTypeDef = ACCOUNT_TYPES.find(
               (t) => t.value === account.account_type
             );
             const AIcon = aTypeDef?.icon;
-            const aColor = account.color ?? "#6B7280";
+            const aColor = account.color ?? COLORS.sageDark;
             return (
               <Pressable
                 key={account.id}
-                className={`flex-row items-center px-4 py-3 active:bg-gray-100 ${
-                  index > 0 ? "border-t border-gray-100" : ""
+                className={`flex-row items-center px-4 py-3 active:bg-z-surface-3 ${
+                  index > 0 ? "border-t border-z-sage-10" : ""
                 }`}
                 onPress={() => {
                   onSelect(account);
@@ -207,16 +273,16 @@ function AccountSelector({
                 }}
               >
                 <View
-                  className="w-7 h-7 rounded-full items-center justify-center mr-3"
+                  className="mr-3 h-7 w-7 items-center justify-center rounded-full"
                   style={{ backgroundColor: aColor + "20" }}
                 >
                   {AIcon && <AIcon size={14} color={aColor} />}
                 </View>
-                <Text className="flex-1 text-gray-900 font-inter-medium text-sm">
+                <Text className="flex-1 font-inter-medium text-sm text-z-white">
                   {account.name}
                 </Text>
                 {selected?.id === account.id && (
-                  <CheckSquare size={16} color="#C5BFAE" />
+                  <CheckSquare size={16} color="#937844" />
                 )}
               </Pressable>
             );
@@ -235,7 +301,16 @@ export default function ImportScreen() {
   const [password, setPassword] = useState("");
   const [parsing, setParsing] = useState(false);
   const [parsedData, setParsedData] = useState<ParsedStatement | null>(null);
+  const [allStatements, setAllStatements] = useState<ParsedStatement[]>([]);
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  const { mode: themeMode } = useTheme();
+  const neutralTheme = themeMode === "neutral";
+  const inkCls = neutralTheme ? "bg-z-ink-neutral" : "bg-z-ink";
+  const insets = useSafeAreaInsets();
+  const topInset = Math.max(insets.top, 12);
+  const [reconExpanded, setReconExpanded] = useState<
+    "none" | "duplicates" | "review" | "unmatched" | "merchants"
+  >("none");
   const [importing, setImporting] = useState(false);
   const [importedCount, setImportedCount] = useState(0);
   const [accounts, setAccounts] = useState<AccountRow[]>([]);
@@ -289,44 +364,94 @@ export default function ImportScreen() {
   const handleParse = useCallback(async () => {
     if (!document) return;
     setParsing(true);
+    const t0 = Date.now();
+    const log = (step: string, extra?: unknown) => {
+      const ms = Date.now() - t0;
+      console.log(`[import +${ms}ms] ${step}`, extra ?? "");
+    };
+
     try {
-      const formData = new FormData();
-      formData.append("file", {
-        uri: document.uri,
-        name: document.name || "statement.pdf",
-        type: "application/pdf",
-      } as any);
-      if (password.trim()) {
-        formData.append("password", password.trim());
-      }
+      log("start", { uri: document.uri, size: document.size });
 
       const {
         data: { session: currentSession },
       } = await supabase.auth.getSession();
       const accessToken = currentSession?.access_token;
 
-      const response = await fetch(`${API_URL}/api/parse-statement`, {
-        method: "POST",
-        headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
-        body: formData,
+      if (!accessToken) {
+        throw new Error("No hay sesión activa. Inicia sesión e intenta de nuevo.");
+      }
+      log("got token");
+
+      const url = `${API_URL}/api/parse-statement`;
+      log("uploading to", url);
+
+      // expo-file-system handles multipart uploads via native NSURLSession.
+      // Unlike RN fetch + FormData, it sets Content-Length correctly, supports
+      // real cancellation, and doesn't hang on HTTPS + multipart + chunked bodies.
+      let uploadResult: FileSystem.FileSystemUploadResult;
+      try {
+        uploadResult = await Promise.race<FileSystem.FileSystemUploadResult>([
+          FileSystem.uploadAsync(url, document.uri, {
+            httpMethod: "POST",
+            uploadType: FileSystem.FileSystemUploadType.MULTIPART,
+            fieldName: "file",
+            mimeType: "application/pdf",
+            parameters: password.trim() ? { password: password.trim() } : {},
+            headers: { Authorization: `Bearer ${accessToken}` },
+          }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("timeout-30s")),
+              30_000,
+            ),
+          ),
+        ]);
+      } catch (netErr) {
+        log("upload error", netErr);
+        if (netErr instanceof Error && netErr.message === "timeout-30s") {
+          throw new Error(
+            "El servidor no respondió en 30 segundos. Intenta de nuevo.",
+          );
+        }
+        throw new Error(
+          `No se pudo conectar al servidor: ${netErr instanceof Error ? netErr.message : "red desconocida"}`,
+        );
+      }
+
+      log("response", {
+        status: uploadResult.status,
+        bodyLen: uploadResult.body?.length ?? 0,
       });
 
-      if (!response.ok) {
-        const payload = await response
-          .json()
-          .catch(() => ({ error: `Parse failed: ${response.status}` }));
-        const errorMessage =
-          typeof payload?.error === "string"
-            ? payload.error
-            : typeof payload?.detail === "string"
-              ? payload.detail
-              : `Parse failed: ${response.status}`;
+      const rawBody = uploadResult.body ?? "";
+      let parsedBody: unknown = null;
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        // body wasn't valid JSON
+      }
+
+      if (uploadResult.status < 200 || uploadResult.status >= 300) {
+        let errorMessage = `HTTP ${uploadResult.status}`;
+        if (parsedBody && typeof parsedBody === "object") {
+          const maybeError = (parsedBody as { error?: unknown; detail?: unknown });
+          if (typeof maybeError.error === "string") errorMessage = maybeError.error;
+          else if (typeof maybeError.detail === "string") errorMessage = maybeError.detail;
+        } else if (rawBody && rawBody.length < 200) {
+          errorMessage = rawBody;
+        }
+        log("error message", errorMessage);
         throw new Error(errorMessage);
       }
 
-      const data = await response.json();
-      const statements: ParsedStatement[] =
-        data.statements ?? (Array.isArray(data) ? data : []);
+      if (!parsedBody) {
+        throw new Error("Respuesta invalida del servidor");
+      }
+      const statements: ParsedStatement[] = Array.isArray(parsedBody)
+        ? (parsedBody as ParsedStatement[])
+        : (parsedBody as { statements?: ParsedStatement[] }).statements ?? [];
+      log("parsed JSON", { statementCount: statements.length });
       const stmt = statements[0];
 
       if (!stmt) {
@@ -345,6 +470,7 @@ export default function ImportScreen() {
         );
       }
 
+      setAllStatements(statements);
       setParsedData(stmt);
       const allIndices = new Set(
         stmt.transactions.map((_: ParsedTransaction, i: number) => i)
@@ -401,7 +527,7 @@ export default function ImportScreen() {
             account_type: accountType,
             institution_name: stmt.bank ?? null,
             currency_code: stmt.currency ?? "COP",
-            color: "#6366f1",
+            color: COLORS.brass,
           });
           const newAccount = await getAccountById(newId);
           if (newAccount) {
@@ -678,6 +804,7 @@ export default function ImportScreen() {
     setDocument(null);
     setPassword("");
     setParsedData(null);
+    setAllStatements([]);
     setSelected(new Set());
     setSelectedAccount(null);
     setReconciliationPreview(null);
@@ -690,40 +817,202 @@ export default function ImportScreen() {
     });
   }, []);
 
+  const switchStatement = useCallback(
+    async (idx: number) => {
+      const next = allStatements[idx];
+      if (!next || !session?.user?.id) return;
+      setParsedData(next);
+      setSelected(
+        new Set(next.transactions.map((_: ParsedTransaction, i: number) => i))
+      );
+      setReconciliationPreview(null);
+      setReviewDecisions({});
+
+      const stmtTypeMap: Record<string, string> = {
+        savings: "CHECKING",
+        credit_card: "CREDIT_CARD",
+        loan: "LOAN",
+      };
+      const accountType = stmtTypeMap[next.statement_type] ?? "CHECKING";
+      const currentAccounts = await getAllAccounts();
+      setAccounts(currentAccounts);
+      const match = findMatchingAccount(currentAccounts, next, accountType);
+      setSelectedAccount(match ?? null);
+    },
+    [allStatements, session?.user?.id]
+  );
+
+  // ===== Shared derivations for Step 2 (hooks can't be inside if-branches) =====
+  const transactions = parsedData?.transactions ?? [];
+  const transactionCount = transactions.length;
+  const currency = (parsedData?.currency ?? "COP") as CurrencyCode;
+  const isCreditCard =
+    parsedData?.statement_type === "credit_card" &&
+    parsedData?.credit_card_metadata != null;
+
+  const reviewHeader = useMemo(() => {
+    if (!parsedData) return null;
+    const activeIdx = allStatements.indexOf(parsedData);
+    const multiCreditCard =
+      allStatements.length > 1 &&
+      allStatements.every(
+        (s) => s.statement_type === "credit_card" && s.credit_card_metadata != null
+      );
+    return (
+      <View className="px-4 pt-2">
+        <View className="mb-4">
+          <StatementChip
+            bank={parsedData.bank}
+            cardLastFour={parsedData.card_last_four}
+            accountNumber={parsedData.account_number}
+            periodFrom={parsedData.period_from}
+            periodTo={parsedData.period_to}
+          />
+        </View>
+
+        {multiCreditCard ? (
+          <>
+            <SectionDivider label="Por pagar" />
+            {allStatements.map((s, i) => (
+              <CreditCardStackCard
+                key={`${s.currency ?? "COP"}-${i}`}
+                currency={(s.currency ?? "COP") as CurrencyCode}
+                metadata={s.credit_card_metadata!}
+                summary={s.summary ?? null}
+                transactionCount={s.transactions.length}
+                active={i === activeIdx}
+                onPress={() => switchStatement(i)}
+              />
+            ))}
+            <View className="h-2" />
+          </>
+        ) : (
+          isCreditCard &&
+          parsedData.credit_card_metadata && (
+            <>
+              <SectionDivider label="Por pagar" />
+              <CreditCardSummary
+                metadata={parsedData.credit_card_metadata}
+                summary={parsedData.summary ?? null}
+                transactionCount={transactionCount}
+                currency={currency}
+              />
+              <View className="h-4" />
+            </>
+          )
+        )}
+
+        <SectionDivider
+          label={isCreditCard ? "Movimientos" : "Transacciones"}
+        />
+
+        <AccountSelector
+          accounts={accounts}
+          selected={selectedAccount}
+          onSelect={setSelectedAccount}
+        />
+      </View>
+    );
+  }, [parsedData, allStatements, switchStatement, isCreditCard, transactionCount, currency, accounts, selectedAccount]);
+
+  const renderTxnRow = useCallback(
+    ({ item, index }: { item: ParsedTransaction; index: number }) => {
+      const isSelected = selected.has(index);
+      const isInflow = item.direction === "INFLOW";
+      const isDebtPayment = isDebtInflow({
+        direction: item.direction,
+        accountType: selectedAccount?.account_type,
+      });
+      const Icon = isSelected ? CheckSquare : Square;
+      const amountClass = isDebtPayment
+        ? "text-z-income"
+        : isInflow
+          ? "text-z-income"
+          : "text-z-white";
+
+      return (
+        <Pressable
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: isSelected }}
+          accessibilityLabel={`${isSelected ? "Deseleccionar" : "Seleccionar"} ${item.description}`}
+          className="mx-4 flex-row items-center rounded-lg px-2 py-3 active:bg-z-surface-2"
+          onPress={() => toggleSelect(index)}
+        >
+          <Icon
+            size={20}
+            color={isSelected ? COLORS.brass : COLORS.sageDark}
+          />
+          <View className="mx-3 flex-1">
+            <Text
+              className="font-inter-medium text-sm text-z-white"
+              numberOfLines={1}
+            >
+              {item.description}
+            </Text>
+            <Text className="mt-0.5 font-inter text-xs text-z-sage-dark">
+              {item.date}
+              {isDebtPayment ? " • Abono a deuda" : ""}
+            </Text>
+          </View>
+          <Text className={`font-inter-bold text-sm ${amountClass}`}>
+            {isInflow ? "+" : "-"}
+            {formatCurrency(Math.abs(item.amount), currency)}
+          </Text>
+        </Pressable>
+      );
+    },
+    [selected, selectedAccount?.account_type, toggleSelect, currency],
+  );
+
+  const txnKeyExtractor = useCallback(
+    (item: ParsedTransaction, index: number) =>
+      `${item.date}|${item.amount}|${item.description}|${index}`,
+    [],
+  );
+
   // ===== STEP 1: Pick PDF =====
   if (step === "pick") {
     return (
-      <View className="flex-1 bg-gray-100 p-4">
-        <Text className="text-gray-900 font-inter-bold text-xl mb-6">
+      <ImportThemeProvider neutral={neutralTheme}>
+      <View className={`flex-1 ${inkCls} px-4 pb-4`} style={{ paddingTop: topInset + 4 }}>
+        <Text className="text-[11px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+          Paso 1 de 4
+        </Text>
+        <Text className="mt-1 font-inter-bold text-xl text-z-white">
           Importar extracto
         </Text>
+        <View className="mt-3 mb-5">
+          <ImportProgress step={1} total={4} />
+        </View>
 
         <Pressable
-          className="border-2 border-dashed border-gray-300 rounded-lg p-8 items-center justify-center bg-white active:bg-gray-100"
+          accessibilityLabel="Seleccionar extracto PDF"
+          accessibilityRole="button"
+          className="items-center justify-center rounded-2xl border border-z-brass-30 bg-z-brass-8 p-8 active:bg-z-brass-12"
           onPress={handlePickDocument}
         >
-          <Upload size={40} color="#9CA3AF" />
-          <Text className="text-gray-500 font-inter-medium text-base mt-4">
+          <Upload size={40} color="#937844" />
+          <Text className="mt-4 font-inter-semibold text-base text-z-white">
             Seleccionar extracto PDF
           </Text>
-          <Text className="text-gray-400 font-inter text-sm mt-1">
+          <Text className="mt-1 font-inter text-sm text-z-sage-dark">
             Toca para abrir el selector
           </Text>
         </Pressable>
 
         {document && (
-          <View className="bg-white rounded-lg p-4 mt-4">
+          <View className="mt-4 rounded-2xl border border-z-sage-10 bg-z-surface-2 p-4">
             <View className="flex-row items-center">
-              <FileText size={20} color="#C5BFAE" />
+              <FileText size={20} color="#937844" />
               <View className="ml-3 flex-1">
                 <Text
-                  className="text-gray-900 font-inter-medium text-sm"
+                  className="font-inter-medium text-sm text-z-white"
                   numberOfLines={1}
                 >
                   {document.name}
                 </Text>
                 {document.size && (
-                  <Text className="text-gray-400 font-inter text-xs mt-0.5">
+                  <Text className="mt-0.5 font-inter text-xs text-z-sage-dark">
                     {(document.size / 1024).toFixed(1)} KB
                   </Text>
                 )}
@@ -731,27 +1020,28 @@ export default function ImportScreen() {
             </View>
 
             <View className="mt-4">
-              <Text className="text-gray-700 font-inter-medium text-sm mb-1.5">
+              <Text className="mb-1.5 font-inter-medium text-sm text-z-sage-light">
                 Contraseña del PDF
               </Text>
               <TextInput
                 value={password}
                 onChangeText={setPassword}
                 placeholder="Si el extracto está cifrado, ingrésala aquí"
+                placeholderTextColor="#938C7E"
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}
                 autoComplete="off"
                 importantForAutofill="no"
                 textContentType="none"
-                className="bg-gray-50 border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+                className="rounded-xl border border-z-sage-10 bg-z-ink px-4 py-3 font-inter text-sm text-z-white"
               />
-              <Text className="text-gray-400 font-inter text-xs mt-2">
+              <Text className="mt-2 font-inter text-xs text-z-sage-dark">
                 Déjalo vacío si el PDF no tiene contraseña.
               </Text>
               {savedPdfPasswords.length > 0 && (
                 <View className="mt-3">
-                  <Text className="text-gray-500 font-inter text-xs mb-1.5">
+                  <Text className="mb-1.5 font-inter text-xs text-z-sage-dark">
                     Contraseñas guardadas:
                   </Text>
                   <ScrollView
@@ -760,16 +1050,17 @@ export default function ImportScreen() {
                     contentContainerStyle={{ gap: 8 }}
                   >
                     {savedPdfPasswords.map((entry) => (
-                        <Pressable
-                          key={entry.accountId}
-                          onPress={() => setPassword(entry.password)}
-                          className="bg-emerald-50 border border-emerald-200 rounded-full px-3 py-1.5 active:bg-emerald-100"
-                        >
-                          <Text className="text-emerald-700 font-inter-medium text-xs">
-                            {entry.accountName}
-                          </Text>
-                        </Pressable>
-                      ))}
+                      <Pressable
+                        key={entry.accountId}
+                        accessibilityLabel={`Usar contraseña guardada de ${entry.accountName}`}
+                        onPress={() => setPassword(entry.password)}
+                        className="rounded-full border border-z-income-30 bg-z-income-12 px-3 py-1.5 active:bg-z-income-20"
+                      >
+                        <Text className="font-inter-medium text-xs text-z-income">
+                          {entry.accountName}
+                        </Text>
+                      </Pressable>
+                    ))}
                   </ScrollView>
                 </View>
               )}
@@ -778,18 +1069,19 @@ export default function ImportScreen() {
         )}
 
         <Pressable
-          className={`mt-6 rounded-lg py-3.5 items-center ${
-            document ? "bg-primary active:bg-primary-dark" : "bg-gray-200"
+          accessibilityLabel="Procesar extracto"
+          className={`mt-6 items-center rounded-xl py-3.5 ${
+            document ? `${BRASS_BUTTON_CLASS} active:opacity-90` : "bg-z-surface-2"
           }`}
           onPress={handleParse}
           disabled={!document || parsing}
         >
           {parsing ? (
-            <ActivityIndicator color="#FFFFFF" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
             <Text
               className={`font-inter-bold text-base ${
-                document ? "text-white" : "text-gray-400"
+                document ? "text-z-ink" : "text-z-sage-dark"
               }`}
             >
               Procesar extracto
@@ -797,117 +1089,78 @@ export default function ImportScreen() {
           )}
         </Pressable>
       </View>
+      </ImportThemeProvider>
     );
   }
 
   // ===== STEP 2: Review =====
   if (step === "review") {
-    const transactions = parsedData?.transactions ?? [];
     const selectedCount = selected.size;
     const canImport = selectedCount > 0 && selectedAccount !== null;
 
     return (
-      <View className="flex-1 bg-gray-100">
-        <View className="px-4 pt-4 pb-2">
-          <Text className="text-gray-900 font-inter-bold text-xl">
-            Revisar transacciones
+      <ImportThemeProvider neutral={neutralTheme}>
+      <View className={`flex-1 ${inkCls}`} style={{ paddingTop: topInset }}>
+        <View className="px-4 pt-2 pb-2">
+          <Text className="text-[11px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+            Paso 2 de 4{isCreditCard ? " · Tarjeta de crédito" : ""}
           </Text>
-          <Text className="text-gray-500 font-inter text-sm mt-1">
-            {selectedCount} de {transactions.length} seleccionadas
+          <Text className="mt-1 font-inter-bold text-xl text-z-white">
+            Encontramos esto
+          </Text>
+          <View className="mt-3">
+            <ImportProgress step={2} total={4} />
+          </View>
+          <Text className="mt-3 font-inter text-sm text-z-sage-dark">
+            {selectedCount} de {transactionCount} seleccionadas
           </Text>
         </View>
 
         <FlatList
           data={transactions}
-          keyExtractor={(_, index) => String(index)}
+          keyExtractor={txnKeyExtractor}
           contentContainerStyle={{ paddingBottom: 120 }}
-          ListHeaderComponent={
-            <View className="px-4 pt-2 pb-1">
-              <AccountSelector
-                accounts={accounts}
-                selected={selectedAccount}
-                onSelect={setSelectedAccount}
-              />
-            </View>
-          }
-          renderItem={({ item, index }) => {
-            const isSelected = selected.has(index);
-            const isInflow = item.direction === "INFLOW";
-            const isDebtPayment = isDebtInflow({
-              direction: item.direction,
-              accountType: selectedAccount?.account_type,
-            });
-            const Icon = isSelected ? CheckSquare : Square;
-
-            return (
-              <Pressable
-                className="flex-row items-center px-4 py-3 bg-white active:bg-gray-100"
-                onPress={() => toggleSelect(index)}
-              >
-                <Icon size={20} color={isSelected ? "#C5BFAE" : "#D1D5DB"} />
-                <View className="flex-1 mx-3">
-                  <Text
-                    className="text-gray-900 font-inter-medium text-sm"
-                    numberOfLines={1}
-                  >
-                    {item.description}
-                  </Text>
-                  <Text className="text-gray-400 font-inter text-xs mt-0.5">
-                    {item.date}
-                    {isDebtPayment ? " • Abono a deuda" : ""}
-                  </Text>
-                </View>
-                <Text
-                  className={`font-inter-bold text-sm ${
-                    isDebtPayment
-                      ? "text-sky-600"
-                      : isInflow
-                        ? "text-green-600"
-                        : "text-gray-900"
-                  }`}
-                >
-                  {isInflow ? "+" : "-"}
-                  {formatCurrency(Math.abs(item.amount))}
-                </Text>
-              </Pressable>
-            );
-          }}
-          ItemSeparatorComponent={() => (
-            <View className="h-px bg-gray-100 ml-12" />
-          )}
+          ListHeaderComponent={reviewHeader}
+          renderItem={renderTxnRow}
+          ItemSeparatorComponent={ItemSeparator}
         />
 
         {/* Bottom buttons */}
-        <View className="absolute bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 flex-row gap-3">
+        <View className="absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 bg-background-92 p-4">
           <Pressable
-            className="flex-1 rounded-lg py-3 items-center border border-gray-300 active:bg-gray-100"
+            accessibilityLabel="Cancelar importación"
+            className={`flex-1 items-center rounded-xl py-3 ${GHOST_BUTTON_CLASS}`}
             onPress={resetFlow}
           >
-            <Text className="text-gray-700 font-inter-medium text-sm">
+            <Text className="font-inter-medium text-sm text-z-sage-light">
               Cancelar
             </Text>
           </Pressable>
           <Pressable
-            className={`flex-1 rounded-lg py-3 items-center ${
-              canImport ? "bg-primary active:bg-primary-dark" : "bg-gray-200"
+            accessibilityLabel="Continuar a reconciliación"
+            className={`flex-1 items-center rounded-xl py-3 ${
+              canImport
+                ? `${BRASS_BUTTON_CLASS} active:opacity-90`
+                : "bg-z-surface-2"
             }`}
             onPress={handlePrepareImport}
             disabled={!canImport || importing}
           >
             {importing ? (
-              <ActivityIndicator color="#FFFFFF" />
+              <ActivityIndicator color={COLORS.ink} />
             ) : (
               <Text
                 className={`font-inter-bold text-sm ${
-                  canImport ? "text-white" : "text-gray-400"
+                  canImport ? "text-z-ink" : "text-z-sage-dark"
                 }`}
               >
-                Revisar conciliación
+                Continuar
               </Text>
             )}
           </Pressable>
         </View>
       </View>
+      </ImportThemeProvider>
     );
   }
 
@@ -917,213 +1170,459 @@ export default function ImportScreen() {
       review: [],
       unmatched: [],
     };
+    const txnsCount = selected.size;
+    const newMerchantNames = Array.from(
+      new Set(
+        preview.unmatched
+          .map((i) => i.transaction.description)
+          .filter((s): s is string => typeof s === "string" && s.length > 0),
+      ),
+    );
+    const narratorLine = (() => {
+      if (preview.review.length > 0)
+        return `Hay ${preview.review.length} ambigu${preview.review.length === 1 ? "o" : "os"} — tú decides. Son solo unos toques.`;
+      if (preview.autoMerge.length > 0)
+        return `Se omiten ${preview.autoMerge.length} duplicado${preview.autoMerge.length === 1 ? "" : "s"}. El resto entra fresco.`;
+      return "Sin sorpresas — nada duplicado, nada ambiguo. Dale.";
+    })();
 
     return (
-      <View className="flex-1 bg-gray-100">
+      <ImportThemeProvider neutral={neutralTheme}>
+      <View className={`flex-1 ${inkCls}`} style={{ paddingTop: topInset }}>
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
         >
-          <Text className="text-gray-900 font-inter-bold text-xl">
+          <Text className="text-[11px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+            Paso 3 de 4
+          </Text>
+          <Text className="mt-1 font-inter-bold text-xl text-z-white">
             Reconciliación
           </Text>
-          <Text className="mt-1 text-gray-500 font-inter text-sm">
-            Evita duplicados antes de guardar el extracto.
-          </Text>
-
-          <View className="mt-4 flex-row gap-3">
-            <View className="flex-1 rounded-xl bg-white p-4">
-              <Text className="text-xs font-inter text-gray-500">Auto-merge</Text>
-              <Text className="mt-1 text-2xl font-inter-bold text-gray-900">
-                {preview.autoMerge.length}
-              </Text>
-            </View>
-            <View className="flex-1 rounded-xl bg-white p-4">
-              <Text className="text-xs font-inter text-gray-500">Revisión</Text>
-              <Text className="mt-1 text-2xl font-inter-bold text-gray-900">
-                {preview.review.length}
-              </Text>
-            </View>
-            <View className="flex-1 rounded-xl bg-white p-4">
-              <Text className="text-xs font-inter text-gray-500">Sin match</Text>
-              <Text className="mt-1 text-2xl font-inter-bold text-gray-900">
-                {preview.unmatched.length}
-              </Text>
-            </View>
+          <View className="mt-3 mb-3">
+            <ImportProgress step={3} total={4} />
           </View>
-
-          {preview.autoMerge.length > 0 ? (
-            <View className="mt-5 rounded-xl bg-white p-4">
-              <Text className="text-sm font-inter-semibold text-gray-900">
-                Coincidencias de alta confianza
+          {selectedAccount && (
+            <View className="mt-4 flex-row items-baseline justify-between gap-3 border-b border-white-6 pb-2.5">
+              <Text
+                numberOfLines={1}
+                className="flex-1 font-inter-semibold text-[15px] text-z-white tracking-tight"
+              >
+                {selectedAccount.name}
               </Text>
-              <View className="mt-3 gap-3">
-                {preview.autoMerge.map((item) => (
-                  <View
-                    key={`auto-${item.importIndex}`}
-                    className="rounded-xl border border-emerald-100 bg-emerald-50 p-3"
-                  >
-                    <Text className="font-inter-medium text-sm text-gray-900">
-                      {item.transaction.description}
-                    </Text>
-                    <Text className="mt-1 text-xs font-inter text-gray-600">
-                      Se fusiona con{" "}
-                      {item.candidate.raw_description ??
-                        item.candidate.merchant_name ??
-                        "movimiento manual"}
-                    </Text>
-                    <Text className="mt-1 text-xs font-inter text-emerald-700">
-                      Score {Math.round(item.score * 100)}%
-                    </Text>
+              <Text className="font-inter text-[11px] text-z-sage-dark">
+                {txnsCount} movs
+              </Text>
+            </View>
+          )}
+
+          {(() => {
+            const toggle = (
+              target:
+                | "unmatched"
+                | "merchants"
+                | "duplicates"
+                | "review"
+            ) => {
+              setReconExpanded((v) => (v === target ? "none" : target));
+            };
+            const isRow1 =
+              reconExpanded === "unmatched" || reconExpanded === "merchants";
+            const isRow2 =
+              reconExpanded === "duplicates" || reconExpanded === "review";
+            return (
+              <>
+                <View className="mt-4 flex-row gap-3">
+                  <View className="flex-1">
+                    <StatTile
+                      label="Nuevos"
+                      hint="se agregan"
+                      value={preview.unmatched.length}
+                      tone="income"
+                      neutral={neutralTheme}
+                      active={reconExpanded === "unmatched"}
+                      onPress={() => toggle("unmatched")}
+                    />
                   </View>
-                ))}
-              </View>
-            </View>
-          ) : null}
+                  <View className="flex-1">
+                    <StatTile
+                      label="Destinatarios"
+                      hint="sugeridos"
+                      value={newMerchantNames.length}
+                      tone="brass"
+                      neutral={neutralTheme}
+                      active={reconExpanded === "merchants"}
+                      onPress={() => toggle("merchants")}
+                    />
+                  </View>
+                </View>
 
-          {preview.review.length > 0 ? (
-            <View className="mt-5 rounded-xl bg-white p-4">
-              <Text className="text-sm font-inter-semibold text-gray-900">
-                Revisión manual
-              </Text>
-              <View className="mt-3 gap-4">
-                {preview.review.map((item) => {
-                  const choice = reviewDecisions[item.importIndex] ?? "KEEP_BOTH";
-                  return (
-                    <View
-                      key={`review-${item.importIndex}`}
-                      className="rounded-xl border border-gray-200 p-3"
-                    >
-                      <Text className="font-inter-medium text-sm text-gray-900">
-                        {item.transaction.description}
-                      </Text>
-                      <Text className="mt-1 text-xs font-inter text-gray-500">
-                        Posible duplicado:{" "}
-                        {item.candidate.raw_description ??
-                          item.candidate.merchant_name ??
-                          "movimiento manual"}
-                      </Text>
-                      <Text className="mt-1 text-xs font-inter text-gray-500">
-                        Score {Math.round(item.score * 100)}%
-                      </Text>
+                <AnimatedAccordion expanded={isRow1} estimatedHeight={700}>
+                  <View className="mt-3 rounded-xl border border-z-sage-10 bg-z-surface-2 p-4">
+                    {reconExpanded === "unmatched" ? (
+                      preview.unmatched.length === 0 ? (
+                        <Narrator tone="sage">
+                          No hay movimientos nuevos en este extracto. Raro pero
+                          OK.
+                        </Narrator>
+                      ) : (
+                        <>
+                          <Text className="font-inter-semibold text-sm text-z-white">
+                            Movimientos nuevos
+                          </Text>
+                          <Text className="mt-1 font-inter-italic text-xs text-z-sage-dark">
+                            No coinciden con nada existente — se importan fresh.
+                          </Text>
+                          <View className="mt-3 gap-1.5">
+                            {preview.unmatched.map((item) => (
+                              <View
+                                key={`unmatched-${item.importIndex}`}
+                                className="rounded-lg border border-white-6 px-3 py-2"
+                              >
+                                <Text className="font-inter text-xs text-z-sage-light">
+                                  {item.transaction.description}
+                                </Text>
+                              </View>
+                            ))}
+                          </View>
+                        </>
+                      )
+                    ) : newMerchantNames.length === 0 ? (
+                      <Narrator tone="sage">
+                        Nada por sugerir — ya tenías a todos registrados.
+                      </Narrator>
+                    ) : (
+                      <>
+                        <Text className="font-inter-semibold text-sm text-z-white">
+                          Destinatarios sugeridos
+                        </Text>
+                        <Text className="mt-1 font-inter-italic text-xs text-z-sage-dark">
+                          Después de importar, revisa cuáles quieres crear.
+                        </Text>
+                        <View className="mt-3 gap-1.5">
+                          {newMerchantNames.map((name) => (
+                            <View
+                              key={`new-m-${name}`}
+                              className="rounded-lg border border-white-6 px-3 py-2"
+                            >
+                              <Text className="font-inter text-xs text-z-sage-light">
+                                {name}
+                              </Text>
+                            </View>
+                          ))}
+                        </View>
+                      </>
+                    )}
+                  </View>
+                </AnimatedAccordion>
 
-                      <View className="mt-3 flex-row gap-2">
-                        <Pressable
-                          onPress={() =>
-                            setReviewDecisions((prev) => ({
-                              ...prev,
-                              [item.importIndex]: "MERGE",
-                            }))
-                          }
-                          className={`flex-1 rounded-xl px-3 py-2 ${
-                            choice === "MERGE" ? "bg-primary" : "bg-gray-100"
-                          }`}
-                        >
-                          <Text
-                            className={`text-center font-inter-medium text-xs ${
-                              choice === "MERGE" ? "text-white" : "text-gray-700"
-                            }`}
-                          >
-                            Fusionar
+                <View className="mt-3 flex-row gap-3">
+                  <View className="flex-1">
+                    <StatTile
+                      label="Duplicados"
+                      hint="se omiten"
+                      value={preview.autoMerge.length}
+                      tone="brass"
+                      neutral={neutralTheme}
+                      active={reconExpanded === "duplicates"}
+                      onPress={() => toggle("duplicates")}
+                    />
+                  </View>
+                  <View className="flex-1">
+                    <StatTile
+                      label="Ambiguos"
+                      hint="tú eliges"
+                      value={preview.review.length}
+                      tone="alert"
+                      neutral={neutralTheme}
+                      active={reconExpanded === "review"}
+                      onPress={() => toggle("review")}
+                    />
+                  </View>
+                </View>
+
+                <AnimatedAccordion expanded={isRow2} estimatedHeight={1200}>
+                  <View className="mt-3 rounded-xl border border-z-sage-10 bg-z-surface-2 p-4">
+                    {reconExpanded === "duplicates" ? (
+                      preview.autoMerge.length === 0 ? (
+                        <Narrator tone="sage">
+                          Cero duplicados. Todo entra fresh, sin pisarse.
+                        </Narrator>
+                      ) : (
+                        <>
+                          <Text className="font-inter-semibold text-sm text-z-white">
+                            Coincidencias de alta confianza
                           </Text>
-                        </Pressable>
-                        <Pressable
-                          onPress={() =>
-                            setReviewDecisions((prev) => ({
-                              ...prev,
-                              [item.importIndex]: "KEEP_BOTH",
-                            }))
-                          }
-                          className={`flex-1 rounded-xl px-3 py-2 ${
-                            choice === "KEEP_BOTH" ? "bg-gray-900" : "bg-gray-100"
-                          }`}
-                        >
-                          <Text
-                            className={`text-center font-inter-medium text-xs ${
-                              choice === "KEEP_BOTH" ? "text-white" : "text-gray-700"
-                            }`}
-                          >
-                            Mantener ambas
+                          <Text className="mt-1 font-inter-italic text-xs text-z-sage-dark">
+                            Se fusionan automáticamente con movimientos
+                            existentes.
                           </Text>
-                        </Pressable>
-                      </View>
-                    </View>
-                  );
-                })}
-              </View>
-            </View>
-          ) : null}
+                          <View className="mt-3 gap-3">
+                            {preview.autoMerge.map((item) => (
+                              <View
+                                key={`auto-${item.importIndex}`}
+                                className="rounded-xl border border-z-income-30 bg-z-income-12 p-3"
+                              >
+                                <Text className="font-inter-medium text-sm text-z-white">
+                                  {item.transaction.description}
+                                </Text>
+                                <Text className="mt-1 font-inter text-xs text-z-sage-light">
+                                  Se fusiona con{" "}
+                                  {item.candidate.raw_description ??
+                                    item.candidate.merchant_name ??
+                                    "movimiento manual"}
+                                </Text>
+                                <Text className="mt-1 font-inter text-xs text-z-income">
+                                  Score {Math.round(item.score * 100)}%
+                                </Text>
+                              </View>
+                            ))}
+                          </View>
+                        </>
+                      )
+                    ) : preview.review.length === 0 ? (
+                      <Narrator tone="sage">
+                        Sin ambigüedades. Nada que decidir.
+                      </Narrator>
+                    ) : (
+                      <>
+                        <Text className="font-inter-semibold text-sm text-z-white">
+                          Decide caso por caso
+                        </Text>
+                        <Text className="mt-1 font-inter-italic text-xs text-z-sage-dark">
+                          Coincidencias parciales — tú eliges fusionar o
+                          mantener ambas.
+                        </Text>
+                        <View className="mt-3 gap-4">
+                          {preview.review.map((item) => {
+                            const choice =
+                              reviewDecisions[item.importIndex] ?? "KEEP_BOTH";
+                            return (
+                              <View
+                                key={`review-${item.importIndex}`}
+                                className="rounded-xl border border-z-sage-10 p-3"
+                              >
+                                <Text className="font-inter-medium text-sm text-z-white">
+                                  {item.transaction.description}
+                                </Text>
+                                <Text className="mt-1 font-inter text-xs text-z-sage-dark">
+                                  Posible duplicado:{" "}
+                                  {item.candidate.raw_description ??
+                                    item.candidate.merchant_name ??
+                                    "movimiento manual"}
+                                </Text>
+                                <Text className="mt-1 font-inter text-xs text-z-sage-dark">
+                                  Score {Math.round(item.score * 100)}%
+                                </Text>
+
+                                <View className="mt-3 flex-row gap-2">
+                                  <Pressable
+                                    onPress={() =>
+                                      setReviewDecisions((prev) => ({
+                                        ...prev,
+                                        [item.importIndex]: "MERGE",
+                                      }))
+                                    }
+                                    className={`flex-1 rounded-xl px-3 py-2 ${
+                                      choice === "MERGE"
+                                        ? "bg-z-brass"
+                                        : "bg-z-surface-3"
+                                    }`}
+                                  >
+                                    <Text
+                                      className={`text-center font-inter-medium text-xs ${
+                                        choice === "MERGE"
+                                          ? "text-z-ink"
+                                          : "text-z-sage-light"
+                                      }`}
+                                    >
+                                      Fusionar
+                                    </Text>
+                                  </Pressable>
+                                  <Pressable
+                                    onPress={() =>
+                                      setReviewDecisions((prev) => ({
+                                        ...prev,
+                                        [item.importIndex]: "KEEP_BOTH",
+                                      }))
+                                    }
+                                    className={`flex-1 rounded-xl px-3 py-2 ${
+                                      choice === "KEEP_BOTH"
+                                        ? "bg-z-sage-dark"
+                                        : "bg-z-surface-3"
+                                    }`}
+                                  >
+                                    <Text
+                                      className={`text-center font-inter-medium text-xs ${
+                                        choice === "KEEP_BOTH"
+                                          ? "text-z-ink"
+                                          : "text-z-sage-light"
+                                      }`}
+                                    >
+                                      Mantener ambas
+                                    </Text>
+                                  </Pressable>
+                                </View>
+                              </View>
+                            );
+                          })}
+                        </View>
+                      </>
+                    )}
+                  </View>
+                </AnimatedAccordion>
+              </>
+            );
+          })()}
+
+          <Narrator>{narratorLine}</Narrator>
         </ScrollView>
 
-        <View className="absolute bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 flex-row gap-3">
+        <View className="absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 bg-background-92 p-4">
           <Pressable
-            className="flex-1 rounded-lg py-3 items-center border border-gray-300 active:bg-gray-100"
+            accessibilityLabel="Volver al paso anterior"
+            className={`flex-1 items-center rounded-xl py-3 ${GHOST_BUTTON_CLASS}`}
             onPress={() => setStep("review")}
           >
-            <Text className="text-gray-700 font-inter-medium text-sm">
+            <Text className="font-inter-medium text-sm text-z-sage-light">
               Volver
             </Text>
           </Pressable>
           <Pressable
-            className={`flex-1 rounded-lg py-3 items-center ${
-              importing ? "bg-gray-300" : "bg-primary active:bg-primary-dark"
+            accessibilityLabel="Confirmar importación"
+            className={`flex-1 items-center rounded-xl py-3 ${
+              importing
+                ? "bg-z-surface-2"
+                : `${BRASS_BUTTON_CLASS} active:opacity-90`
             }`}
             onPress={handleImport}
             disabled={importing}
           >
             {importing ? (
-              <ActivityIndicator color="#FFFFFF" />
+              <ActivityIndicator color={COLORS.ink} />
             ) : (
-              <Text className="font-inter-bold text-sm text-white">
+              <Text className="font-inter-bold text-sm text-z-ink">
                 Confirmar importación
               </Text>
             )}
           </Pressable>
         </View>
       </View>
+      </ImportThemeProvider>
     );
   }
 
-  // ===== STEP 3: Result =====
+  // ===== STEP 4: Result =====
   return (
-    <View className="flex-1 bg-gray-100 items-center justify-center px-8">
-      <CheckCircle size={64} color="#C5BFAE" />
-      <Text className="text-gray-900 font-inter-bold text-xl mt-6">
-        Importacion exitosa
+    <ImportThemeProvider neutral={neutralTheme}>
+    <View className={`flex-1 items-center justify-center ${inkCls} px-8`} style={{ paddingTop: topInset }}>
+      <View className="absolute left-0 right-0 top-0 px-4 pt-4">
+        <Text className="text-[11px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+          Paso 4 de 4
+        </Text>
+        <View className="mt-3">
+          <ImportProgress step={4} total={4} />
+        </View>
+      </View>
+
+      <CheckCircle size={64} color="#5CB88A" />
+      <Text className="mt-6 font-inter-bold text-xl text-z-white">
+        Importación exitosa
       </Text>
-      <Text className="text-gray-500 font-inter text-base mt-2 text-center">
+      <Text className="mt-2 text-center font-inter text-base text-z-sage-light">
         {importedCount}{" "}
         {importedCount === 1
-          ? "transaccion importada"
+          ? "transacción importada"
           : "transacciones importadas"}
       </Text>
-      <Text className="text-gray-400 font-inter text-sm mt-2 text-center">
+      <Text className="mt-2 text-center font-inter text-sm text-z-sage-dark">
         {importSummary.autoMerged} auto-merge, {importSummary.manualMerged} merge manual,{" "}
         {importSummary.leftAsSeparate} separadas
       </Text>
       {selectedAccount && (
-        <Text className="text-gray-400 font-inter text-sm mt-1">
+        <Text className="mt-1 font-inter text-sm text-z-sage-dark">
           en {selectedAccount.name}
         </Text>
       )}
 
       <Pressable
-        className="bg-primary rounded-lg py-3.5 px-8 mt-8 active:bg-primary-dark"
+        className="mt-8 rounded-xl bg-z-brass px-8 py-3.5 active:opacity-90"
         onPress={() => {
           resetFlow();
           router.navigate("/(tabs)/transactions");
         }}
       >
-        <Text className="text-white font-inter-bold text-base">
+        <Text className="font-inter-bold text-base text-z-ink">
           Ver transacciones
         </Text>
       </Pressable>
 
       <Pressable className="mt-4 py-2" onPress={resetFlow}>
-        <Text className="text-gray-500 font-inter-medium text-sm">
+        <Text className="font-inter-medium text-sm text-z-sage-dark">
           Importar otro extracto
         </Text>
       </Pressable>
     </View>
+    </ImportThemeProvider>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  tone,
+  hint,
+  neutral,
+  active,
+  onPress,
+}: {
+  label: string;
+  value: number;
+  tone: "white" | "brass" | "alert" | "income";
+  hint?: string;
+  neutral: boolean;
+  active?: boolean;
+  onPress?: () => void;
+}) {
+  const surfaceCls = neutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2";
+  const isZero = value === 0;
+  const valueColor = isZero
+    ? "text-z-sage-dark"
+    : tone === "brass"
+      ? "text-z-brass"
+      : tone === "alert"
+        ? "text-z-debt"
+        : tone === "income"
+          ? "text-z-income"
+          : "text-z-white";
+  const borderCls = active ? "border-z-brass" : "border-white-6";
+  const interactive = typeof onPress === "function";
+  const Wrapper: typeof Pressable | typeof View = interactive ? Pressable : View;
+  return (
+    <Wrapper
+      {...(interactive
+        ? {
+            onPress,
+            accessibilityRole: "button" as const,
+            accessibilityState: { expanded: !!active },
+            accessibilityLabel: `Ver ${label.toLowerCase()}`,
+          }
+        : {})}
+      className={`rounded-2xl border ${borderCls} ${surfaceCls} px-4 pt-3.5 pb-4`}
+    >
+      <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+        {label}
+      </Text>
+      <Text
+        className={`mt-1.5 text-[34px] font-inter-bold tabular-nums tracking-tight ${valueColor}`}
+      >
+        {value}
+      </Text>
+      {hint && (
+        <Text className="mt-1 font-inter text-[12px] text-z-sage-dark">
+          {hint}
+        </Text>
+      )}
+    </Wrapper>
   );
 }

--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -252,7 +252,7 @@ function AccountSelector({
             Seleccionar cuenta...
           </Text>
         )}
-        <ChevronDown size={16} color="#938C7E" />
+        <ChevronDown size={16} color={COLORS.sageDark} />
       </Pressable>
 
       {open && (
@@ -263,9 +263,13 @@ function AccountSelector({
             );
             const AIcon = aTypeDef?.icon;
             const aColor = account.color ?? COLORS.sageDark;
+            const isSelected = selected?.id === account.id;
             return (
               <Pressable
                 key={account.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Seleccionar cuenta ${account.name}`}
+                accessibilityState={{ selected: isSelected }}
                 className={`flex-row items-center px-4 py-3 active:bg-z-surface-3 ${
                   index > 0 ? "border-t border-z-sage-10" : ""
                 }`}
@@ -283,8 +287,8 @@ function AccountSelector({
                 <Text className="flex-1 font-inter-medium text-sm text-z-white">
                   {account.name}
                 </Text>
-                {selected?.id === account.id && (
-                  <CheckSquare size={16} color="#937844" />
+                {isSelected && (
+                  <CheckSquare size={16} color={COLORS.brass} />
                 )}
               </Pressable>
             );
@@ -994,7 +998,7 @@ export default function ImportScreen() {
           className="items-center justify-center rounded-2xl border border-z-brass-30 bg-z-brass-8 p-8 active:bg-z-brass-12"
           onPress={handlePickDocument}
         >
-          <Upload size={40} color="#937844" />
+          <Upload size={40} color={COLORS.brass} />
           <Text className="mt-4 font-inter-semibold text-base text-z-white">
             Seleccionar extracto PDF
           </Text>
@@ -1006,7 +1010,7 @@ export default function ImportScreen() {
         {document && (
           <View className="mt-4 rounded-2xl border border-z-sage-10 bg-z-surface-2 p-4">
             <View className="flex-row items-center">
-              <FileText size={20} color="#937844" />
+              <FileText size={20} color={COLORS.brass} />
               <View className="ml-3 flex-1">
                 <Text
                   className="font-inter-medium text-sm text-z-white"
@@ -1030,7 +1034,7 @@ export default function ImportScreen() {
                 value={password}
                 onChangeText={setPassword}
                 placeholder="Si el extracto está cifrado, ingrésala aquí"
-                placeholderTextColor="#938C7E"
+                placeholderTextColor={COLORS.sageDark}
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -1055,6 +1059,7 @@ export default function ImportScreen() {
                     {savedPdfPasswords.map((entry) => (
                       <Pressable
                         key={entry.accountId}
+                        accessibilityRole="button"
                         accessibilityLabel={`Usar contraseña guardada de ${entry.accountName}`}
                         onPress={() => setPassword(entry.password)}
                         className="rounded-full border border-z-income-30 bg-z-income-12 px-3 py-1.5 active:bg-z-income-20"
@@ -1072,6 +1077,7 @@ export default function ImportScreen() {
         )}
 
         <Pressable
+          accessibilityRole="button"
           accessibilityLabel="Procesar extracto"
           className={`mt-6 items-center rounded-xl py-3.5 ${
             document ? `${BRASS_BUTTON_CLASS} active:opacity-90` : "bg-z-surface-2"
@@ -1131,6 +1137,7 @@ export default function ImportScreen() {
         {/* Bottom buttons */}
         <View className={`absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 ${actionBarCls} p-4`}>
           <Pressable
+            accessibilityRole="button"
             accessibilityLabel="Cancelar importación"
             className={`flex-1 items-center rounded-xl py-3 ${GHOST_BUTTON_CLASS}`}
             onPress={resetFlow}
@@ -1140,6 +1147,7 @@ export default function ImportScreen() {
             </Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
             accessibilityLabel="Continuar a reconciliación"
             className={`flex-1 items-center rounded-xl py-3 ${
               canImport
@@ -1489,6 +1497,7 @@ export default function ImportScreen() {
 
         <View className={`absolute bottom-0 left-0 right-0 flex-row gap-3 border-t border-white-6 ${actionBarCls} p-4`}>
           <Pressable
+            accessibilityRole="button"
             accessibilityLabel="Volver al paso anterior"
             className={`flex-1 items-center rounded-xl py-3 ${GHOST_BUTTON_CLASS}`}
             onPress={() => setStep("review")}
@@ -1498,7 +1507,8 @@ export default function ImportScreen() {
             </Text>
           </Pressable>
           <Pressable
-            accessibilityLabel="Confirmar importación"
+            accessibilityRole="button"
+            accessibilityLabel={`Confirmar importación de ${selected.size} movimiento${selected.size === 1 ? "" : "s"}`}
             className={`flex-1 items-center rounded-xl py-3 ${
               importing
                 ? "bg-z-surface-2"
@@ -1511,7 +1521,8 @@ export default function ImportScreen() {
               <ActivityIndicator color={COLORS.ink} />
             ) : (
               <Text className="font-inter-bold text-sm text-z-ink">
-                Confirmar importación
+                Confirmar {selected.size}{" "}
+                {selected.size === 1 ? "movimiento" : "movimientos"}
               </Text>
             )}
           </Pressable>
@@ -1534,7 +1545,7 @@ export default function ImportScreen() {
         </View>
       </View>
 
-      <CheckCircle size={64} color="#5CB88A" />
+      <CheckCircle size={64} color={COLORS.income} />
       <Text className="mt-6 font-inter-bold text-xl text-z-white">
         Importación exitosa
       </Text>
@@ -1545,7 +1556,8 @@ export default function ImportScreen() {
           : "transacciones importadas"}
       </Text>
       <Text className="mt-2 text-center font-inter text-sm text-z-sage-dark">
-        {importSummary.autoMerged} auto-merge, {importSummary.manualMerged} merge manual,{" "}
+        {importSummary.autoMerged} fusionadas automáticamente ·{" "}
+        {importSummary.manualMerged} fusionadas manualmente ·{" "}
         {importSummary.leftAsSeparate} separadas
       </Text>
       {selectedAccount && (
@@ -1567,6 +1579,36 @@ export default function ImportScreen() {
           Ver transacciones
         </Text>
       </Pressable>
+
+      {(() => {
+        const newMerchantCount = reconciliationPreview
+          ? new Set(
+              reconciliationPreview.unmatched
+                .map((i) => i.transaction.description)
+                .filter(
+                  (s): s is string => typeof s === "string" && s.length > 0,
+                ),
+            ).size
+          : 0;
+        if (newMerchantCount === 0) return null;
+        return (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Revisar ${newMerchantCount} destinatarios sugeridos`}
+            className="mt-4 py-2"
+            onPress={() => {
+              resetFlow();
+              router.navigate("/(tabs)/destinatarios" as never);
+            }}
+          >
+            <Text className="font-inter-medium text-sm text-z-brass">
+              Revisar {newMerchantCount} destinatario
+              {newMerchantCount === 1 ? "" : "s"} nuevo
+              {newMerchantCount === 1 ? "" : "s"}
+            </Text>
+          </Pressable>
+        );
+      })()}
 
       <Pressable
         accessibilityRole="button"

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -322,7 +322,7 @@ export default function SettingsScreen() {
           icon={
             <RefreshCw
               size={18}
-              color={status === "error" ? "#EF4444" : "#938C7E"}
+              color={status === "error" ? COLORS.debt : COLORS.sageDark}
             />
           }
           label="Estado"
@@ -340,7 +340,7 @@ export default function SettingsScreen() {
           onPress={handleSyncNow}
           disabled={syncing}
         >
-          <RefreshCw size={18} color="#C5BFAE" />
+          <RefreshCw size={18} color={COLORS.sageLight} />
           <Text className="ml-3 text-primary font-inter-bold text-sm">
             {syncing ? "Sincronizando..." : "Sincronizar ahora"}
           </Text>
@@ -423,9 +423,9 @@ export default function SettingsScreen() {
               <Switch
                 value={biometricsOn}
                 onValueChange={handleToggleBiometrics}
-                trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                trackColor={{ false: COLORS.switchTrack, true: COLORS.income }}
                 thumbColor={COLORS.foreground}
-                ios_backgroundColor="#3A3A3A"
+                ios_backgroundColor={COLORS.switchTrack}
               />
             </View>
             {biometricsOn && (
@@ -441,9 +441,9 @@ export default function SettingsScreen() {
                   <Switch
                     value={bgReauthOn}
                     onValueChange={handleToggleBgReauth}
-                    trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                    trackColor={{ false: COLORS.switchTrack, true: COLORS.income }}
                     thumbColor={COLORS.foreground}
-                    ios_backgroundColor="#3A3A3A"
+                    ios_backgroundColor={COLORS.switchTrack}
                   />
                 </View>
               </>

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -36,7 +36,7 @@ import { COLORS } from "../../lib/constants/colors";
 
 function SectionHeader({ title }: { title: string }) {
   return (
-    <Text className="text-muted-foreground font-inter-semibold text-xs uppercase px-4 pt-5 pb-2">
+    <Text className="text-z-sage-dark font-inter-semibold text-xs uppercase px-4 pt-5 pb-2">
       {title}
     </Text>
   );

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -31,12 +31,70 @@ import { useAuth } from "../../lib/auth";
 import { supabase } from "../../lib/supabase";
 import { clearDatabase, getDatabase } from "../../lib/db/database";
 import { disableDemoMode } from "../../lib/demo-mode";
+import { useTheme, type ThemeMode } from "../../lib/theme";
+import { COLORS } from "../../lib/constants/colors";
 
 function SectionHeader({ title }: { title: string }) {
   return (
     <Text className="text-muted-foreground font-inter-semibold text-xs uppercase px-4 pt-5 pb-2">
       {title}
     </Text>
+  );
+}
+
+function ThemeSelector() {
+  const { mode, setMode } = useTheme();
+  const options: Array<{
+    id: ThemeMode;
+    label: string;
+    blurb: string;
+    swatch: string;
+  }> = [
+    { id: "sage", label: "Sage", blurb: "Verde cálido (actual)", swatch: "#1E221E" },
+    { id: "neutral", label: "Neutral", blurb: "Gris oscuro sin tinte", swatch: "#18181b" },
+  ];
+  return (
+    <View className="px-4 py-3">
+      <View className="flex-row gap-2.5">
+        {options.map((opt) => {
+          const selected = opt.id === mode;
+          return (
+            <Pressable
+              key={opt.id}
+              onPress={() => setMode(opt.id)}
+              accessibilityRole="radio"
+              accessibilityState={{ selected }}
+              accessibilityLabel={`Tema ${opt.label}`}
+              className={`flex-1 rounded-xl border px-3 py-3 ${
+                selected
+                  ? "border-z-brass bg-z-brass-8"
+                  : "border-white-6 bg-z-surface-3"
+              }`}
+            >
+              <View className="flex-row items-center gap-2">
+                <View
+                  style={{ backgroundColor: opt.swatch }}
+                  className="h-5 w-5 rounded-full border border-white-10"
+                />
+                <Text
+                  className={`font-inter-semibold text-sm ${
+                    selected ? "text-z-brass" : "text-z-white"
+                  }`}
+                >
+                  {opt.label}
+                </Text>
+              </View>
+              <Text className="mt-1 font-inter text-[11px] text-z-sage-dark">
+                {opt.blurb}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <Text className="mt-3 font-inter-italic text-[11px] text-z-sage-dark">
+        Más temas en camino — incluido uno claro.
+      </Text>
+    </View>
   );
 }
 
@@ -230,8 +288,11 @@ export default function SettingsScreen() {
         ? "Error de sincronizacion"
         : "Sincronizado";
 
+  const { mode: themeMode } = useTheme();
+  const inkCls = themeMode === "neutral" ? "bg-z-ink-neutral" : "bg-background";
+
   return (
-    <ScrollView className="flex-1 bg-background">
+    <ScrollView className={`flex-1 ${inkCls}`}>
       {/* Profile section */}
       <SectionHeader title="Perfil" />
       <View className="bg-z-surface-2-55">
@@ -309,6 +370,12 @@ export default function SettingsScreen() {
             </Pressable>
           </>
         )}
+      </View>
+
+      {/* Appearance section */}
+      <SectionHeader title="Apariencia" />
+      <View className="bg-z-surface-2-55">
+        <ThemeSelector />
       </View>
 
       {/* Accounts section */}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -8,10 +8,13 @@ import {
 import { useFonts } from "expo-font";
 import {
   Inter_400Regular,
+  Inter_400Regular_Italic,
   Inter_500Medium,
+  Inter_500Medium_Italic,
   Inter_600SemiBold,
   Inter_700Bold,
 } from "@expo-google-fonts/inter";
+import { Kalam_700Bold } from "@expo-google-fonts/kalam";
 import { Stack, useRootNavigationState, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -30,6 +33,7 @@ import {
   isBackgroundReauthEnabled,
 } from "../lib/biometrics";
 import { BiometricLockScreen } from "../components/common/BiometricLockScreen";
+import { ZetaThemeProvider } from "../lib/theme";
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -48,9 +52,12 @@ export default function RootLayout() {
   const [loaded, error] = useFonts({
     ...FontAwesome.font,
     Inter_400Regular,
+    Inter_400Regular_Italic,
     Inter_500Medium,
+    Inter_500Medium_Italic,
     Inter_600SemiBold,
     Inter_700Bold,
+    Kalam_700Bold,
   });
 
   useEffect(() => {
@@ -206,6 +213,7 @@ function RootLayoutNav() {
 
   return (
     <SafeAreaProvider>
+      <ZetaThemeProvider>
       <ThemeProvider value={DarkTheme}>
         <BugReportViewShot>
           <Stack>
@@ -311,6 +319,7 @@ function RootLayoutNav() {
           </View>
         )}
       </ThemeProvider>
+      </ZetaThemeProvider>
     </SafeAreaProvider>
   );
 }

--- a/mobile/components/common/Narrator.tsx
+++ b/mobile/components/common/Narrator.tsx
@@ -1,0 +1,29 @@
+import { View, Text } from "react-native";
+
+type Props = {
+  children: string;
+  tone?: "brass" | "sage";
+  spacing?: "default" | "tight";
+};
+
+/**
+ * Narrator — handwritten-voice annotation.
+ * For conversational, low-stakes guidance: "Sin sorpresas, dale.", "1 ambiguo — son solo unos toques."
+ * Never for errors or critical copy.
+ *
+ * Visually: centered, brighter than surrounding copy, off-rhythm from the grid.
+ * Should read as if someone scribbled a note in the margin — intentional, not shy.
+ */
+export function Narrator({ children, tone = "brass", spacing = "default" }: Props) {
+  const color = tone === "sage" ? "text-z-sage-light" : "text-z-brass";
+  const mtCls = spacing === "tight" ? "mt-4" : "mt-8";
+  return (
+    <View className={`${mtCls} items-center px-4`}>
+      <Text
+        className={`text-center font-narrator text-[24px] leading-[30px] ${color}`}
+      >
+        {children}
+      </Text>
+    </View>
+  );
+}

--- a/mobile/components/import/CreditCardStackCard.tsx
+++ b/mobile/components/import/CreditCardStackCard.tsx
@@ -1,0 +1,246 @@
+import { useMemo, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { ChevronDown } from "lucide-react-native";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
+import { projectMinimumPayoff12mo } from "../../lib/utils/cc-projection";
+import { useImportTheme } from "./import-theme";
+
+type CreditCardMetadata = {
+  credit_limit: number | null;
+  available_credit: number | null;
+  interest_rate: number | null;
+  late_interest_rate: number | null;
+  total_payment_due: number | null;
+  minimum_payment: number | null;
+  payment_due_date: string | null;
+};
+
+type StatementSummary = {
+  previous_balance: number | null;
+  total_credits: number | null;
+  total_debits: number | null;
+  final_balance: number | null;
+  purchases_and_charges: number | null;
+  interest_charged: number | null;
+};
+
+type Props = {
+  currency: CurrencyCode;
+  metadata: CreditCardMetadata;
+  summary: StatementSummary | null;
+  transactionCount: number;
+  active?: boolean;
+  onPress?: () => void;
+};
+
+function compactAmount(value: number, currency: CurrencyCode): string {
+  if (currency !== "COP") return formatCurrency(value, currency);
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  if (abs >= 1_000_000) {
+    const m = abs / 1_000_000;
+    return `${sign}$ ${m.toFixed(m < 10 ? 2 : 1)}m`;
+  }
+  if (abs >= 1_000) return `${sign}$ ${Math.round(abs / 1_000)}k`;
+  return `${sign}$ ${Math.round(abs)}`;
+}
+
+export function CreditCardStackCard({
+  currency,
+  metadata,
+  summary,
+  transactionCount,
+  active = false,
+  onPress,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  const balance = metadata.total_payment_due;
+  const minPayment = metadata.minimum_payment;
+  const interestRateEA = metadata.interest_rate;
+  const dueDate = metadata.payment_due_date;
+
+  const projection = useMemo(
+    () =>
+      balance != null && interestRateEA != null && minPayment != null
+        ? projectMinimumPayoff12mo(balance, interestRateEA / 100, minPayment)
+        : null,
+    [balance, interestRateEA, minPayment],
+  );
+
+  const { neutral } = useImportTheme();
+  const borderCls = active ? "border-z-brass" : "border-white-6";
+  const bgCls = active
+    ? "bg-z-brass-8"
+    : neutral
+      ? "bg-z-surface-2-neutral"
+      : "bg-z-surface-2";
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Ver movimientos en ${currency}`}
+      className={`mb-2 rounded-2xl border ${borderCls} ${bgCls} p-3.5`}
+    >
+      <View className="flex-row items-center justify-between">
+        <Text className="text-[11px] font-inter-bold uppercase tracking-[0.18em] text-z-brass">
+          {currency}
+        </Text>
+        {dueDate && (
+          <Text className="text-xs font-inter-semibold text-z-debt">
+            Vence {formatDate(dueDate, "d MMM")}
+          </Text>
+        )}
+      </View>
+
+      <View className="mt-2 flex-row items-end gap-3">
+        <View className="flex-1">
+          <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            Saldo
+          </Text>
+          <Text className="mt-0.5 text-[22px] font-inter-bold tracking-tight text-z-white">
+            {balance != null ? formatCurrency(balance, currency) : "—"}
+          </Text>
+        </View>
+        {minPayment != null && (
+          <>
+            <View className="h-10 w-px self-center bg-z-sage-10" />
+            <View className="flex-1">
+              <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+                Pago mínimo
+              </Text>
+              <Text className="mt-0.5 text-[22px] font-inter-bold tracking-tight text-z-brass">
+                {formatCurrency(minPayment, currency)}
+              </Text>
+            </View>
+          </>
+        )}
+      </View>
+
+      {interestRateEA != null && (
+        <Text className="mt-1.5 text-[11px] font-inter text-z-sage-dark">
+          Tasa {interestRateEA.toFixed(2)}% E.A.
+        </Text>
+      )}
+
+      {projection && (
+        <View className="mt-2.5 border-t border-z-sage-10 pt-2.5">
+          {projection.growing ? (
+            <Text className="font-inter-italic text-[11px] text-z-debt">
+              El mínimo no cubre intereses — saldo crecería.
+            </Text>
+          ) : (
+            <Text className="font-inter-italic text-[11px] text-z-brass">
+              Con mínimo:{" "}
+              <Text className="font-inter-bold not-italic text-z-alert">
+                {compactAmount(projection.interestAccrued, currency)}
+              </Text>{" "}
+              en intereses 12 meses · queda{" "}
+              <Text className="font-inter-semibold not-italic text-z-sage-light">
+                {compactAmount(projection.remainingBalance, currency)}
+              </Text>
+            </Text>
+          )}
+        </View>
+      )}
+
+      <Pressable
+        onPress={() => setExpanded((v) => !v)}
+        accessibilityRole="button"
+        accessibilityLabel={expanded ? "Ocultar detalles" : "Ver detalles"}
+        className="mt-2.5 flex-row items-center gap-1 self-start"
+      >
+        <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          {expanded ? "Ocultar detalles" : "Ver detalles"}
+        </Text>
+        <View style={{ transform: [{ rotate: expanded ? "180deg" : "0deg" }] }}>
+          <ChevronDown size={12} color={COLORS.sageDark} />
+        </View>
+      </Pressable>
+
+      {expanded && (
+        <View className="mt-2.5 gap-1.5 border-t border-z-sage-10 pt-2.5">
+          <DetailRow
+            label="Cupo total"
+            value={
+              metadata.credit_limit != null
+                ? formatCurrency(metadata.credit_limit, currency)
+                : null
+            }
+          />
+          <DetailRow
+            label="Cupo disponible"
+            value={
+              metadata.available_credit != null
+                ? formatCurrency(metadata.available_credit, currency)
+                : null
+            }
+          />
+          <DetailRow
+            label="Tasa moratoria"
+            value={
+              metadata.late_interest_rate != null
+                ? `${metadata.late_interest_rate.toFixed(2)}% E.A.`
+                : null
+            }
+          />
+          <DetailRow
+            label="Saldo anterior"
+            value={
+              summary?.previous_balance != null
+                ? formatCurrency(summary.previous_balance, currency)
+                : null
+            }
+          />
+          <DetailRow
+            label="Compras y cargos"
+            value={
+              summary?.purchases_and_charges != null
+                ? formatCurrency(summary.purchases_and_charges, currency)
+                : null
+            }
+          />
+          <DetailRow
+            label="Abonos"
+            value={
+              summary?.total_credits != null
+                ? formatCurrency(summary.total_credits, currency)
+                : null
+            }
+          />
+          <DetailRow
+            label="Intereses del mes"
+            value={
+              summary?.interest_charged != null
+                ? formatCurrency(summary.interest_charged, currency)
+                : null
+            }
+          />
+          <DetailRow
+            label="Saldo final"
+            value={
+              summary?.final_balance != null
+                ? formatCurrency(summary.final_balance, currency)
+                : null
+            }
+          />
+          <DetailRow label="Movimientos" value={String(transactionCount)} />
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string | null }) {
+  if (value == null) return null;
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-[11px] font-inter text-z-sage-dark">{label}</Text>
+      <Text className="text-[12px] font-inter-semibold text-z-sage-light">
+        {value}
+      </Text>
+    </View>
+  );
+}

--- a/mobile/components/import/CreditCardStackCard.tsx
+++ b/mobile/components/import/CreditCardStackCard.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from "lucide-react-native";
 import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
 import { COLORS } from "../../lib/constants/colors";
 import { projectMinimumPayoff12mo } from "../../lib/utils/cc-projection";
+import { AnimatedAccordion } from "../ui/AnimatedAccordion";
 import { useImportTheme } from "./import-theme";
 
 type CreditCardMetadata = {
@@ -160,7 +161,7 @@ export function CreditCardStackCard({
         </View>
       </Pressable>
 
-      {expanded && (
+      <AnimatedAccordion expanded={expanded} estimatedHeight={320}>
         <View className="mt-2.5 gap-1.5 border-t border-z-sage-10 pt-2.5">
           <DetailRow
             label="Cupo total"
@@ -228,7 +229,7 @@ export function CreditCardStackCard({
           />
           <DetailRow label="Movimientos" value={String(transactionCount)} />
         </View>
-      )}
+      </AnimatedAccordion>
     </Pressable>
   );
 }

--- a/mobile/components/import/CreditCardSummary.tsx
+++ b/mobile/components/import/CreditCardSummary.tsx
@@ -1,0 +1,271 @@
+import { useMemo } from "react";
+import { View, Text } from "react-native";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import { projectMinimumPayoff12mo } from "../../lib/utils/cc-projection";
+import { useImportTheme } from "./import-theme";
+
+type CreditCardMetadata = {
+  credit_limit: number | null;
+  available_credit: number | null;
+  interest_rate: number | null;
+  late_interest_rate: number | null;
+  total_payment_due: number | null;
+  minimum_payment: number | null;
+  payment_due_date: string | null;
+};
+
+type StatementSummary = {
+  previous_balance: number | null;
+  total_credits: number | null;
+  total_debits: number | null;
+  final_balance: number | null;
+  purchases_and_charges: number | null;
+  interest_charged: number | null;
+};
+
+type Props = {
+  metadata: CreditCardMetadata;
+  summary: StatementSummary | null;
+  transactionCount: number;
+  currency: CurrencyCode;
+};
+
+/**
+ * Compact currency formatter for projection stats.
+ * $1.420.800 → "$ 1.42m", $492.000 → "$ 492k", $340 → "$ 340".
+ * COP-only compacting — other currencies fall back to formatCurrency.
+ */
+function compactAmount(value: number, currency: CurrencyCode): string {
+  if (currency !== "COP") return formatCurrency(value, currency);
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  if (abs >= 1_000_000) {
+    const m = abs / 1_000_000;
+    return `${sign}$ ${m.toFixed(m < 10 ? 2 : 1)}m`;
+  }
+  if (abs >= 1_000) {
+    return `${sign}$ ${Math.round(abs / 1_000)}k`;
+  }
+  return `${sign}$ ${Math.round(abs)}`;
+}
+
+/**
+ * Whole-calendar-day difference between today and a "YYYY-MM-DD" string.
+ * Treats both as local-timezone dates (Colombia UTC-5), not UTC midnight.
+ */
+function daysUntil(iso: string): number | null {
+  const match = iso.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return null;
+  const target = new Date(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+  );
+  target.setHours(0, 0, 0, 0);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const MS_PER_DAY = 1000 * 60 * 60 * 24;
+  return Math.round((target.getTime() - today.getTime()) / MS_PER_DAY);
+}
+
+export function CreditCardSummary({
+  metadata,
+  summary,
+  transactionCount,
+  currency,
+}: Props) {
+  const { neutral } = useImportTheme();
+  const surface2Cls = neutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2";
+  const surface3Cls = neutral ? "bg-z-surface-3-neutral" : "bg-z-surface-3";
+
+  const balance = metadata.total_payment_due;
+  const dueDate = metadata.payment_due_date;
+  const minPayment = metadata.minimum_payment;
+  const interestRateEA = metadata.interest_rate;
+
+  const projection = useMemo(
+    () =>
+      balance != null && interestRateEA != null && minPayment != null
+        ? projectMinimumPayoff12mo(balance, interestRateEA / 100, minPayment)
+        : null,
+    [balance, interestRateEA, minPayment],
+  );
+
+  const days = useMemo(() => (dueDate ? daysUntil(dueDate) : null), [dueDate]);
+  const daysLabel =
+    days == null
+      ? null
+      : days < 0
+        ? `${Math.abs(days)} días tarde`
+        : days === 0
+          ? "hoy"
+          : `${days} día${days === 1 ? "" : "s"}`;
+
+  const spent = summary?.purchases_and_charges ?? null;
+  const paid = summary?.total_credits ?? null;
+  const hasPeriodData = spent != null || paid != null || transactionCount > 0;
+
+  return (
+    <View>
+      {/* DUE NOW card */}
+      <View className={`rounded-2xl border border-white-6 ${surface2Cls} p-4`}>
+        <View className="flex-row items-start justify-between gap-3">
+          <View className="flex-1">
+            <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+              Saldo total
+            </Text>
+            <Text className="mt-1 text-[28px] font-inter-bold text-z-white tracking-tight">
+              {balance != null ? formatCurrency(balance, currency) : "—"}
+            </Text>
+          </View>
+          {dueDate && (
+            <View className="items-end">
+              <Text className="text-[10px] font-inter-semibold uppercase text-z-debt tracking-[0.18em]">
+                Vence
+              </Text>
+              <Text className="mt-1 text-xl font-inter-semibold text-z-debt">
+                {formatDate(dueDate, "d MMM")}
+              </Text>
+              {daysLabel && (
+                <Text className="mt-0.5 text-[11px] font-inter text-z-sage-dark">
+                  {daysLabel}
+                </Text>
+              )}
+            </View>
+          )}
+        </View>
+
+        {(minPayment != null || interestRateEA != null) && (
+          <View className="mt-3.5 flex-row gap-2">
+            <View className={`flex-1 rounded-xl border border-white-6 ${surface3Cls} px-3 py-2.5`}>
+              <Text className="text-[9px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+                Pago mínimo
+              </Text>
+              <Text className="mt-1 text-lg font-inter-bold text-z-brass tracking-tight">
+                {minPayment != null ? formatCurrency(minPayment, currency) : "—"}
+              </Text>
+            </View>
+            <View className={`flex-1 rounded-xl border border-white-6 ${surface3Cls} px-3 py-2.5`}>
+              <Text className="text-[9px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+                Tasa
+              </Text>
+              <Text className="mt-1 text-lg font-inter-bold text-z-white tracking-tight">
+                {interestRateEA != null
+                  ? `${interestRateEA.toFixed(2)}`
+                  : "—"}
+                {interestRateEA != null && (
+                  <Text className="text-xs font-inter-medium text-z-sage-dark">
+                    {" "}
+                    %&nbsp;E.A.
+                  </Text>
+                )}
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {projection && (
+          <View className="mt-3.5 rounded-xl border border-z-brass-30 bg-z-brass-6 px-4 py-3">
+            <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+              Si pagas solo el mínimo
+            </Text>
+
+            {projection.growing ? (
+              <>
+                <Text className="mt-2.5 font-inter-medium-italic text-sm text-z-debt">
+                  El mínimo no cubre los intereses.
+                </Text>
+                <Text className="mt-1 font-inter-italic text-xs text-z-brass">
+                  El saldo crecería cada mes. Paga más para empezar a reducirlo.
+                </Text>
+              </>
+            ) : (
+              <>
+                <View className="mt-2.5 flex-row items-end gap-4">
+                  <View className="flex-1">
+                    <Text className="text-[22px] font-inter-bold text-z-white tracking-tight">
+                      {projection.months} meses
+                    </Text>
+                    <Text className="mt-1 font-inter-italic text-xs text-z-brass">
+                      aún pagando
+                    </Text>
+                  </View>
+                  <View className="w-px self-stretch bg-z-brass-25" />
+                  <View className="flex-1">
+                    <Text className="text-[22px] font-inter-bold text-z-alert tracking-tight">
+                      {compactAmount(projection.interestAccrued, currency)}
+                    </Text>
+                    <Text className="mt-1 font-inter-italic text-xs text-z-brass">
+                      en intereses
+                    </Text>
+                  </View>
+                </View>
+                <View className="mt-2.5 border-t border-z-brass-20 pt-2.5">
+                  <Text className="font-inter-italic text-xs text-z-brass">
+                    Quedarían{" "}
+                    <Text className="font-inter-semibold text-z-sage-light">
+                      {compactAmount(projection.remainingBalance, currency)}
+                    </Text>{" "}
+                    de saldo en deuda.
+                  </Text>
+                </View>
+              </>
+            )}
+          </View>
+        )}
+      </View>
+
+      {/* THIS PERIOD tiles */}
+      {hasPeriodData && (
+        <View className="mt-4 flex-row gap-2">
+          <PeriodTile
+            label="Gastos"
+            value={spent != null ? compactAmount(spent, currency) : "—"}
+            tone="spent"
+          />
+          <PeriodTile
+            label="Abonos"
+            value={paid != null ? compactAmount(paid, currency) : "—"}
+            tone="paid"
+          />
+          <PeriodTile
+            label="Movs"
+            value={String(transactionCount)}
+            tone="txns"
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function PeriodTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: "spent" | "paid" | "txns";
+}) {
+  const { neutral } = useImportTheme();
+  const surfaceCls = neutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2";
+  const valueClass =
+    tone === "spent"
+      ? "text-z-debt"
+      : tone === "paid"
+        ? "text-z-income"
+        : "text-z-white";
+  return (
+    <View className={`flex-1 rounded-xl border border-white-6 ${surfaceCls} p-3`}>
+      <Text className="text-[9px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+        {label}
+      </Text>
+      <Text
+        className={`mt-1.5 text-xl font-inter-bold tracking-tight ${valueClass}`}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}

--- a/mobile/components/import/ImportProgress.tsx
+++ b/mobile/components/import/ImportProgress.tsx
@@ -1,0 +1,23 @@
+import { View } from "react-native";
+
+type Props = {
+  /** 1-indexed current step */
+  step: number;
+  /** Total number of steps */
+  total: number;
+};
+
+export function ImportProgress({ step, total }: Props) {
+  return (
+    <View className="flex-row gap-1">
+      {Array.from({ length: total }).map((_, i) => (
+        <View
+          key={i}
+          className={`h-[3px] flex-1 rounded-full ${
+            i < step ? "bg-z-brass" : "bg-z-sage-10"
+          }`}
+        />
+      ))}
+    </View>
+  );
+}

--- a/mobile/components/import/SectionDivider.tsx
+++ b/mobile/components/import/SectionDivider.tsx
@@ -1,0 +1,15 @@
+import { View, Text } from "react-native";
+
+type Props = { label: string };
+
+export function SectionDivider({ label }: Props) {
+  return (
+    <View className="my-3 flex-row items-center gap-3">
+      <View className="h-px flex-1 bg-z-sage-10" />
+      <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+        {label}
+      </Text>
+      <View className="h-px flex-1 bg-z-sage-10" />
+    </View>
+  );
+}

--- a/mobile/components/import/StatementChip.tsx
+++ b/mobile/components/import/StatementChip.tsx
@@ -1,0 +1,53 @@
+import { View, Text } from "react-native";
+import { formatDate } from "@zeta/shared";
+
+type Props = {
+  bank: string;
+  cardLastFour?: string | null;
+  accountNumber?: string | null;
+  periodFrom?: string | null;
+  periodTo?: string | null;
+};
+
+function buildTitle(
+  bank: string,
+  cardLastFour?: string | null,
+  accountNumber?: string | null,
+): string {
+  const bankLabel = bank.toUpperCase();
+  if (cardLastFour) return `${bankLabel} · ••${cardLastFour}`;
+  if (accountNumber) return `${bankLabel} · ${accountNumber}`;
+  return bankLabel;
+}
+
+function formatPeriod(from?: string | null, to?: string | null): string | null {
+  if (!from && !to) return null;
+  if (from && to) return `${formatDate(from, "d MMM")} – ${formatDate(to, "d MMM yyyy")}`;
+  if (from) return `Desde ${formatDate(from, "d MMM yyyy")}`;
+  if (to) return `Hasta ${formatDate(to!, "d MMM yyyy")}`;
+  return null;
+}
+
+export function StatementChip({
+  bank,
+  cardLastFour,
+  accountNumber,
+  periodFrom,
+  periodTo,
+}: Props) {
+  const title = buildTitle(bank, cardLastFour, accountNumber);
+  const period = formatPeriod(periodFrom, periodTo);
+
+  return (
+    <View className="rounded-xl border border-z-brass-25 bg-z-brass-8 px-4 py-2.5">
+      <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+        {title}
+      </Text>
+      {period && (
+        <Text className="mt-0.5 text-xs font-inter text-z-sage-light">
+          {period}
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/mobile/components/import/import-theme.tsx
+++ b/mobile/components/import/import-theme.tsx
@@ -1,0 +1,32 @@
+import { useTheme } from "../../lib/theme";
+
+/**
+ * Back-compat shim — import screens originally had their own context.
+ * Now delegates to the global theme so the Settings toggle can drive it.
+ */
+export function useImportTheme(): { neutral: boolean } {
+  const { mode } = useTheme();
+  return { neutral: mode === "neutral" };
+}
+
+/**
+ * No-op provider kept so existing screen wrappers don't break during the
+ * migration. The global ZetaThemeProvider in _layout is the real source.
+ */
+export function ImportThemeProvider({
+  children,
+}: {
+  neutral?: boolean;
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}
+
+export function themeClasses(neutral: boolean) {
+  return {
+    ink: neutral ? "bg-z-ink-neutral" : "bg-z-ink",
+    surface1: neutral ? "bg-z-surface-neutral" : "bg-z-surface",
+    surface2: neutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2",
+    surface3: neutral ? "bg-z-surface-3-neutral" : "bg-z-surface-3",
+  };
+}

--- a/mobile/components/ui/ExpandableStatTile.tsx
+++ b/mobile/components/ui/ExpandableStatTile.tsx
@@ -1,0 +1,80 @@
+import { Pressable, Text, View } from "react-native";
+import type { ReactNode } from "react";
+
+export type StatTone = "white" | "brass" | "alert" | "income" | "debt";
+
+type Props = {
+  label: string;
+  /** Already-formatted value (number, currency, string, or custom node). */
+  value: ReactNode;
+  hint?: string;
+  tone?: StatTone;
+  /** Override dim detection. When value is a number === 0 it dims automatically. */
+  dim?: boolean;
+  /** When true, swap surface to the neutral-theme variant. */
+  neutral?: boolean;
+  /** Brass-highlight border when expanded. */
+  active?: boolean;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+};
+
+const toneClass: Record<StatTone, string> = {
+  white: "text-z-white",
+  brass: "text-z-brass",
+  alert: "text-z-debt",
+  income: "text-z-income",
+  debt: "text-z-debt",
+};
+
+/**
+ * Interactive stat tile used across surfaces where a metric expands a detail
+ * panel (import reconcile grid, dashboard "Gasto hoy", etc.). Pair with
+ * <AnimatedAccordion> for the expansion; this component only renders the tile.
+ */
+export function ExpandableStatTile({
+  label,
+  value,
+  hint,
+  tone = "white",
+  dim,
+  neutral = false,
+  active = false,
+  onPress,
+  accessibilityLabel,
+}: Props) {
+  const surfaceCls = neutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2";
+  const isDim = dim ?? (typeof value === "number" && value === 0);
+  const valueColor = isDim ? "text-z-sage-dark" : toneClass[tone];
+  const borderCls = active ? "border-z-brass" : "border-white-6";
+  const interactive = typeof onPress === "function";
+  const Wrapper = interactive ? Pressable : View;
+  return (
+    <Wrapper
+      {...(interactive
+        ? {
+            onPress,
+            accessibilityRole: "button" as const,
+            accessibilityState: { expanded: active },
+            accessibilityLabel:
+              accessibilityLabel ?? `Ver ${label.toLowerCase()}`,
+          }
+        : {})}
+      className={`rounded-2xl border ${borderCls} ${surfaceCls} px-4 pt-3.5 pb-4`}
+    >
+      <Text className="text-[10px] font-inter-semibold uppercase text-z-sage-dark tracking-[0.18em]">
+        {label}
+      </Text>
+      <Text
+        className={`mt-1.5 text-[34px] font-inter-bold tabular-nums tracking-tight ${valueColor}`}
+      >
+        {value}
+      </Text>
+      {hint && (
+        <Text className="mt-1 font-inter text-[12px] text-z-sage-dark">
+          {hint}
+        </Text>
+      )}
+    </Wrapper>
+  );
+}

--- a/mobile/components/ui/ExpandableStatTile.tsx
+++ b/mobile/components/ui/ExpandableStatTile.tsx
@@ -22,7 +22,7 @@ type Props = {
 const toneClass: Record<StatTone, string> = {
   white: "text-z-white",
   brass: "text-z-brass",
-  alert: "text-z-debt",
+  alert: "text-z-alert",
   income: "text-z-income",
   debt: "text-z-debt",
 };

--- a/mobile/lib/constants/colors.ts
+++ b/mobile/lib/constants/colors.ts
@@ -15,4 +15,5 @@ export const COLORS = {
   alert: "#D4A843",
   oliveDeep: "#3F4632",
   ringTrack: "#2a2d28",
+  switchTrack: "#3A3A3A",
 } as const;

--- a/mobile/lib/constants/styles.ts
+++ b/mobile/lib/constants/styles.ts
@@ -41,3 +41,10 @@ export const SECTION_EYEBROW_CLASS =
 /** Mobile v2 action button (brass ghost) */
 export const MOBILE_ACTION_BUTTON_CLASS =
   "rounded-lg border border-z-brass-20 bg-z-brass-8 px-2.5 py-1 text-[10px] font-inter-semibold text-z-brass";
+
+/**
+ * Bottom padding for scrollable screens so content clears the floating tab bar.
+ * Mirrors webapp MOBILE_TAB_BAR_CLEARANCE_CLASS but as a numeric padding value
+ * for RN contentContainerStyle.
+ */
+export const MOBILE_TAB_BAR_CLEARANCE = 120;

--- a/mobile/lib/theme.tsx
+++ b/mobile/lib/theme.tsx
@@ -1,0 +1,72 @@
+import * as SecureStore from "expo-secure-store";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ThemeMode = "sage" | "neutral";
+
+const THEME_KEY = "zeta.theme-mode";
+const DEFAULT_THEME: ThemeMode = "sage";
+
+type ThemeContextValue = {
+  mode: ThemeMode;
+  setMode: (next: ThemeMode) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  mode: DEFAULT_THEME,
+  setMode: () => {},
+});
+
+export function ZetaThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>(DEFAULT_THEME);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await SecureStore.getItemAsync(THEME_KEY);
+        if (stored === "sage" || stored === "neutral") {
+          setModeState(stored);
+        }
+      } catch {
+        // non-fatal — fall back to default
+      }
+    })();
+  }, []);
+
+  const setMode = useCallback(async (next: ThemeMode) => {
+    setModeState(next);
+    try {
+      await SecureStore.setItemAsync(THEME_KEY, next);
+    } catch {
+      // non-fatal
+    }
+  }, []);
+
+  const value = useMemo(() => ({ mode, setMode }), [mode, setMode]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext);
+}
+
+/**
+ * Resolve theme-aware surface classes.
+ * Swap these usages anywhere a surface needs to respect the user's choice.
+ */
+export function themeSurfaceClasses(mode: ThemeMode) {
+  const isNeutral = mode === "neutral";
+  return {
+    ink: isNeutral ? "bg-z-ink-neutral" : "bg-z-ink",
+    surface1: isNeutral ? "bg-z-surface-neutral" : "bg-z-surface",
+    surface2: isNeutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2",
+    surface3: isNeutral ? "bg-z-surface-3-neutral" : "bg-z-surface-3",
+  };
+}

--- a/mobile/lib/theme.tsx
+++ b/mobile/lib/theme.tsx
@@ -68,5 +68,7 @@ export function themeSurfaceClasses(mode: ThemeMode) {
     surface1: isNeutral ? "bg-z-surface-neutral" : "bg-z-surface",
     surface2: isNeutral ? "bg-z-surface-2-neutral" : "bg-z-surface-2",
     surface3: isNeutral ? "bg-z-surface-3-neutral" : "bg-z-surface-3",
+    /** Translucent surface for sticky bottom action bars. */
+    actionBar: isNeutral ? "bg-z-ink-neutral-92" : "bg-background-92",
   };
 }

--- a/mobile/lib/utils/cc-projection.ts
+++ b/mobile/lib/utils/cc-projection.ts
@@ -1,0 +1,65 @@
+/**
+ * Credit card minimum-payment projection math.
+ *
+ * Given balance B, annual EA rate r, and minimum monthly payment M,
+ * simulates paying only the minimum for the next 12 months.
+ *
+ * Monthly rate derived from EA: r_mo = (1 + r) ** (1/12) - 1
+ *
+ * Returns growing=true when the minimum doesn't cover monthly interest;
+ * in that case the UI should hide the 12-month numbers and warn the user.
+ */
+
+export type CcMinProjection = {
+  months: number;
+  interestAccrued: number;
+  remainingBalance: number;
+  growing: boolean;
+};
+
+export function projectMinimumPayoff12mo(
+  balance: number,
+  annualEA: number,
+  minPayment: number,
+): CcMinProjection | null {
+  if (
+    !Number.isFinite(balance) ||
+    !Number.isFinite(annualEA) ||
+    !Number.isFinite(minPayment) ||
+    balance <= 0 ||
+    annualEA < 0 ||
+    minPayment <= 0
+  ) {
+    return null;
+  }
+
+  const rMo = Math.pow(1 + annualEA, 1 / 12) - 1;
+
+  // Minimum doesn't cover first-month interest — balance grows.
+  if (minPayment <= balance * rMo) {
+    return {
+      months: 12,
+      interestAccrued: 0,
+      remainingBalance: balance,
+      growing: true,
+    };
+  }
+
+  let current = balance;
+  let interest = 0;
+  const months = 12;
+
+  for (let i = 0; i < months; i++) {
+    const monthInterest = current * rMo;
+    interest += monthInterest;
+    current = current + monthInterest - minPayment;
+    if (current < 0) current = 0;
+  }
+
+  return {
+    months,
+    interestAccrued: interest,
+    remainingBalance: current,
+    growing: false,
+  };
+}

--- a/mobile/lib/utils/cc-projection.ts
+++ b/mobile/lib/utils/cc-projection.ts
@@ -47,17 +47,22 @@ export function projectMinimumPayoff12mo(
 
   let current = balance;
   let interest = 0;
-  const months = 12;
+  const maxMonths = 12;
+  let monthsToPayoff = maxMonths;
 
-  for (let i = 0; i < months; i++) {
+  for (let i = 0; i < maxMonths; i++) {
     const monthInterest = current * rMo;
     interest += monthInterest;
     current = current + monthInterest - minPayment;
-    if (current < 0) current = 0;
+    if (current <= 0) {
+      current = 0;
+      monthsToPayoff = i + 1;
+      break;
+    }
   }
 
   return {
-    months,
+    months: monthsToPayoff,
     interestAccrued: interest,
     remainingBalance: current,
     growing: false,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.4.2",
+    "@expo-google-fonts/kalam": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-community/datetimepicker": "8.6.0",
     "@react-navigation/native": "^7.1.8",

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -122,6 +122,9 @@ module.exports = {
         "background-90": "rgba(18,20,18,0.90)",
         "background-92": "rgba(18,20,18,0.92)",
 
+        // neutral ink opacity (base #0d0d0e = rgb(13,13,14))
+        "z-ink-neutral-92": "rgba(13,13,14,0.92)",
+
         // muted-foreground opacity (base #938C7E = rgb(147,140,126))
         "muted-fg-50": "rgba(147,140,126,0.50)",
         "muted-fg-70": "rgba(147,140,126,0.70)",

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -97,6 +97,12 @@ module.exports = {
         "z-surface-2-80": "rgba(30,34,30,0.80)",
         "z-surface-2-95": "rgba(30,34,30,0.95)",
 
+        // ─── Neutral theme (A/B test — no green tint) ─────────────────────
+        "z-ink-neutral": "#0d0d0e",
+        "z-surface-neutral": "#121214",
+        "z-surface-2-neutral": "#18181b",
+        "z-surface-3-neutral": "#1f1f23",
+
         // white overlays
         "white-3": "rgba(255,255,255,0.03)",
         "white-4": "rgba(255,255,255,0.04)",
@@ -131,9 +137,12 @@ module.exports = {
       },
       fontFamily: {
         inter: ["Inter_400Regular"],
+        "inter-italic": ["Inter_400Regular_Italic"],
         "inter-medium": ["Inter_500Medium"],
+        "inter-medium-italic": ["Inter_500Medium_Italic"],
         "inter-semibold": ["Inter_600SemiBold"],
         "inter-bold": ["Inter_700Bold"],
+        narrator: ["Kalam_700Bold"],
       },
       borderRadius: {
         sm: "6px",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@expo-google-fonts/inter':
         specifier: ^0.4.2
         version: 0.4.2
+      '@expo-google-fonts/kalam':
+        specifier: ^0.4.1
+        version: 0.4.1
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1274,6 +1277,9 @@ packages:
 
   '@expo-google-fonts/inter@0.4.2':
     resolution: {integrity: sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==}
+
+  '@expo-google-fonts/kalam@0.4.1':
+    resolution: {integrity: sha512-A5LZoojqb9OCzOI/2WDRofaIQGGzC5zzmKxqxCFIx1jSYOO8g7q+5fZdd+QfJ6pY6VLzO4j5xoJq0ptcHFpQSg==}
 
   '@expo-google-fonts/material-symbols@0.4.26':
     resolution: {integrity: sha512-1RBDVbRQDIAldwf0oV9QjEallOJ+FkkuYxgKFc345Vzi0dK/ipVITWTUTJHr49Jh1XQuEyVKdHH+mo3DXqZU7g==}
@@ -9746,6 +9752,8 @@ snapshots:
   '@excalidraw/random-username@1.1.0': {}
 
   '@expo-google-fonts/inter@0.4.2': {}
+
+  '@expo-google-fonts/kalam@0.4.1': {}
 
   '@expo-google-fonts/material-symbols@0.4.26': {}
 


### PR DESCRIPTION
## Summary
Shipping the Claude Design "Zeta Wireframes" slice 1: global theme (Sage / Neutral), Kalam narrator font, redesigned PDF-import wizard (2×2 reconcile grid with accordion expansion, multi-currency credit card stack, safe-area awareness).

## Blocked by
- [ ] #192 must merge + deploy to prod first — mobile uploads need the `/api` middleware fix.

## zetas-front-guy blockers (to fix before marking ready)
- [ ] `settings.tsx:325,343,426,428,444,446` — hardcoded hex (`#EF4444`, `#C5BFAE`, `#3A3A3A`). Use `COLORS.debt`, `COLORS.sageLight`, add `switchTrack` token.
- [ ] `import.tsx:1427,1449,1549,1561` — "Fusionar" / "Mantener ambas" / result-step buttons bypass `BRASS_BUTTON_CLASS`/`GHOST_BUTTON_CLASS`. Missing `accessibilityRole`/`accessibilityLabel`.
- [ ] `import.tsx:1275,1350` — English loanword "fresh" in Spanish copy. Replace with "limpios" / "sin duplicados".
- [ ] `import.tsx:1122,1195` — `paddingBottom: 120` magic number. Extract `MOBILE_TAB_BAR_CLEARANCE`.
- [ ] Neutral-theme gap: fixed action bar uses `bg-background-92` (sage-only). Add `z-ink-neutral-92` or semantic `bg-action-bar` token.
- [ ] Extract `ExpandableStatTile` (`components/ui/ExpandableStatTile.tsx`) — reuse in import reconcile + `InicioMetricsGrid` "Gasto hoy". Migrate `CreditCardStackCard` to `AnimatedAccordion`.

## Commits
1. `feat(mobile): add global theme provider + Kalam narrator font`
2. `feat(mobile): redesign PDF import wizard (Claude Design slice 1)`
3. `docs(handover): slice-1 import redesign + webapp middleware hotfix`

## Test plan
- [ ] iOS sim (iPhone 17 Pro, iOS 26.2): upload Bancolombia CC PDF end-to-end once #192 is deployed → expect `statementCount: 2`
- [ ] Toggle Settings → Apariencia → Sage / Neutral → theme persists across restart
- [ ] Reconcile grid: tap each tile → AnimatedAccordion expands correct detail row
- [ ] Multi-currency CC: toggle currency chip → account auto-rematches
- [ ] Narrator visible on reconcile step even when a panel is expanded
- [ ] Dynamic Island clearance on all 4 wizard steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)