### PR TITLE
feat(mobile): captura crea destinatario/recurrente + cuentas v2

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
         "SUPABASE_URL": "${NEXT_PUBLIC_SUPABASE_URL}",
         "SUPABASE_SECRET_KEY": "${SUPABASE_SECRET_KEY}"
       }
+    },
+    "ios-simulator": {
+      "command": "npx",
+      "args": ["-y", "ios-simulator-mcp"]
     }
   }
 }

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -48,6 +48,13 @@
 - **Audit SQL:** `SELECT account_id, currency_code, count(*) FROM recurring_transaction_templates_enc WHERE direction='INFLOW' AND frequency='MONTHLY' AND category_id IS NULL GROUP BY 1,2 HAVING count(*) > 1;`
 - **Found:** 2026-04-18 — fixed in PR #174; merge follow-up flagged by recurring-doctor review.
 
+### Recurrence engine — end-of-month date drift in webapp + mobile trigger
+- **Priority:** Medium
+- **What:** `packages/shared/src/utils/recurrence.ts` `getOccurrencesBetween` uses date-fns `addMonths`, which collapses Jan 31 → Feb 28 and sticks at 28 for subsequent months. The same drift exists in the Supabase trigger (`20260422003433_auto_generate_recurring_occurrences.sql`) to match webapp behavior. `day_of_month` column is stored but unused in generation.
+- **Why not fixed in PR #212:** Fixing in the trigger alone would silently diverge from webapp. Proper fix: one PR that updates both `@zeta/shared` (use `day_of_month` as anchor with end-of-month clamping) and the trigger.
+- **Surface area:** Any template whose `start_date` is the 29th/30th/31st of a month. Rare but real — payroll, rent, credit-card cutoffs.
+- **Found:** 2026-04-22 — flagged by gemini-code-assist on PR #212.
+
 ### Investigate why migration 20260416120000 stamped without running
 - **Priority:** Medium
 - **What:** The remote `supabase_migrations.schema_migrations` table has `20260416120000` marked applied, but the underlying DDL (ALTER TABLE, view rebuild) never executed. Likely causes: (a) a manual `supabase migration repair --status applied`, (b) a partial `db push` that errored mid-migration but still stamped optimistically, (c) a DB reset/restore that restored the history row but not the schema. Check CI deploy logs around 2026-04-16 and grep shell history for `migration repair`. If this recurs, any future migration that depends on `sub_payments` would compile locally but fail in prod.

--- a/mobile/app/(tabs)/accounts.tsx
+++ b/mobile/app/(tabs)/accounts.tsx
@@ -12,7 +12,15 @@ import { Plus } from "lucide-react-native";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
 import { AccountCard } from "../../components/accounts/AccountCard";
+import { MobileHeader } from "../../components/ui/MobileHeader";
 import { useSync } from "../../lib/sync/hooks";
+import { COLORS } from "../../lib/constants/colors";
+import {
+  BRASS_BUTTON_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE,
+  PANEL_SURFACE_SUBTLE_CLASS,
+  SECTION_EYEBROW_CLASS,
+} from "../../lib/constants/styles";
 
 const DEBT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
 
