### PR TITLE
feat(import): assign pattern to existing destinatario in wizard step 3

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -99,11 +99,12 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 
 ## Features
 
-### Import wizard — attach pattern to existing destinatario
+### Mobile — capture "Crear destinatario" + "Asignar a existente" ungate
 - **Priority:** Medium
-- **What:** Step 3 (Destinatarios) of `/import` only offers "Crear destinatario" on each unmatched suggestion. When the cleaned pattern is actually a spelling variant of a destinatario that already exists (e.g., `Rappi Colombia*Dl` vs existing `rappi colombia`), the only recoverable path today is to skip, finish the import, then edit patterns at `/destinatarios`. Add a second action to every suggestion card: "Asignar a destinatario existente" → opens a picker (reuse the zone-picker pattern), on confirm appends the pattern to that destinatario's `destinatario_patterns`, refreshes the in-memory `destinatarioRules`, re-runs `matchDestinatario`, and collapses the suggestion. Optional polish: sort the picker by match score or by destinatario-spend to surface the likely target first.
-- **Touches:** new server action `addPatternToDestinatario(destinatarioId, pattern)` in `actions/destinatarios.ts` (insert into `destinatario_patterns` with `match_type: "contains"`, `priority: 100`; `updateTag("destinatarios")`); `step-destinatarios.tsx` UI (picker + wiring); `import-wizard.tsx` passes the updated rules so later steps use them.
-- **Found:** User feedback during Nu import session, 2026-04-17
+- **What:** The "Opciones relacionadas" collapsible in `mobile/app/capture.tsx` currently Alerts `Próximamente` for both "Crear destinatario" and "Crear pago recurrente". Webapp equivalent already works via `createDestinatario` + `attachPatternToDestinatario` (shipped PR #202). Mobile needs analogous support before these can ungate.
+- **Gaps:** mobile `lib/repositories/destinatarios.ts` is read-only (no `createDestinatario`, no `attachPatternToDestinatario`). Need to add both, wire sync push entries for `destinatarios` + `destinatario_rules` tables, and — for "Asignar a existente" — load the destinatario list on screen mount. Same shape as the webapp new `attachPatternToDestinatario` action.
+- **Recurring template**: separate slice — also read-only on mobile (`recurring.ts` only exposes reads + confirm/skip). Needs full `createRecurringTemplate` repo + sync.
+- **Found:** Capture redesign session, 2026-04-20.
 
 ### Dashboard RECIENTE — inline category assignment on row expand
 - **Priority:** High (scoped for Phase 2 Dashboard polish)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -99,6 +99,11 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 
 ## Features
 
+### Mobile — capture amount live-formatting
+- **Priority:** Medium
+- **What:** The centered amount TextInput in `mobile/app/capture.tsx` displays raw digits (`124124`). User expects COP-style thousand grouping (`124.124`) while typing. Solution prototyped during 2026-04-20 session: format via `raw.replace(/\B(?=(\d{3})+(?!\d))/g, ".")` on display, strip dots + convert decimal comma → dot on onChangeText. Deferred to the mobile migration session to keep the destinatario PR focused.
+- **Found:** User feedback, 2026-04-20.
+
 ### Mobile — capture "Crear destinatario" + "Asignar a existente" ungate
 - **Priority:** Medium
 - **What:** The "Opciones relacionadas" collapsible in `mobile/app/capture.tsx` currently Alerts `Próximamente` for both "Crear destinatario" and "Crear pago recurrente". Webapp equivalent already works via `createDestinatario` + `attachPatternToDestinatario` (shipped PR #202). Mobile needs analogous support before these can ungate.

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -691,6 +691,60 @@ export async function addDestinatarioRule(
   return { success: true, data, conflicts };
 }
 
+// ─── attachPatternToDestinatario ──────────────────────────────────────────────
+
+/**
+ * Lean alternative to addDestinatarioRule for callers that don't use
+ * useActionState — accepts plain args and returns the created rule row.
+ * Used by the import wizard's "Asignar a existente" flow on step 3.
+ */
+export async function attachPatternToDestinatario(
+  destinatarioId: string,
+  pattern: string
+): Promise<ActionResult<DestinatarioRuleRow>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = destinatarioRuleSchema.safeParse({
+    match_type: "contains",
+    pattern,
+    priority: 100,
+  });
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  // Defense-in-depth: verify the destinatario belongs to the caller
+  const { data: dest } = await supabase
+    .from("destinatarios")
+    .select("id")
+    .eq("id", destinatarioId)
+    .eq("user_id", user.id)
+    .single();
+  if (!dest) return { success: false, error: "Destinatario no encontrado" };
+
+  const { data, error } = await supabase
+    .from("destinatario_rules")
+    .insert({
+      user_id: user.id,
+      destinatario_id: destinatarioId,
+      ...parsed.data,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return { success: false, error: "Este patrón ya está asignado" };
+    }
+    return { success: false, error: error.message };
+  }
+
+  updateTag("destinatarios");
+  updateTag("attention");
+  return { success: true, data };
+}
+
 // ─── removeDestinatarioRule ───────────────────────────────────────────────────
 
 export async function removeDestinatarioRule(

--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -654,20 +654,11 @@ export async function addDestinatarioRule(
     return { success: false, error: parsed.error.issues[0].message };
   }
 
-  // Check for conflicting patterns
-  const { data: existingRules } = await supabase
-    .from("destinatario_rules")
-    .select("pattern, destinatario_id")
-    .eq("user_id", user.id);
-
-  const newPatternLower = parsed.data.pattern.toLowerCase();
-  const conflicts: { pattern: string; destinatarioId: string }[] = [];
-  for (const rule of existingRules ?? []) {
-    const existingLower = rule.pattern.toLowerCase();
-    if (existingLower.includes(newPatternLower) || newPatternLower.includes(existingLower)) {
-      conflicts.push({ pattern: rule.pattern, destinatarioId: rule.destinatario_id });
-    }
-  }
+  const conflicts = await findPatternConflicts(
+    supabase,
+    user.id,
+    parsed.data.pattern
+  );
 
   const { data, error } = await supabase
     .from("destinatario_rules")
@@ -691,17 +682,56 @@ export async function addDestinatarioRule(
   return { success: true, data, conflicts };
 }
 
+// ─── findPatternConflicts ─────────────────────────────────────────────────────
+
+type SupabaseClient = Awaited<
+  ReturnType<typeof getAuthenticatedClient>
+>["supabase"];
+
+/**
+ * Detects overlapping patterns against the user's existing destinatario rules.
+ * A conflict is any existing rule whose (lowercased) pattern contains or is
+ * contained by the candidate — the engine's substring match would make them
+ * ambiguous. Shared by addDestinatarioRule and attachPatternToDestinatario.
+ */
+async function findPatternConflicts(
+  supabase: SupabaseClient,
+  userId: string,
+  pattern: string
+): Promise<{ pattern: string; destinatarioId: string }[]> {
+  const { data: existingRules } = await supabase
+    .from("destinatario_rules")
+    .select("pattern, destinatario_id")
+    .eq("user_id", userId);
+
+  const candidate = pattern.toLowerCase();
+  const conflicts: { pattern: string; destinatarioId: string }[] = [];
+  for (const rule of existingRules ?? []) {
+    const existing = rule.pattern.toLowerCase();
+    if (existing.includes(candidate) || candidate.includes(existing)) {
+      conflicts.push({ pattern: rule.pattern, destinatarioId: rule.destinatario_id });
+    }
+  }
+  return conflicts;
+}
+
 // ─── attachPatternToDestinatario ──────────────────────────────────────────────
+
+export type AttachPatternResult = ActionResult<DestinatarioRuleRow> & {
+  conflicts?: { pattern: string; destinatarioId: string }[];
+};
 
 /**
  * Lean alternative to addDestinatarioRule for callers that don't use
- * useActionState — accepts plain args and returns the created rule row.
+ * useActionState — accepts plain args and returns the created rule row
+ * along with any pattern conflicts detected (informational only, same shape
+ * as addDestinatarioRule).
  * Used by the import wizard's "Asignar a existente" flow on step 3.
  */
 export async function attachPatternToDestinatario(
   destinatarioId: string,
   pattern: string
-): Promise<ActionResult<DestinatarioRuleRow>> {
+): Promise<AttachPatternResult> {
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
 
@@ -723,6 +753,12 @@ export async function attachPatternToDestinatario(
     .single();
   if (!dest) return { success: false, error: "Destinatario no encontrado" };
 
+  const conflicts = await findPatternConflicts(
+    supabase,
+    user.id,
+    parsed.data.pattern
+  );
+
   const { data, error } = await supabase
     .from("destinatario_rules")
     .insert({
@@ -742,7 +778,7 @@ export async function attachPatternToDestinatario(
 
   updateTag("destinatarios");
   updateTag("attention");
-  return { success: true, data };
+  return { success: true, data, conflicts };
 }
 
 // ─── removeDestinatarioRule ───────────────────────────────────────────────────

--- a/webapp/src/components/import/step-destinatarios.tsx
+++ b/webapp/src/components/import/step-destinatarios.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
-import { ChevronDown, ChevronRight, Loader2, Plus, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Link2, Loader2, Plus, X } from "lucide-react";
 import {
   cleanDescription,
   matchDestinatario,
   prepareDestinatarioRules,
 } from "@zeta/shared";
 import type { DestinatarioRule } from "@zeta/shared";
-import { createDestinatario } from "@/actions/destinatarios";
+import {
+  attachPatternToDestinatario,
+  createDestinatario,
+} from "@/actions/destinatarios";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
@@ -17,6 +20,13 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { formatCurrency } from "@/lib/utils/currency";
 import { capitalize } from "@/lib/utils/string";
 import type { CurrencyCode, CategoryWithChildren } from "@/types/domain";
@@ -57,11 +67,40 @@ export function StepDestinatarios({
   const [currentRules, setCurrentRules] = useState<DestinatarioRule[]>(destinatarioRules);
 
   const [editingPattern, setEditingPattern] = useState<string | null>(null);
+  const [assigningPattern, setAssigningPattern] = useState<string | null>(null);
+  const [assignTargetId, setAssignTargetId] = useState<string>("");
   const [formName, setFormName] = useState("");
   const [formCategory, setFormCategory] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [matchedOpen, setMatchedOpen] = useState(false);
+
+  // Unique destinatarios derivable from the rule set — covers everyone the
+  // user has at least one existing pattern for. Sorted by most-used first
+  // so likely targets surface at the top.
+  const existingDestinatarios = useMemo(() => {
+    const map = new Map<
+      string,
+      { id: string; name: string; defaultCategoryId: string | null; patternCount: number }
+    >();
+    for (const rule of currentRules) {
+      const prev = map.get(rule.destinatario_id);
+      if (prev) {
+        prev.patternCount += 1;
+      } else {
+        map.set(rule.destinatario_id, {
+          id: rule.destinatario_id,
+          name: rule.destinatario_name,
+          defaultCategoryId: rule.default_category_id,
+          patternCount: 1,
+        });
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => {
+      if (b.patternCount !== a.patternCount) return b.patternCount - a.patternCount;
+      return a.name.localeCompare(b.name);
+    });
+  }, [currentRules]);
 
   const { matchedGroups, suggestions } = useMemo(() => {
     const prepared = prepareDestinatarioRules(currentRules);
@@ -133,8 +172,17 @@ export function StepDestinatarios({
 
   function handleStartEditing(suggestion: SuggestionGroup) {
     setEditingPattern(suggestion.cleanedPattern);
+    setAssigningPattern(null);
     setFormName(capitalize(suggestion.cleanedPattern));
     setFormCategory(null);
+    setFormError(null);
+    setExpanded((prev) => new Set(prev).add(suggestion.cleanedPattern));
+  }
+
+  function handleStartAssigning(suggestion: SuggestionGroup) {
+    setAssigningPattern(suggestion.cleanedPattern);
+    setEditingPattern(null);
+    setAssignTargetId(existingDestinatarios[0]?.id ?? "");
     setFormError(null);
     setExpanded((prev) => new Set(prev).add(suggestion.cleanedPattern));
   }
@@ -142,6 +190,45 @@ export function StepDestinatarios({
   function handleDismiss(pattern: string) {
     setDismissedPatterns((prev) => new Set(prev).add(pattern));
     if (editingPattern === pattern) setEditingPattern(null);
+    if (assigningPattern === pattern) setAssigningPattern(null);
+  }
+
+  function handleAssign(pattern: string) {
+    if (!assignTargetId) {
+      setFormError("Elige un destinatario");
+      return;
+    }
+    const target = existingDestinatarios.find((d) => d.id === assignTargetId);
+    if (!target) {
+      setFormError("Destinatario no encontrado");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await attachPatternToDestinatario(
+        assignTargetId,
+        pattern.toLowerCase()
+      );
+
+      if (result.success) {
+        setCurrentRules((prev) => [
+          ...prev,
+          {
+            destinatario_id: target.id,
+            destinatario_name: target.name,
+            default_category_id: target.defaultCategoryId,
+            match_type: "contains" as const,
+            pattern: pattern.toLowerCase(),
+            priority: 100,
+          },
+        ]);
+        setCreatedPatterns((prev) => new Set(prev).add(pattern));
+        setAssigningPattern(null);
+        setFormError(null);
+      } else {
+        setFormError(result.error);
+      }
+    });
   }
 
   function handleCreate(pattern: string) {
@@ -227,6 +314,7 @@ export function StepDestinatarios({
         <div className="space-y-3">
           {visibleSuggestions.map((suggestion) => {
             const isEditing = editingPattern === suggestion.cleanedPattern;
+            const isAssigning = assigningPattern === suggestion.cleanedPattern;
             const isExpanded = expanded.has(suggestion.cleanedPattern);
 
             return (
@@ -257,7 +345,7 @@ export function StepDestinatarios({
                     </p>
                   </div>
 
-                  {!isEditing && (
+                  {!isEditing && !isAssigning && (
                     <div className="flex shrink-0 items-center gap-1">
                       <Button
                         type="button"
@@ -267,8 +355,20 @@ export function StepDestinatarios({
                         onClick={() => handleStartEditing(suggestion)}
                       >
                         <Plus className="h-3 w-3" />
-                        Crear destinatario
+                        Crear
                       </Button>
+                      {existingDestinatarios.length > 0 && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="h-7 gap-1 text-xs"
+                          onClick={() => handleStartAssigning(suggestion)}
+                        >
+                          <Link2 className="h-3 w-3" />
+                          Asignar
+                        </Button>
+                      )}
                       <Button
                         type="button"
                         size="sm"
@@ -296,6 +396,69 @@ export function StepDestinatarios({
                         </span>
                       </div>
                     ))}
+                  </div>
+                )}
+
+                {isAssigning && (
+                  <div className="mt-3 space-y-2 border-t pt-3">
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium text-muted-foreground">
+                        Destinatario existente
+                      </label>
+                      <Select
+                        value={assignTargetId}
+                        onValueChange={(v) => {
+                          setAssignTargetId(v);
+                          if (formError) setFormError(null);
+                        }}
+                      >
+                        <SelectTrigger className="h-8 text-sm">
+                          <SelectValue placeholder="Elegir destinatario" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {existingDestinatarios.map((d) => (
+                            <SelectItem key={d.id} value={d.id}>
+                              {d.name}
+                              <span className="ml-2 text-xs text-muted-foreground">
+                                {d.patternCount}{" "}
+                                {d.patternCount === 1 ? "patrón" : "patrones"}
+                              </span>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    {formError && <p className="text-xs text-z-debt">{formError}</p>}
+
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="h-7 gap-1 text-xs"
+                        disabled={isPending || !assignTargetId}
+                        onClick={() => handleAssign(suggestion.cleanedPattern)}
+                      >
+                        {isPending ? (
+                          <>
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            Asignando...
+                          </>
+                        ) : (
+                          "Asignar patrón"
+                        )}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 text-xs"
+                        disabled={isPending}
+                        onClick={() => setAssigningPattern(null)}
+                      >
+                        Cancelar
+                      </Button>
+                    </div>
                   </div>
                 )}
 

--- a/webapp/src/components/import/step-destinatarios.tsx
+++ b/webapp/src/components/import/step-destinatarios.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { ChevronDown, ChevronRight, Link2, Loader2, Plus, X } from "lucide-react";
 import {
   cleanDescription,
@@ -11,6 +11,7 @@ import type { DestinatarioRule } from "@zeta/shared";
 import {
   attachPatternToDestinatario,
   createDestinatario,
+  getDestinatarios,
 } from "@/actions/destinatarios";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -75,32 +76,73 @@ export function StepDestinatarios({
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [matchedOpen, setMatchedOpen] = useState(false);
 
-  // Unique destinatarios derivable from the rule set — covers everyone the
-  // user has at least one existing pattern for. Sorted by most-used first
-  // so likely targets surface at the top.
+  // Full destinatarios list so the "Asignar" picker includes destinatarios
+  // that have no rules yet (otherwise deriving from currentRules alone would
+  // hide them). Fetched once when the user lands on this step.
+  const [allDestinatarios, setAllDestinatarios] = useState<
+    { id: string; name: string; default_category_id: string | null }[]
+  >([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await getDestinatarios();
+      if (cancelled || !result.success) return;
+      setAllDestinatarios(
+        result.data.map((d) => ({
+          id: d.id,
+          name: d.name,
+          default_category_id: d.default_category_id,
+        }))
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Merge the full list with pattern counts derived from currentRules.
+  // Sort by most-patterns-first so likely targets surface at the top.
   const existingDestinatarios = useMemo(() => {
+    const patternCounts = new Map<string, number>();
+    for (const rule of currentRules) {
+      patternCounts.set(
+        rule.destinatario_id,
+        (patternCounts.get(rule.destinatario_id) ?? 0) + 1
+      );
+    }
+
     const map = new Map<
       string,
       { id: string; name: string; defaultCategoryId: string | null; patternCount: number }
     >();
-    for (const rule of currentRules) {
-      const prev = map.get(rule.destinatario_id);
-      if (prev) {
-        prev.patternCount += 1;
-      } else {
-        map.set(rule.destinatario_id, {
-          id: rule.destinatario_id,
-          name: rule.destinatario_name,
-          defaultCategoryId: rule.default_category_id,
-          patternCount: 1,
-        });
-      }
+
+    for (const d of allDestinatarios) {
+      map.set(d.id, {
+        id: d.id,
+        name: d.name,
+        defaultCategoryId: d.default_category_id,
+        patternCount: patternCounts.get(d.id) ?? 0,
+      });
     }
+
+    // Rules can surface destinatarios created mid-session before the fetch
+    // landed — include them so the picker updates immediately.
+    for (const rule of currentRules) {
+      if (map.has(rule.destinatario_id)) continue;
+      map.set(rule.destinatario_id, {
+        id: rule.destinatario_id,
+        name: rule.destinatario_name,
+        defaultCategoryId: rule.default_category_id,
+        patternCount: patternCounts.get(rule.destinatario_id) ?? 1,
+      });
+    }
+
     return Array.from(map.values()).sort((a, b) => {
       if (b.patternCount !== a.patternCount) return b.patternCount - a.patternCount;
       return a.name.localeCompare(b.name);
     });
-  }, [currentRules]);
+  }, [allDestinatarios, currentRules]);
 
   const { matchedGroups, suggestions } = useMemo(() => {
     const prepared = prepareDestinatarioRules(currentRules);


### PR DESCRIPTION
## Summary

Step 3 of the import wizard now offers a second action alongside "Crear destinatario" on each unmatched suggestion card: **"Asignar"** — attach the detected pattern to an existing destinatario without leaving the flow. Fixes the annoying round-trip when the cleaned pattern is just a spelling variant of a destinatario the user already has.

### Before
- Suggestion only offered "Crear destinatario" + dismiss.
- Spelling variants (e.g. `Rappi Colombia*Dl` vs existing `rappi colombia`) forced: skip → finish import → go to `/destinatarios` → manually add the pattern.

### After
- Actions row: **Crear / Asignar / dismiss**.
- "Asignar" opens an inline Select of the user's existing destinatarios (derived from `currentRules`, sorted by most-patterns-first).
- Confirm → new rule inserted → `currentRules` updated in-memory → subsequent wizard steps honor the match immediately.
- Button only renders when at least one existing destinatario is found.

### Server action
New lean `attachPatternToDestinatario(destinatarioId, pattern)` in `actions/destinatarios.ts`:
- Plain args (not `useActionState` FormData shape), returns `ActionResult<DestinatarioRuleRow>`.
- Validates via `destinatarioRuleSchema` (same as `addDestinatarioRule`).
- Defense-in-depth: verifies the destinatario belongs to the caller before inserting.
- Handles duplicate-pattern unique violation (code 23505) with a Spanish message.
- `updateTag("destinatarios")` + `updateTag("attention")` on success.

### Backlog hygiene
- Removed: "Import wizard — attach pattern to existing destinatario" (shipped here)
- Added: follow-up "Mobile — capture 'Crear destinatario' + 'Asignar' ungate" — the webapp capture UI in PR #201 gated these with `Próximamente` because the mobile `destinatarios` repository is read-only. Noted the repo + sync push work needed to ungate on mobile too.

## Test plan
- [ ] Start a PDF import with transactions matching a spelling variant of an existing destinatario
- [ ] On step 3, suggestion card shows all three buttons (Crear / Asignar / dismiss)
- [ ] Click Asignar → Select populated, most-used destinatario at top
- [ ] Pick destinatario → "Asignar patrón" → row collapses, matched group count increments, `currentRules` contains new rule
- [ ] Continue through import → new pattern applied to subsequent matching txs without re-visiting this step
- [ ] Try assigning a pattern that already exists on that destinatario → user-friendly error "Este patrón ya está asignado"
- [ ] New user with zero destinatarios: Asignar button hidden entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)