### PR TITLE
fix: purge webapp cache after mobile onboarding completes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -240,15 +240,6 @@
 - **What:** Slice-1 extracted `mobile/components/ui/ExpandableStatTile.tsx` and migrated the import reconcile grid, but `InicioMetricsGrid` "Gasto hoy" was left on its bespoke `PANEL_INSET_CLASS` chip shape (different value size, ring-chart sibling, compact currency formatter). A future pass should either (a) widen `ExpandableStatTile` with a `variant="inset-compact"` option to absorb it, or (b) extract a sibling `CompactStatTile` primitive. Worth doing next time we touch either surface.
 - **Found:** zetas-front-guy follow-up on slice-1, 2026-04-19
 
-### Mobile onboarding → webapp cache staleness (cross-platform)
-- **Priority:** Medium
-- **What:** Mobile onboarding (`mobile/app/onboarding.tsx`) writes `profiles` + `accounts` directly to Supabase. The webapp's `(dashboard)/layout.tsx` guard reads `profile.onboarding_completed` via `getProfile()` which is `"use cache"` + `cacheTag("profile")` with `cacheLife("zeta")` (stale 120s / revalidate 300s). If a user completes onboarding on mobile and opens the webapp within that window, the cached profile still has `onboarding_completed: false` → the layout redirects them back to `/onboarding`, hiding the data they already entered.
-- **Options:**
-  - (a) Add a `POST /api/cache/onboarding-complete` route handler in webapp that authenticates via `getRequestUser` and calls `updateTag("profile")` + `updateTag("accounts")`. Mobile calls it after `persistOnboarding()` succeeds. Requires webapp hotfix + mobile call in one coordinated release.
-  - (b) Layout guard reads `onboarding_completed` via a separate uncached query (`createClient() → profile_onboarding_completed` view), keeping the rest of `getProfile()` cached. Self-contained to webapp.
-- **Recommendation:** Option (a) — correctness + cheap round-trip only at onboarding-complete. Option (b) adds a DB hit to every layout render.
-- **Found:** mobile-webapp-parity review on PR #195, 2026-04-19
-
 ### Mobile onboarding — follow-up polish from slice-2 review
 - **Priority:** Low
 - **What:** Non-blocking items deferred from the zetas-front-guy / frontend-auditor / ux-analyst / mobile-sync-doctor / mobile-webapp-parity reviews on PR #195:

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -179,6 +179,22 @@ export default function MobileOnboardingScreen() {
 
       if (completeError) throw completeError;
 
+      // Fire-and-forget: ping the webapp so its Route Cache expires the
+      // profile/accounts tags. If the user opens the webapp right after, the
+      // dashboard guard sees the fresh `onboarding_completed: true` instead
+      // of the cached stale value (up to 120s) and doesn't redirect back.
+      // Failure here is non-fatal — the cache will still expire on its own.
+      const apiUrl = process.env.EXPO_PUBLIC_API_URL;
+      const accessToken = session.access_token;
+      if (apiUrl && accessToken) {
+        void fetch(`${apiUrl}/api/cache/onboarding-complete`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }).catch((cacheErr) => {
+          console.warn("[onboarding] cache purge failed (non-fatal):", cacheErr);
+        });
+      }
+
       return true;
     } catch (err) {
       // Never surface raw PostgREST messages — they can leak internal table

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -190,9 +190,21 @@ export default function MobileOnboardingScreen() {
         void fetch(`${apiUrl}/api/cache/onboarding-complete`, {
           method: "POST",
           headers: { Authorization: `Bearer ${accessToken}` },
-        }).catch((cacheErr) => {
-          console.warn("[onboarding] cache purge failed (non-fatal):", cacheErr);
-        });
+        })
+          .then((res) => {
+            if (!res.ok) {
+              console.warn(
+                "[onboarding] cache purge returned non-ok:",
+                res.status,
+              );
+            }
+          })
+          .catch((cacheErr) => {
+            console.warn(
+              "[onboarding] cache purge failed (non-fatal):",
+              cacheErr,
+            );
+          });
       }
 
       return true;

--- a/webapp/src/app/api/cache/onboarding-complete/route.ts
+++ b/webapp/src/app/api/cache/onboarding-complete/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { updateTag } from "next/cache";
+import { getRequestUser } from "@/app/api/_shared/auth";
+
+/**
+ * Mobile onboarding completion hook.
+ *
+ * Mobile writes `profiles` + `accounts` directly to Supabase (offline-first
+ * pattern) and has no way to invalidate the Next.js Route Cache. The webapp
+ * layout guard reads `profile.onboarding_completed` through `getProfile()`
+ * which is `"use cache"` + `cacheTag("profile")` with `cacheLife("zeta")`
+ * (stale 120s). Without this endpoint, a user who onboards on mobile and
+ * opens the webapp within that window would get redirected back to
+ * `/onboarding` because the cached profile still says `onboarding_completed: false`.
+ *
+ * Mobile calls this endpoint (fire-and-forget) after `persistOnboarding()`
+ * succeeds. Auth is per-user session (Bearer or cookie); the endpoint refuses
+ * anonymous requests. Tag invalidation is global per tag name — the extra
+ * cost of clearing for all users on this one event is negligible.
+ */
+export async function POST(request: NextRequest) {
+  const user = await getRequestUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+  }
+
+  updateTag("profile");
+  updateTag("accounts");
+  updateTag("dashboard:hero");
+  updateTag("dashboard:accounts");
+
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
Closes the webapp-cache staleness window flagged by `mobile-webapp-parity` on PR #195.

Mobile onboarding writes `profiles` + `accounts` directly to Supabase (offline-first pattern) and cannot invalidate Next.js Route Cache. The webapp's `(dashboard)/layout.tsx` guard reads `profile.onboarding_completed` through `getProfile()` which is `"use cache"` + `cacheTag("profile")` with `cacheLife("zeta")` (stale 120s). **Without this fix**, a user who finishes onboarding on mobile then opens the webapp within ~2 min gets redirected back to `/onboarding` — even though Supabase already shows them as complete.

## Changes
- `webapp/src/app/api/cache/onboarding-complete/route.ts` — new `POST` route. Authenticates via `getRequestUser` (Bearer or cookie), then calls `updateTag("profile")` + `updateTag("accounts")` + `updateTag("dashboard:hero")` + `updateTag("dashboard:accounts")`. Returns `{ ok: true }`.
- `mobile/app/onboarding.tsx` — after `persistOnboarding()` succeeds, `void fetch(...)` to the new route with the user's Bearer token. Non-blocking; failures log a warning and continue. If the route is unreachable, the tags still expire on their own after 120s (unchanged from today's behaviour).
- `BACKLOG.md` — remove the tracking entry.

## Why `updateTag` not `revalidateTag`
Per `CLAUDE.md`: `updateTag` immediately expires the cache + clears Router Cache for read-your-own-writes. `revalidateTag` would continue serving the stale (pre-onboarding) profile until the background revalidation finishes — exactly the bug this PR fixes.

## Test plan
- [x] `pnpm build` (webapp) — clean
- [x] `npx tsc --noEmit` (mobile) — clean
- [ ] Mobile sim: complete onboarding → open webapp within 120s → dashboard loads correctly (not redirected to `/onboarding`)
- [ ] Logged-out POST to `/api/cache/onboarding-complete` → 401 `"No autenticado"`
- [ ] Logged-in POST with valid Bearer → 200 `{ ok: true }`
- [ ] No regression on existing webapp cookie-based flows (existing /api routes unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)