### PR TITLE
fix(mobile): capture screens — tokens, voice locale, preflight

### DIFF
--- a/mobile/app/capture-screenshot.tsx
+++ b/mobile/app/capture-screenshot.tsx
@@ -251,7 +251,7 @@ export default function CaptureScreenshotScreen() {
         >
           <ArrowLeft size={18} color={COLORS.foreground} />
         </Pressable>
-        <Text className="text-lg font-semibold text-z-fg">
+        <Text className="text-lg font-semibold text-z-white">
           Capturar extracto
         </Text>
       </View>
@@ -266,7 +266,7 @@ export default function CaptureScreenshotScreen() {
       >
         {step === "pick" && (
           <View className="mt-4 gap-3">
-            <Text className="text-sm text-z-fg-dim">
+            <Text className="text-sm text-z-sage-dark">
               Toma una foto del extracto o elige una imagen de tu galería. Zeta detecta las transacciones automáticamente.
             </Text>
             <Pressable
@@ -285,7 +285,7 @@ export default function CaptureScreenshotScreen() {
               className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-4`}
             >
               <ImageIcon size={18} color={COLORS.foreground} />
-              <Text className="text-base font-medium text-z-fg">
+              <Text className="text-base font-medium text-z-white">
                 Elegir de galería
               </Text>
             </Pressable>
@@ -300,12 +300,12 @@ export default function CaptureScreenshotScreen() {
               style={{ width: "100%", height: 420, borderRadius: 16, backgroundColor: "rgba(255,255,255,0.06)" }}
             />
             {error ? (
-              <Text className="text-sm text-z-negative">{error}</Text>
+              <Text className="text-sm text-z-expense">{error}</Text>
             ) : null}
             {step === "parsing" ? (
               <View className="items-center py-4">
                 <ActivityIndicator color={COLORS.brass} />
-                <Text className="mt-2 text-sm text-z-fg-dim">
+                <Text className="mt-2 text-sm text-z-sage-dark">
                   Analizando imagen…
                 </Text>
               </View>
@@ -326,7 +326,7 @@ export default function CaptureScreenshotScreen() {
                   className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-3`}
                 >
                   <RefreshCw size={16} color={COLORS.foreground} />
-                  <Text className="text-sm font-medium text-z-fg">
+                  <Text className="text-sm font-medium text-z-white">
                     Cambiar imagen
                   </Text>
                 </Pressable>
@@ -338,20 +338,20 @@ export default function CaptureScreenshotScreen() {
         {step === "review" && parsed && (
           <View className="mt-4 gap-4">
             <View>
-              <Text className="text-xs uppercase tracking-[0.14em] text-z-fg-dim">
+              <Text className="text-xs uppercase tracking-[0.14em] text-z-sage-dark">
                 {parsed.bank ?? "Extracto"}
               </Text>
-              <Text className="mt-1 text-base font-semibold text-z-fg">
+              <Text className="mt-1 text-base font-semibold text-z-white">
                 {parsed.transactions.length} transacciones detectadas
               </Text>
             </View>
 
             <View className="gap-2">
-              <Text className="text-xs uppercase tracking-[0.14em] text-z-fg-dim">
+              <Text className="text-xs uppercase tracking-[0.14em] text-z-sage-dark">
                 Cuenta destino
               </Text>
               {accounts.length === 0 ? (
-                <Text className="text-sm text-z-fg-dim">
+                <Text className="text-sm text-z-sage-dark">
                   No tienes cuentas creadas. Crea una primero desde Ajustes.
                 </Text>
               ) : (
@@ -371,7 +371,7 @@ export default function CaptureScreenshotScreen() {
                         >
                           <Text
                             className={`text-xs ${
-                              isSelected ? "font-semibold text-z-brass" : "text-z-fg"
+                              isSelected ? "font-semibold text-z-brass" : "text-z-white"
                             }`}
                           >
                             {a.name}
@@ -391,14 +391,14 @@ export default function CaptureScreenshotScreen() {
                   className="flex-row items-center justify-between rounded-2xl bg-z-surface-2-55 px-4 py-3"
                 >
                   <View className="flex-1 pr-3">
-                    <Text className="text-sm text-z-fg" numberOfLines={1}>
+                    <Text className="text-sm text-z-white" numberOfLines={1}>
                       {t.description || "Sin descripción"}
                     </Text>
-                    <Text className="text-xs text-z-fg-dim">{t.date}</Text>
+                    <Text className="text-xs text-z-sage-dark">{t.date}</Text>
                   </View>
                   <Text
                     className={`text-sm font-semibold ${
-                      t.direction === "OUTFLOW" ? "text-z-negative" : "text-z-positive"
+                      t.direction === "OUTFLOW" ? "text-z-expense" : "text-z-income"
                     }`}
                   >
                     {t.direction === "OUTFLOW" ? "-" : "+"}
@@ -414,7 +414,7 @@ export default function CaptureScreenshotScreen() {
             </View>
 
             {error ? (
-              <Text className="text-sm text-z-negative">{error}</Text>
+              <Text className="text-sm text-z-expense">{error}</Text>
             ) : null}
 
             <Pressable
@@ -435,14 +435,14 @@ export default function CaptureScreenshotScreen() {
         {step === "importing" && (
           <View className="mt-6 items-center gap-3">
             <ActivityIndicator color={COLORS.brass} />
-            <Text className="text-sm text-z-fg-dim">Importando transacciones…</Text>
+            <Text className="text-sm text-z-sage-dark">Importando transacciones…</Text>
           </View>
         )}
 
         {step === "done" && (
           <View className="mt-6 items-center gap-4">
             <CheckCircle size={48} color={COLORS.income} />
-            <Text className="text-lg font-semibold text-z-fg">
+            <Text className="text-lg font-semibold text-z-white">
               {importedCount} transacciones importadas
             </Text>
             <View className="w-full gap-3">
@@ -451,7 +451,7 @@ export default function CaptureScreenshotScreen() {
                 accessibilityRole="button"
                 className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-4`}
               >
-                <Text className="text-base font-medium text-z-fg">
+                <Text className="text-base font-medium text-z-white">
                   Capturar otra
                 </Text>
               </Pressable>

--- a/mobile/app/capture-voice.tsx
+++ b/mobile/app/capture-voice.tsx
@@ -55,15 +55,23 @@ type Parsed = {
 };
 
 /**
- * Resolve the speech-recognition locale from the device, falling back to a
- * regional Spanish default (`es-CO`) for Zeta's primary market. Reads
- * `Intl.DateTimeFormat().resolvedOptions().locale` so no extra dependency is
- * needed — Hermes supports Intl in RN 0.70+.
+ * Resolve the speech-recognition locale.
+ *
+ * Zeta is Spanish-first and the quick-capture parser only understands Spanish
+ * phrasing (e.g. `"gasté 50 mil en Éxito ayer"`), so we force a Spanish locale
+ * regardless of the device's display language. If the device is already in a
+ * Spanish variant (es-MX, es-ES, …) we honor it to get region-appropriate
+ * pronunciation; otherwise we fall back to the primary market default `es-CO`.
  */
 function resolveLocale(): string {
   try {
     const locale = Intl.DateTimeFormat().resolvedOptions().locale;
-    if (locale && /^[a-z]{2}(-[A-Z]{2})?$/.test(locale)) return locale;
+    if (
+      locale &&
+      /^es(-[A-Z]{2})?$/.test(locale)
+    ) {
+      return locale;
+    }
   } catch {
     /* fall through */
   }
@@ -182,6 +190,24 @@ export default function CaptureVoiceScreen() {
       );
       return;
     }
+
+    // Preflight: bail out with a clear message before the native layer throws
+    // opaque errors like `kAFAssistantErrorDomain error 7` (which surfaces on
+    // simulators that lack the on-device speech model, and on real devices
+    // when the locale model hasn't been downloaded yet).
+    if (!ExpoSpeechRecognitionModule.isRecognitionAvailable()) {
+      setError(
+        "Reconocimiento de voz no disponible en este dispositivo.",
+      );
+      return;
+    }
+    if (!ExpoSpeechRecognitionModule.supportsOnDeviceRecognition()) {
+      setError(
+        "Tu dispositivo no soporta reconocimiento de voz on-device. Pruébalo en un dispositivo físico reciente (iOS 13+ / Android con servicios de Google actualizados).",
+      );
+      return;
+    }
+
     ExpoSpeechRecognitionModule.start({
       lang: resolveLocale(),
       interimResults: true,
@@ -259,7 +285,7 @@ export default function CaptureVoiceScreen() {
         >
           <ArrowLeft size={18} color={COLORS.foreground} />
         </Pressable>
-        <Text className="text-lg font-semibold text-z-fg">
+        <Text className="text-lg font-semibold text-z-white">
           Capturar por voz
         </Text>
       </View>
@@ -273,14 +299,14 @@ export default function CaptureVoiceScreen() {
       >
         {step === "idle" && (
           <View className="mt-6 gap-4 items-center">
-            <Text className="text-sm text-z-fg-dim text-center">
+            <Text className="text-sm text-z-sage-dark text-center">
               Pulsa el micrófono y di el movimiento. Ejemplo: &quot;Gasté 50 mil en Éxito ayer&quot; o &quot;Ingreso de 3 millones por salario&quot;.
             </Text>
-            <Text className="text-xs text-z-fg-dim text-center">
+            <Text className="text-xs text-z-sage-dark text-center">
               La transcripción ocurre en tu dispositivo. El audio no se envía a ningún servidor.
             </Text>
             {error ? (
-              <Text className="text-sm text-z-negative text-center">{error}</Text>
+              <Text className="text-sm text-z-expense text-center">{error}</Text>
             ) : null}
             <Pressable
               onPress={startListening}
@@ -300,9 +326,9 @@ export default function CaptureVoiceScreen() {
             >
               <Mic size={36} color={COLORS.brass} />
             </Animated.View>
-            <Text className="text-sm font-medium text-z-fg">Escuchando…</Text>
+            <Text className="text-sm font-medium text-z-white">Escuchando…</Text>
             <View className="w-full rounded-2xl bg-z-surface-2-55 px-4 py-3 min-h-20">
-              <Text className="text-base text-z-fg">
+              <Text className="text-base text-z-white">
                 {transcript || "…"}
               </Text>
             </View>
@@ -312,7 +338,7 @@ export default function CaptureVoiceScreen() {
               className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-3`}
             >
               <Square size={16} color={COLORS.foreground} />
-              <Text className="text-sm font-medium text-z-fg">Detener</Text>
+              <Text className="text-sm font-medium text-z-white">Detener</Text>
             </Pressable>
           </View>
         )}
@@ -320,10 +346,10 @@ export default function CaptureVoiceScreen() {
         {step === "review" && (
           <View className="mt-6 gap-4">
             <View className="rounded-2xl bg-z-surface-2-55 px-4 py-3">
-              <Text className="text-xs uppercase tracking-[0.14em] text-z-fg-dim">
+              <Text className="text-xs uppercase tracking-[0.14em] text-z-sage-dark">
                 Dijiste
               </Text>
-              <Text className="mt-1 text-base text-z-fg">
+              <Text className="mt-1 text-base text-z-white">
                 {finalTranscript || transcript || "(vacío)"}
               </Text>
             </View>
@@ -332,36 +358,36 @@ export default function CaptureVoiceScreen() {
               <>
                 <View className="gap-2 rounded-2xl bg-z-surface-2-55 px-4 py-3">
                   <View className="flex-row items-center justify-between">
-                    <Text className="text-xs uppercase tracking-[0.14em] text-z-fg-dim">
+                    <Text className="text-xs uppercase tracking-[0.14em] text-z-sage-dark">
                       Detectado
                     </Text>
                     <Text
                       className={`text-sm font-semibold ${
                         parsed.direction === "OUTFLOW"
-                          ? "text-z-negative"
-                          : "text-z-positive"
+                          ? "text-z-expense"
+                          : "text-z-income"
                       }`}
                     >
                       {parsed.direction === "OUTFLOW" ? "Gasto" : "Ingreso"}
                     </Text>
                   </View>
-                  <Text className="text-xl font-semibold text-z-fg">
+                  <Text className="text-xl font-semibold text-z-white">
                     {formatCurrency(
                       parsed.amount,
                       (accounts.find((a) => a.id === selectedAccountId)?.currency_code ||
                         "COP") as CurrencyCode,
                     )}
                   </Text>
-                  <Text className="text-sm text-z-fg">{parsed.description}</Text>
-                  <Text className="text-xs text-z-fg-dim">{parsed.transaction_date}</Text>
+                  <Text className="text-sm text-z-white">{parsed.description}</Text>
+                  <Text className="text-xs text-z-sage-dark">{parsed.transaction_date}</Text>
                 </View>
 
                 <View className="gap-2">
-                  <Text className="text-xs uppercase tracking-[0.14em] text-z-fg-dim">
+                  <Text className="text-xs uppercase tracking-[0.14em] text-z-sage-dark">
                     Cuenta destino
                   </Text>
                   {accounts.length === 0 ? (
-                    <Text className="text-sm text-z-fg-dim">
+                    <Text className="text-sm text-z-sage-dark">
                       No tienes cuentas. Crea una primero desde Ajustes.
                     </Text>
                   ) : (
@@ -381,7 +407,7 @@ export default function CaptureVoiceScreen() {
                             >
                               <Text
                                 className={`text-xs ${
-                                  isSelected ? "font-semibold text-z-brass" : "text-z-fg"
+                                  isSelected ? "font-semibold text-z-brass" : "text-z-white"
                                 }`}
                               >
                                 {a.name}
@@ -395,7 +421,7 @@ export default function CaptureVoiceScreen() {
                 </View>
 
                 {error ? (
-                  <Text className="text-sm text-z-negative">{error}</Text>
+                  <Text className="text-sm text-z-expense">{error}</Text>
                 ) : null}
 
                 <View className="gap-2">
@@ -417,7 +443,7 @@ export default function CaptureVoiceScreen() {
                     className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-3`}
                   >
                     <RefreshCw size={16} color={COLORS.foreground} />
-                    <Text className="text-sm font-medium text-z-fg">
+                    <Text className="text-sm font-medium text-z-white">
                       Intentar de nuevo
                     </Text>
                   </Pressable>
@@ -425,7 +451,7 @@ export default function CaptureVoiceScreen() {
               </>
             ) : (
               <View className="gap-3">
-                <Text className="text-sm text-z-negative">
+                <Text className="text-sm text-z-expense">
                   {error ?? "No pude interpretar lo que dijiste."}
                 </Text>
                 <Pressable
@@ -445,14 +471,14 @@ export default function CaptureVoiceScreen() {
         {step === "saving" && (
           <View className="mt-6 items-center gap-3">
             <ActivityIndicator color={COLORS.brass} />
-            <Text className="text-sm text-z-fg-dim">Guardando…</Text>
+            <Text className="text-sm text-z-sage-dark">Guardando…</Text>
           </View>
         )}
 
         {step === "done" && (
           <View className="mt-6 items-center gap-4">
             <CheckCircle size={48} color={COLORS.income} />
-            <Text className="text-lg font-semibold text-z-fg">
+            <Text className="text-lg font-semibold text-z-white">
               Transacción guardada
             </Text>
             <View className="w-full gap-3">
@@ -461,7 +487,7 @@ export default function CaptureVoiceScreen() {
                 accessibilityRole="button"
                 className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-4`}
               >
-                <Text className="text-base font-medium text-z-fg">
+                <Text className="text-base font-medium text-z-white">
                   Capturar otra
                 </Text>
               </Pressable>

--- a/mobile/app/capture-voice.tsx
+++ b/mobile/app/capture-voice.tsx
@@ -65,12 +65,15 @@ type Parsed = {
  */
 function resolveLocale(): string {
   try {
-    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
-    if (
-      locale &&
-      /^es(-[A-Z]{2})?$/.test(locale)
-    ) {
-      return locale;
+    const raw = Intl.DateTimeFormat().resolvedOptions().locale;
+    if (raw) {
+      // Normalize Android-style underscores + any casing variance so we can
+      // match `es`, `es-MX`, `es_MX`, `es-419`, `es-CL`, etc. — and hand the
+      // native layer a BCP-47 string (`-` separator) regardless.
+      const normalized = raw.replace(/_/g, "-");
+      if (normalized.toLowerCase().startsWith("es")) {
+        return normalized;
+      }
     }
   } catch {
     /* fall through */


### PR DESCRIPTION
## Summary

Tres fixes correlacionados que salen al probar los flujos de PR #218 en iOS simulator.

### 1. Design tokens inexistentes → texto ilegible
Las pantallas usaban clases inventadas (`text-z-fg`, `text-z-fg-dim`, `text-z-negative`, `text-z-positive`) que no están en `tailwind.config.js`. NativeWind las descarta silenciosamente → toda la tipografía se renderizaba con el default heredado (texto casi negro sobre superficie casi negra → ilegible).

Reemplazado por la paleta real:
- `text-z-fg` → `text-z-white` (primario)
- `text-z-fg-dim` → `text-z-sage-dark` (secundario)
- `text-z-negative` → `text-z-expense`
- `text-z-positive` → `text-z-income`

### 2. Voice locale rechazado por SFSpeechRecognizer
`resolveLocale()` honraba `Intl.DateTimeFormat().resolvedOptions().locale`. En device con idioma inglés ubicado en Colombia, eso resuelve a `en-CO`, que no está soportado → `Locale en-CO is not supported`.

Zeta es Spanish-first y `parseQuickCaptureText` solo entiende frases en español (_"Gasté 50 mil en Éxito ayer"_). Ahora `resolveLocale()` solo honra device locale si es variante de español (`es-MX`, `es-ES`, `es-CL`, ...); de lo contrario cae a `es-CO`.

### 3. Preflight antes de `start()` → errores nativos crípticos
El simulador sin modelo on-device emitía `kAFAssistantErrorDomain error 7`. Ahora llamamos `isRecognitionAvailable()` + `supportsOnDeviceRecognition()` antes de iniciar y mostramos mensaje explícito en español.

`requiresOnDeviceRecognition: true` se mantiene (privacy claim). Preferimos fallar claro que degradar.

## Test plan

- [x] TS check limpio
- [x] Metro hot-reload aplicó los cambios en simulador
- [ ] Re-probar en dispositivo físico con idioma español → flujo completo
- [ ] Probar voz en Android emulator (tras descargar language pack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)