### PR TITLE
feat(supabase): pg_cron cleanup of anonymous demo users + budgets FK fix

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -111,6 +111,19 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 
 ## Features
 
+### Budget setup — per-category opt-in + calculator shortcut
+- **Priority:** Medium
+- **What:** When setting up budgets the user wants to pick categories one by one and only assign amounts to the ones they care about — leaving the rest blank is a valid state, not an error. Also: every amount input should expose a small calculator button (popover/drawer) so the user can do quick math without leaving the form.
+- **Why:** Current budget setup assumes every category needs a number. For people starting lean, that's friction. The calculator lets "we spend ~300k on groceries + ~120k on café" become one inline add without switching apps.
+- **Touches:** budget setup UI (`webapp/src/app/presupuesto/...` or the plan presupuesto tab), `CurrencyInput` component — add an adornment button that opens a lightweight calculator.
+- **Found:** User request, 2026-04-21.
+
+### Empty-state "Primeros pasos recomendados" — 4×4 grid layout
+- **Priority:** Low
+- **What:** The "Primeros pasos recomendados" view shown when the app has no data should render the suggested actions as a 4×4 grid (or close to it) instead of the current stacked list. Gives the user a richer menu of entry points at a glance.
+- **Touches:** wherever the first-run recommendations render on the dashboard / /import / /plan empty states — locate and unify.
+- **Found:** User request, 2026-04-21.
+
 ### Mobile — capture amount live-formatting
 - **Priority:** Medium
 - **What:** The centered amount TextInput in `mobile/app/capture.tsx` displays raw digits (`124124`). User expects COP-style thousand grouping (`124.124`) while typing. Solution prototyped during 2026-04-20 session: format via `raw.replace(/\B(?=(\d{3})+(?!\d))/g, ".")` on display, strip dots + convert decimal comma → dot on onChangeText. Deferred to the mobile migration session to keep the destinatario PR focused.
@@ -302,17 +315,13 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 
 ## Tech Debt
 
-### Anonymous demo session — cleanup cron + rate limiting
-- **Priority:** Medium (blocks scaling "Ver demo")
-- **Context:** PR #205 (2026-04-21) shipped `startDemoSession()` — landing hero + signup page call it to let visitors try the app without registering. Each click creates a real `auth.users` row (`is_anonymous=true`) + encrypted `profiles` row + DEK + ~4 demo accounts + ~40 transactions + 5 budgets. Without cleanup these accumulate forever and count against Supabase MAU billing.
-- **What to build:**
-  1. Scheduled cleanup — delete anonymous users older than N days. Two options:
-     - Supabase cron job calling a SECURITY DEFINER function `cleanup_anonymous_demo_users(p_older_than interval)` that deletes from `auth.users WHERE is_anonymous = true AND created_at < now() - p_older_than`. Cascades to profile + accounts + transactions + budgets via FK.
-     - Next.js route `/api/cron/cleanup-demo` hit by Vercel cron (daily). Uses admin client to delete. Guard with shared secret header.
-  2. Captcha on `signInAnonymously()` — Supabase Auth → Rate Limits. Protects against bot spam that would otherwise balloon the MAU count.
-  3. Optional: monitor anonymous count weekly (`SELECT count(*) FROM auth.users WHERE is_anonymous = true;`) and alert if growth spikes.
-- **Default policy suggestion:** delete anonymous users after 7 days of inactivity. Short enough to stop MAU creep, long enough that a visitor returning the next day still has their demo data.
-- **Touches:** new migration with the cleanup function + cron trigger, or `webapp/src/app/api/cron/cleanup-demo/route.ts` + Vercel cron config.
+### Anonymous demo session — captcha + rate limiting
+- **Priority:** Medium (pairs with the cleanup cron that shipped via pg_cron)
+- **Context:** The daily pg_cron deletes idle anonymous users older than 7 days, but nothing stops a bot from creating 10k anonymous users in an hour. Supabase's built-in per-IP rate limit helps; captcha on the anonymous sign-in endpoint is the real guardrail.
+- **What to configure (no code):**
+  1. Supabase Dashboard → Auth → Rate Limits → reduce anonymous sign-ins per IP/hour (default 30).
+  2. Supabase Dashboard → Auth → Captcha → enable hCaptcha/Turnstile specifically for `signInAnonymously`. Requires passing a captcha token from the client — wire it into `startDemoSession` and `startGuestSession` if enabled.
+  3. Weekly observability query: `SELECT count(*) FROM auth.users WHERE is_anonymous = true;` — alert if growth spikes between cron runs.
 - **Found:** PR #205 follow-up, 2026-04-21.
 
 ### Tx detail — `router.refresh()` on tag picker close

--- a/supabase/migrations/20260421180000_anonymous_cleanup_cron.sql
+++ b/supabase/migrations/20260421180000_anonymous_cleanup_cron.sql
@@ -24,7 +24,10 @@ ALTER TABLE public.budgets
   ADD CONSTRAINT budgets_user_id_fkey
     FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
-CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+-- pg_cron is not relocatable: it always creates its own `cron` schema for
+-- the job tables + the schedule/unschedule functions, regardless of any
+-- WITH SCHEMA hint. Leave it bare so `cron.schedule(...)` below resolves.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
 
 -- SECURITY DEFINER so it can DELETE from auth.users. Ownership stays with
 -- the migration runner (postgres / supabase_admin), execution restricted to
