### PR TITLE
feat(mobile): captura formatea monto con separadores de miles

### DIFF
--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -37,7 +37,7 @@ import {
   CategoryZonePickerSheet,
   type CategoryRow as PickerCategoryRow,
 } from "../components/transactions/CategoryZonePickerSheet";
-import { parseLocalizedAmount } from "../lib/amount";
+import { formatAmountInput, parseFormattedAmount } from "../lib/amount";
 import { useAuth } from "../lib/auth";
 import { getAllAccounts, type AccountRow } from "../lib/repositories/accounts";
 import {
@@ -272,7 +272,7 @@ export default function CaptureScreen() {
     [categories, direction]
   );
 
-  const parsedAmount = parseLocalizedAmount(amountInput);
+  const parsedAmount = parseFormattedAmount(amountInput);
   const hasValidAmount = Number.isFinite(parsedAmount) && parsedAmount > 0;
   const amountToneClass =
     !hasValidAmount
@@ -481,7 +481,7 @@ export default function CaptureScreen() {
           </Text>
           <TextInput
             value={amountInput}
-            onChangeText={setAmountInput}
+            onChangeText={(next) => setAmountInput(formatAmountInput(next))}
             keyboardType="decimal-pad"
             placeholder="0"
             placeholderTextColor={COLORS.sageDark}

--- a/mobile/lib/amount.ts
+++ b/mobile/lib/amount.ts
@@ -32,3 +32,60 @@ export function parseLocalizedAmount(input: string): number {
 
   return Number(trimmed);
 }
+
+/**
+ * Format a partial amount string for live display in an input:
+ *   "5000"      -> "5.000"
+ *   "1234567"   -> "1.234.567"
+ *   "1234,5"    -> "1.234,5"
+ *   "5.000"     -> "5.000"  (dots already placed)
+ *   "5.00"      -> "500"    (backspacing from "5.000" — dot treated as thousands)
+ * Rule: `.` is always a thousand separator; `,` is the decimal marker.
+ * This matches Colombian COP convention and keeps backspace intuitive.
+ */
+export function formatAmountInput(input: string): string {
+  const sanitized = (input ?? "").replace(/[^\d.,]/g, "");
+  if (!sanitized) return "";
+
+  const lastComma = sanitized.lastIndexOf(",");
+  let integerSource: string;
+  let decimalPart: string | null = null;
+
+  if (lastComma === -1) {
+    integerSource = sanitized;
+  } else {
+    const tail = sanitized.slice(lastComma + 1);
+    if (tail.length <= 2 && !/[.,]/.test(tail)) {
+      integerSource = sanitized.slice(0, lastComma);
+      decimalPart = tail;
+    } else {
+      integerSource = sanitized;
+    }
+  }
+
+  const digits = integerSource.replace(/\D/g, "").replace(/^0+(?=\d)/, "");
+  if (digits === "" && decimalPart === null) return "";
+  const integerDigits = digits === "" ? "0" : digits;
+  const grouped = integerDigits.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return decimalPart === null ? grouped : `${grouped},${decimalPart}`;
+}
+
+/**
+ * Parse a formatted amount input (as produced by `formatAmountInput`) to a
+ * number. Dots are treated as thousand separators, comma as the decimal mark.
+ */
+export function parseFormattedAmount(formatted: string): number {
+  const sanitized = (formatted ?? "").replace(/[^\d.,]/g, "");
+  if (!sanitized) return Number.NaN;
+
+  const lastComma = sanitized.lastIndexOf(",");
+  if (lastComma === -1) {
+    return Number(sanitized.replace(/\./g, ""));
+  }
+  const tail = sanitized.slice(lastComma + 1);
+  if (tail.length <= 2 && !/[.,]/.test(tail)) {
+    const integer = sanitized.slice(0, lastComma).replace(/[.,]/g, "");
+    return Number(`${integer || "0"}.${tail || "0"}`);
+  }
+  return Number(sanitized.replace(/[.,]/g, ""));
+}

--- a/mobile/lib/amount.ts
+++ b/mobile/lib/amount.ts
@@ -34,6 +34,14 @@ export function parseLocalizedAmount(input: string): number {
 }
 
 /**
+ * A tail is a decimal fraction when it has 0-2 digits and no separators —
+ * the user typed `,` or `,xx` rather than a thousand group.
+ */
+function isDecimalTail(tail: string): boolean {
+  return tail.length <= 2 && !/[.,]/.test(tail);
+}
+
+/**
  * Format a partial amount string for live display in an input:
  *   "5000"      -> "5.000"
  *   "1234567"   -> "1.234.567"
@@ -48,18 +56,14 @@ export function formatAmountInput(input: string): string {
   if (!sanitized) return "";
 
   const lastComma = sanitized.lastIndexOf(",");
-  let integerSource: string;
+  let integerSource = sanitized;
   let decimalPart: string | null = null;
 
-  if (lastComma === -1) {
-    integerSource = sanitized;
-  } else {
+  if (lastComma !== -1) {
     const tail = sanitized.slice(lastComma + 1);
-    if (tail.length <= 2 && !/[.,]/.test(tail)) {
+    if (isDecimalTail(tail)) {
       integerSource = sanitized.slice(0, lastComma);
       decimalPart = tail;
-    } else {
-      integerSource = sanitized;
     }
   }
 
@@ -83,7 +87,7 @@ export function parseFormattedAmount(formatted: string): number {
     return Number(sanitized.replace(/\./g, ""));
   }
   const tail = sanitized.slice(lastComma + 1);
-  if (tail.length <= 2 && !/[.,]/.test(tail)) {
+  if (isDecimalTail(tail)) {
     const integer = sanitized.slice(0, lastComma).replace(/[.,]/g, "");
     return Number(`${integer || "0"}.${tail || "0"}`);
   }


### PR DESCRIPTION
## Summary
- `mobile/app/capture.tsx` ahora muestra el monto con formato COP en vivo mientras el usuario escribe (`124124` → `124.124`).
- Añade `formatAmountInput` y `parseFormattedAmount` en `mobile/lib/amount.ts`. El dot actúa siempre como separador de miles; la coma marca el decimal — backspace se comporta como espera (borra un dígito).
- `parseLocalizedAmount` queda intacta, los otros inputs numéricos (subscriptions, transaction edit, budgets, plan sheets) no cambian.

## Test plan
- [x] `pnpm --filter @zeta/shared test src/utils/__tests__/recurrence.test.ts` (no afecta este PR, sanity)
- [x] `npx tsc --noEmit` en mobile — limpio sobre archivos tocados
- [x] `pnpm build` webapp — `Compiled successfully`
- [ ] Smoke en simulador: escribir `5000`, `5000000`, backspace a `500`, luego `5000,50`, verificar display y que guardar persiste el valor correcto.

Cierra el ítem "Mobile capture amount live-formatting" del BACKLOG.