### PR TITLE
fix(recurrence): corrige drift de fin de mes en ambas implementaciones

### DIFF
--- a/packages/shared/src/utils/__tests__/recurrence.test.ts
+++ b/packages/shared/src/utils/__tests__/recurrence.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { getNextOccurrence, getOccurrencesBetween } from "../recurrence";
+
+describe("getOccurrencesBetween — end-of-month anchor", () => {
+  it("Jan 31 MONTHLY returns Jan 31, Feb 28, Mar 31, Apr 30, May 31", () => {
+    const dates = getOccurrencesBetween(
+      "2026-01-31",
+      "MONTHLY",
+      null,
+      new Date("2026-01-01T00:00:00"),
+      new Date("2026-05-31T00:00:00")
+    );
+    expect(dates).toEqual([
+      "2026-01-31",
+      "2026-02-28",
+      "2026-03-31",
+      "2026-04-30",
+      "2026-05-31",
+    ]);
+  });
+
+  it("Jan 30 MONTHLY clamps Feb to 28 but returns to 30 in Mar", () => {
+    const dates = getOccurrencesBetween(
+      "2026-01-30",
+      "MONTHLY",
+      null,
+      new Date("2026-01-01T00:00:00"),
+      new Date("2026-03-31T00:00:00")
+    );
+    expect(dates).toEqual(["2026-01-30", "2026-02-28", "2026-03-30"]);
+  });
+
+  it("Feb 29 ANNUAL clamps to Feb 28 in non-leap years", () => {
+    const dates = getOccurrencesBetween(
+      "2024-02-29",
+      "ANNUAL",
+      null,
+      new Date("2024-01-01T00:00:00"),
+      new Date("2028-12-31T00:00:00")
+    );
+    expect(dates).toEqual([
+      "2024-02-29",
+      "2025-02-28",
+      "2026-02-28",
+      "2027-02-28",
+      "2028-02-29",
+    ]);
+  });
+
+  it("Jan 31 QUARTERLY clamps to Apr 30 and recovers to Jul 31 / Oct 31", () => {
+    const dates = getOccurrencesBetween(
+      "2026-01-31",
+      "QUARTERLY",
+      null,
+      new Date("2026-01-01T00:00:00"),
+      new Date("2026-12-31T00:00:00")
+    );
+    expect(dates).toEqual([
+      "2026-01-31",
+      "2026-04-30",
+      "2026-07-31",
+      "2026-10-31",
+    ]);
+  });
+
+  it("WEEKLY advances by 7 days without drift", () => {
+    const dates = getOccurrencesBetween(
+      "2026-01-05",
+      "WEEKLY",
+      null,
+      new Date("2026-01-01T00:00:00"),
+      new Date("2026-02-02T00:00:00")
+    );
+    expect(dates).toEqual([
+      "2026-01-05",
+      "2026-01-12",
+      "2026-01-19",
+      "2026-01-26",
+      "2026-02-02",
+    ]);
+  });
+});
+
+describe("getNextOccurrence — drift anchor", () => {
+  it("Jan 31 template returns Mar 31 when asked from Mar 1", () => {
+    const next = getNextOccurrence(
+      "2026-01-31",
+      "MONTHLY",
+      null,
+      new Date("2026-03-01T00:00:00")
+    );
+    expect(next).toBe("2026-03-31");
+  });
+
+  it("Jan 31 template returns Apr 30 when asked from Apr 1", () => {
+    const next = getNextOccurrence(
+      "2026-01-31",
+      "MONTHLY",
+      null,
+      new Date("2026-04-01T00:00:00")
+    );
+    expect(next).toBe("2026-04-30");
+  });
+
+  it("respects end date", () => {
+    const next = getNextOccurrence(
+      "2026-01-31",
+      "MONTHLY",
+      "2026-03-15",
+      new Date("2026-04-01T00:00:00")
+    );
+    expect(next).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/recurrence.ts
+++ b/packages/shared/src/utils/recurrence.ts
@@ -1,4 +1,4 @@
-import { addWeeks, addMonths, addYears, parseISO, isBefore, isAfter, startOfDay } from "date-fns";
+import { addWeeks, addMonths, addYears, format, parseISO, isBefore, isAfter, startOfDay } from "date-fns";
 import type { RecurrenceFrequency } from "../types/domain";
 
 /**
@@ -47,7 +47,7 @@ export function getNextOccurrence(
   if (frequency === "ONCE") {
     if (isBefore(start, from)) return null;
     if (end && isAfter(start, end)) return null;
-    return start.toISOString().split("T")[0];
+    return format(start, "yyyy-MM-dd");
   }
 
   let k = 0;
@@ -58,7 +58,7 @@ export function getNextOccurrence(
   }
 
   if (end && isAfter(current, end)) return null;
-  return current.toISOString().split("T")[0];
+  return format(current, "yyyy-MM-dd");
 }
 
 /**
@@ -80,7 +80,7 @@ export function getOccurrencesBetween(
   if (frequency === "ONCE") {
     if (!isAfter(start, to) && !isBefore(start, from)) {
       if (!end || !isAfter(start, end)) {
-        dates.push(start.toISOString().split("T")[0]);
+        dates.push(format(start, "yyyy-MM-dd"));
       }
     }
     return dates;
@@ -95,7 +95,7 @@ export function getOccurrencesBetween(
 
   while (!isAfter(current, to)) {
     if (end && isAfter(current, end)) break;
-    dates.push(current.toISOString().split("T")[0]);
+    dates.push(format(current, "yyyy-MM-dd"));
     k += 1;
     current = occurrenceAt(start, k, frequency);
   }

--- a/packages/shared/src/utils/recurrence.ts
+++ b/packages/shared/src/utils/recurrence.ts
@@ -2,22 +2,25 @@ import { addWeeks, addMonths, addYears, parseISO, isBefore, isAfter, startOfDay 
 import type { RecurrenceFrequency } from "../types/domain";
 
 /**
- * Advance a date by one period of the given frequency.
+ * Compute the k-th occurrence of a recurring series from its anchor start date.
+ * Computing relative to `start` (rather than iteratively from previous occurrence)
+ * avoids end-of-month drift — e.g., a series starting Jan 31 stays anchored on
+ * the 31st and only clamps in shorter months (Feb 28, Apr 30), not permanently.
  */
-function advanceByFrequency(date: Date, frequency: RecurrenceFrequency): Date {
+function occurrenceAt(start: Date, k: number, frequency: RecurrenceFrequency): Date {
   switch (frequency) {
     case "WEEKLY":
-      return addWeeks(date, 1);
+      return addWeeks(start, k);
     case "BIWEEKLY":
-      return addWeeks(date, 2);
+      return addWeeks(start, k * 2);
     case "MONTHLY":
-      return addMonths(date, 1);
+      return addMonths(start, k);
     case "QUARTERLY":
-      return addMonths(date, 3);
+      return addMonths(start, k * 3);
     case "ANNUAL":
-      return addYears(date, 1);
+      return addYears(start, k);
     case "ONCE":
-      return date; // no advancement — single occurrence at start_date
+      return start;
     default: {
       const _exhaustive: never = frequency;
       return _exhaustive;
@@ -39,26 +42,22 @@ export function getNextOccurrence(
   const start = startOfDay(parseISO(startDate));
   const end = endDate ? startOfDay(parseISO(endDate)) : null;
 
-  // If end date has passed, no more occurrences
   if (end && isBefore(end, from)) return null;
 
-  // ONCE: single occurrence at start_date
   if (frequency === "ONCE") {
-    if (end && isBefore(end, from)) return null;
     if (isBefore(start, from)) return null;
+    if (end && isAfter(start, end)) return null;
     return start.toISOString().split("T")[0];
   }
 
+  let k = 0;
   let current = start;
-
-  // Advance until we reach or pass fromDate
   while (isBefore(current, from)) {
-    current = advanceByFrequency(current, frequency);
+    k += 1;
+    current = occurrenceAt(start, k, frequency);
   }
 
-  // Check if this occurrence is past the end date
   if (end && isAfter(current, end)) return null;
-
   return current.toISOString().split("T")[0];
 }
 
@@ -78,7 +77,6 @@ export function getOccurrencesBetween(
   const from = startOfDay(rangeStart);
   const to = startOfDay(rangeEnd);
 
-  // ONCE: single occurrence at start_date if within range
   if (frequency === "ONCE") {
     if (!isAfter(start, to) && !isBefore(start, from)) {
       if (!end || !isAfter(start, end)) {
@@ -88,18 +86,18 @@ export function getOccurrencesBetween(
     return dates;
   }
 
+  let k = 0;
   let current = start;
-
-  // Advance to first occurrence on or after rangeStart
   while (isBefore(current, from)) {
-    current = advanceByFrequency(current, frequency);
+    k += 1;
+    current = occurrenceAt(start, k, frequency);
   }
 
-  // Collect all dates within range
   while (!isAfter(current, to)) {
     if (end && isAfter(current, end)) break;
     dates.push(current.toISOString().split("T")[0]);
-    current = advanceByFrequency(current, frequency);
+    k += 1;
+    current = occurrenceAt(start, k, frequency);
   }
 
   return dates;

--- a/supabase/migrations/20260422020000_fix_recurrence_eom_drift.sql
+++ b/supabase/migrations/20260422020000_fix_recurrence_eom_drift.sql
@@ -1,0 +1,98 @@
+-- =============================================================================
+-- Fix end-of-month drift in generate_occurrences_for_template.
+--
+-- Previous version iterated `v_cursor := v_cursor + interval '1 month'`, which
+-- drifts: Jan 31 → Feb 28 (clamped) → Mar 28 → Apr 28 ... permanently stuck on
+-- the 28th instead of returning to the 31st in long months.
+--
+-- Fix: anchor all arithmetic on `v_start_date` and use a step counter. Postgres'
+-- interval arithmetic clamps only where the target month is shorter, so
+-- `v_start_date + k * interval '1 month'` preserves the 31st anchor.
+--
+-- Mirrors packages/shared/src/utils/recurrence.ts occurrenceAt() after the same
+-- fix on the JS side. Keep these two implementations in sync.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION generate_occurrences_for_template(p_template_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id       uuid;
+  v_amount        numeric(15,2);
+  v_start_date    date;
+  v_end_date      date;
+  v_frequency     text;
+  v_is_active     boolean;
+  v_range_start   date;
+  v_range_end     date;
+  v_cursor        date;
+  v_step          integer;
+BEGIN
+  SELECT user_id, amount, start_date, end_date, frequency::text, is_active
+    INTO v_user_id, v_amount, v_start_date, v_end_date, v_frequency, v_is_active
+  FROM recurring_transaction_templates_enc
+  WHERE id = p_template_id;
+
+  IF NOT FOUND THEN RETURN; END IF;
+  IF NOT v_is_active THEN RETURN; END IF;
+
+  v_range_start := date_trunc('month', now())::date;
+  v_range_end   := (date_trunc('month', now())
+                     + interval '1 month'
+                     - interval '1 day'
+                     + interval '14 days')::date;
+
+  IF v_frequency = 'ONCE' THEN
+    IF v_start_date BETWEEN v_range_start AND v_range_end
+       AND (v_end_date IS NULL OR v_start_date <= v_end_date) THEN
+      INSERT INTO recurring_occurrences
+        (template_id, user_id, occurrence_date, expected_amount, status)
+      VALUES
+        (p_template_id, v_user_id, v_start_date, v_amount, 'pending')
+      ON CONFLICT (template_id, occurrence_date) DO NOTHING;
+    END IF;
+    RETURN;
+  END IF;
+
+  v_step  := 0;
+  v_cursor := v_start_date;
+
+  -- Advance to first occurrence at or after range_start, always relative to anchor.
+  WHILE v_cursor < v_range_start LOOP
+    v_step := v_step + 1;
+    v_cursor := CASE v_frequency
+      WHEN 'WEEKLY'    THEN v_start_date + (v_step * interval '7 days')
+      WHEN 'BIWEEKLY'  THEN v_start_date + (v_step * interval '14 days')
+      WHEN 'MONTHLY'   THEN v_start_date + (v_step * interval '1 month')
+      WHEN 'QUARTERLY' THEN v_start_date + (v_step * interval '3 months')
+      WHEN 'ANNUAL'    THEN v_start_date + (v_step * interval '1 year')
+      ELSE NULL
+    END;
+    IF v_cursor IS NULL THEN RETURN; END IF;
+  END LOOP;
+
+  WHILE v_cursor <= v_range_end LOOP
+    IF v_end_date IS NOT NULL AND v_cursor > v_end_date THEN EXIT; END IF;
+
+    INSERT INTO recurring_occurrences
+      (template_id, user_id, occurrence_date, expected_amount, status)
+    VALUES
+      (p_template_id, v_user_id, v_cursor, v_amount, 'pending')
+    ON CONFLICT (template_id, occurrence_date) DO NOTHING;
+
+    v_step := v_step + 1;
+    v_cursor := CASE v_frequency
+      WHEN 'WEEKLY'    THEN v_start_date + (v_step * interval '7 days')
+      WHEN 'BIWEEKLY'  THEN v_start_date + (v_step * interval '14 days')
+      WHEN 'MONTHLY'   THEN v_start_date + (v_step * interval '1 month')
+      WHEN 'QUARTERLY' THEN v_start_date + (v_step * interval '3 months')
+      WHEN 'ANNUAL'    THEN v_start_date + (v_step * interval '1 year')
+      ELSE NULL
+    END;
+    IF v_cursor IS NULL THEN EXIT; END IF;
+  END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260422020000_fix_recurrence_eom_drift.sql
+++ b/supabase/migrations/20260422020000_fix_recurrence_eom_drift.sql
@@ -57,31 +57,22 @@ BEGIN
     RETURN;
   END IF;
 
-  v_step  := 0;
+  -- Single loop over every step from anchor; insert only when the cursor
+  -- falls inside [range_start, range_end]. Keeps the frequency CASE in one
+  -- place (vs. a duplicated advance-then-collect pattern).
+  v_step := 0;
   v_cursor := v_start_date;
-
-  -- Advance to first occurrence at or after range_start, always relative to anchor.
-  WHILE v_cursor < v_range_start LOOP
-    v_step := v_step + 1;
-    v_cursor := CASE v_frequency
-      WHEN 'WEEKLY'    THEN v_start_date + (v_step * interval '7 days')
-      WHEN 'BIWEEKLY'  THEN v_start_date + (v_step * interval '14 days')
-      WHEN 'MONTHLY'   THEN v_start_date + (v_step * interval '1 month')
-      WHEN 'QUARTERLY' THEN v_start_date + (v_step * interval '3 months')
-      WHEN 'ANNUAL'    THEN v_start_date + (v_step * interval '1 year')
-      ELSE NULL
-    END;
-    IF v_cursor IS NULL THEN RETURN; END IF;
-  END LOOP;
 
   WHILE v_cursor <= v_range_end LOOP
     IF v_end_date IS NOT NULL AND v_cursor > v_end_date THEN EXIT; END IF;
 
-    INSERT INTO recurring_occurrences
-      (template_id, user_id, occurrence_date, expected_amount, status)
-    VALUES
-      (p_template_id, v_user_id, v_cursor, v_amount, 'pending')
-    ON CONFLICT (template_id, occurrence_date) DO NOTHING;
+    IF v_cursor >= v_range_start THEN
+      INSERT INTO recurring_occurrences
+        (template_id, user_id, occurrence_date, expected_amount, status)
+      VALUES
+        (p_template_id, v_user_id, v_cursor, v_amount, 'pending')
+      ON CONFLICT (template_id, occurrence_date) DO NOTHING;
+    END IF;
 
     v_step := v_step + 1;
     v_cursor := CASE v_frequency


### PR DESCRIPTION
## Summary
- Plantillas con `start_date` en 29/30/31 colapsaban permanentemente al 28 (o último de mes corto) porque la generación iteraba `current + 1 month` desde el valor anterior.
- Corrección pareada: `@zeta/shared/recurrence.ts` y `supabase/migrations/.../generate_occurrences_for_template` ahora anclan en `start_date` y avanzan con un contador de pasos (`addMonths(start, k)` / `v_start_date + (v_step * interval '1 month')`).
- Postgres y `date-fns` ambos preservan el anchor de día al sumar meses desde el inicio — clampan solo donde el mes destino es más corto.
- 8 tests nuevos cubren Jan 31 / Jan 30 MONTHLY, Jan 31 QUARTERLY, Feb 29 ANNUAL en años no bisiestos, WEEKLY y `getNextOccurrence`.

## Alcance
- **Solo nuevas generaciones.** Ocurrencias ya materializadas con drift no se auto-corrigen (`ON CONFLICT DO NOTHING`). Si se necesita backfill, requiere una migración de datos separada.
- Callers afectados vía `@zeta/shared`: `webapp/src/lib/utils/occurrence-generator.ts`, `webapp/src/actions/recurring-templates.ts`, `webapp/src/actions/cashflow-planner.ts`, `webapp/src/components/recurring/recurring-list.tsx`. Todos delegan a la función compartida — comportamiento cambia en un solo lugar.

## Test plan
- [x] `pnpm --filter @zeta/shared test src/utils/__tests__/recurrence.test.ts` — 8/8 pass
- [x] `pnpm build` webapp — `Compiled successfully`
- [x] `recurring-doctor` agent review: PASS (JS/SQL parity verificada, sin regresión en callers)
- [ ] Aplicar migración en remoto y regenerar ocurrencias para una plantilla de prueba con `start_date = 2026-01-31`, verificar que la secuencia sea Jan 31 / Feb 28 / Mar 31 / Apr 30 / May 31.

Cierra el ítem "Recurrence engine end-of-month drift" del BACKLOG (feedback Gemini en PR #212).