@@ -35,7 +38,7 @@ CREATE OR REPLACE FUNCTION public.cleanup_anonymous_demo_users(
 RETURNS INTEGER
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public, auth
+SET search_path = public, auth, pg_catalog
 AS $$
 DECLARE
   deleted_count INTEGER;

--- a/supabase/migrations/20260421180000_anonymous_cleanup_cron.sql
+++ b/supabase/migrations/20260421180000_anonymous_cleanup_cron.sql
@@ -1,0 +1,75 @@
+-- ===========================================================================
+-- Scheduled cleanup of abandoned anonymous demo users
+--
+-- PRs #205/#206 added two landing-page CTAs that create anonymous Supabase
+-- users ("Ver demo" and "Usar sin cuenta"). Each click inserts a real
+-- auth.users row + encrypted profile + (optional) seeded demo data.
+-- Without cleanup these accumulate forever and count against MAU billing.
+--
+-- Policy: delete anonymous users that haven't signed in during the last
+-- 7 days. Short enough to stop MAU creep, long enough that a visitor
+-- returning the next day still has their session.
+--
+-- FK cascades handle the rest — profiles_enc, accounts, transactions,
+-- budgets, user_encryption_keys, destinatarios_enc, recurring_*, etc. all
+-- reference auth.users(id) ON DELETE CASCADE.
+-- ===========================================================================
+
+-- The original budgets table predates ON DELETE CASCADE as a default and was
+-- created with plain `REFERENCES auth.users` (NO ACTION). That blocks any
+-- DELETE on auth.users that belongs to a user with seeded demo budgets,
+-- which would defeat the cron below. Fix it here so the cascade works.
+ALTER TABLE public.budgets
+  DROP CONSTRAINT IF EXISTS budgets_user_id_fkey,
+  ADD CONSTRAINT budgets_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+-- SECURITY DEFINER so it can DELETE from auth.users. Ownership stays with
+-- the migration runner (postgres / supabase_admin), execution restricted to
+-- service_role + the cron invoker below.
+CREATE OR REPLACE FUNCTION public.cleanup_anonymous_demo_users(
+  p_older_than INTERVAL DEFAULT INTERVAL '7 days'
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  WITH deleted AS (
+    DELETE FROM auth.users
+    WHERE is_anonymous = true
+      AND COALESCE(last_sign_in_at, created_at) < now() - p_older_than
+    RETURNING id
+  )
+  SELECT count(*) INTO deleted_count FROM deleted;
+
+  RAISE NOTICE 'cleanup_anonymous_demo_users deleted % rows (older than %)', deleted_count, p_older_than;
+  RETURN deleted_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.cleanup_anonymous_demo_users(INTERVAL) IS
+  'Deletes anonymous users idle longer than p_older_than. Scheduled daily via pg_cron; safe to invoke manually too.';
+
+REVOKE ALL ON FUNCTION public.cleanup_anonymous_demo_users(INTERVAL) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.cleanup_anonymous_demo_users(INTERVAL) TO service_role;
+
+-- Reschedule idempotently: drop any prior job with this name, then create fresh.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cleanup-anonymous-demo-users') THEN
+    PERFORM cron.unschedule('cleanup-anonymous-demo-users');
+  END IF;
+END $$;
+
+-- Daily at 07:00 UTC (02:00 Colombia time) — off-peak for the app.
+SELECT cron.schedule(
+  'cleanup-anonymous-demo-users',
+  '0 7 * * *',
+  $$SELECT public.cleanup_anonymous_demo_users(interval '7 days')$$
+);


### PR DESCRIPTION
## Summary

Scheduled deletion of abandoned anonymous users created by the landing "Ver demo" / "Usar sin cuenta" CTAs. Without this, every curious visitor leaves behind an `auth.users` row + encrypted profile + seeded data that counts against Supabase MAU billing forever.

## Migration — `20260421180000_anonymous_cleanup_cron.sql`

1. Fixes `budgets.user_id_fkey` — it was `ON DELETE NO ACTION` since day one, which would abort the DELETE on `auth.users` for any anonymous user with a seeded budget. Now `ON DELETE CASCADE`.
2. `CREATE EXTENSION IF NOT EXISTS pg_cron`.
3. `public.cleanup_anonymous_demo_users(p_older_than INTERVAL DEFAULT '7 days')` — SECURITY DEFINER, returns integer count, deletes `auth.users WHERE is_anonymous = true AND COALESCE(last_sign_in_at, created_at) < now() - p_older_than`. FK cascades handle the rest of the graph.
4. `REVOKE EXECUTE FROM PUBLIC; GRANT TO service_role` — only the service role can invoke manually.
5. `cron.schedule('cleanup-anonymous-demo-users', '0 7 * * *', ...)` — daily at 07:00 UTC (02:00 Bogotá). Idempotent — the migration drops any prior job with the same name before scheduling.

## Policy

- **7 days of inactivity** before deletion. Short enough to stop MAU creep; long enough that a visitor returning the next day still has their demo data.
- **Observability**: `SELECT start_time, status, return_message FROM cron.job_run_details WHERE jobname = 'cleanup-anonymous-demo-users' ORDER BY start_time DESC LIMIT 30;`

## Review

Spawned `supabase-migrator`. Surfaced one blocker (budgets cascade gap) — **fixed in this migration**. SECURITY DEFINER ownership, `pg_cron` schema resolution, `search_path` hardening, and `auth.users` column names all confirmed correct.

## Test plan

- [ ] `npx supabase db push` applies cleanly on a fresh copy.
- [ ] Manual smoke: create an anonymous user, shift its `created_at` back 8 days, run `SELECT public.cleanup_anonymous_demo_users();` — row + cascaded rows go away.
- [ ] Re-apply the migration after `supabase db reset` — idempotent (no duplicate cron job, function replaced).
- [ ] `SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'cleanup-anonymous-demo-users';` returns one row.

## Follow-ups (backlog)

- Captcha + rate limits on the anonymous sign-in endpoint (dashboard config only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)