@@ -63,58 +71,64 @@ export default function AccountsScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-gray-100">
-        <ActivityIndicator size="large" color="#C5BFAE" />
+      <View className="flex-1 items-center justify-center bg-background">
+        <ActivityIndicator size="large" color={COLORS.brass} />
       </View>
     );
   }
 
   return (
-    <View className="flex-1 bg-gray-100">
+    <View className="flex-1 bg-background">
+      <MobileHeader
+        variant="main"
+        title="Cuentas"
+        titleFont="narrator"
+        subtitle={
+          accounts.length === 1
+            ? "1 cuenta activa"
+            : `${accounts.length} cuentas activas`
+        }
+      />
       <FlatList
         data={accounts}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={{ paddingBottom: 100 }}
+        contentContainerStyle={{ paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
             onRefresh={handleRefresh}
-            tintColor="#C5BFAE"
+            tintColor={COLORS.brass}
           />
         }
         ListHeaderComponent={
-          <View className="px-4 pt-4 pb-2">
+          <View className="px-4 pt-4 pb-2 gap-4">
             {/* Net Worth Card */}
-            <View className="bg-white rounded-2xl p-5 mb-4 shadow-sm">
-              <Text className="text-gray-500 font-inter text-sm">
-                Patrimonio neto
-              </Text>
+            <View className={`${PANEL_SURFACE_SUBTLE_CLASS} p-5`}>
+              <Text className={SECTION_EYEBROW_CLASS}>Patrimonio neto</Text>
               <Text
-                className={`font-inter-bold text-3xl mt-1 ${
-                  isNegative ? "text-red-500" : "text-gray-900"
+                className={`font-inter-bold text-3xl mt-2 ${
+                  isNegative ? "text-z-debt" : "text-foreground"
                 }`}
               >
                 {formatCurrency(Math.abs(netWorth), "COP" as CurrencyCode)}
-              </Text>
-              <Text className="text-gray-400 font-inter text-xs mt-1">
-                {accounts.length}{" "}
-                {accounts.length === 1 ? "cuenta activa" : "cuentas activas"}
               </Text>
             </View>
 
             {/* Nueva cuenta button */}
             <Pressable
-              className="bg-primary rounded-xl py-3.5 items-center flex-row justify-center gap-2 active:bg-primary-dark mb-4"
+              className={`${BRASS_BUTTON_CLASS} rounded-xl py-3.5 items-center flex-row justify-center gap-2 active:bg-z-brass-80`}
               onPress={() => router.push("/account/create")}
+              accessibilityRole="button"
+              accessibilityLabel="Nueva cuenta"
             >
-              <Plus size={18} color="#FFFFFF" />
-              <Text className="text-white font-inter-bold text-sm">
+              <Plus size={18} color={COLORS.ink} />
+              <Text className="text-z-ink font-inter-bold text-sm">
                 Nueva cuenta
               </Text>
             </Pressable>
 
             {accounts.length > 0 && (
-              <Text className="text-gray-500 font-inter-semibold text-xs uppercase mb-2 px-1">
+              <Text className={`${SECTION_EYEBROW_CLASS} px-1`}>
                 Mis cuentas
               </Text>
             )}
@@ -122,7 +136,7 @@ export default function AccountsScreen() {
         }
         ListEmptyComponent={
           <View className="flex-1 items-center justify-center px-8 pt-8">
-            <Text className="text-gray-400 font-inter text-base text-center">
+            <Text className="text-muted-foreground font-inter text-base text-center">
               No tienes cuentas registradas.{"\n"}Crea una para empezar.
             </Text>
           </View>

--- a/mobile/app/(tabs)/accounts.tsx
+++ b/mobile/app/(tabs)/accounts.tsx
@@ -92,7 +92,10 @@ export default function AccountsScreen() {
       <FlatList
         data={accounts}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={{ paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
+        contentContainerStyle={{
+          paddingHorizontal: 16,
+          paddingBottom: MOBILE_TAB_BAR_CLEARANCE,
+        }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -101,7 +104,7 @@ export default function AccountsScreen() {
           />
         }
         ListHeaderComponent={
-          <View className="px-4 pt-4 pb-2 gap-4">
+          <View className="pt-4 pb-2 gap-4">
             {/* Net Worth Card */}
             <View className={`${PANEL_SURFACE_SUBTLE_CLASS} p-5`}>
               <Text className={SECTION_EYEBROW_CLASS}>Patrimonio neto</Text>
@@ -135,7 +138,7 @@ export default function AccountsScreen() {
           </View>
         }
         ListEmptyComponent={
-          <View className="flex-1 items-center justify-center px-8 pt-8">
+          <View className="flex-1 items-center justify-center px-4 pt-8">
             <Text className="text-muted-foreground font-inter text-base text-center">
               No tienes cuentas registradas.{"\n"}Crea una para empezar.
             </Text>
@@ -143,12 +146,10 @@ export default function AccountsScreen() {
         }
         ItemSeparatorComponent={() => <View className="h-2" />}
         renderItem={({ item }) => (
-          <View className="px-4">
-            <AccountCard
-              account={item}
-              onPress={() => router.push(`/account/${item.id}`)}
-            />
-          </View>
+          <AccountCard
+            account={item}
+            onPress={() => router.push(`/account/${item.id}`)}
+          />
         )}
       />
     </View>

--- a/mobile/app/account/create.tsx
+++ b/mobile/app/account/create.tsx
@@ -11,13 +11,18 @@ import {
 } from "react-native";
 import { useRouter } from "expo-router";
 import { useState } from "react";
-import { X } from "lucide-react-native";
 import { AccountTypeGrid } from "../../components/accounts/AccountTypeGrid";
 import { ColorPicker } from "../../components/accounts/ColorPicker";
 import { CurrencyPicker } from "../../components/accounts/CurrencyPicker";
+import { MobileHeader } from "../../components/ui/MobileHeader";
 import { createAccount } from "../../lib/repositories/accounts";
 import { useAuth } from "../../lib/auth";
 import { setPdfPasswordForAccount } from "../../lib/pdf-passwords";
+import { COLORS } from "../../lib/constants/colors";
+import {
+  BRASS_BUTTON_CLASS,
+  PANEL_INSET_CLASS,
+} from "../../lib/constants/styles";
 
 function FormField({
   label,
@@ -30,14 +35,16 @@ function FormField({
 }) {
   return (
     <View className="mb-4">
-      <Text className="text-gray-700 font-inter-medium text-sm mb-1.5">
+      <Text className="mb-1.5 text-[13px] font-inter-semibold text-foreground">
         {label}
-        {required && <Text className="text-red-500"> *</Text>}
+        {required && <Text className="text-z-debt"> *</Text>}
       </Text>
       {children}
     </View>
   );
 }
+
+const INPUT_CLASS = `${PANEL_INSET_CLASS} px-4 py-3 text-sm font-inter text-foreground`;
 
 function NumericInput({
   value,
@@ -50,11 +57,11 @@ function NumericInput({
 }) {
   return (
     <TextInput
-      className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+      className={INPUT_CLASS}
       value={value}
       onChangeText={onChangeText}
       placeholder={placeholder ?? "0"}
-      placeholderTextColor="#9CA3AF"
+      placeholderTextColor={COLORS.sageDark}
       keyboardType="decimal-pad"
     />
   );
@@ -80,16 +87,19 @@ function DayPicker({
         return (
           <Pressable
             key={day}
-            className={`w-10 h-10 rounded-full items-center justify-center border-2 ${
+            className={`w-10 h-10 rounded-full items-center justify-center border ${
               isSelected
-                ? "bg-primary border-primary"
-                : "bg-white border-gray-200"
+                ? "bg-z-brass border-z-brass"
+                : "bg-black-10 border-white-6"
             }`}
             onPress={() => onSelect(isSelected ? "" : day)}
+            accessibilityRole="button"
+            accessibilityLabel={`Día ${day}`}
+            accessibilityState={{ selected: isSelected }}
           >
             <Text
-              className={`font-inter-medium text-sm ${
-                isSelected ? "text-white" : "text-gray-700"
+              className={`font-inter-semibold text-sm ${
+                isSelected ? "text-z-ink" : "text-foreground"
               }`}
             >
               {day}
@@ -180,22 +190,10 @@ export default function CreateAccountScreen() {
 
   return (
     <KeyboardAvoidingView
-      className="flex-1 bg-gray-50"
+      className="flex-1 bg-background"
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
-      {/* Header */}
-      <View className="flex-row items-center justify-between px-4 pt-4 pb-2 bg-gray-50">
-        <Pressable
-          onPress={() => router.canGoBack() ? router.back() : router.navigate("/(tabs)/accounts")}
-          className="w-8 h-8 items-center justify-center rounded-full bg-gray-200 active:bg-gray-300"
-        >
-          <X size={18} color="#6B7280" />
-        </Pressable>
-        <Text className="text-gray-900 font-inter-bold text-base">
-          Nueva cuenta
-        </Text>
-        <View className="w-8" />
-      </View>
+      <MobileHeader variant="sub" title="Nueva cuenta" />
 
       <ScrollView
         className="flex-1"
@@ -214,11 +212,11 @@ export default function CreateAccountScreen() {
         {/* Name */}
         <FormField label="Nombre" required>
           <TextInput
-            className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+            className={INPUT_CLASS}
             value={name}
             onChangeText={setName}
             placeholder="Ej: Bancolombia Ahorros"
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={COLORS.sageDark}
             autoCapitalize="words"
           />
         </FormField>
@@ -226,11 +224,11 @@ export default function CreateAccountScreen() {
         {/* Institution */}
         <FormField label="Entidad financiera">
           <TextInput
-            className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+            className={INPUT_CLASS}
             value={institution}
             onChangeText={setInstitution}
             placeholder="Ej: Bancolombia"
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={COLORS.sageDark}
             autoCapitalize="words"
           />
         </FormField>
@@ -299,11 +297,11 @@ export default function CreateAccountScreen() {
         {/* PDF password */}
         <FormField label="Contraseña del extracto PDF">
           <TextInput
-            className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+            className={INPUT_CLASS}
             value={pdfPassword}
             onChangeText={setPdfPassword}
             placeholder="Si los PDFs de esta cuenta tienen clave"
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={COLORS.sageDark}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -311,7 +309,7 @@ export default function CreateAccountScreen() {
             importantForAutofill="no"
             textContentType="none"
           />
-          <Text className="text-gray-400 font-inter text-xs mt-1.5">
+          <Text className="mt-1.5 text-xs font-inter text-muted-foreground">
             Se sugiere automáticamente al importar extractos de esta cuenta.
           </Text>
         </FormField>
@@ -323,16 +321,19 @@ export default function CreateAccountScreen() {
 
         {/* Submit */}
         <Pressable
-          className={`rounded-xl py-4 items-center mt-2 ${
-            saving ? "bg-gray-300" : "bg-primary active:bg-primary-dark"
+          className={`${BRASS_BUTTON_CLASS} rounded-xl py-4 items-center mt-2 ${
+            saving ? "opacity-50" : "active:bg-z-brass-80"
           }`}
           onPress={handleSave}
           disabled={saving}
+          accessibilityRole="button"
+          accessibilityLabel="Crear cuenta"
+          accessibilityState={{ disabled: saving }}
         >
           {saving ? (
-            <ActivityIndicator color="#FFFFFF" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
-            <Text className="text-white font-inter-bold text-base">
+            <Text className="text-z-ink font-inter-bold text-base">
               Crear cuenta
             </Text>
           )}

--- a/mobile/app/account/create.tsx
+++ b/mobile/app/account/create.tsx
@@ -1,5 +1,4 @@
 import {
-  View,
   Text,
   TextInput,
   ScrollView,
@@ -14,6 +13,11 @@ import { useState } from "react";
 import { AccountTypeGrid } from "../../components/accounts/AccountTypeGrid";
 import { ColorPicker } from "../../components/accounts/ColorPicker";
 import { CurrencyPicker } from "../../components/accounts/CurrencyPicker";
+import {
+  DayPicker,
+  FormField,
+  NumericInput,
+} from "../../components/accounts/AccountFormFields";
 import { MobileHeader } from "../../components/ui/MobileHeader";
 import { createAccount } from "../../lib/repositories/accounts";
 import { useAuth } from "../../lib/auth";
@@ -21,95 +25,8 @@ import { setPdfPasswordForAccount } from "../../lib/pdf-passwords";
 import { COLORS } from "../../lib/constants/colors";
 import {
   BRASS_BUTTON_CLASS,
-  PANEL_INSET_CLASS,
+  FORM_INPUT_CLASS,
 } from "../../lib/constants/styles";
-
-function FormField({
-  label,
-  children,
-  required,
-}: {
-  label: string;
-  children: React.ReactNode;
-  required?: boolean;
-}) {
-  return (
-    <View className="mb-4">
-      <Text className="mb-1.5 text-[13px] font-inter-semibold text-foreground">
-        {label}
-        {required && <Text className="text-z-debt"> *</Text>}
-      </Text>
-      {children}
-    </View>
-  );
-}
-
-const INPUT_CLASS = `${PANEL_INSET_CLASS} px-4 py-3 text-sm font-inter text-foreground`;
-
-function NumericInput({
-  value,
-  onChangeText,
-  placeholder,
-}: {
-  value: string;
-  onChangeText: (v: string) => void;
-  placeholder?: string;
-}) {
-  return (
-    <TextInput
-      className={INPUT_CLASS}
-      value={value}
-      onChangeText={onChangeText}
-      placeholder={placeholder ?? "0"}
-      placeholderTextColor={COLORS.sageDark}
-      keyboardType="decimal-pad"
-    />
-  );
-}
-
-const CREDIT_CARD_DAYS = Array.from({ length: 31 }, (_, i) => String(i + 1));
-
-function DayPicker({
-  value,
-  onSelect,
-}: {
-  value: string;
-  onSelect: (v: string) => void;
-}) {
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{ gap: 8 }}
-    >
-      {CREDIT_CARD_DAYS.map((day) => {
-        const isSelected = value === day;
-        return (
-          <Pressable
-            key={day}
-            className={`w-10 h-10 rounded-full items-center justify-center border ${
-              isSelected
-                ? "bg-z-brass border-z-brass"
-                : "bg-black-10 border-white-6"
-            }`}
-            onPress={() => onSelect(isSelected ? "" : day)}
-            accessibilityRole="button"
-            accessibilityLabel={`Día ${day}`}
-            accessibilityState={{ selected: isSelected }}
-          >
-            <Text
-              className={`font-inter-semibold text-sm ${
-                isSelected ? "text-z-ink" : "text-foreground"
-              }`}
-            >
-              {day}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </ScrollView>
-  );
-}
 
 export default function CreateAccountScreen() {
   const router = useRouter();
@@ -212,7 +129,7 @@ export default function CreateAccountScreen() {
         {/* Name */}
         <FormField label="Nombre" required>
           <TextInput
-            className={INPUT_CLASS}
+            className={FORM_INPUT_CLASS}
             value={name}
             onChangeText={setName}
             placeholder="Ej: Bancolombia Ahorros"
@@ -224,7 +141,7 @@ export default function CreateAccountScreen() {
         {/* Institution */}
         <FormField label="Entidad financiera">
           <TextInput
-            className={INPUT_CLASS}
+            className={FORM_INPUT_CLASS}
             value={institution}
             onChangeText={setInstitution}
             placeholder="Ej: Bancolombia"
@@ -297,7 +214,7 @@ export default function CreateAccountScreen() {
         {/* PDF password */}
         <FormField label="Contraseña del extracto PDF">
           <TextInput
-            className={INPUT_CLASS}
+            className={FORM_INPUT_CLASS}
             value={pdfPassword}
             onChangeText={setPdfPassword}
             placeholder="Si los PDFs de esta cuenta tienen clave"

--- a/mobile/app/account/edit/[id].tsx
+++ b/mobile/app/account/edit/[id].tsx
@@ -11,10 +11,10 @@ import {
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { X } from "lucide-react-native";
 import { AccountTypeGrid } from "../../../components/accounts/AccountTypeGrid";
 import { ColorPicker } from "../../../components/accounts/ColorPicker";
 import { CurrencyPicker } from "../../../components/accounts/CurrencyPicker";
+import { MobileHeader } from "../../../components/ui/MobileHeader";
 import {
   getAccountById,
   updateAccount,
@@ -24,6 +24,11 @@ import {
   getPdfPasswordForAccount,
   setPdfPasswordForAccount,
 } from "../../../lib/pdf-passwords";
+import { COLORS } from "../../../lib/constants/colors";
+import {
+  BRASS_BUTTON_CLASS,
+  PANEL_INSET_CLASS,
+} from "../../../lib/constants/styles";
 
 function FormField({
   label,
@@ -36,14 +41,16 @@ function FormField({
 }) {
   return (
     <View className="mb-4">
-      <Text className="text-gray-700 font-inter-medium text-sm mb-1.5">
+      <Text className="mb-1.5 text-[13px] font-inter-semibold text-foreground">
         {label}
-        {required && <Text className="text-red-500"> *</Text>}
+        {required && <Text className="text-z-debt"> *</Text>}
       </Text>
       {children}
     </View>
   );
 }
+
+const INPUT_CLASS = `${PANEL_INSET_CLASS} px-4 py-3 text-sm font-inter text-foreground`;
 
 function NumericInput({
   value,
@@ -56,11 +63,11 @@ function NumericInput({
 }) {
   return (
     <TextInput
-      className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+      className={INPUT_CLASS}
       value={value}
       onChangeText={onChangeText}
       placeholder={placeholder ?? "0"}
-      placeholderTextColor="#9CA3AF"
+      placeholderTextColor={COLORS.sageDark}
       keyboardType="decimal-pad"
     />
   );
@@ -86,16 +93,19 @@ function DayPicker({
         return (
           <Pressable
             key={day}
-            className={`w-10 h-10 rounded-full items-center justify-center border-2 ${
+            className={`w-10 h-10 rounded-full items-center justify-center border ${
               isSelected
-                ? "bg-primary border-primary"
-                : "bg-white border-gray-200"
+                ? "bg-z-brass border-z-brass"
+                : "bg-black-10 border-white-6"
             }`}
             onPress={() => onSelect(isSelected ? "" : day)}
+            accessibilityRole="button"
+            accessibilityLabel={`Día ${day}`}
+            accessibilityState={{ selected: isSelected }}
           >
             <Text
-              className={`font-inter-medium text-sm ${
-                isSelected ? "text-white" : "text-gray-700"
+              className={`font-inter-semibold text-sm ${
+                isSelected ? "text-z-ink" : "text-foreground"
               }`}
             >
               {day}
@@ -213,30 +223,18 @@ export default function EditAccountScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-gray-50">
-        <ActivityIndicator size="large" color="#10B981" />
+      <View className="flex-1 items-center justify-center bg-background">
+        <ActivityIndicator size="large" color={COLORS.brass} />
       </View>
     );
   }
 
   return (
     <KeyboardAvoidingView
-      className="flex-1 bg-gray-50"
+      className="flex-1 bg-background"
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
-      {/* Header */}
-      <View className="flex-row items-center justify-between px-4 pt-4 pb-2 bg-gray-50">
-        <Pressable
-          onPress={() => router.back()}
-          className="w-8 h-8 items-center justify-center rounded-full bg-gray-200 active:bg-gray-300"
-        >
-          <X size={18} color="#6B7280" />
-        </Pressable>
-        <Text className="text-gray-900 font-inter-bold text-base">
-          Editar cuenta
-        </Text>
-        <View className="w-8" />
-      </View>
+      <MobileHeader variant="sub" title="Editar cuenta" />
 
       <ScrollView
         className="flex-1"
@@ -256,11 +254,11 @@ export default function EditAccountScreen() {
         {/* Name */}
         <FormField label="Nombre" required>
           <TextInput
-            className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+            className={INPUT_CLASS}
             value={name}
             onChangeText={setName}
             placeholder="Ej: Bancolombia Ahorros"
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={COLORS.sageDark}
             autoCapitalize="words"
           />
         </FormField>
@@ -268,11 +266,11 @@ export default function EditAccountScreen() {
         {/* Institution */}
         <FormField label="Entidad financiera">
           <TextInput
-            className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+            className={INPUT_CLASS}
             value={institution}
             onChangeText={setInstitution}
             placeholder="Ej: Bancolombia"
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={COLORS.sageDark}
             autoCapitalize="words"
           />
         </FormField>
@@ -332,11 +330,11 @@ export default function EditAccountScreen() {
         {/* PDF password */}
         <FormField label="Contraseña del extracto PDF">
           <TextInput
-            className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-gray-900 font-inter text-sm"
+            className={INPUT_CLASS}
             value={pdfPassword}
             onChangeText={setPdfPassword}
             placeholder="Si los PDFs de esta cuenta tienen clave"
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={COLORS.sageDark}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -344,7 +342,7 @@ export default function EditAccountScreen() {
             importantForAutofill="no"
             textContentType="none"
           />
-          <Text className="text-gray-400 font-inter text-xs mt-1.5">
+          <Text className="mt-1.5 text-xs font-inter text-muted-foreground">
             Se sugiere automáticamente al importar extractos de esta cuenta.
           </Text>
         </FormField>
@@ -356,16 +354,19 @@ export default function EditAccountScreen() {
 
         {/* Submit */}
         <Pressable
-          className={`rounded-xl py-4 items-center mt-2 ${
-            saving ? "bg-gray-300" : "bg-primary active:bg-primary-dark"
+          className={`${BRASS_BUTTON_CLASS} rounded-xl py-4 items-center mt-2 ${
+            saving ? "opacity-50" : "active:bg-z-brass-80"
           }`}
           onPress={handleSave}
           disabled={saving}
+          accessibilityRole="button"
+          accessibilityLabel="Guardar cambios"
+          accessibilityState={{ disabled: saving }}
         >
           {saving ? (
-            <ActivityIndicator color="#FFFFFF" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
-            <Text className="text-white font-inter-bold text-base">
+            <Text className="text-z-ink font-inter-bold text-base">
               Guardar cambios
             </Text>
           )}

--- a/mobile/app/account/edit/[id].tsx
+++ b/mobile/app/account/edit/[id].tsx
@@ -14,6 +14,11 @@ import { useEffect, useState } from "react";
 import { AccountTypeGrid } from "../../../components/accounts/AccountTypeGrid";
 import { ColorPicker } from "../../../components/accounts/ColorPicker";
 import { CurrencyPicker } from "../../../components/accounts/CurrencyPicker";
+import {
+  DayPicker,
+  FormField,
+  NumericInput,
+} from "../../../components/accounts/AccountFormFields";
 import { MobileHeader } from "../../../components/ui/MobileHeader";
 import {
   getAccountById,
@@ -27,95 +32,8 @@ import {
 import { COLORS } from "../../../lib/constants/colors";
 import {
   BRASS_BUTTON_CLASS,
-  PANEL_INSET_CLASS,
+  FORM_INPUT_CLASS,
 } from "../../../lib/constants/styles";
-
-function FormField({
-  label,
-  children,
-  required,
-}: {
-  label: string;
-  children: React.ReactNode;
-  required?: boolean;
-}) {
-  return (
-    <View className="mb-4">
-      <Text className="mb-1.5 text-[13px] font-inter-semibold text-foreground">
-        {label}
-        {required && <Text className="text-z-debt"> *</Text>}
-      </Text>
-      {children}
-    </View>
-  );
-}
-
-const INPUT_CLASS = `${PANEL_INSET_CLASS} px-4 py-3 text-sm font-inter text-foreground`;
-
-function NumericInput({
-  value,
-  onChangeText,
-  placeholder,
-}: {
-  value: string;
-  onChangeText: (v: string) => void;
-  placeholder?: string;
-}) {
-  return (
-    <TextInput
-      className={INPUT_CLASS}
-      value={value}
-      onChangeText={onChangeText}
-      placeholder={placeholder ?? "0"}
-      placeholderTextColor={COLORS.sageDark}
-      keyboardType="decimal-pad"
-    />
-  );
-}
-
-const CREDIT_CARD_DAYS = Array.from({ length: 31 }, (_, i) => String(i + 1));
-
-function DayPicker({
-  value,
-  onSelect,
-}: {
-  value: string;
-  onSelect: (v: string) => void;
-}) {
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{ gap: 8 }}
-    >
-      {CREDIT_CARD_DAYS.map((day) => {
-        const isSelected = value === day;
-        return (
-          <Pressable
-            key={day}
-            className={`w-10 h-10 rounded-full items-center justify-center border ${
-              isSelected
-                ? "bg-z-brass border-z-brass"
-                : "bg-black-10 border-white-6"
-            }`}
-            onPress={() => onSelect(isSelected ? "" : day)}
-            accessibilityRole="button"
-            accessibilityLabel={`Día ${day}`}
-            accessibilityState={{ selected: isSelected }}
-          >
-            <Text
-              className={`font-inter-semibold text-sm ${
-                isSelected ? "text-z-ink" : "text-foreground"
-              }`}
-            >
-              {day}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </ScrollView>
-  );
-}
 
 export default function EditAccountScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -254,7 +172,7 @@ export default function EditAccountScreen() {
         {/* Name */}
         <FormField label="Nombre" required>
           <TextInput
-            className={INPUT_CLASS}
+            className={FORM_INPUT_CLASS}
             value={name}
             onChangeText={setName}
             placeholder="Ej: Bancolombia Ahorros"
@@ -266,7 +184,7 @@ export default function EditAccountScreen() {
         {/* Institution */}
         <FormField label="Entidad financiera">
           <TextInput
-            className={INPUT_CLASS}
+            className={FORM_INPUT_CLASS}
             value={institution}
             onChangeText={setInstitution}
             placeholder="Ej: Bancolombia"
@@ -330,7 +248,7 @@ export default function EditAccountScreen() {
         {/* PDF password */}
         <FormField label="Contraseña del extracto PDF">
           <TextInput
-            className={INPUT_CLASS}
+            className={FORM_INPUT_CLASS}
             value={pdfPassword}
             onChangeText={setPdfPassword}
             placeholder="Si los PDFs de esta cuenta tienen clave"

--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -400,9 +400,16 @@ export default function CaptureScreen() {
               description: trimmedDescription,
               category_id: categoryId,
               destinatario_id: newDestinatarioId,
+              account_type: selectedAccount?.account_type ?? null,
             });
           } catch (err) {
             console.error("Create recurring template from capture failed:", err);
+            Alert.alert(
+              "No se creó el recurrente",
+              err instanceof Error
+                ? err.message
+                : "Ocurrió un error creando la plantilla recurrente."
+            );
           }
         }
       }

--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -45,6 +45,8 @@ import {
   type CategoryRow,
 } from "../lib/repositories/categories";
 import { createTransaction } from "../lib/repositories/transactions";
+import { createDestinatarioWithPattern } from "../lib/repositories/destinatarios";
+import { createRecurringTemplate } from "../lib/repositories/recurring";
 import { toLocalDateString } from "../lib/utils/date";
 import {
   BRASS_BUTTON_CLASS,
@@ -218,6 +220,8 @@ export default function CaptureScreen() {
   const [categoryId, setCategoryId] = useState<string | null>(null);
   const [categoryName, setCategoryName] = useState<string | null>(null);
   const [isSubscription, setIsSubscription] = useState(false);
+  const [createDestinatario, setCreateDestinatario] = useState(false);
+  const [createRecurring, setCreateRecurring] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -335,6 +339,7 @@ export default function CaptureScreen() {
 
     setSaving(true);
     try {
+      const trimmedDescription = description.trim();
       await createTransaction({
         user_id: session.user.id,
         account_id: accountId,
@@ -342,15 +347,65 @@ export default function CaptureScreen() {
         currency_code: currencyCode,
         direction,
         transaction_date: transactionDate,
-        description: description.trim(),
-        merchant_name: description.trim(),
-        raw_description: description.trim(),
+        description: trimmedDescription,
+        merchant_name: trimmedDescription,
+        raw_description: trimmedDescription,
         category_id: categoryId,
         notes: notes.trim() || null,
         provider: "MANUAL",
         capture_method: "MANUAL_FORM",
         is_subscription: isSubscription,
       });
+
+      let newDestinatarioId: string | null = null;
+      if (createDestinatario) {
+        try {
+          const { destinatarioId } = await createDestinatarioWithPattern({
+            user_id: session.user.id,
+            name: trimmedDescription,
+            default_category_id: categoryId,
+            pattern: trimmedDescription,
+          });
+          newDestinatarioId = destinatarioId;
+        } catch (err) {
+          console.error("Create destinatario from capture failed:", err);
+        }
+      }
+
+      if (createRecurring) {
+        // DEBT accounts (CREDIT_CARD/LOAN) require direction=INFLOW +
+        // transfer_source_account_id per webapp validator. Capture doesn't
+        // surface a source picker, so skip rather than write bad data.
+        const isDebtAccount =
+          selectedAccount?.account_type === "CREDIT_CARD" ||
+          selectedAccount?.account_type === "LOAN";
+        if (isDebtAccount) {
+          Alert.alert(
+            "No disponible en esta cuenta",
+            "Crear pago recurrente en tarjetas de crédito o préstamos requiere elegir una cuenta origen. Hazlo desde la pantalla de Recurrentes."
+          );
+        } else {
+          try {
+            const dayOfMonth = Number(transactionDate.slice(8, 10)) || 1;
+            await createRecurringTemplate({
+              user_id: session.user.id,
+              account_id: accountId,
+              amount: parsedAmount,
+              currency_code: currencyCode,
+              direction,
+              frequency: "MONTHLY",
+              start_date: transactionDate,
+              day_of_month: dayOfMonth,
+              merchant_name: trimmedDescription,
+              description: trimmedDescription,
+              category_id: categoryId,
+              destinatario_id: newDestinatarioId,
+            });
+          } catch (err) {
+            console.error("Create recurring template from capture failed:", err);
+          }
+        }
+      }
 
       await SecureStore.setItemAsync(DEFAULT_ACCOUNT_KEY, accountId);
       router.back();
@@ -574,17 +629,7 @@ export default function CaptureScreen() {
             <View
               className={`${PANEL_INSET_CLASS} mt-2 px-4 py-4 gap-4`}
             >
-              <Pressable
-                onPress={() =>
-                  Alert.alert(
-                    "Próximamente",
-                    "Crear destinatario desde esta pantalla llega pronto."
-                  )
-                }
-                accessibilityRole="button"
-                accessibilityLabel="Crear destinatario"
-                className="flex-row items-start gap-3 active:opacity-70"
-              >
+              <View className="flex-row items-start gap-3">
                 <View className="flex-1">
                   <Text className="text-sm font-inter-semibold text-foreground">
                     Crear destinatario
@@ -593,32 +638,36 @@ export default function CaptureScreen() {
                     Guarda este comercio para reconocerlo más rápido la próxima vez.
                   </Text>
                 </View>
-                <ChevronRight size={16} color={COLORS.sageDark} />
-              </Pressable>
+                <Switch
+                  value={createDestinatario}
+                  onValueChange={setCreateDestinatario}
+                  trackColor={{ false: COLORS.switchTrack, true: COLORS.income }}
+                  thumbColor={COLORS.foreground}
+                  ios_backgroundColor={COLORS.switchTrack}
+                  accessibilityLabel="Crear destinatario al guardar"
+                />
+              </View>
 
               <View className="h-px bg-white-6" />
 
-              <Pressable
-                onPress={() =>
-                  Alert.alert(
-                    "Próximamente",
-                    "Crear pago recurrente desde esta pantalla llega pronto."
-                  )
-                }
-                accessibilityRole="button"
-                accessibilityLabel="Crear pago recurrente"
-                className="flex-row items-start gap-3 active:opacity-70"
-              >
+              <View className="flex-row items-start gap-3">
                 <View className="flex-1">
                   <Text className="text-sm font-inter-semibold text-foreground">
                     Crear pago recurrente
                   </Text>
                   <Text className="mt-0.5 text-[11px] font-inter text-muted-foreground">
-                    Útil si este movimiento se repite cada semana, mes o trimestre.
+                    Útil si este movimiento se repite cada mes. Se crea una plantilla mensual.
                   </Text>
                 </View>
-                <ChevronRight size={16} color={COLORS.sageDark} />
-              </Pressable>
+                <Switch
+                  value={createRecurring}
+                  onValueChange={setCreateRecurring}
+                  trackColor={{ false: COLORS.switchTrack, true: COLORS.income }}
+                  thumbColor={COLORS.foreground}
+                  ios_backgroundColor={COLORS.switchTrack}
+                  accessibilityLabel="Crear pago recurrente al guardar"
+                />
+              </View>
             </View>
           )}
         </View>

--- a/mobile/components/accounts/AccountFormFields.tsx
+++ b/mobile/components/accounts/AccountFormFields.tsx
@@ -1,0 +1,89 @@
+import { ScrollView, Pressable, Text, TextInput, View } from "react-native";
+import type { ReactNode } from "react";
+import { COLORS } from "../../lib/constants/colors";
+import { FORM_INPUT_CLASS } from "../../lib/constants/styles";
+
+export function FormField({
+  label,
+  children,
+  required,
+}: {
+  label: string;
+  children: ReactNode;
+  required?: boolean;
+}) {
+  return (
+    <View className="mb-4">
+      <Text className="mb-1.5 text-[13px] font-inter-semibold text-foreground">
+        {label}
+        {required && <Text className="text-z-debt"> *</Text>}
+      </Text>
+      {children}
+    </View>
+  );
+}
+
+export function NumericInput({
+  value,
+  onChangeText,
+  placeholder,
+}: {
+  value: string;
+  onChangeText: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <TextInput
+      className={FORM_INPUT_CLASS}
+      value={value}
+      onChangeText={onChangeText}
+      placeholder={placeholder ?? "0"}
+      placeholderTextColor={COLORS.sageDark}
+      keyboardType="decimal-pad"
+    />
+  );
+}
+
+const DAYS_OF_MONTH = Array.from({ length: 31 }, (_, i) => String(i + 1));
+
+export function DayPicker({
+  value,
+  onSelect,
+}: {
+  value: string;
+  onSelect: (v: string) => void;
+}) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{ gap: 8 }}
+    >
+      {DAYS_OF_MONTH.map((day) => {
+        const isSelected = value === day;
+        return (
+          <Pressable
+            key={day}
+            className={`w-10 h-10 rounded-full items-center justify-center border ${
+              isSelected
+                ? "bg-z-brass border-z-brass"
+                : "bg-black-10 border-white-6"
+            }`}
+            onPress={() => onSelect(isSelected ? "" : day)}
+            accessibilityRole="button"
+            accessibilityLabel={`Día ${day}`}
+            accessibilityState={{ selected: isSelected }}
+          >
+            <Text
+              className={`font-inter-semibold text-sm ${
+                isSelected ? "text-z-ink" : "text-foreground"
+              }`}
+            >
+              {day}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/mobile/components/accounts/AccountTypeGrid.tsx
+++ b/mobile/components/accounts/AccountTypeGrid.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { ACCOUNT_TYPES } from "../../lib/constants/accounts";
+import { COLORS } from "../../lib/constants/colors";
 
 type Props = {
   selected: string;
@@ -17,25 +18,31 @@ export function AccountTypeGrid({ selected, onSelect, disabled = false }: Props)
         return (
           <Pressable
             key={type.value}
-            className={`flex-1 min-w-[44%] rounded-xl p-3.5 border-2 ${
+            className={`flex-1 min-w-[44%] rounded-xl p-3.5 border ${
               isSelected
-                ? "border-primary bg-primary/10"
-                : "border-gray-200 bg-white"
-            } ${disabled ? "opacity-60" : "active:bg-gray-50"}`}
+                ? "border-z-brass bg-z-brass-8"
+                : "border-white-6 bg-z-surface-2-55"
+            } ${disabled ? "opacity-60" : "active:bg-black-10"}`}
             onPress={() => !disabled && onSelect(type.value)}
+            accessibilityRole="button"
+            accessibilityLabel={type.label}
+            accessibilityState={{ selected: isSelected, disabled }}
           >
             <Icon
               size={22}
-              color={isSelected ? "#10B981" : "#6B7280"}
+              color={isSelected ? COLORS.brass : COLORS.sageDark}
             />
             <Text
               className={`font-inter-semibold text-sm mt-2 ${
-                isSelected ? "text-primary" : "text-gray-900"
+                isSelected ? "text-z-brass" : "text-foreground"
               }`}
             >
               {type.label}
             </Text>
-            <Text className="text-gray-400 font-inter text-xs mt-0.5" numberOfLines={2}>
+            <Text
+              className="text-muted-foreground font-inter text-xs mt-0.5"
+              numberOfLines={2}
+            >
               {type.description}
             </Text>
           </Pressable>

--- a/mobile/components/accounts/CurrencyPicker.tsx
+++ b/mobile/components/accounts/CurrencyPicker.tsx
@@ -18,16 +18,19 @@ export function CurrencyPicker({ selected, onSelect }: Props) {
         return (
           <Pressable
             key={currency.code}
-            className={`rounded-full px-4 py-2 border-2 active:opacity-80 ${
+            className={`rounded-full px-4 py-2 border active:opacity-80 ${
               isSelected
-                ? "bg-primary border-primary"
+                ? "bg-z-brass border-z-brass"
                 : "bg-z-surface-2-55 border-white-6"
             }`}
             onPress={() => onSelect(currency.code)}
+            accessibilityRole="button"
+            accessibilityLabel={currency.code}
+            accessibilityState={{ selected: isSelected }}
           >
             <Text
               className={`font-inter-semibold text-sm ${
-                isSelected ? "text-white" : "text-muted-foreground"
+                isSelected ? "text-z-ink" : "text-muted-foreground"
               }`}
             >
               {currency.code}

--- a/mobile/lib/constants/styles.ts
+++ b/mobile/lib/constants/styles.ts
@@ -25,6 +25,9 @@ export const PANEL_SURFACE_SUBTLE_CLASS =
 /** Compact inset surface */
 export const PANEL_INSET_CLASS = "rounded-2xl border border-white-6 bg-black-10";
 
+/** Token-based text input surface — used by all v2 form fields */
+export const FORM_INPUT_CLASS = `${PANEL_INSET_CLASS} px-4 py-3 text-sm font-inter text-foreground`;
+
 /** Mobile v2 card: inset container with padding */
 export const MOBILE_CARD_CLASS = `${PANEL_SURFACE_SUBTLE_CLASS} p-3`;
 

--- a/mobile/lib/db/schema.ts
+++ b/mobile/lib/db/schema.ts
@@ -352,6 +352,16 @@ export const DB_MIGRATIONS: DbMigration[] = [
       `ALTER TABLE profiles ADD COLUMN mobile_dashboard_config TEXT`,
     ],
   },
+  {
+    version: 10,
+    statements: [
+      // ── recurring_transaction_templates: destinatario linkage ──────────
+      // Webapp added this column in 20260417170859_add_destinatario_id_to_recurring_templates.sql.
+      // Mobile needs it so the capture flow can link a new recurring template
+      // to the destinatario created in the same save.
+      `ALTER TABLE recurring_transaction_templates ADD COLUMN destinatario_id TEXT`,
+    ],
+  },
 ];
 
 export const LATEST_DB_VERSION =

--- a/mobile/lib/repositories/destinatarios.ts
+++ b/mobile/lib/repositories/destinatarios.ts
@@ -1,3 +1,4 @@
+import * as Crypto from "expo-crypto";
 import { getDatabase } from "../db/database";
 
 export type DestinatarioRow = {
@@ -70,4 +71,92 @@ export async function getRulesForDestinatario(
      ORDER BY priority DESC`,
     [destinatarioId]
   );
+}
+
+export type CreateDestinatarioParams = {
+  user_id: string;
+  name: string;
+  default_category_id?: string | null;
+  notes?: string | null;
+  pattern?: string | null;
+};
+
+/**
+ * Creates a destinatario locally and (optionally) a single matching rule.
+ * Both inserts + sync_queue entries run in one SQLite transaction.
+ * Mirrors webapp/src/actions/destinatarios.ts `createDestinatario` shape.
+ */
+export async function createDestinatarioWithPattern(
+  params: CreateDestinatarioParams
+): Promise<{ destinatarioId: string; ruleId: string | null }> {
+  const db = await getDatabase();
+  const destinatarioId = Crypto.randomUUID();
+  const ruleId = params.pattern?.trim() ? Crypto.randomUUID() : null;
+  const now = new Date().toISOString();
+
+  const destPayload = {
+    id: destinatarioId,
+    user_id: params.user_id,
+    name: params.name,
+    default_category_id: params.default_category_id ?? null,
+    notes: params.notes ?? null,
+    is_active: true,
+    created_at: now,
+    updated_at: now,
+  };
+
+  await db.withTransactionAsync(async () => {
+    await db.runAsync(
+      `INSERT INTO destinatarios
+        (id, user_id, name, default_category_id, notes, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+      [
+        destPayload.id,
+        destPayload.user_id,
+        destPayload.name,
+        destPayload.default_category_id,
+        destPayload.notes,
+        now,
+        now,
+      ]
+    );
+
+    await db.runAsync(
+      `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+       VALUES ('destinatarios', ?, 'INSERT', ?, ?)`,
+      [destinatarioId, JSON.stringify(destPayload), now]
+    );
+
+    if (ruleId && params.pattern) {
+      const rulePayload = {
+        id: ruleId,
+        user_id: params.user_id,
+        destinatario_id: destinatarioId,
+        pattern: params.pattern.trim(),
+        match_type: "contains" as const,
+        priority: 100,
+      };
+
+      await db.runAsync(
+        `INSERT INTO destinatario_rules
+          (id, user_id, destinatario_id, pattern, match_type, priority, match_count, created_at)
+         VALUES (?, ?, ?, ?, 'contains', 100, 0, ?)`,
+        [
+          rulePayload.id,
+          rulePayload.user_id,
+          rulePayload.destinatario_id,
+          rulePayload.pattern,
+          now,
+        ]
+      );
+
+      await db.runAsync(
+        `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+         VALUES ('destinatario_rules', ?, 'INSERT', ?, ?)`,
+        [ruleId, JSON.stringify(rulePayload), now]
+      );
+    }
+  });
+
+  return { destinatarioId, ruleId };
 }

--- a/mobile/lib/repositories/destinatarios.ts
+++ b/mobile/lib/repositories/destinatarios.ts
@@ -1,5 +1,6 @@
 import * as Crypto from "expo-crypto";
 import { getDatabase } from "../db/database";
+import { enqueueInsert } from "../sync/queue";
 
 export type DestinatarioRow = {
   id: string;
@@ -120,12 +121,7 @@ export async function createDestinatarioWithPattern(
         now,
       ]
     );
-
-    await db.runAsync(
-      `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
-       VALUES ('destinatarios', ?, 'INSERT', ?, ?)`,
-      [destinatarioId, JSON.stringify(destPayload), now]
-    );
+    await enqueueInsert(db, "destinatarios", destinatarioId, destPayload, now);
 
     if (ruleId && params.pattern) {
       const rulePayload = {
@@ -149,12 +145,7 @@ export async function createDestinatarioWithPattern(
           now,
         ]
       );
-
-      await db.runAsync(
-        `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
-         VALUES ('destinatario_rules', ?, 'INSERT', ?, ?)`,
-        [ruleId, JSON.stringify(rulePayload), now]
-      );
+      await enqueueInsert(db, "destinatario_rules", ruleId, rulePayload, now);
     }
   });
 

--- a/mobile/lib/repositories/recurring.ts
+++ b/mobile/lib/repositories/recurring.ts
@@ -206,14 +206,15 @@ export async function createRecurringTemplate(
         [params.account_id]
       )
     )?.account_type;
-  if (acctType && DEBT_ACCOUNT_TYPES.has(acctType)) {
-    if (!params.transfer_source_account_id) {
-      throw new Error(
-        "Debes seleccionar la cuenta origen para un pago de deuda."
-      );
-    }
-    params = { ...params, direction: "INFLOW" };
+  const isDebtAccount = !!acctType && DEBT_ACCOUNT_TYPES.has(acctType);
+  if (isDebtAccount && !params.transfer_source_account_id) {
+    throw new Error(
+      "Debes seleccionar la cuenta origen para un pago de deuda."
+    );
   }
+  const effectiveDirection: TransactionDirection = isDebtAccount
+    ? "INFLOW"
+    : params.direction;
 
   const payload = {
     id,
@@ -222,7 +223,7 @@ export async function createRecurringTemplate(
     category_id: params.category_id ?? null,
     amount: params.amount,
     currency_code: params.currency_code,
-    direction: params.direction,
+    direction: effectiveDirection,
     frequency: params.frequency,
     day_of_month: params.day_of_month ?? null,
     day_of_week: params.day_of_week ?? null,

--- a/mobile/lib/repositories/recurring.ts
+++ b/mobile/lib/repositories/recurring.ts
@@ -1,5 +1,7 @@
 import * as Crypto from "expo-crypto";
+import type { RecurrenceFrequency, TransactionDirection } from "@zeta/shared";
 import { getDatabase } from "../db/database";
+import { enqueueInsert } from "../sync/queue";
 
 /** Convert a recurring amount to its monthly equivalent based on frequency. */
 export function toMonthlyAmount(amount: number, frequency: string): number {
@@ -162,8 +164,8 @@ export type CreateRecurringTemplateParams = {
   account_id: string;
   amount: number;
   currency_code: string;
-  direction: "INFLOW" | "OUTFLOW";
-  frequency: "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "QUARTERLY" | "ANNUAL";
+  direction: TransactionDirection;
+  frequency: RecurrenceFrequency;
   start_date: string;
   end_date?: string | null;
   merchant_name?: string | null;
@@ -173,6 +175,8 @@ export type CreateRecurringTemplateParams = {
   day_of_month?: number | null;
   day_of_week?: number | null;
   transfer_source_account_id?: string | null;
+  /** Optional pre-fetched account type — lets callers skip the DEBT guard's SELECT. */
+  account_type?: string | null;
 };
 
 /**
@@ -194,11 +198,15 @@ export async function createRecurringTemplate(
   // Defense-in-depth: enforce the same debt-account rules the webapp's
   // `insertRecurringTemplateFromFormData` applies. Callers (e.g. capture.tsx)
   // should pre-check, but a stray caller must not produce corrupt rows.
-  const acct = await db.getFirstAsync<{ account_type: string }>(
-    "SELECT account_type FROM accounts WHERE id = ?",
-    [params.account_id]
-  );
-  if (acct && DEBT_ACCOUNT_TYPES.has(acct.account_type)) {
+  const acctType =
+    params.account_type ??
+    (
+      await db.getFirstAsync<{ account_type: string }>(
+        "SELECT account_type FROM accounts WHERE id = ?",
+        [params.account_id]
+      )
+    )?.account_type;
+  if (acctType && DEBT_ACCOUNT_TYPES.has(acctType)) {
     if (!params.transfer_source_account_id) {
       throw new Error(
         "Debes seleccionar la cuenta origen para un pago de deuda."
@@ -258,11 +266,7 @@ export async function createRecurringTemplate(
       ]
     );
 
-    await db.runAsync(
-      `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
-       VALUES ('recurring_transaction_templates', ?, 'INSERT', ?, ?)`,
-      [id, JSON.stringify(payload), now]
-    );
+    await enqueueInsert(db, "recurring_transaction_templates", id, payload, now);
   });
 
   return id;

--- a/mobile/lib/repositories/recurring.ts
+++ b/mobile/lib/repositories/recurring.ts
@@ -1,3 +1,4 @@
+import * as Crypto from "expo-crypto";
 import { getDatabase } from "../db/database";
 
 /** Convert a recurring amount to its monthly equivalent based on frequency. */
@@ -154,6 +155,117 @@ export async function getRecurringSummary(month: string) {
   );
 
   return row ?? { total_expected: 0, pending_count: 0, paid_count: 0, skipped_count: 0 };
+}
+
+export type CreateRecurringTemplateParams = {
+  user_id: string;
+  account_id: string;
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+  frequency: "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "QUARTERLY" | "ANNUAL";
+  start_date: string;
+  end_date?: string | null;
+  merchant_name?: string | null;
+  description?: string | null;
+  category_id?: string | null;
+  destinatario_id?: string | null;
+  day_of_month?: number | null;
+  day_of_week?: number | null;
+  transfer_source_account_id?: string | null;
+};
+
+/**
+ * Create a recurring template locally and enqueue for sync.
+ * Mirrors webapp `createRecurringTemplate` shape minus sub_payments
+ * (mobile doesn't yet handle multi-currency sub-payments).
+ * Server-side occurrences generation (ensureCurrentOccurrences) happens
+ * on pull after the template syncs.
+ */
+const DEBT_ACCOUNT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
+
+export async function createRecurringTemplate(
+  params: CreateRecurringTemplateParams
+): Promise<string> {
+  const db = await getDatabase();
+  const id = Crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  // Defense-in-depth: enforce the same debt-account rules the webapp's
+  // `insertRecurringTemplateFromFormData` applies. Callers (e.g. capture.tsx)
+  // should pre-check, but a stray caller must not produce corrupt rows.
+  const acct = await db.getFirstAsync<{ account_type: string }>(
+    "SELECT account_type FROM accounts WHERE id = ?",
+    [params.account_id]
+  );
+  if (acct && DEBT_ACCOUNT_TYPES.has(acct.account_type)) {
+    if (!params.transfer_source_account_id) {
+      throw new Error(
+        "Debes seleccionar la cuenta origen para un pago de deuda."
+      );
+    }
+    params = { ...params, direction: "INFLOW" };
+  }
+
+  const payload = {
+    id,
+    user_id: params.user_id,
+    account_id: params.account_id,
+    category_id: params.category_id ?? null,
+    amount: params.amount,
+    currency_code: params.currency_code,
+    direction: params.direction,
+    frequency: params.frequency,
+    day_of_month: params.day_of_month ?? null,
+    day_of_week: params.day_of_week ?? null,
+    start_date: params.start_date,
+    end_date: params.end_date ?? null,
+    merchant_name: params.merchant_name ?? null,
+    description: params.description ?? null,
+    destinatario_id: params.destinatario_id ?? null,
+    transfer_source_account_id: params.transfer_source_account_id ?? null,
+    is_active: true,
+    created_at: now,
+    updated_at: now,
+  };
+
+  await db.withTransactionAsync(async () => {
+    await db.runAsync(
+      `INSERT INTO recurring_transaction_templates
+        (id, user_id, account_id, category_id, amount, currency_code, direction, frequency,
+         day_of_month, day_of_week, start_date, end_date, merchant_name, description,
+         destinatario_id, transfer_source_account_id, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+      [
+        payload.id,
+        payload.user_id,
+        payload.account_id,
+        payload.category_id,
+        payload.amount,
+        payload.currency_code,
+        payload.direction,
+        payload.frequency,
+        payload.day_of_month,
+        payload.day_of_week,
+        payload.start_date,
+        payload.end_date,
+        payload.merchant_name,
+        payload.description,
+        payload.destinatario_id,
+        payload.transfer_source_account_id,
+        now,
+        now,
+      ]
+    );
+
+    await db.runAsync(
+      `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+       VALUES ('recurring_transaction_templates', ?, 'INSERT', ?, ?)`,
+      [id, JSON.stringify(payload), now]
+    );
+  });
+
+  return id;
 }
 
 /** Mark an occurrence as paid and enqueue for sync. */

--- a/mobile/lib/sync/queue.ts
+++ b/mobile/lib/sync/queue.ts
@@ -1,0 +1,46 @@
+import type { SQLiteDatabase } from "expo-sqlite";
+
+/**
+ * Enqueue an INSERT into sync_queue. Caller handles the local table INSERT.
+ * Typically wrapped with the local INSERT in a single SQLite transaction.
+ */
+export async function enqueueInsert(
+  db: SQLiteDatabase,
+  tableName: string,
+  recordId: string,
+  payload: Record<string, unknown>,
+  now: string = new Date().toISOString()
+): Promise<void> {
+  await db.runAsync(
+    `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+     VALUES (?, ?, 'INSERT', ?, ?)`,
+    [tableName, recordId, JSON.stringify(payload), now]
+  );
+}
+
+export async function enqueueUpdate(
+  db: SQLiteDatabase,
+  tableName: string,
+  recordId: string,
+  payload: Record<string, unknown>,
+  now: string = new Date().toISOString()
+): Promise<void> {
+  await db.runAsync(
+    `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+     VALUES (?, ?, 'UPDATE', ?, ?)`,
+    [tableName, recordId, JSON.stringify(payload), now]
+  );
+}
+
+export async function enqueueDelete(
+  db: SQLiteDatabase,
+  tableName: string,
+  recordId: string,
+  now: string = new Date().toISOString()
+): Promise<void> {
+  await db.runAsync(
+    `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+     VALUES (?, ?, 'DELETE', ?, ?)`,
+    [tableName, recordId, JSON.stringify({ id: recordId }), now]
+  );
+}

--- a/supabase/migrations/20260422003433_auto_generate_recurring_occurrences.sql
+++ b/supabase/migrations/20260422003433_auto_generate_recurring_occurrences.sql
@@ -1,0 +1,163 @@
+-- =============================================================================
+-- Auto-generate recurring_occurrences when a template is inserted or activated.
+--
+-- Closes a webapp/mobile divergence: mobile creates templates directly via
+-- Supabase but never calls the webapp's ensureCurrentOccurrences(), so mobile
+-- users' Plan page stays empty until a webapp user visits it.
+--
+-- Mirrors webapp/src/lib/utils/occurrence-generator.ts +
+-- packages/shared/src/utils/recurrence.ts:
+--   - Only fires when is_active = true
+--   - Range: [date_trunc('month', now()), date_trunc('month', now()) + 1 month - 1 day + 14 days]
+--   - Start date = GREATEST(template.start_date, range_start)
+--   - Step: WEEKLY=7d, BIWEEKLY=14d, MONTHLY=1mo, QUARTERLY=3mo, ANNUAL=1yr, ONCE=single
+--   - Respects end_date (stops when occurrence > end_date)
+--   - Idempotent via UNIQUE (template_id, occurrence_date) + ON CONFLICT DO NOTHING
+--
+-- The INSTEAD OF INSERT/UPDATE triggers on the `recurring_transaction_templates`
+-- view forward to `recurring_transaction_templates_enc`, so AFTER INSERT / AFTER
+-- UPDATE on the base table fire for every path (webapp view INSERT, mobile
+-- direct insert via service-role, admin client, etc.).
+-- =============================================================================
+
+-- Idempotency guard: drop prior versions so this migration is reversible and
+-- safe to re-run during local troubleshooting.
+DROP TRIGGER IF EXISTS recurring_templates_enc_generate_occurrences_ins
+  ON recurring_transaction_templates_enc;
+DROP TRIGGER IF EXISTS recurring_templates_enc_generate_occurrences_upd
+  ON recurring_transaction_templates_enc;
+DROP FUNCTION IF EXISTS generate_occurrences_for_template(uuid);
+DROP FUNCTION IF EXISTS recurring_templates_enc_generate_occurrences_fn();
+
+-- -----------------------------------------------------------------------------
+-- Core generator: materializes occurrences for a single template id.
+-- Mirrors getOccurrencesBetween() from packages/shared/src/utils/recurrence.ts.
+-- SECURITY DEFINER so it runs even when called from a trigger context where
+-- RLS would otherwise block the INSERT into recurring_occurrences.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION generate_occurrences_for_template(p_template_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id       uuid;
+  v_amount        numeric(15,2);
+  v_start_date    date;
+  v_end_date      date;
+  v_frequency     text;
+  v_is_active     boolean;
+  v_range_start   date;
+  v_range_end     date;
+  v_cursor        date;
+BEGIN
+  -- Read the template directly from the encrypted base table (non-PII columns
+  -- are not encrypted, so no decryption needed).
+  SELECT user_id, amount, start_date, end_date, frequency::text, is_active
+    INTO v_user_id, v_amount, v_start_date, v_end_date, v_frequency, v_is_active
+  FROM recurring_transaction_templates_enc
+  WHERE id = p_template_id;
+
+  IF NOT FOUND THEN RETURN; END IF;
+  IF NOT v_is_active THEN RETURN; END IF;
+
+  -- Range: current month start through end-of-month + 14 days.
+  v_range_start := date_trunc('month', now())::date;
+  v_range_end   := (date_trunc('month', now())
+                     + interval '1 month - 1 day'
+                     + interval '14 days')::date;
+
+  -- ONCE: single occurrence at start_date, if it falls in range and not past end_date.
+  IF v_frequency = 'ONCE' THEN
+    IF v_start_date BETWEEN v_range_start AND v_range_end
+       AND (v_end_date IS NULL OR v_start_date <= v_end_date) THEN
+      INSERT INTO recurring_occurrences
+        (template_id, user_id, occurrence_date, expected_amount, status)
+      VALUES
+        (p_template_id, v_user_id, v_start_date, v_amount, 'pending')
+      ON CONFLICT (template_id, occurrence_date) DO NOTHING;
+    END IF;
+    RETURN;
+  END IF;
+
+  -- Recurring: walk from start_date forward until we reach range_start,
+  -- then emit every step that falls within [range_start, range_end].
+  v_cursor := v_start_date;
+
+  WHILE v_cursor < v_range_start LOOP
+    v_cursor := CASE v_frequency
+      WHEN 'WEEKLY'    THEN v_cursor + interval '7 days'
+      WHEN 'BIWEEKLY'  THEN v_cursor + interval '14 days'
+      WHEN 'MONTHLY'   THEN v_cursor + interval '1 month'
+      WHEN 'QUARTERLY' THEN v_cursor + interval '3 months'
+      WHEN 'ANNUAL'    THEN v_cursor + interval '1 year'
+      ELSE NULL
+    END;
+    IF v_cursor IS NULL THEN RETURN; END IF;  -- unknown frequency: bail
+  END LOOP;
+
+  WHILE v_cursor <= v_range_end LOOP
+    IF v_end_date IS NOT NULL AND v_cursor > v_end_date THEN EXIT; END IF;
+
+    INSERT INTO recurring_occurrences
+      (template_id, user_id, occurrence_date, expected_amount, status)
+    VALUES
+      (p_template_id, v_user_id, v_cursor, v_amount, 'pending')
+    ON CONFLICT (template_id, occurrence_date) DO NOTHING;
+
+    v_cursor := CASE v_frequency
+      WHEN 'WEEKLY'    THEN v_cursor + interval '7 days'
+      WHEN 'BIWEEKLY'  THEN v_cursor + interval '14 days'
+      WHEN 'MONTHLY'   THEN v_cursor + interval '1 month'
+      WHEN 'QUARTERLY' THEN v_cursor + interval '3 months'
+      WHEN 'ANNUAL'    THEN v_cursor + interval '1 year'
+      ELSE NULL
+    END;
+    IF v_cursor IS NULL THEN EXIT; END IF;
+  END LOOP;
+END;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Trigger dispatcher: handles both AFTER INSERT and AFTER UPDATE.
+-- On UPDATE, only re-generates when the active flag flips on, or when the
+-- schedule fields change (start_date, frequency, end_date) on an active row.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION recurring_templates_enc_generate_occurrences_fn()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.is_active THEN
+      PERFORM generate_occurrences_for_template(NEW.id);
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE path
+  IF NEW.is_active AND (
+       NOT OLD.is_active
+       OR OLD.start_date IS DISTINCT FROM NEW.start_date
+       OR OLD.frequency  IS DISTINCT FROM NEW.frequency
+       OR OLD.end_date   IS DISTINCT FROM NEW.end_date
+     ) THEN
+    PERFORM generate_occurrences_for_template(NEW.id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER recurring_templates_enc_generate_occurrences_ins
+  AFTER INSERT ON recurring_transaction_templates_enc
+  FOR EACH ROW
+  EXECUTE FUNCTION recurring_templates_enc_generate_occurrences_fn();
+
+CREATE TRIGGER recurring_templates_enc_generate_occurrences_upd
+  AFTER UPDATE ON recurring_transaction_templates_enc
+  FOR EACH ROW
+  EXECUTE FUNCTION recurring_templates_enc_generate_occurrences_fn();

--- a/supabase/migrations/20260422010000_refine_recurring_occurrence_trigger.sql
+++ b/supabase/migrations/20260422010000_refine_recurring_occurrence_trigger.sql
@@ -1,0 +1,27 @@
+-- =============================================================================
+-- Perf refinement of 20260422003433_auto_generate_recurring_occurrences.sql:
+-- move the "should we regenerate occurrences?" predicate into the trigger's
+-- WHEN clause so the SECURITY DEFINER function (which does a SELECT on
+-- recurring_transaction_templates_enc) isn't invoked for unrelated updates
+-- (updated_at-only touches from sync, amount/merchant edits, etc.).
+--
+-- Schedule columns on _enc (is_active, start_date, frequency, end_date) are
+-- plaintext, so they're safe to reference in a WHEN clause.
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS recurring_templates_enc_generate_occurrences_upd
+  ON recurring_transaction_templates_enc;
+
+CREATE TRIGGER recurring_templates_enc_generate_occurrences_upd
+  AFTER UPDATE ON recurring_transaction_templates_enc
+  FOR EACH ROW
+  WHEN (
+    NEW.is_active
+    AND (
+      NOT OLD.is_active
+      OR OLD.start_date IS DISTINCT FROM NEW.start_date
+      OR OLD.frequency  IS DISTINCT FROM NEW.frequency
+      OR OLD.end_date   IS DISTINCT FROM NEW.end_date
+    )
+  )
+  EXECUTE FUNCTION recurring_templates_enc_generate_occurrences_fn();


### PR DESCRIPTION
## Summary

Two sequential mobile slices closing audit gaps vs. the webapp.

**Slice 1 — Capture screen crea destinatario + recurrente** (`d5b49b0`)
- Replaces two \`Alert("Próximamente")\` stubs in \`capture.tsx\` with Switch toggles that run alongside transaction save
- New repo methods: \`createDestinatarioWithPattern()\`, \`createRecurringTemplate()\` (local SQLite INSERT + sync_queue enqueue)
- DEBT account guard (CREDIT_CARD / LOAN): blocks recurring creation at UI (clear message pointing to Recurrentes) and at repo layer (defense-in-depth throw)
- SQLite migration v10: adds \`destinatario_id\` column to \`recurring_transaction_templates\` so a capture that toggles both can link them
- Supabase migration: AFTER INSERT/UPDATE trigger on \`recurring_transaction_templates_enc\` auto-generates \`recurring_occurrences\` for current month + 14 days — closes the divergence where mobile-created templates were invisible in Plan until a webapp session

**Slice 2 — Cuentas + formularios a tokens v2** (\`91e7b49\`)
- Last straggler of pre-v2 UI. Replaces hardcoded light-mode classes (\`bg-gray-100/white\`, \`text-gray-500/900\`, \`border-gray-200\`, undefined \`bg-primary\`) with the design-system tokens used everywhere else in the app
- Screens: \`(tabs)/accounts.tsx\`, \`account/create.tsx\`, \`account/edit/[id].tsx\`
- Subcomponents: \`AccountTypeGrid\`, \`CurrencyPicker\` (same white-tile issue)
- Uses \`MobileHeader\` (safe-area-aware) instead of ad-hoc headers

## Gates

- \`mobile-webapp-parity\` — flagged 3 issues; all addressed (DEBT guard, destinatario_id linkage, occurrences trigger)
- \`mobile-sync-doctor\` — confirmed \`name_hmac\` omission safe, payload shapes correct; repo-layer DEBT guard added as defense-in-depth
- \`pnpm build\` (webapp) — clean
- \`npx tsc --noEmit\` (mobile) — clean on touched files
- Supabase migration applied to remote (\`20260422003433_auto_generate_recurring_occurrences.sql\`) — verified live in simulator

## Test plan

- [ ] Capture → toggle "Crear destinatario" → save → destinatario appears in webapp after sync
- [ ] Capture → toggle "Crear pago recurrente" → save → template + occurrences appear in Plan
- [ ] Toggle both on same capture → recurring template has \`destinatario_id\` set
- [ ] Capture on a CREDIT_CARD account + toggle recurrente → Alert blocks, no row created
- [ ] Cuentas tab renders dark-mode with brass highlights, subtitle counts correctly
- [ ] Nueva cuenta flow end-to-end (type grid selection, currency chips, color picker, submit)
- [ ] Edit existing cuenta with same v2 styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)