### PR TITLE
fix(landing): skip middleware on / to prevent 502s from oversized Set-Cookie headers

### DIFF
--- a/webapp/middleware.ts
+++ b/webapp/middleware.ts
@@ -7,6 +7,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).+)",
   ],
 };

--- a/webapp/middleware.ts
+++ b/webapp/middleware.ts
@@ -7,6 +7,9 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    // `.+` (not `.*`) intentionally excludes bare `/` — Supabase SSR's chunked
+    // `sb-*-auth-token.N` cookies push landing response headers past NPM's
+    // `proxy_buffer_size` and return 502. Landing is public, no session needed.
     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).+)",
   ],
 };


### PR DESCRIPTION
## Summary
- Changes the middleware matcher from `.*` to `.+` so the bare `/` path falls through entirely.
- Fixes intermittent `502 Bad Gateway` (openresty/NPM) on the landing page for authenticated users.

## Root cause
NPM error log on `pfm.sanson1911.cloud`:
```
upstream sent too big header while reading response header from upstream
```
`webapp/middleware.ts` ran on `/` → `updateSession()` called Supabase SSR's `setAll`, which writes the session as chunked cookies (`sb-<ref>-auth-token.0`, `.1`, `.2`, …). Each chunk ≈ 1–2KB. Combined with `link` preloads + `Vary` + CSP, the response header block exceeded NPM's default `proxy_buffer_size` (4k) and NPM dropped the connection with 502. Anonymous visitors (≈ 927B of headers) were fine; authenticated users landing on `/` were not.

## Fix
Bare `/` is a public marketing page and does not need session refresh. Excluding it from the matcher means no `Set-Cookie` on that response, so response headers stay well under the proxy buffer. All other paths (`/login`, `/dashboard`, `/api/*`, …) continue to match.

## Trade-off
Previously the middleware set `Cache-Control: no-cache, no-store, must-revalidate` on `/` to prevent Safari from serving stale HTML after deploys. The landing now serves with Next.js ISR default (`s-maxage=31536000`), so browsers may cache stale landing HTML between deploys. Acceptable for a rarely-changing marketing page; revisit with `export const revalidate` if we start shipping frequent landing-copy changes.

## Test plan
- [x] `pnpm build` — clean
- [ ] Deploy to prod; log in as user that previously reproduced the 502; visit `/` → expect 200 (not 502)
- [ ] Tail NPM proxy-host-2 error log for 10 min post-deploy → no further `upstream sent too big header` entries
- [ ] `/login`, `/dashboard`, `/api/*` still hit middleware (auth redirect + session refresh work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)