### PR TITLE
fix: pass full categories to Movimientos and clear tab bar in picker drawer

### DIFF
--- a/webapp/src/app/(dashboard)/transactions/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/page.tsx
@@ -95,7 +95,7 @@ export default async function TransactionsPage({
       <div className="pb-20 lg:hidden lg:pb-0">
         <MovimientosRoot
           transactions={transactionsResult.data}
-          outflowCategories={outflowCategories}
+          categories={categories}
           accounts={accounts}
           tags={allTags}
           count={transactionsResult.count}

--- a/webapp/src/components/categories/category-zone-picker.tsx
+++ b/webapp/src/components/categories/category-zone-picker.tsx
@@ -23,6 +23,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { trackClientEvent } from "@/lib/utils/analytics";
 import {
@@ -368,7 +369,7 @@ export function CategoryZonePicker({
           <DrawerHeader>
             <DrawerTitle>Elegir categoría</DrawerTitle>
           </DrawerHeader>
-          <div className="overflow-y-auto px-2 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+          <div className={cn("overflow-y-auto px-2", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
             {pickerContent}
           </div>
         </DrawerContent>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-root.tsx
@@ -23,7 +23,7 @@ import type {
 
 interface MovimientosRootProps {
   transactions: TransactionWithAccount[];
-  outflowCategories: CategoryWithChildren[];
+  categories: CategoryWithChildren[];
   accounts: Account[];
   tags: Tag[];
   count: number;
@@ -36,7 +36,7 @@ interface MovimientosRootProps {
 
 export function MovimientosRoot({
   transactions,
-  outflowCategories,
+  categories,
   accounts,
   tags,
   count,
@@ -141,7 +141,7 @@ export function MovimientosRoot({
         uncategorizedTransactions={uncategorizedTransactions}
         uncategorizedCount={uncategorizedCount}
         pendingEmails={pendingEmails}
-        categories={outflowCategories}
+        categories={categories}
         accounts={accounts}
         currency={currency}
         expandedTool={activeZone?.startsWith("tool-") ? activeZone.replace("tool-", "") : null}
@@ -170,7 +170,7 @@ export function MovimientosRoot({
               </p>
               <div className="space-y-0.5">
                 {txs.map((tx) => (
-                  <MovimientosTransactionRow key={tx.id} transaction={tx} categories={outflowCategories} tags={tagsByTxId.get(tx.id)} linkableAccountIds={linkableAccountIds} />
+                  <MovimientosTransactionRow key={tx.id} transaction={tx} categories={categories} tags={tagsByTxId.get(tx.id)} linkableAccountIds={linkableAccountIds} />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
Follow-up to #191. After that PR merged, manual testing surfaced two regressions on mobile Movimientos that the earlier diff didn't reach.

## Summary

- **Empty picker on Movimientos income rows.** `MovimientosRoot` received `outflowCategories` server-side and forwarded that list to every `MovimientosTransactionRow`. The picker's direction filter (added in #191) then narrowed an already-outflow-only list to zero zones for INFLOW transactions — so tapping Categoría on income rows showed only "Sin categoría" and "Crear nueva categoría". Rename the prop to `categories` and pass the full list from `transactions/page.tsx` (already loaded alongside `outflowCategories`). The picker's internal filter handles per-transaction narrowing.
- **"Crear nueva categoría" hidden under the tab bar.** The drawer variant of `CategoryZonePicker` padded its scroll container with `pb-[calc(1rem+env(safe-area-inset-bottom))]`, which ignores the mobile tab-bar height. Switch to `MOBILE_TAB_BAR_CLEARANCE_CLASS` — the shared helper CLAUDE.md calls out for this exact case.

## Test plan

- [ ] Movimientos → expand an INFLOW tx → tap Categoría → income zones appear (not empty).
- [ ] Movimientos → expand an OUTFLOW tx → tap Categoría → outflow zones only.
- [ ] In the same drawer, scroll to the bottom → "Crear nueva categoría" is fully visible above the tab bar.
- [ ] Transaction detail page and inicio feed (both fixed in #191) still behave correctly.

https://claude.ai/code/session_018rvrwQcme5fXwWhRmjuHAK