### PR TITLE
feat(transactions): Flow 03 webapp — Layout B form redesign

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -75,16 +75,28 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
   - Anonymous cleanup cron — see new Tech Debt entry.
 
 ### Flow 02 — Home redesign (webapp dashboard)
-- **Priority:** High
-- **What:** Three variants in the wireframe. A = Safe (widgets + month hero), B = Bold (widget-driven), C = Novel (timeline-scrub). Decide variant before building.
+- **Priority:** Done (mobile + desktop zones) · follow-up deferred
+- **Status:** Variant B shipped PR #204 (2026-04-20). Mobile Pulse widget + widget grid + arrange sheet; desktop `HeroZone` / `WidgetsZone` / `HealthZone` / `MobileZone` in `webapp/src/app/(dashboard)/dashboard/page.tsx`.
+- **Deferred (PR 3):** true drag-to-reorder + inline S/M/L resize for the widget zone (wireframe "Arrange" frame). Reanimated + gesture-handler work. Current edit mode = WidgetEditSheet move up/down + size chips.
 
 ### Flow 03 — Add transaction (quick-capture redesign)
-- **Priority:** Medium
-- **What:** A = structured sheet, B = conversational, C = radial action. Current webapp uses structured form; this is a rethink.
+- **Priority:** Shipped (webapp mobile viewport) · follow-ups deferred
+- **Status:** Mobile RN shipped PR #201. Webapp mobile `/transactions/new` redesigned to Layout B (sectioned: `Detalles` → `Asignar` → `Más opciones`) — 2026-04-21. Full-page route preserved (kept out of drawer due to virtual-keyboard interactions).
+- **What shipped (webapp):**
+  - Form restructured into three visual sections with `SectionEyebrow` — `Detalles` (descripción, cuenta, fecha, categoría), `Asignar` (destinatario picker), `Más opciones` collapsible (es suscripción, crear recurrente, notas).
+  - `DestinatarioZonePicker` replaces the legacy "Crear destinatario" switch — supports inline create + recents in one control.
+  - `is_subscription` now wired end-to-end: schema (`transactionSchema`) + action (`persistTransaction` INSERT) + form Switch row.
+  - `destinatario_id` now accepted by `transactionSchema` — user-picked destinatarios flow through to `persistTransaction` and `linkTransactionToOccurrence` (prior code only honored "create-via-switch" destinatarios, so occurrence matching improves).
+  - Submit button uses `BRASS_BUTTON_CLASS` (brass + `text-z-ink`, per token rule).
+- **Deferred / follow-ups:**
+  - Tags picker inline (today requires entity id; `TagZonePicker` needs a "pending tags" mode). Users add tags via transaction detail after save.
+  - Cuenta + Fecha paired side-by-side (reverted — layout clipped at narrow viewports; stacked stays).
+  - Missing `htmlFor` on DatePicker / CategoryZonePicker / DestinatarioZonePicker labels (sub-components don't expose `id`; a11y gap is loose labeling only).
+  - Desktop `TransactionFormDialog` (unchanged — out of scope per user decision).
 
 ### Flow 04 — Import redesign (webapp)
-- **Priority:** Medium
-- **Status:** Variant A (mobile-first 4-step) shipped — 2026-04-21.
+- **Priority:** Done
+- **Status:** Variant A (mobile-first 4-step) shipped PR #209 — 2026-04-21.
 - **What shipped:**
   - Collapsed from 6 steps (upload/review/destinatarios/confirm/reconcile/results) to **4 steps** (subir/revisar/reconciliar/listo) matching the mobile app + wireframe Variant A.
   - Destinatario matching and auto-categorization now run silently in step 2; users fix later on the dedicated `/destinatarios` and `/transactions` pages.
@@ -105,7 +117,8 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 
 ### Flow 05 — Plan redesign
 - **Priority:** Medium
-- **What:** A = current de-noised, B = 50/30/20 as a story, C = calendar-first. Today's `/plan` is closest to A but noisy.
+- **Status:** PR #170 polished `/plan` (NETO, chips, templates, presupuesto grouping, zone-based tabs `PlanResumenZone` / `PlanMobileZone`). Not an explicit wireframe-Variant-A pass — decide whether polish is sufficient or full redesign is still needed.
+- **What:** A = current de-noised, B = 50/30/20 as a story, C = calendar-first.
 
 ### Flow 06 — Settings redesign (Variant A)
 - **Priority:** High · **Ready to merge** (branch `feat/settings-visual-polish`, 2026-04-20)

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -823,10 +823,20 @@ export async function updateTransaction(
 
   const categoryChanged = existing?.category_id !== parsed.data.category_id;
 
+  // `updateTransaction` reuses `transactionSchema` but does not read the
+  // `is_subscription` / `destinatario_id` form fields. Strip them from the
+  // spread so their Zod defaults (false / undefined) don't overwrite the
+  // existing row on every edit.
+  const {
+    is_subscription: _ignoredIsSubscription,
+    destinatario_id: _ignoredDestinatarioId,
+    ...updatableFields
+  } = parsed.data;
+
   const { data, error } = await supabase
     .from("transactions")
     .update({
-      ...parsed.data,
+      ...updatableFields,
       clean_description: parsed.data.merchant_name || parsed.data.raw_description || null,
       ...(categoryChanged ? { categorization_source: "USER_OVERRIDE" as const } : {}),
     })

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -37,6 +37,7 @@ type PersistTransactionParams = {
   notes?: string | null;
   capture_method?: Transaction["capture_method"];
   capture_input_text?: string | null;
+  is_subscription?: boolean;
 };
 
 type BalanceAccountRow = {
@@ -387,6 +388,7 @@ async function persistTransaction(
       capture_method: params.capture_method ?? "MANUAL_FORM",
       capture_input_text: params.capture_input_text ?? null,
       categorization_source: params.category_id ? "USER_CREATED" : "SYSTEM_DEFAULT",
+      is_subscription: params.is_subscription ?? false,
     })
     .select()
     .single();
@@ -652,8 +654,10 @@ export async function createTransaction(
     raw_description: formData.get("raw_description") || undefined,
     merchant_name: formData.get("merchant_name") || undefined,
     category_id: formData.get("category_id") || undefined,
+    destinatario_id: formData.get("destinatario_id") || undefined,
     notes: formData.get("notes") || undefined,
     capture_input_text: formData.get("capture_input_text") || undefined,
+    is_subscription: formData.get("is_subscription"),
   });
 
   if (!parsed.success) {
@@ -692,11 +696,14 @@ export async function createTransaction(
     parsed.data.raw_description ||
     null;
 
+  const finalDestinatarioId =
+    relatedSetup.data.destinatarioId ?? parsed.data.destinatario_id ?? null;
+
   const transactionResult = await persistTransaction(supabase, {
     userId: user.id,
     ...parsed.data,
     merchant_name: normalizedMerchantName,
-    destinatario_id: relatedSetup.data.destinatarioId,
+    destinatario_id: finalDestinatarioId,
     capture_method: "MANUAL_FORM",
   });
 
@@ -713,7 +720,7 @@ export async function createTransaction(
   await linkTransactionToOccurrence(
     parsed.data.account_id, parsed.data.transaction_date,
     parsed.data.amount, parsed.data.direction, transactionResult.data.id,
-    relatedSetup.data.destinatarioId ?? null,
+    finalDestinatarioId,
   );
 
   return transactionResult;

--- a/webapp/src/components/mobile/fab-menu.tsx
+++ b/webapp/src/components/mobile/fab-menu.tsx
@@ -76,12 +76,8 @@ export function FabMenu({ open, onOpenChange, onAction, contextActions }: FabMen
   );
 
   const handleNewTransaction = useCallback(() => {
-    // Mark as "closed via back" so the cleanup effect does NOT call
-    // history.back() — that would race with the navigation and cancel it.
     closedViaBackRef.current = true;
     onOpenChange(false);
-    // Replace (not push) so the fabMenu history entry is overwritten,
-    // giving the user a clean back-button path.
     router.replace("/transactions/new");
   }, [onOpenChange, router]);
 

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -8,10 +8,12 @@ import {
   ArrowDownLeft,
   ArrowLeftRight,
   ChevronDown,
+  Repeat,
 } from "lucide-react";
 import { createTransaction } from "@/actions/transactions";
 import { Button } from "@/components/ui/button";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import { DestinatarioZonePicker } from "@/components/destinatarios/destinatario-zone-picker";
 import {
   Collapsible,
   CollapsibleContent,
@@ -21,6 +23,7 @@ import { AmountInput } from "@/components/ui/amount-input";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import {
   Select,
   SelectContent,
@@ -30,6 +33,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
 import type {
   Account,
   CategoryWithChildren,
@@ -137,9 +141,12 @@ export function MobileTransactionForm({
 
   const today = new Date().toISOString().split("T")[0];
   const [merchantName, setMerchantName] = useState("");
+  const [transactionDate, setTransactionDate] = useState<string>(today);
+  const [isSubscription, setIsSubscription] = useState(false);
+  const [notes, setNotes] = useState("");
+  const [destinatarioId, setDestinatarioId] = useState<string | null>(null);
+  const [destinatarioSelectedName, setDestinatarioSelectedName] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [createDestinatarioSetup, setCreateDestinatarioSetup] = useState(false);
-  const [destinatarioName, setDestinatarioName] = useState("");
   const [createRecurringSetup, setCreateRecurringSetup] = useState(false);
   const [recurringFrequency, setRecurringFrequency] = useState<
     (typeof FREQUENCY_OPTIONS)[number]["value"]
@@ -151,23 +158,11 @@ export function MobileTransactionForm({
 
   useEffect(() => {
     if (transactionType === "transfer") {
-      setCreateDestinatarioSetup(false);
       setCreateRecurringSetup(false);
       setAdvancedOpen(false);
       setRecurringTransferSourceAccountId("");
     }
   }, [transactionType]);
-
-  function handleCreateDestinatarioSetup(checked: boolean) {
-    setCreateDestinatarioSetup(checked);
-
-    if (checked) {
-      setAdvancedOpen(true);
-      if (!destinatarioName.trim()) {
-        setDestinatarioName(merchantName.trim());
-      }
-    }
-  }
 
   function handleCreateRecurringSetup(checked: boolean) {
     setCreateRecurringSetup(checked);
@@ -213,19 +208,18 @@ export function MobileTransactionForm({
 
       {/* Hidden fields */}
       <input type="hidden" name="direction" value={direction} />
-      <input type="hidden" name="transaction_date" value={today} />
+      <input type="hidden" name="transaction_date" value={transactionDate} />
       <input type="hidden" name="currency_code" value={currencyCode} />
       <input
         type="hidden"
-        name="create_destinatario"
-        value={createDestinatarioSetup ? "true" : "false"}
+        name="is_subscription"
+        value={isSubscription ? "true" : "false"}
       />
       <input
         type="hidden"
         name="create_recurring_template"
         value={createRecurringSetup ? "true" : "false"}
       />
-      <input type="hidden" name="destinatario_name" value={destinatarioName} />
       <input type="hidden" name="recurring_frequency" value={recurringFrequency} />
       <input type="hidden" name="recurring_start_date" value={recurringStartDate} />
       <input
@@ -262,7 +256,10 @@ export function MobileTransactionForm({
         autoFocus={!showTypeSelector}
       />
 
-      {/* Description */}
+      {/* ── DETALLES ────────────────────────────────────────── */}
+      <SectionEyebrow>Detalles</SectionEyebrow>
+
+      {/* Description — full width */}
       <div className="space-y-2">
         <Label htmlFor="mobile-merchant">Descripción</Label>
         <Input
@@ -274,7 +271,7 @@ export function MobileTransactionForm({
         />
       </div>
 
-      {/* Account */}
+      {/* Cuenta */}
       <div className="space-y-2">
         <Label htmlFor="mobile-account">Cuenta</Label>
         <Select
@@ -282,13 +279,12 @@ export function MobileTransactionForm({
           value={selectedAccountId}
           onValueChange={(value) => {
             setSelectedAccountId(value);
-
             if (recurringTransferSourceAccountId === value) {
               setRecurringTransferSourceAccountId("");
             }
           }}
         >
-          <SelectTrigger>
+          <SelectTrigger id="mobile-account">
             <SelectValue placeholder="Seleccionar cuenta" />
           </SelectTrigger>
           <SelectContent>
@@ -301,7 +297,17 @@ export function MobileTransactionForm({
         </Select>
       </div>
 
-      {/* Category */}
+      {/* Fecha */}
+      <div className="space-y-2">
+        <Label>Fecha</Label>
+        <DatePicker
+          value={transactionDate}
+          onChange={(v) => setTransactionDate(v ?? today)}
+          placeholder="Seleccionar fecha"
+        />
+      </div>
+
+      {/* Category — full width */}
       <div className="space-y-2">
         <Label>Categoría</Label>
         <CategoryZonePicker
@@ -313,6 +319,28 @@ export function MobileTransactionForm({
           name="category_id"
         />
       </div>
+
+      {/* ── ASIGNAR ─────────────────────────────────────────── */}
+      {allowRelatedSetup && (
+        <>
+          <SectionEyebrow>Asignar</SectionEyebrow>
+
+          <div className="space-y-2">
+            <Label>Destinatario</Label>
+            <DestinatarioZonePicker
+              value={destinatarioId}
+              onValueChange={(id, name) => {
+                setDestinatarioId(id);
+                setDestinatarioSelectedName(name);
+              }}
+              selectedName={destinatarioSelectedName}
+              placeholder="Elegir o crear destinatario"
+              triggerClassName="w-full"
+            />
+            <input type="hidden" name="destinatario_id" value={destinatarioId ?? ""} />
+          </div>
+        </>
+      )}
 
       {allowRelatedSetup && (
         <>
@@ -327,9 +355,9 @@ export function MobileTransactionForm({
                 className="flex w-full items-start justify-between gap-4 px-4 py-3 text-left sm:items-center"
               >
                 <div className="space-y-1">
-                  <p className="text-sm font-medium">Opciones relacionadas</p>
+                  <p className="text-sm font-medium">Más opciones</p>
                   <p className="text-xs text-muted-foreground">
-                    Expande para crear un destinatario o sembrar este gasto como recurrente.
+                    Suscripción, pago recurrente y notas.
                   </p>
                 </div>
                 <ChevronDown
@@ -341,33 +369,26 @@ export function MobileTransactionForm({
             </CollapsibleTrigger>
 
             <CollapsibleContent className="space-y-4 border-t px-4 py-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="space-y-0.5 pr-4">
-                  <Label htmlFor="mobile-create_destinatario" className="cursor-pointer">
-                    Crear destinatario
+              {/* Es una suscripción */}
+              <div className="flex items-center gap-3">
+                <Repeat className="size-[18px] shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <Label
+                    htmlFor="mobile-is_subscription"
+                    className="cursor-pointer text-sm font-medium"
+                  >
+                    Es una suscripción
                   </Label>
-                  <p className="text-xs text-muted-foreground">
-                    Guarda este comercio para reconocerlo más rápido la próxima vez.
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    Marca este movimiento como parte de una suscripción
                   </p>
                 </div>
                 <Switch
-                  id="mobile-create_destinatario"
-                  checked={createDestinatarioSetup}
-                  onCheckedChange={handleCreateDestinatarioSetup}
+                  id="mobile-is_subscription"
+                  checked={isSubscription}
+                  onCheckedChange={setIsSubscription}
                 />
               </div>
-
-              {createDestinatarioSetup && (
-                <div className="space-y-2">
-                  <Label htmlFor="mobile-destinatario_name">Nombre del destinatario</Label>
-                  <Input
-                    id="mobile-destinatario_name"
-                    value={destinatarioName}
-                    onChange={(event) => setDestinatarioName(event.target.value)}
-                    placeholder="Ej: Netflix"
-                  />
-                </div>
-              )}
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-0.5 pr-4">
@@ -451,13 +472,29 @@ export function MobileTransactionForm({
                   )}
                 </>
               )}
+
+              {/* Notas (opcional) */}
+              <div className="space-y-2">
+                <Label htmlFor="mobile-notes">Notas (opcional)</Label>
+                <Input
+                  id="mobile-notes"
+                  name="notes"
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  placeholder="Detalle extra"
+                />
+              </div>
             </CollapsibleContent>
           </Collapsible>
         </>
       )}
 
       {/* Submit */}
-      <Button type="submit" className="h-12 w-full" disabled={pending}>
+      <Button
+        type="submit"
+        className={cn(BRASS_BUTTON_CLASS, "h-12 w-full")}
+        disabled={pending}
+      >
         {pending ? (
           <>
             <Loader2 className="mr-2 size-4 animate-spin" />

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -161,6 +161,11 @@ export function MobileTransactionForm({
       setCreateRecurringSetup(false);
       setAdvancedOpen(false);
       setRecurringTransferSourceAccountId("");
+      // Destinatario + suscripción don't apply to transfers — clear any
+      // stale values so hidden inputs don't submit them.
+      setIsSubscription(false);
+      setDestinatarioId(null);
+      setDestinatarioSelectedName(null);
     }
   }, [transactionType]);
 

--- a/webapp/src/lib/validators/transaction.ts
+++ b/webapp/src/lib/validators/transaction.ts
@@ -18,9 +18,14 @@ export const transactionSchema = z.object({
     (val) => (val === "" || val === null ? undefined : val),
     uuidStr().optional().nullable()
   ),
+  destinatario_id: z.preprocess(
+    (val) => (val === "" || val === null ? undefined : val),
+    uuidStr().optional().nullable()
+  ),
   notes: z.string().optional(),
   capture_input_text: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  is_subscription: formBoolean,
 });
 
 export type TransactionFormData = z.infer<typeof transactionSchema>;


### PR DESCRIPTION
## Summary

- Restructures `/transactions/new` (webapp mobile viewport) into a sectioned layout per Flow 03: `Detalles` → `Asignar` → `Más opciones` collapsible.
- Replaces the "Crear destinatario" switch with `DestinatarioZonePicker` (inline create + recents in one control).
- Wires `is_subscription` and user-picked `destinatario_id` end-to-end (schema + action + INSERT + occurrence linkage).

## Presentation

- Full-page route **preserved** — drawer presentation was tried and reverted (virtual-keyboard interactions are noisier inside a bottom sheet).
- FAB still navigates to `/transactions/new`.

## Form layout

```
Direction pills (Gasto / Ingreso / Transferencia)
Amount hero (COP + big number)

— DETALLES —
Descripción
Cuenta
Fecha
Categoría (zone picker)

— ASIGNAR —
Destinatario (zone picker: create + recents)

▾ Más opciones  (collapsible)
   · Es una suscripción
   · Crear pago recurrente  (+ frecuencia / fecha inicio / cuenta origen para deudas)
   · Notas
```

## Backend

- `transactionSchema`:
  - `destinatario_id` (optional nullable uuid, same preprocess as `category_id`).
  - `is_subscription` (formBoolean, default false).
- `persistTransaction` INSERT now writes `is_subscription`.
- `createTransaction` computes `finalDestinatarioId = relatedSetup.destinatarioId ?? parsed.destinatario_id ?? null` — `linkTransactionToOccurrence` now receives this, so occurrence matching works for existing destinatarios, not just create-via-switch.

## Agent reviews

| Agent | Result |
|---|---|
| `server-action-reviewer` | PASS — finalDestinatarioId fallback flagged as a *positive correctness change* |
| `frontend-auditor` | 3 fixes applied (dangling htmlFor, DatePicker clipping, dashed tags hint removed) |
| `zetas-front-guy` | 1 fix applied (submit button → BRASS_BUTTON_CLASS) |

## Follow-ups (in BACKLOG.md)

- Tags picker inline during creation (needs `TagZonePicker` "pending tags" mode — today requires entity id).
- Cuenta + Fecha paired side-by-side at narrow viewports (attempted; DatePicker clipped).
- `htmlFor` on DatePicker / CategoryZonePicker / DestinatarioZonePicker labels (sub-components don't expose `id`; loose labeling only).
- Desktop `TransactionFormDialog` redesign (out of scope per user decision).

## Test plan

- [ ] Open FAB → Nueva transacción on mobile viewport. Form renders with sections.
- [ ] Create a Gasto with an existing destinatario. Verify the transaction is linked to the destinatario in the detail view.
- [ ] Create a Gasto with "Es una suscripción" toggled. Verify `is_subscription=true` persists.
- [ ] Create a recurring transaction via "Más opciones → Crear pago recurrente". Verify template is created and linked.
- [ ] Transferencia type hides the `Asignar` and `Más opciones` sections (unchanged behavior).
- [ ] Desktop `TransactionFormDialog` still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)