### PR TITLE
fix(guest): agent review cleanup + promotion clarity

### DIFF
--- a/webapp/src/actions/demo.ts
+++ b/webapp/src/actions/demo.ts
@@ -118,7 +118,7 @@ export async function startGuestSession(): Promise<void> {
       .from("profiles")
       .select("demo_mode, onboarding_completed")
       .eq("id", userId)
-      .single();
+      .maybeSingle();
 
     // Demo → Guest transition: wipe the seeded mock set and clear both flags
     // so the visitor's own data replaces the demo through onboarding.

--- a/webapp/src/app/(auth)/login/page.tsx
+++ b/webapp/src/app/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 import { LoginForm } from "@/components/auth/login-form";
+import { AuthSessionShortcuts } from "@/components/auth/auth-session-shortcuts";
 import { PANEL_SURFACE_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +34,7 @@ export default async function LoginPage({
       <div className={cn(PANEL_SURFACE_CLASS, "p-6")}>
         <LoginForm />
       </div>
+      <AuthSessionShortcuts />
     </div>
   );
 }

--- a/webapp/src/app/(auth)/signup/page.tsx
+++ b/webapp/src/app/(auth)/signup/page.tsx
@@ -1,40 +1,30 @@
 import { SignupForm } from "@/components/auth/signup-form";
-import { startDemoSession, startGuestSession } from "@/actions/demo";
+import { AuthSessionShortcuts } from "@/components/auth/auth-session-shortcuts";
+import { createClient } from "@/lib/supabase/server";
 import { PANEL_SURFACE_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 
-export default function SignupPage() {
+export default async function SignupPage() {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getUser();
+  const fromGuest = data.user?.is_anonymous === true;
+
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center">
         <h2 className="text-2xl font-bold tracking-tight">
-          Conoce adónde va tu plata.
+          {fromGuest ? "Guarda tus datos." : "Conoce adónde va tu plata."}
         </h2>
         <p className="text-sm text-muted-foreground">
-          Importa una vez. Nosotros categorizamos el resto.
+          {fromGuest
+            ? "Crea tu cuenta para no perder nada de lo que ya configuraste."
+            : "Importa una vez. Nosotros categorizamos el resto."}
         </p>
       </div>
       <div className={cn(PANEL_SURFACE_CLASS, "p-6")}>
-        <SignupForm />
+        <SignupForm fromGuest={fromGuest} />
       </div>
-      <div className="flex flex-col items-center gap-2 text-center">
-        <form action={startGuestSession}>
-          <button
-            type="submit"
-            className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >
-            Usar sin cuenta →
-          </button>
-        </form>
-        <form action={startDemoSession}>
-          <button
-            type="submit"
-            className="text-xs text-muted-foreground/80 underline-offset-4 hover:text-foreground hover:underline"
-          >
-            o ver el demo con datos de ejemplo
-          </button>
-        </form>
-      </div>
+      {!fromGuest && <AuthSessionShortcuts />}
     </div>
   );
 }

--- a/webapp/src/components/auth/auth-session-shortcuts.tsx
+++ b/webapp/src/components/auth/auth-session-shortcuts.tsx
@@ -1,0 +1,29 @@
+import { startDemoSession, startGuestSession } from "@/actions/demo";
+
+/**
+ * Two text-link shortcuts rendered under the login + signup forms:
+ * start a guest session (empty onboarding) or start a demo session
+ * (pre-seeded mock data). Both post to server actions so no JS is needed.
+ */
+export function AuthSessionShortcuts() {
+  return (
+    <div className="flex flex-col items-center gap-2 text-center">
+      <form action={startGuestSession}>
+        <button
+          type="submit"
+          className="text-sm text-z-sage-dark underline-offset-4 hover:text-z-white hover:underline focus-visible:outline-none focus-visible:underline"
+        >
+          Usar sin cuenta →
+        </button>
+      </form>
+      <form action={startDemoSession}>
+        <button
+          type="submit"
+          className="text-xs text-z-sage-dark/80 underline-offset-4 hover:text-z-white hover:underline focus-visible:outline-none focus-visible:underline"
+        >
+          o ver el demo con datos de ejemplo
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/webapp/src/components/auth/auth-session-shortcuts.tsx
+++ b/webapp/src/components/auth/auth-session-shortcuts.tsx
@@ -11,7 +11,7 @@ export function AuthSessionShortcuts() {
       <form action={startGuestSession}>
         <button
           type="submit"
-          className="text-sm text-z-sage-dark underline-offset-4 hover:text-z-white hover:underline focus-visible:outline-none focus-visible:underline"
+          className="text-sm text-z-sage-dark underline-offset-4 hover:text-z-white hover:underline rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-z-brass/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:underline"
         >
           Usar sin cuenta →
         </button>
@@ -19,7 +19,7 @@ export function AuthSessionShortcuts() {
       <form action={startDemoSession}>
         <button
           type="submit"
-          className="text-xs text-z-sage-dark/80 underline-offset-4 hover:text-z-white hover:underline focus-visible:outline-none focus-visible:underline"
+          className="text-xs text-z-sage-dark/80 underline-offset-4 hover:text-z-white hover:underline rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-z-brass/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:underline"
         >
           o ver el demo con datos de ejemplo
         </button>

--- a/webapp/src/components/auth/signup-form.tsx
+++ b/webapp/src/components/auth/signup-form.tsx
@@ -9,7 +9,13 @@ import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 
-export function SignupForm() {
+interface SignupFormProps {
+  /** When true, signup will promote the current anonymous session in place
+   *  — we surface a copy line so the user knows their data carries over. */
+  fromGuest?: boolean;
+}
+
+export function SignupForm({ fromGuest = false }: SignupFormProps = {}) {
   const [state, formAction, pending] = useActionState<AuthActionResult, FormData>(
     signUp,
     {}
@@ -17,6 +23,11 @@ export function SignupForm() {
 
   return (
     <form action={formAction} className="space-y-4">
+      {fromGuest && (
+        <div className="rounded-md border border-z-brass/20 bg-z-brass/8 p-3 text-xs text-z-brass">
+          Tus datos se mantienen al crear la cuenta. Nada se pierde.
+        </div>
+      )}
       {state.error && (
         <div className="bg-destructive/10 text-destructive text-sm rounded-md p-3">
           {state.error}

--- a/webapp/src/components/dashboard/guest-banner.tsx
+++ b/webapp/src/components/dashboard/guest-banner.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { UserPlus, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 
 /**
  * Banner shown when the visitor is signed in anonymously and is NOT in
@@ -14,14 +16,14 @@ export function GuestBanner() {
       <div className="flex items-center gap-2.5 text-sm">
         <UserRound className="size-4 shrink-0 text-z-brass" />
         <span className="font-medium text-z-brass">Sin cuenta</span>
-        <span className="text-muted-foreground">
-          — Crea cuenta para no perder tus datos
+        <span className="text-z-sage-dark">
+          — Tus datos se mantienen al crear cuenta
         </span>
       </div>
       <Button
         asChild
         size="sm"
-        className="h-7 gap-1.5 bg-z-brass px-2.5 text-xs text-z-ink hover:bg-z-brass/90"
+        className={cn(BRASS_BUTTON_CLASS, "h-7 gap-1.5 px-2.5 text-xs")}
       >
         <Link href="/signup">
           <UserPlus className="size-3.5" />


### PR DESCRIPTION
## Summary

Post-merge cleanup for PR #206. Three agent reviews (server-action, zetas-front-guy, ux-analyst) ran against the guest/demo flow; this PR applies the must-fixes and a couple of UX clarifications.

## Changes

**Server action**
- `demo.ts`: `.single()` → `.maybeSingle()` on the profile lookup in `startGuestSession` so a brand-new anonymous user whose trigger-created profile hasn't committed yet falls through cleanly instead of logging `PGRST116`.

**Frontend (Zeta tokens)**
- `guest-banner.tsx`: replaces the inline brass-button reconstruction with `BRASS_BUTTON_CLASS`, swaps `text-muted-foreground` → `text-z-sage-dark`, updates copy to "Tus datos se mantienen al crear cuenta".
- `components/auth/auth-session-shortcuts.tsx` (new): extracts the duplicated shortcut block from signup + login, uses Zeta tokens, adds `focus-visible:underline` for keyboard affordance.
- `(auth)/signup/page.tsx` + `(auth)/login/page.tsx`: consume the new component.

**UX — promotion clarity**
- `(auth)/signup/page.tsx`: now async. Detects `user.is_anonymous` on the server and swaps the hero copy ("Guarda tus datos." + "Crea tu cuenta para no perder nada...") and passes `fromGuest` to `SignupForm`. Hides the shortcut block while the visitor is already mid-promotion.
- `components/auth/signup-form.tsx`: when `fromGuest`, renders a brass reassurance block above the form: "Tus datos se mantienen al crear la cuenta. Nada se pierde."

**Login shortcut restored**
- The login-side "Usar sin cuenta" addition didn't make it into the PR #206 squash. This PR puts it back via `AuthSessionShortcuts`.

## Declined findings

- `is_demo=true` on transactions delete in the demo→guest cleanup — the `transactions` table doesn't have an `is_demo` column (only `accounts` and `budgets` do). The existing `account_id IN demoAccountIds` filter is already exclusive since demo accounts are a closed set.
- Landing four-CTA balance and demo→guest confirm dialog — ux-analyst flagged both; deferred to a dedicated polish pass so this PR stays focused on design-system violations + promotion clarity.

## Test plan

- [ ] Fresh anonymous guest click → `/onboarding` renders without PGRST116 in logs.
- [ ] Anonymous guest at `/signup` sees the reassurance block + different hero copy; shortcut block hidden.
- [ ] Real visitor at `/signup` sees the original hero copy + the shortcut block below the form.
- [ ] `/login` shows the shortcut block below the form.
- [ ] `GuestBanner` brass CTA visually matches `DemoBanner` (both via `BRASS_BUTTON_CLASS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)