### PR TITLE
feat(mobile): Movimientos parity slice 1 + perf refactor + mobile-perf-doctor agent

### DIFF
--- a/.claude/agents/mobile-perf-doctor.md
+++ b/.claude/agents/mobile-perf-doctor.md
@@ -1,0 +1,448 @@
+---
+name: mobile-perf-doctor
+description: >
+  Use this agent when reviewing, debugging, or writing mobile (Expo/React Native) UI code that could stutter, jank, or degrade at scale. Specializes in FlatList virtualization, Reanimated worklet cost, React.memo prop-reference stability, lazy mounting, NativeWind v3 quirks, and Expo/RN threading gotchas. Spawn after any mobile feature that renders lists of 30+ items, after any screen with heavy gestures/animations, and as a review gate for scroll/expand/transition jank.
+
+  Examples:
+  <example>
+  Context: User reports the mobile Movimientos list gets slow after a few pagination loads.
+  user: "After 2-3 paginations on /movimientos the scroll trembles and the Lectura expand animation stutters."
+  assistant: "I'll spawn mobile-perf-doctor to audit the row memoization, prop-reference stability, and FlatList window config."
+  </example>
+
+  <example>
+  Context: Developer is adding a new scrollable feed screen on mobile.
+  user: "Built the new recurrentes list — 80+ occurrences per month, each with its own action chips."
+  assistant: "Let me use mobile-perf-doctor to review the list virtualization, row memoization, and action-chip mount strategy before it ships."
+  </example>
+
+  <example>
+  Context: Expand/collapse animation feels janky even on a short list.
+  user: "The Lectura chart stutters when I open it."
+  assistant: "I'll use mobile-perf-doctor to check whether the chart SVG is conditionally mounted and whether the parent Root re-renders are cascading into memoized children."
+  </example>
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - mcp__codebase-memory-mcp__search_graph
+  - mcp__codebase-memory-mcp__search_code
+  - mcp__codebase-memory-mcp__get_code_snippet
+  - mcp__codebase-memory-mcp__trace_call_path
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
+---
+
+You are a senior mobile performance engineer specializing in Expo/React Native + NativeWind v3 + Reanimated 4 + Expo SQLite. Your job is to audit mobile UI code for render cost, scroll jank, animation stutter, and the patterns that make apps feel slow even when profiles look fine. You produce an actionable punch list — not a generic "React perf 101" essay.
+
+## Zeta mobile context
+
+- Stack: Expo 55 + React Native 0.83 + expo-router + NativeWind v3 + react-native-reanimated 4 + react-native-svg + expo-sqlite
+- Data layer: offline-first — `mobile/lib/repositories/*` read from SQLite, `useSync()` reconciles with Supabase. All reads are synchronous-feeling (no network in the hot path).
+- UI composition: `MobileZone`, `AnimatedAccordion`, `MobileSheet`, `MobileHeader`, `MCard`, `ExpandableChip` are the canonical containers.
+- Design tokens: pre-computed opacity variants (e.g. `bg-z-brass-10`, `bg-black-10`, `border-white-6`) — NativeWind v3 cannot consume `color/opacity` syntax.
+- Animation: Reanimated 4 shared values + `useAnimatedStyle`. No LayoutAnimation.
+
+## Code Discovery Protocol
+
+1. **First**: Use `search_graph` / `search_code` to find list screens, animated components, or repository functions
+2. **For call chains**: Use `trace_call_path` to see what re-renders on a given state change
+3. **For snippets**: Use `get_code_snippet` to read the target function without loading the whole file
+4. **For docs**: Use `resolve-library-id` + `query-docs` to verify React Native / Reanimated / FlatList patterns before making a claim
+5. **Fallback**: Grep for literal patterns only (e.g. `useSharedValue`, `<FlatList`, `React.memo`)
+6. **Never**: Don't Read a whole component just to check one prop — use `get_code_snippet` or targeted Grep
+
+## Key Files
+
+- `mobile/app/(tabs)/*` — tab root screens
+- `mobile/components/*/*Root.tsx` — per-feature screen roots (MovimientosRoot, PlanRoot, etc.)
+- `mobile/components/ui/AnimatedAccordion.tsx` — canonical expand/collapse; animates `maxHeight` + `opacity`
+- `mobile/components/ui/MobileSheet.tsx` — canonical bottom-sheet Modal
+- `mobile/components/ui/useExpandableZone.ts` — "one open at a time" accordion controller
+- `mobile/lib/repositories/*` — SQLite query surface; watch `SELECT t.*` bloat and missing LIMIT/OFFSET
+- `mobile/tailwind.config.js` — pre-computed opacity tokens
+
+## Audit Methodology
+
+For each finding, report:
+- **Severity:** CRITICAL / HIGH / MEDIUM / LOW
+- **File:Line**
+- **Symptom** (what the user sees)
+- **Root cause** (why — in one sentence)
+- **Fix** with code snippet
+
+Go through all six sections. Do NOT skip a section just because nothing jumped out — explicitly note "clean" findings too.
+
+---
+
+## Section 1: Prop-reference stability (memo integrity)
+
+The single most common mobile perf bug: a memoized row component that re-renders on every parent state change because its props are a new object literal each render.
+
+### 1.1 Identify memoized components
+
+```
+Grep pattern: "= memo\(|React\.memo\(" in mobile/components/
+```
+
+For each memoized component, trace its callers and check whether the props it receives are reference-stable across parent renders. Flag:
+
+- **Object/array literals built inline at the call site** — `transaction={{ id, ...tx }}` creates new refs every render → memo defeated
+- **`.map()`/`.filter()` transforms that rebuild items** — if the transform creates new objects (not just including/excluding existing refs), every item gets a new reference even if content didn't change
+- **`useMemo` deps that change on every render** — e.g. a dep that's itself a fresh object literal
+- **Inline callbacks** — `onPress={() => doThing(id)}` where the parent isn't memoizing it → memoized children re-render. Pair with `useCallback` + stable deps
+
+**Golden rule:** if a memoized row component receives data from a `useState` array, pass the array item *directly*. Don't rebuild it into a "view model" object — the rebuild is the reference leak.
+
+### 1.2 Callback stability
+
+```
+Grep pattern: "onPress={\(\)" in mobile/components/
+```
+
+For callbacks passed to memoized components:
+- Must be wrapped in `useCallback` with stable deps
+- Or must be module-scope functions (no closure over render-scope state)
+
+Flag inline arrow functions passed to any `memo`-wrapped child.
+
+### 1.3 Context + props combo
+
+If a component reads context AND receives memoized props, a context change re-renders it regardless of prop memoization. Flag any hot-path row component that consumes `useContext` / provider hooks (`useAppData`, `useSync`, etc.) directly — should be hoisted to parent.
+
+---
+
+## Section 2: List virtualization
+
+### 2.1 FlatList / SectionList config
+
+```
+Grep pattern: "<FlatList|<SectionList|<FlashList" in mobile/
+```
+
+For every list, check:
+
+- **`keyExtractor`** — must be stable and based on `item.id`. `keyExtractor={(_, i) => i.toString()}` breaks memoization on data change
+- **`renderItem`** — must be a `useCallback` with stable deps, OR extracted to module scope
+- **`windowSize`** (default `21`) — too high keeps offscreen rows mounted. For typical Zeta row heights, `windowSize={5}` is usually correct. Flag `windowSize >= 10`
+- **`maxToRenderPerBatch`** (default `10`) — lower values mean smaller render blocks per scroll frame. `maxToRenderPerBatch={10}` is sane; `20+` causes scroll jank on fast flings
+- **`initialNumToRender`** — should approximate visible rows, not "all"
+- **`removeClippedSubviews`** — **iOS only: leave `false`** (known flicker bugs on iOS since RN 0.70). Enable on Android with `Platform.OS === "android"`
+- **`getItemLayout`** — if rows are fixed-height, provide it. Skips measurement pass, enables instant scroll-to-index
+- **`initialScrollIndex` without `getItemLayout`** — will not work reliably
+
+### 2.2 Nested ScrollView ≠ virtualization
+
+Flag any `<ScrollView>` wrapping a `.map()` over 30+ items — it mounts *everything*. Must use `FlatList` / `SectionList` / `FlashList`.
+
+### 2.3 ListHeaderComponent stability
+
+A list header that includes heavy computation (SVG charts, aggregations) will re-render on every list data change unless memoized with stable deps. Check:
+
+- `ListHeaderComponent` is a memoized React element (wrap in `useMemo` with only the actual deps)
+- Header doesn't close over constantly-changing state (e.g. search typing)
+- Header content isn't an inline JSX expression rebuilt on every render
+
+### 2.4 FlashList migration hints
+
+For lists > 200 items or heterogeneous (mixed header/row types), consider `@shopify/flash-list`. Mention it only as a future option, not a required fix.
+
+---
+
+## Section 3: Animation & Reanimated cost
+
+### 3.1 Worklet accounting
+
+```
+Grep pattern: "useSharedValue|useAnimatedStyle" in mobile/components/
+```
+
+Each `useSharedValue` registers a JS↔UI-thread shared value. For list rows, this is typically fine *per row* — the worklets are cheap — **but** only if the row itself doesn't re-render constantly. A memoized row with an accordion worklet is fine; a non-memoized row is paying the worklet setup cost on every render cascade.
+
+Flag:
+- Reanimated hooks inside components that aren't memoized AND render more than 20 instances
+- `withTiming` / `withSpring` called inside a `useEffect` that fires on every render (missing deps)
+- `useAnimatedStyle` returning an object with a computed property that closes over stale state (worklet captures `.value` snapshot only)
+
+### 3.2 AnimatedAccordion usage
+
+Zeta's `AnimatedAccordion` always mounts children (by design, for measurement). That means a collapsed accordion still pays for its subtree's render + reconciliation.
+
+**Scale rule — one-per-screen vs per-row:**
+
+- **Per-row content (many instances)** — conditionally mount the heavy subtree to avoid paying its cost N times:
+  ```tsx
+  <AnimatedAccordion expanded={open}>
+    {open && <HeavySubtree />}
+  </AnimatedAccordion>
+  ```
+  The mount cost on first expand is trivial compared to keeping 200 copies live.
+
+- **One-per-screen content (single instance)** — always mount. Conditional mount creates a **pop-in tear**: the SVG/chart renders at full size instantly while `AnimatedAccordion` tweens `maxHeight` from 0 → estimate. Keep it mounted; the cost is a single subtree, negligible.
+
+**Close-animation rule — retain last content until the collapse finishes:**
+
+When an accordion *swaps* children based on an `activeId` / `activeTool` / `activeChip`, and the "none selected" state renders no children, the close animation collapses a blank container — looks clipped, feels broken.
+
+Fix: retain the last-rendered content for the duration of the close animation (~260ms). Pattern from `mobile/components/inicio/WidgetGrid.tsx` → `WidgetGridRow`:
+
+```tsx
+const [lastActive, setLastActive] = useState(activeTool);
+const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+useEffect(() => {
+  if (clearTimer.current) clearTimeout(clearTimer.current);
+  if (activeTool) {
+    setLastActive(activeTool);
+  } else {
+    clearTimer.current = setTimeout(() => setLastActive(null), 260);
+  }
+  return () => { if (clearTimer.current) clearTimeout(clearTimer.current); };
+}, [activeTool]);
+
+const rendered = activeTool ?? lastActive;
+
+<AnimatedAccordion expanded={activeTool !== null}>
+  {rendered === "A" && <PanelA />}
+  {rendered === "B" && <PanelB />}
+</AnimatedAccordion>
+```
+
+Same pattern applies when the content depends on a derived value (e.g. `days = expanded ? aggregate() : []`) — the derived value must stay populated past the close. Either recompute unconditionally (if cheap) or retain via the same timer pattern.
+
+**Flag any `AnimatedAccordion` whose children** (1) can become null/empty while `expanded` is still flipping true→false, or (2) receive props that snap to an empty state the moment `expanded` flips false.
+
+Reference memory: `feedback_expand_animation_keep_content_mounted.md`.
+
+**Affordance rule — match the dashboard pattern:**
+
+Cards that expand/collapse on tap should surface a rotating `ChevronDown` + "Ocultar" / "Ver …" label (see `PulseWidget`). Ascii arrows (`▾ / ▴`) or no affordance at all break visual consistency with Inicio.
+
+### 3.3 SVG rendering
+
+```
+Grep pattern: "react-native-svg|<Svg " in mobile/components/
+```
+
+SVGs render on the JS thread. A chart with 50+ path points + labels renders 50+ native views. Flag:
+- SVG charts mounted inside a list row (should be one per screen, not per item)
+- SVG computations (`buildPoints`, `aggregate*`) not memoized
+- Aggregations gated on `expanded` that leave the chart with empty data during the close animation — see Section 3.2 close-animation rule. For one-per-screen charts, always compute.
+
+### 3.4 Layout animations
+
+React Native `LayoutAnimation` is buggy on iOS, interacts poorly with Reanimated, and is deprecated on new architecture. Flag any usage. Prefer Reanimated's `Layout` transitions or explicit shared-value animation.
+
+---
+
+## Section 4: Mount / lifecycle
+
+### 4.1 Modal mount strategy
+
+```
+Grep pattern: "<Modal |<MobileSheet" in mobile/components/
+```
+
+Stock `<Modal>` renders its children even when `visible={false}` (Android; iOS varies). Flag:
+- Modals mounted at the top of a list screen where each row has its own Modal instance (hoist to parent, gate via id state)
+- Modals whose children include heavy forms / pickers — gate with `{visible && <Children />}` to defer mount
+
+### 4.2 Conditional mounting
+
+Pickers, sheets, drawers, charts behind an "expand" interaction should be conditionally mounted, not merely hidden via `maxHeight: 0` or `display: none`. A mounted-but-hidden component still participates in reconciliation.
+
+### 4.3 Focus/mount effects
+
+```
+Grep pattern: "useFocusEffect|useEffect" in mobile/components/*/*.tsx
+```
+
+- `useFocusEffect` fires on EVERY tab refocus. Flag expensive work (cross-table queries, full aggregations) done there without deps-based early exit
+- `useEffect` with missing deps that causes a fetch loop — check ESLint `react-hooks/exhaustive-deps` compliance; the most common pattern is `loadData` being recreated every render
+- Async effects that don't guard against unmount — `if (cancelled) return;` pattern
+
+### 4.4 Race guards on paginated loaders
+
+Any `loadData({ reset | appendPage })` that can run concurrently with itself (e.g. user toggles a filter while a page fetch is in flight) needs a request-id guard. Without it, a stale page resolves against a fresh dataset and corrupts state:
+
+```ts
+const requestIdRef = useRef(0);
+const loadData = useCallback(async (opts) => {
+  const requestId = ++requestIdRef.current;
+  const result = await query(opts);
+  if (requestId !== requestIdRef.current) return; // stale — drop it
+  setState(result);
+}, [/* filter deps */]);
+```
+
+Additionally: **don't put the append-offset (`transactions.length`) in `loadData`'s dep list.** That recreates the callback on every append and retriggers `useFocusEffect`. Read the count via `useRef` updated each render:
+
+```ts
+const txCountRef = useRef(0);
+txCountRef.current = transactions.length;
+// inside loadData: const offset = reset ? 0 : txCountRef.current;
+```
+
+Flag:
+- Paginated loaders without a request-id guard where filters / month / account can change mid-flight
+- Loaders whose dep list includes `data.length` (or similar) — causes needless retriggers
+
+---
+
+## Section 5: Data layer (SQLite repositories)
+
+### 5.1 Query surface bloat
+
+```
+Grep pattern: "getAllAsync|getFirstAsync" in mobile/lib/repositories/
+```
+
+Flag:
+- `SELECT t.*` when only 5–10 columns are read — pulls every encrypted+trigger column, slows parse
+- Missing `LIMIT` on list queries — a user with 10k transactions will ingest 10k rows into JS memory
+- Missing index backing a `WHERE` / `ORDER BY` column — check `mobile/lib/db/migrations/`
+- N+1 inside a loop: `for (const id of ids) { await getById(id) }` — batch via `IN (?)` instead
+
+### 5.2 Summary totals must come from SQL, not from the paginated feed
+
+Classic mobile-perf footgun: a list screen paginates 25 rows at a time AND derives summary totals (count, totalInflow, totalOutflow, uncategorizedCount, daily aggregations) from the *loaded* subset. Totals silently inflate as the user scrolls. The summary card, visible above the fold, shows wrong numbers on first paint.
+
+Rule: **summary aggregates are a separate query.**
+
+```ts
+// repo
+export async function getMonthlyAggregates({ month, accountId? }) {
+  return db.getFirstAsync(`
+    SELECT COUNT(*) AS count,
+           COALESCE(SUM(CASE WHEN direction='INFLOW' AND ... THEN amount END), 0) AS total_inflow,
+           ...
+    FROM transactions t LEFT JOIN accounts a ON ...
+    WHERE t.transaction_date LIKE ? ...
+  `, params);
+}
+
+// screen
+const [agg, firstPage] = await Promise.all([
+  getMonthlyAggregates(opts),
+  getTransactions({ ...opts, limit: PAGE_SIZE }),
+]);
+```
+
+Flag:
+- Summary cards / header metrics / chart aggregations that `.reduce()` over `transactions` state when that state is the paginated feed
+- Chart data computed client-side from paginated rows (should be a `GROUP BY date` query)
+- Uncategorized-count / sample derived from the feed subset — use a `WHERE category_id IS NULL LIMIT N` query
+
+The client-side `reduce` is fine when the list isn't paginated (i.e., full dataset always loaded). It's a bug the moment pagination enters the picture.
+
+### 5.3 Pagination contract
+
+List screens should accept `{ limit, offset }`. If the repo only takes `limit`, the screen can't paginate — flag as a missing capability.
+
+### 5.4 In-memory transforms
+
+After loading N rows, doing `rows.filter().map().reduce()` on a large N is acceptable — JS is fast. But if the screen also re-runs those transforms on every state change (search typing, filter toggle), wrap in `useMemo` with real deps. Grep for transforms inside the render body.
+
+---
+
+## Section 6: NativeWind v3 / style cost
+
+### 6.1 Opacity token compliance
+
+NativeWind v3 **does not** support `color/opacity` syntax (`bg-black/60`, `text-white/15`). Flag any `/[0-9]` opacity in className — on some targets it silently falls back to transparent. Replace with pre-computed tokens from `mobile/tailwind.config.js` (e.g. `bg-black-40`, `text-white-15`).
+
+### 6.2 Inline style churn
+
+```
+Grep pattern: "style=\{\{" in mobile/components/
+```
+
+Flag inline `style={{ ... }}` on components inside memoized rows. Every render allocates a new object; even if the style content is identical, React Native diffs by reference and re-applies. For color-dynamic styles, extract a `useMemo(() => ({ backgroundColor }), [backgroundColor])`.
+
+### 6.3 Class string interpolation in lists
+
+Dynamic className concatenation (`` `${PANEL_INSET_CLASS} ${expanded ? "bg-z-brass-6" : ""}` ``) is fine, but when done inside a memoized row with a prop-derived flag, confirm the flag is stable. Otherwise it's a reference change the memo catches — not a perf bug, just noise.
+
+### 6.4 Missing `hitSlop` on small touch targets
+
+Pills < 44pt have tap-miss perf impact (user rage-taps → extra render cycles). Flag `h-8 w-8` pressables without `hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}`.
+
+---
+
+## Section 7: Expo / RN gotchas specific to Zeta
+
+### 7.1 Safe-area
+
+Every top-level screen must honor `useSafeAreaInsets()` or mount `<MobileHeader>` (which handles it). Screens with content clipped under the notch → visual jank, not perf, but same review scope.
+
+### 7.2 `useFocusEffect` double-fire
+
+expo-router 4 fires `useFocusEffect` twice on initial mount on iOS in some navigator types. Flag callbacks that trigger expensive operations without a deduplication guard.
+
+### 7.3 Reanimated + FlatList scroll gesture conflict
+
+If a list has pan-gesture handlers (e.g. swipe-to-delete rows) AND the list is inside a nested scroll container, flag. Use `Gesture.Native()` composition to avoid thread-locking jank.
+
+### 7.4 Encryption decryption in the hot path
+
+Some SQLite queries touch views that decrypt server-side — mobile has no such view. But grep for any repository function calling `/rpc/zeta_decrypt*` or similar network-decrypting patterns in the render path.
+
+---
+
+## Section 8: Verification
+
+Before declaring findings, verify:
+
+1. The code is actually in the render hot path (not a dead import or a dev-only util)
+2. The suggested fix doesn't break functionality — read the caller chain
+3. The fix follows Zeta patterns — reuse `MobileSheet`, `AnimatedAccordion`, `useExpandableZone` instead of reinventing
+4. Use `trace_call_path` or `query_graph` before claiming "this is called from 5 places"
+
+---
+
+## Output Format
+
+```markdown
+# Mobile Perf Audit — <feature/screen>
+
+## Executive summary
+- N critical (blocks shipping)
+- N high (this sprint)
+- N medium (backlog)
+- Estimated user-visible impact: <brief>
+
+## Critical
+1. **<file>:<line>** — <symptom>
+   Root cause: <one sentence>
+   Fix:
+   ```tsx
+   // current
+   ...
+   // fixed
+   ...
+   ```
+
+## High
+[same structure]
+
+## Medium / Low
+[brief list]
+
+## What's already good
+- <pattern or decision worth calling out>
+
+## Recommended next steps
+1. <ordered action plan>
+```
+
+## Rules of engagement
+
+- **Never** recommend replacing `FlatList` with a `ScrollView + .map()` for any list. That is a perf regression regardless of item count.
+- **Never** suggest removing `React.memo` to "simplify" — if memoization isn't working, fix the prop stability, don't drop memo.
+- **Do not** recommend `FlashList` as a default. It's a valid option for very large, homogeneous lists but carries its own layout-estimation caveats.
+- **Flag, don't fix.** This agent reviews; it doesn't edit. The caller applies fixes.
+- **Be specific.** "Might re-render" is not a finding. "Re-renders on every keystroke because `handleSearchChange` closes over `transactions` without `useCallback`" is.
+- **Severity honesty.** Only flag CRITICAL if it will stutter a scroll gesture or block a user interaction > 100ms on a mid-tier Android device. Everything else is HIGH at most.

--- a/.github/workflows/mobile-pr-verify.yml
+++ b/.github/workflows/mobile-pr-verify.yml
@@ -1,0 +1,48 @@
+name: Mobile PR Verify
+
+# Lightweight pre-merge check for mobile changes: install deps with the
+# pinned lockfile and type-check the RN app. Catches broken imports, type
+# drift with @zeta/shared, and lockfile-out-of-sync bugs before they reach
+# main. Does NOT run EAS builds (those are manual / release flows).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '.github/workflows/mobile-pr-verify.yml'
+      - 'mobile/**'
+      - 'packages/shared/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+concurrency:
+  group: mobile-pr-verify-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Mobile tsc transitively checks @zeta/shared's public types, so we
+      # don't run a separate shared typecheck here (it has pre-existing test
+      # + dev-dep noise that is unrelated to PRs).
+      - name: Typecheck mobile app
+        working-directory: mobile
+        run: npx tsc --noEmit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,15 @@ Spawn these specialized agents for domain-specific review and diagnosis. Each ha
 | `ux-analyst` | "Review the app experience", UX cohesion, interaction inconsistencies, navigation logic, flow gaps. Spawn when asked to audit UX or review the overall experience. |
 | `mobile-sync-doctor` | Mobile SQLite ↔ Supabase sync. Encryption alignment, column drift, boolean/JSON mapping, push payload safety. Spawn when adding synced tables or debugging mobile data issues. |
 | `mobile-webapp-parity` | **Cross-platform gate.** Before any mobile change that writes to Supabase or needs schema changes. Prevents mobile-only tables, enum drift, missing side effects. |
+| `mobile-perf-doctor` | **Mobile perf gate.** After any mobile list/feed/animated screen, or when scroll/expand/transition feels janky. Audits memo prop-stability, FlatList config, Reanimated cost, lazy-mount, NativeWind v3 tokens. |
 
 **Review gates** (enforced before shipping, same priority as `pnpm build`):
-1. `perf-auditor` — every feature
+1. `perf-auditor` — every webapp feature
 2. `zetas-front-guy` — every TSX/CSS change
 3. `server-action-reviewer` — every new/modified server action
 4. `mobile-sync-doctor` — every new synced table or mobile push mutation
 5. `mobile-webapp-parity` — every mobile feature that touches Supabase
+6. `mobile-perf-doctor` — every mobile list screen or animated surface
 
 ## Performance Rules
 - **Cache all data reads**: `"use cache"` + `cacheTag()` + `cacheLife("zeta")`. Never add an uncached DB query to a render path.

--- a/mobile/components/movimientos/MovimientosHerramientas.tsx
+++ b/mobile/components/movimientos/MovimientosHerramientas.tsx
@@ -1,58 +1,260 @@
+import { useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, Pressable } from "react-native";
-import { Tag, Upload } from "lucide-react-native";
+import { ArrowDownLeft, ArrowRight, ArrowUpRight, ChevronRight, FileUp, Tag } from "lucide-react-native";
 import { useRouter } from "expo-router";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
 import { COLORS } from "../../lib/constants/colors";
 import { MobileZone } from "../ui/MobileZone";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { AnimatedAccordion } from "../ui/AnimatedAccordion";
+import {
+  BRASS_BUTTON_CLASS,
+  BRASS_GHOST_BUTTON_CLASS,
+  PANEL_INSET_CLASS,
+  SECTION_EYEBROW_CLASS,
+} from "../../lib/constants/styles";
+import type { TransactionListRow } from "../../lib/repositories/transactions";
+import type { CategoryRow } from "../../lib/repositories/categories";
+
+const MAX_ITEMS = 5;
 
 interface MovimientosHerramientasProps {
+  uncategorizedTransactions: TransactionListRow[];
   uncategorizedCount: number;
+  categories: CategoryRow[];
+  activeTool: "categorizar" | "importar" | null;
+  onToggleTool: (tool: "categorizar" | "importar") => void;
+  /** Delegate picker opening to the Root (which owns the single hoisted CategoryPickerSheet). */
+  onRequestCategoryPicker: (transactionId: string) => void;
 }
 
 export function MovimientosHerramientas({
+  uncategorizedTransactions,
   uncategorizedCount,
+  categories,
+  activeTool,
+  onToggleTool,
+  onRequestCategoryPicker,
 }: MovimientosHerramientasProps) {
   const router = useRouter();
+
+  void categories;
+
+  const visibleUncategorized = useMemo(
+    () => uncategorizedTransactions.slice(0, MAX_ITEMS),
+    [uncategorizedTransactions]
+  );
+
+  // Retain last-active tool during the close animation so the accordion fades
+  // real content instead of clipping an empty box.
+  // See feedback_expand_animation_keep_content_mounted.md.
+  const [lastTool, setLastTool] = useState<typeof activeTool>(activeTool);
+  const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (clearTimer.current) {
+      clearTimeout(clearTimer.current);
+      clearTimer.current = null;
+    }
+    if (activeTool) {
+      setLastTool(activeTool);
+    } else {
+      clearTimer.current = setTimeout(() => setLastTool(null), 260);
+    }
+    return () => {
+      if (clearTimer.current) {
+        clearTimeout(clearTimer.current);
+        clearTimer.current = null;
+      }
+    };
+  }, [activeTool]);
+
+  const renderedTool = activeTool ?? lastTool;
 
   return (
     <MobileZone eyebrow="HERRAMIENTAS">
       <View className="flex-row gap-1.5">
-        {/* Categorize chip */}
         <Pressable
-          onPress={() => router.push("/categorizar" as any)}
-          className={`${PANEL_INSET_CLASS} flex-1 items-center p-3`}
+          onPress={() => onToggleTool("categorizar")}
+          className={`flex-1 rounded-2xl border p-2.5 items-center ${
+            activeTool === "categorizar"
+              ? "border-z-brass-30 bg-z-brass-10"
+              : "border-z-brass-20 bg-z-brass-6"
+          }`}
         >
-          <View className="h-8 w-8 items-center justify-center rounded-xl bg-z-brass-10 mb-1.5">
-            <Tag size={16} color={COLORS.brass} />
-          </View>
-          <Text className="text-[10px] font-inter-semibold text-muted-foreground">
+          <Text className="text-[22px] font-inter-bold leading-tight text-z-brass">
+            {uncategorizedCount}
+          </Text>
+          <Text className="mt-0.5 text-[10px] font-inter-semibold text-muted-foreground">
             Categorizar
           </Text>
-          {uncategorizedCount > 0 && (
-            <View className="mt-1 rounded-full bg-z-brass px-1.5 py-0.5">
-              <Text className="text-[9px] font-inter-bold text-z-ink">
-                {uncategorizedCount}
+          {uncategorizedCount > 0 ? (
+            <View className="mt-1 flex-row items-center gap-1">
+              <View className="h-1.5 w-1.5 rounded-full bg-z-debt" />
+              <Text className="text-[9px] font-inter text-z-debt">
+                {uncategorizedCount} por resolver
               </Text>
             </View>
+          ) : (
+            <Text className="mt-1 text-[9px] font-inter text-muted-foreground">
+              Todo en orden
+            </Text>
           )}
         </Pressable>
 
-        {/* Import chip */}
         <Pressable
-          onPress={() => router.push("/(tabs)/import" as any)}
-          className={`${PANEL_INSET_CLASS} flex-1 items-center p-3`}
+          onPress={() => onToggleTool("importar")}
+          className={`flex-1 rounded-2xl border p-2.5 items-center ${
+            activeTool === "importar"
+              ? "border-z-sage-30 bg-z-sage-20"
+              : "border-z-sage-20 bg-z-sage-10"
+          }`}
         >
-          <View className="h-8 w-8 items-center justify-center rounded-xl bg-z-brass-10 mb-1.5">
-            <Upload size={16} color={COLORS.brass} />
+          <View className="h-6 w-6 items-center justify-center rounded-lg bg-z-sage-20">
+            <FileUp size={14} color={COLORS.sageLight} />
           </View>
-          <Text className="text-[10px] font-inter-semibold text-muted-foreground">
+          <Text className="mt-1 text-[10px] font-inter-semibold text-muted-foreground">
             Importar
           </Text>
-          <Text className="mt-1 text-[9px] font-inter text-muted-fg-50">
-            PDF o extracto
+          <Text className="mt-1 text-[9px] font-inter text-z-sage-light">
+            Subir PDF
           </Text>
         </Pressable>
       </View>
+
+      <AnimatedAccordion expanded={activeTool !== null} estimatedHeight={260}>
+        <View className={`mt-1.5 ${PANEL_INSET_CLASS} border-white-8 bg-black-20 p-3`}>
+          {renderedTool === "categorizar" && (
+            <CategorizarDetail
+              items={visibleUncategorized}
+              visibleCount={uncategorizedCount}
+              onPick={onRequestCategoryPicker}
+              onSeeAll={() => router.push("/categorizar" as any)}
+            />
+          )}
+          {renderedTool === "importar" && (
+            <ImportarDetail onOpen={() => router.push("/(tabs)/import" as any)} />
+          )}
+        </View>
+      </AnimatedAccordion>
     </MobileZone>
+  );
+}
+
+/* ─── Categorizar detail ─────────────────────────────────────────────── */
+
+function CategorizarDetail({
+  items,
+  visibleCount,
+  onPick,
+  onSeeAll,
+}: {
+  items: TransactionListRow[];
+  visibleCount: number;
+  onPick: (txId: string) => void;
+  onSeeAll: () => void;
+}) {
+  if (visibleCount <= 0) {
+    return (
+      <View className="gap-1.5">
+        <Text className={`${SECTION_EYEBROW_CLASS} text-z-brass`}>
+          Transacciones sin categoría
+        </Text>
+        <Text className="text-xs font-inter text-z-sage-light">
+          Todas las transacciones están categorizadas.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-2">
+      <Text className={`${SECTION_EYEBROW_CLASS} text-z-brass`}>
+        Transacciones sin categoría
+      </Text>
+
+      <View>
+        {items.map((tx) => {
+          const isInflow = tx.direction === "INFLOW";
+          const label = tx.merchant_name ?? tx.description ?? "Sin descripción";
+          return (
+            <Pressable
+              key={tx.id}
+              onPress={() => onPick(tx.id)}
+              className="flex-row items-center gap-2 rounded-lg px-1.5 py-1.5 active:bg-white-5"
+            >
+              <View
+                className={`h-5 w-5 items-center justify-center rounded-md ${isInflow ? "bg-z-income-10" : "bg-z-expense-12"}`}
+              >
+                {isInflow ? (
+                  <ArrowDownLeft size={11} color={COLORS.income} />
+                ) : (
+                  <ArrowUpRight size={11} color={COLORS.expense} />
+                )}
+              </View>
+              <View className="min-w-0 flex-1">
+                <Text className="text-xs font-inter-medium text-foreground" numberOfLines={1}>
+                  {label}
+                </Text>
+                <Text className="text-[10px] font-inter text-muted-foreground">
+                  {formatDate(tx.transaction_date, "dd MMM")}
+                </Text>
+              </View>
+              <Text className="text-xs font-inter-semibold text-foreground">
+                {formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}
+              </Text>
+              <View className={`${BRASS_GHOST_BUTTON_CLASS} ml-1 flex-row items-center gap-1 rounded-full px-2 py-0.5`}>
+                <Tag size={9} color={COLORS.brass} />
+                <Text className="text-[9px] font-inter-semibold text-z-brass">
+                  Categoría
+                </Text>
+              </View>
+              <ChevronRight size={12} color={COLORS.sageDark} />
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View className="flex-row items-center justify-between pt-1">
+        <Text className="text-[10px] font-inter text-muted-foreground">
+          Mostrando {items.length} de {visibleCount}
+        </Text>
+        <Pressable onPress={onSeeAll} className="flex-row items-center gap-1">
+          <Text className="text-[11px] font-inter-semibold text-z-brass">
+            Categorizar todas
+          </Text>
+          <ArrowRight size={11} color={COLORS.brass} />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+/* ─── Importar detail ────────────────────────────────────────────────── */
+
+function ImportarDetail({ onOpen }: { onOpen: () => void }) {
+  return (
+    <View className="gap-2">
+      <Text className={`${SECTION_EYEBROW_CLASS} text-z-sage-light`}>
+        Importar extracto
+      </Text>
+      <Pressable
+        onPress={onOpen}
+        className="flex-row items-center gap-3 rounded-xl p-2 active:bg-white-5"
+      >
+        <View className="h-8 w-8 items-center justify-center rounded-lg border border-z-sage-20 bg-z-sage-10">
+          <FileUp size={16} color={COLORS.sageLight} />
+        </View>
+        <View className="min-w-0 flex-1">
+          <Text className="text-[11px] font-inter-semibold text-foreground">
+            Subir PDF del banco
+          </Text>
+          <Text className="text-[9px] font-inter text-muted-foreground">
+            Extracto mensual de cualquier banco
+          </Text>
+        </View>
+        <View className={`${BRASS_BUTTON_CLASS} rounded-lg px-3 py-1`}>
+          <Text className="text-[10px] font-inter-semibold text-z-ink">Subir</Text>
+        </View>
+      </Pressable>
+    </View>
   );
 }

--- a/mobile/components/movimientos/MovimientosHerramientas.tsx
+++ b/mobile/components/movimientos/MovimientosHerramientas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { ArrowDownLeft, ArrowRight, ArrowUpRight, ChevronRight, FileUp, Tag } from "lucide-react-native";
 import { useRouter } from "expo-router";
@@ -12,13 +12,13 @@ import {
   PANEL_INSET_CLASS,
   SECTION_EYEBROW_CLASS,
 } from "../../lib/constants/styles";
-import type { TransactionListRow } from "../../lib/repositories/transactions";
+import type { UncategorizedSampleRow } from "../../lib/repositories/transactions";
 import type { CategoryRow } from "../../lib/repositories/categories";
 
 const MAX_ITEMS = 5;
 
 interface MovimientosHerramientasProps {
-  uncategorizedTransactions: TransactionListRow[];
+  uncategorizedTransactions: UncategorizedSampleRow[];
   uncategorizedCount: number;
   categories: CategoryRow[];
   activeTool: "categorizar" | "importar" | null;
@@ -27,7 +27,7 @@ interface MovimientosHerramientasProps {
   onRequestCategoryPicker: (transactionId: string) => void;
 }
 
-export function MovimientosHerramientas({
+function MovimientosHerramientasBase({
   uncategorizedTransactions,
   uncategorizedCount,
   categories,
@@ -147,7 +147,7 @@ function CategorizarDetail({
   onPick,
   onSeeAll,
 }: {
-  items: TransactionListRow[];
+  items: UncategorizedSampleRow[];
   visibleCount: number;
   onPick: (txId: string) => void;
   onSeeAll: () => void;
@@ -258,3 +258,5 @@ function ImportarDetail({ onOpen }: { onOpen: () => void }) {
     </View>
   );
 }
+
+export const MovimientosHerramientas = memo(MovimientosHerramientasBase);

--- a/mobile/components/movimientos/MovimientosLectura.tsx
+++ b/mobile/components/movimientos/MovimientosLectura.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { View, Text, Pressable } from "react-native";
 import { ChevronDown } from "lucide-react-native";
 import Svg, { Polyline, Circle, Line, Text as SvgText } from "react-native-svg";
@@ -42,13 +42,16 @@ function expandDayBuckets(
   const firstDate = new Date(`${dates[0]}T12:00:00`);
   const lastDate = new Date(`${dates[dates.length - 1]}T12:00:00`);
   const today = new Date();
-  const todayStr = today.toISOString().split("T")[0];
+  // Local-timezone YYYY-MM-DD — Colombia is UTC-5, so toISOString() would
+  // return the UTC day and cause an off-by-one early-morning. See gotcha in
+  // CLAUDE.md ("Never use new Date('YYYY-MM-DD')... midnight UTC").
+  const todayStr = toLocalDateString(today);
   const endDate = lastDate > today ? lastDate : today;
 
   const result: DayData[] = [];
   const cursor = new Date(firstDate);
   while (cursor <= endDate) {
-    const dateStr = cursor.toISOString().split("T")[0];
+    const dateStr = toLocalDateString(cursor);
     const vals = dayMap.get(dateStr) ?? { income: 0, expense: 0 };
     const dayNum = cursor.getDate();
     const monthNum = cursor.getMonth() + 1;
@@ -62,6 +65,13 @@ function expandDayBuckets(
     cursor.setDate(cursor.getDate() + 1);
   }
   return result;
+}
+
+function toLocalDateString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 function compactAmount(amount: number): string {
@@ -201,7 +211,7 @@ function FlowChart({ days }: { days: DayData[] }) {
   );
 }
 
-export function MovimientosLectura({
+function MovimientosLecturaBase({
   count,
   totalInflow,
   totalOutflow,
@@ -273,3 +283,5 @@ export function MovimientosLectura({
     </MobileZone>
   );
 }
+
+export const MovimientosLectura = memo(MovimientosLecturaBase);

--- a/mobile/components/movimientos/MovimientosLectura.tsx
+++ b/mobile/components/movimientos/MovimientosLectura.tsx
@@ -1,82 +1,273 @@
+import { useMemo } from "react";
 import { View, Text, Pressable } from "react-native";
+import { ChevronDown } from "lucide-react-native";
+import Svg, { Polyline, Circle, Line, Text as SvgText } from "react-native-svg";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { MobileZone } from "../ui/MobileZone";
 import { AnimatedAccordion } from "../ui/AnimatedAccordion";
 import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { COLORS } from "../../lib/constants/colors";
 
 interface MovimientosLecturaProps {
   count: number;
   totalInflow: number;
   totalOutflow: number;
+  /** Per-day aggregates from getMonthlyAggregates — already debt-filtered server-side. */
+  daysByDate: { date: string; income: number; expense: number }[];
   currency: CurrencyCode;
   expanded: boolean;
   onToggle: () => void;
+}
+
+interface DayData {
+  label: string;
+  day: number;
+  income: number;
+  expense: number;
+}
+
+function expandDayBuckets(
+  buckets: { date: string; income: number; expense: number }[]
+): DayData[] {
+  if (buckets.length === 0) return [];
+
+  const dayMap = new Map<string, { income: number; expense: number }>();
+  for (const b of buckets) {
+    dayMap.set(b.date, { income: b.income, expense: b.expense });
+  }
+
+  const dates = Array.from(dayMap.keys()).sort();
+  if (dates.length === 0) return [];
+
+  const firstDate = new Date(`${dates[0]}T12:00:00`);
+  const lastDate = new Date(`${dates[dates.length - 1]}T12:00:00`);
+  const today = new Date();
+  const todayStr = today.toISOString().split("T")[0];
+  const endDate = lastDate > today ? lastDate : today;
+
+  const result: DayData[] = [];
+  const cursor = new Date(firstDate);
+  while (cursor <= endDate) {
+    const dateStr = cursor.toISOString().split("T")[0];
+    const vals = dayMap.get(dateStr) ?? { income: 0, expense: 0 };
+    const dayNum = cursor.getDate();
+    const monthNum = cursor.getMonth() + 1;
+    const isToday = dateStr === todayStr;
+    result.push({
+      label: isToday ? "Hoy" : `${dayNum}/${monthNum}`,
+      day: dayNum,
+      income: vals.income,
+      expense: vals.expense,
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return result;
+}
+
+function compactAmount(amount: number): string {
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(0)}k`;
+  return `$${amount}`;
+}
+
+const VB_W = 280;
+const VB_H = 80;
+const PAD_L = 42;
+const PAD_R = 10;
+const PAD_Y = 12;
+
+function buildPoints(values: number[], maxVal: number): string {
+  if (values.length === 0) return "";
+  const usableW = VB_W - PAD_L - PAD_R;
+  const step = values.length > 1 ? usableW / (values.length - 1) : 0;
+  return values
+    .map((v, i) => {
+      const x = PAD_L + i * step;
+      const y = PAD_Y + (1 - v / Math.max(maxVal, 1)) * (VB_H - PAD_Y * 2);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+function FlowChart({ days }: { days: DayData[] }) {
+  if (days.length === 0) {
+    return (
+      <View className="mt-3 h-16 items-center justify-center rounded-xl border border-white-6 bg-black-10">
+        <Text className="text-[11px] font-inter text-muted-foreground">Sin datos</Text>
+      </View>
+    );
+  }
+
+  const incomeVals = days.map((d) => d.income);
+  const expenseVals = days.map((d) => d.expense);
+  const maxVal = Math.max(...incomeVals, ...expenseVals, 1);
+
+  const lastIdx = days.length - 1;
+  const usableW = VB_W - PAD_L - PAD_R;
+  const step = days.length > 1 ? usableW / (days.length - 1) : 0;
+  const todayX = PAD_L + lastIdx * step;
+  const todayY =
+    PAD_Y + (1 - incomeVals[lastIdx] / Math.max(maxVal, 1)) * (VB_H - PAD_Y * 2);
+
+  return (
+    <View className="mt-3" style={{ gap: 8 }}>
+      <Svg
+        viewBox={`0 0 ${VB_W} ${VB_H}`}
+        width="100%"
+        height={80}
+        preserveAspectRatio="none"
+      >
+        {/* Income line */}
+        <Polyline
+          points={buildPoints(incomeVals, maxVal)}
+          fill="none"
+          stroke={COLORS.income}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {/* Expense line (dashed) */}
+        <Polyline
+          points={buildPoints(expenseVals, maxVal)}
+          fill="none"
+          stroke={COLORS.brass}
+          strokeWidth={2}
+          strokeDasharray="6 4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {/* Today marker */}
+        <Circle cx={todayX} cy={todayY} r={4} fill={COLORS.income} />
+        <Circle cx={todayX} cy={todayY} r={7} fill={COLORS.income} opacity={0.12} />
+        <Line
+          x1={todayX}
+          y1={4}
+          x2={todayX}
+          y2={VB_H - 4}
+          stroke={COLORS.foreground}
+          strokeOpacity={0.08}
+          strokeWidth={1}
+          strokeDasharray="3 3"
+        />
+        {/* Y-axis labels */}
+        <SvgText x={PAD_L - 4} y={14} textAnchor="end" fontSize={7} fill={COLORS.sageDark}>
+          {compactAmount(maxVal)}
+        </SvgText>
+        <SvgText x={PAD_L - 4} y={VB_H / 2 + 2} textAnchor="end" fontSize={7} fill={COLORS.sageDark}>
+          {compactAmount(maxVal / 2)}
+        </SvgText>
+        <SvgText x={PAD_L - 4} y={VB_H - 6} textAnchor="end" fontSize={7} fill={COLORS.sageDark}>
+          $0
+        </SvgText>
+      </Svg>
+
+      {/* Day labels — sparse */}
+      <View className="flex-row justify-between px-1">
+        {days.map((d, i) => {
+          const showLabel =
+            i === 0 ||
+            i === lastIdx ||
+            (days.length > 5 && i % Math.ceil(days.length / 4) === 0);
+          if (!showLabel) {
+            return <View key={`${d.label}-${i}`} style={{ width: 1 }} />;
+          }
+          const isToday = d.label === "Hoy";
+          return (
+            <Text
+              key={`${d.label}-${i}`}
+              className={`text-[8px] ${isToday ? "font-inter-semibold text-z-brass" : "font-inter-medium text-muted-foreground"}`}
+            >
+              {d.label}
+            </Text>
+          );
+        })}
+      </View>
+
+      {/* Legend */}
+      <View className="flex-row items-center justify-center gap-4">
+        <View className="flex-row items-center gap-1.5">
+          <View className="h-1.5 w-1.5 rounded-full bg-z-income" />
+          <Text className="text-[9px] font-inter text-muted-foreground">Ingresos</Text>
+        </View>
+        <View className="flex-row items-center gap-1.5">
+          <View
+            className="h-[2px] w-3 rounded-full"
+            style={{ backgroundColor: COLORS.brass, opacity: 0.9 }}
+          />
+          <Text className="text-[9px] font-inter text-muted-foreground">Gastos</Text>
+        </View>
+      </View>
+    </View>
+  );
 }
 
 export function MovimientosLectura({
   count,
   totalInflow,
   totalOutflow,
+  daysByDate,
   currency,
   expanded,
   onToggle,
 }: MovimientosLecturaProps) {
-  const net = totalInflow - totalOutflow;
+  // Expand SQL day buckets into contiguous per-day rows for the chart.
+  // Data is already debt-filtered server-side in getMonthlyAggregates.
+  // Per feedback_expand_animation_keep_content_mounted: always compute so the
+  // close animation fades a populated chart rather than "Sin datos".
+  const days = useMemo(() => expandDayBuckets(daysByDate), [daysByDate]);
 
   return (
     <MobileZone eyebrow="LECTURA">
       <Pressable
         onPress={onToggle}
-        className={`${PANEL_INSET_CLASS} p-3 ${expanded ? "border-z-brass-30" : ""}`}
+        className={`${PANEL_INSET_CLASS} p-3 ${expanded ? "border-z-brass-30 bg-z-brass-6" : ""}`}
       >
-        {/* Summary row */}
-        <View className="flex-row items-baseline justify-between">
-          <Text className="text-xs font-inter text-muted-foreground">
-            {count} movimientos
-          </Text>
-          <Text className={`text-sm font-inter-semibold ${net >= 0 ? "text-z-income" : "text-z-expense"}`}>
-            {net >= 0 ? "+" : ""}{formatCurrency(net, currency)}
-          </Text>
-        </View>
+        <Text className="mb-2 text-[13px] font-inter-semibold text-foreground">
+          Resumen del mes
+        </Text>
 
-        {/* Inflow / Outflow mini row */}
-        <View className="mt-2 flex-row gap-4">
-          <View className="flex-row items-center gap-1">
-            <View className="h-2 w-2 rounded-full bg-z-income" />
-            <Text className="text-[11px] font-inter text-muted-foreground">
-              +{formatCurrency(totalInflow, currency)}
+        <View className="flex-row gap-1">
+          <View className="flex-1 items-center">
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[4px] text-muted-foreground">
+              Movimientos
+            </Text>
+            <Text className="mt-1 text-[18px] font-inter-bold leading-tight text-foreground">
+              {count}
             </Text>
           </View>
-          <View className="flex-row items-center gap-1">
-            <View className="h-2 w-2 rounded-full bg-z-expense" />
-            <Text className="text-[11px] font-inter text-muted-foreground">
-              -{formatCurrency(totalOutflow, currency)}
+          <View className="flex-1 items-center">
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[4px] text-muted-foreground">
+              Ingresos
             </Text>
-          </View>
-        </View>
-      </Pressable>
-
-      {/* Expanded detail */}
-      <AnimatedAccordion expanded={expanded} estimatedHeight={150}>
-        <View className={`mt-1.5 ${PANEL_INSET_CLASS} border-z-brass-20 bg-black-20 p-3 gap-2`}>
-          <View className="flex-row justify-between">
-            <Text className="text-[11px] font-inter text-muted-foreground">Ingresos</Text>
-            <Text className="text-sm font-inter-semibold text-z-income">
+            <Text className="mt-1 text-[15px] font-inter-bold leading-tight text-z-income">
               {formatCurrency(totalInflow, currency)}
             </Text>
           </View>
-          <View className="flex-row justify-between">
-            <Text className="text-[11px] font-inter text-muted-foreground">Gastos</Text>
-            <Text className="text-sm font-inter-semibold text-z-expense">
+          <View className="flex-1 items-center">
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-[4px] text-muted-foreground">
+              Gastos
+            </Text>
+            <Text className="mt-1 text-[15px] font-inter-bold leading-tight text-foreground">
               {formatCurrency(totalOutflow, currency)}
             </Text>
           </View>
-          <View className="border-t border-white-8 pt-1.5 flex-row justify-between">
-            <Text className="text-[11px] font-inter-semibold text-foreground">Balance</Text>
-            <Text className={`text-sm font-inter-semibold ${net >= 0 ? "text-z-income" : "text-z-expense"}`}>
-              {net >= 0 ? "+" : ""}{formatCurrency(net, currency)}
-            </Text>
-          </View>
+        </View>
+
+        <View className="mt-2 flex-row items-center justify-center gap-1">
+          <Text className="text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
+            {expanded ? "Ocultar" : "Ver flujo por día"}
+          </Text>
+          <ChevronDown
+            size={12}
+            color={COLORS.sageDark}
+            style={{ transform: [{ rotate: expanded ? "180deg" : "0deg" }] }}
+          />
+        </View>
+      </Pressable>
+
+      <AnimatedAccordion expanded={expanded} estimatedHeight={180}>
+        <View className={`mt-1.5 ${PANEL_INSET_CLASS} border-z-brass-20 bg-black-20 p-3`}>
+          <FlowChart days={days} />
         </View>
       </AnimatedAccordion>
     </MobileZone>

--- a/mobile/components/movimientos/MovimientosRoot.tsx
+++ b/mobile/components/movimientos/MovimientosRoot.tsx
@@ -10,6 +10,7 @@ import {
   updateTransaction,
   type MonthlyAggregates,
   type TransactionListRow,
+  type UncategorizedSampleRow,
 } from "../../lib/repositories/transactions";
 import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
 import { getAllCategories, type CategoryRow } from "../../lib/repositories/categories";
@@ -51,7 +52,7 @@ export function MovimientosRoot() {
     uncategorizedCount: 0,
     daysByDate: [],
   });
-  const [uncategorizedSample, setUncategorizedSample] = useState<TransactionListRow[]>([]);
+  const [uncategorizedSample, setUncategorizedSample] = useState<UncategorizedSampleRow[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -121,8 +122,7 @@ export function MovimientosRoot() {
   useFocusEffect(
     useCallback(() => {
       void loadData({ reset: true });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [searchQuery, currentMonth, filters.accountId])
+    }, [loadData])
   );
 
   const handleRefresh = useCallback(async () => {
@@ -195,6 +195,15 @@ export function MovimientosRoot() {
     setPickerTxId(txId);
   }, []);
 
+  const handleToggleTool = useCallback(
+    (tool: ToolId) => toggle(`tool-${tool}`),
+    [toggle]
+  );
+
+  const handleToggleLectura = useCallback(() => toggle("lectura"), [toggle]);
+
+  const handleClosePicker = useCallback(() => setPickerTxId(null), []);
+
   const handleCategorySelect = useCallback(
     async (categoryId: string) => {
       const txId = pickerTxId;
@@ -260,7 +269,7 @@ export function MovimientosRoot() {
           daysByDate={daysByDate}
           currency={currency}
           expanded={activeZone === "lectura"}
-          onToggle={() => toggle("lectura")}
+          onToggle={handleToggleLectura}
         />
 
         <MovimientosHerramientas
@@ -268,7 +277,7 @@ export function MovimientosRoot() {
           uncategorizedCount={uncategorizedCount}
           categories={categories}
           activeTool={activeTool}
-          onToggleTool={(tool) => toggle(`tool-${tool}`)}
+          onToggleTool={handleToggleTool}
           onRequestCategoryPicker={handleRequestPicker}
         />
 
@@ -295,7 +304,8 @@ export function MovimientosRoot() {
       accounts,
       searchQuery,
       filters,
-      toggle,
+      handleToggleLectura,
+      handleToggleTool,
       handleRequestPicker,
     ]
   );
@@ -357,7 +367,7 @@ export function MovimientosRoot() {
           categories={categories}
           visible
           onSelect={handleCategorySelect}
-          onClose={() => setPickerTxId(null)}
+          onClose={handleClosePicker}
         />
       )}
     </View>

--- a/mobile/components/movimientos/MovimientosRoot.tsx
+++ b/mobile/components/movimientos/MovimientosRoot.tsx
@@ -1,22 +1,40 @@
-import { useMemo, useCallback, useState } from "react";
-import { View, Text, ScrollView, RefreshControl } from "react-native";
+import { useMemo, useCallback, useRef, useState } from "react";
+import { View, Text, RefreshControl, FlatList, ActivityIndicator, Platform } from "react-native";
 import { useFocusEffect } from "expo-router";
 import { formatDate, type CurrencyCode } from "@zeta/shared";
 import { useSync } from "../../lib/sync/hooks";
-import { getTransactions, type TransactionListRow } from "../../lib/repositories/transactions";
+import {
+  getMonthlyAggregates,
+  getTopUncategorized,
+  getTransactions,
+  updateTransaction,
+  type MonthlyAggregates,
+  type TransactionListRow,
+} from "../../lib/repositories/transactions";
 import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
-import { computeCashflow } from "../../lib/utils/cashflow";
+import { getAllCategories, type CategoryRow } from "../../lib/repositories/categories";
 import { toLocalMonthString } from "../../lib/utils/date";
 import { COLORS } from "../../lib/constants/colors";
 import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
 import { useExpandableZone } from "../ui/useExpandableZone";
 import { MonthSelector } from "../common/MonthSelector";
-import { SearchBar } from "../transactions/SearchBar";
 import { MovimientosLectura } from "./MovimientosLectura";
 import { MovimientosHerramientas } from "./MovimientosHerramientas";
+import {
+  MovimientosUtilidades,
+  type MovimientosFilters,
+} from "./MovimientosUtilidades";
 import { MovimientosTransactionRow } from "./MovimientosTransactionRow";
+import { CategoryPickerSheet } from "../categorizar/CategoryPickerSheet";
 import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+
+type ToolId = "categorizar" | "importar";
+const PAGE_SIZE = 25;
+
+type FeedItem =
+  | { type: "header"; date: string }
+  | { type: "row"; tx: TransactionListRow };
 
 export function MovimientosRoot() {
   const { sync } = useSync();
@@ -25,67 +43,284 @@ export function MovimientosRoot() {
   const [refreshing, setRefreshing] = useState(false);
   const [transactions, setTransactions] = useState<TransactionListRow[]>([]);
   const [accounts, setAccounts] = useState<AccountRow[]>([]);
+  const [categories, setCategories] = useState<CategoryRow[]>([]);
+  const [aggregates, setAggregates] = useState<MonthlyAggregates>({
+    count: 0,
+    totalInflow: 0,
+    totalOutflow: 0,
+    uncategorizedCount: 0,
+    daysByDate: [],
+  });
+  const [uncategorizedSample, setUncategorizedSample] = useState<TransactionListRow[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [currentMonth, setCurrentMonth] = useState(
-    () => toLocalMonthString()
-  );
+  const [filters, setFilters] = useState<MovimientosFilters>({
+    accountId: null,
+    direction: "all",
+    showExcluded: false,
+  });
+  const [currentMonth, setCurrentMonth] = useState(() => toLocalMonthString());
+  const [pickerTxId, setPickerTxId] = useState<string | null>(null);
 
-  const loadData = useCallback(async () => {
-    try {
-      const [txs, accts] = await Promise.all([
-        getTransactions({
+  /** Bumped on every loadData call; stale in-flight results drop their setState. */
+  const requestIdRef = useRef(0);
+  /** Snapshot of transactions.length captured without entering loadData's dep list.
+   *  loadData would otherwise recreate on every append and retrigger useFocusEffect. */
+  const txCountRef = useRef(0);
+  txCountRef.current = transactions.length;
+
+  const loadData = useCallback(
+    async ({ reset = true }: { reset?: boolean } = {}) => {
+      const requestId = ++requestIdRef.current;
+      try {
+        const offset = reset ? 0 : txCountRef.current;
+        const queryOpts = {
           search: searchQuery || undefined,
           month: currentMonth,
-          limit: 200,
-        }) as Promise<TransactionListRow[]>,
-        getAllAccounts(),
-      ]);
-      setTransactions(txs);
-      setAccounts(accts);
-    } catch (error) {
-      console.error("Failed to load movimientos data:", error);
-    }
-  }, [searchQuery, currentMonth]);
+          accountId: filters.accountId ?? undefined,
+          limit: PAGE_SIZE,
+          offset,
+        };
+
+        if (reset) {
+          const [txs, accts, cats, agg, sample] = await Promise.all([
+            getTransactions(queryOpts),
+            getAllAccounts(),
+            getAllCategories(),
+            getMonthlyAggregates({
+              month: currentMonth,
+              accountId: filters.accountId ?? undefined,
+            }),
+            getTopUncategorized({
+              month: currentMonth,
+              accountId: filters.accountId ?? undefined,
+              limit: 5,
+            }),
+          ]);
+          if (requestId !== requestIdRef.current) return;
+          setTransactions(txs);
+          setAccounts(accts);
+          setCategories(cats);
+          setAggregates(agg);
+          setUncategorizedSample(sample);
+          setHasMore(txs.length === PAGE_SIZE);
+        } else {
+          const page = await getTransactions(queryOpts);
+          if (requestId !== requestIdRef.current) return;
+          setTransactions((prev) => [...prev, ...page]);
+          setHasMore(page.length === PAGE_SIZE);
+        }
+      } catch (error) {
+        console.error("Failed to load movimientos data:", error);
+      }
+    },
+    [searchQuery, currentMonth, filters.accountId]
+  );
 
   useFocusEffect(
     useCallback(() => {
-      loadData();
-    }, [loadData])
+      void loadData({ reset: true });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [searchQuery, currentMonth, filters.accountId])
   );
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
       await sync();
-      await loadData();
+      await loadData({ reset: true });
     } finally {
       setRefreshing(false);
     }
   }, [sync, loadData]);
 
-  // Compute summary
-  const { count, totalInflow, totalOutflow, uncategorizedCount } = useMemo(() => {
-    const { totalInflow: inflow, totalOutflow: outflow } = computeCashflow(transactions, accounts);
-    let uncat = 0;
-    for (const tx of transactions) {
-      if (!tx.is_excluded && tx.direction === "OUTFLOW" && !tx.category_id) uncat++;
+  const handleEndReached = useCallback(async () => {
+    if (!hasMore || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      await loadData({ reset: false });
+    } finally {
+      setLoadingMore(false);
     }
-    return { count: transactions.length, totalInflow: inflow, totalOutflow: outflow, uncategorizedCount: uncat };
-  }, [transactions, accounts]);
+  }, [hasMore, loadingMore, loadData]);
 
-  // Group transactions by date
-  const groupedByDate = useMemo(() => {
+  /** Post-SQL filters (direction, showExcluded) — accountId handled server-side.
+   *  These only affect which rows render in the feed; monthly summary totals come
+   *  from getMonthlyAggregates (SQL, unaffected by pagination or client filters). */
+  const filteredTransactions = useMemo(() => {
+    return transactions.filter((tx) => {
+      if (!filters.showExcluded && tx.is_excluded) return false;
+      if (filters.direction !== "all" && tx.direction !== filters.direction)
+        return false;
+      return true;
+    });
+  }, [transactions, filters.direction, filters.showExcluded]);
+
+  // Summary totals come from SQL aggregates, not the paginated feed.
+  // Fixes the "numbers grow as you scroll" bug — Lectura + Herramientas now
+  // reflect the full month regardless of how much feed is loaded.
+  const { count, totalInflow, totalOutflow, uncategorizedCount, daysByDate } =
+    aggregates;
+
+  /** Flattened feed — [header, row, row, header, row, ...] for FlatList.
+   *  TransactionItem references are stable when the underlying row is untouched,
+   *  so memoized MovimientosTransactionRow skips re-render on unrelated state changes. */
+  const feedItems = useMemo<FeedItem[]>(() => {
     const groups = new Map<string, TransactionListRow[]>();
-    for (const tx of transactions) {
+    for (const tx of filteredTransactions) {
       const date = tx.transaction_date;
       const existing = groups.get(date);
       if (existing) existing.push(tx);
       else groups.set(date, [tx]);
     }
-    return Array.from(groups.entries()).sort(([a], [b]) => b.localeCompare(a));
-  }, [transactions]);
+    const sorted = Array.from(groups.entries()).sort(([a], [b]) =>
+      b.localeCompare(a)
+    );
+    const out: FeedItem[] = [];
+    for (const [date, txs] of sorted) {
+      out.push({ type: "header", date });
+      for (const tx of txs) out.push({ type: "row", tx });
+    }
+    return out;
+  }, [filteredTransactions]);
 
   const currency: CurrencyCode = "COP";
+  const activeTool: ToolId | null =
+    activeZone === "tool-categorizar" || activeZone === "tool-importar"
+      ? (activeZone.replace("tool-", "") as ToolId)
+      : null;
+
+  const handleRequestPicker = useCallback((txId: string) => {
+    setPickerTxId(txId);
+  }, []);
+
+  const handleCategorySelect = useCallback(
+    async (categoryId: string) => {
+      const txId = pickerTxId;
+      if (!txId) return;
+      setPickerTxId(null);
+      // Optimistic local update — keeps row mounted, no reload needed.
+      const cat = categories.find((c) => c.id === categoryId);
+      setTransactions((prev) =>
+        prev.map((t) =>
+          t.id === txId
+            ? {
+                ...t,
+                category_id: categoryId,
+                category_name: cat?.name ?? t.category_name,
+                category_name_es: cat?.name_es ?? cat?.name ?? t.category_name_es,
+                category_color: cat?.color ?? t.category_color,
+                category_icon: cat?.icon ?? t.category_icon,
+              }
+            : t
+        )
+      );
+      try {
+        await updateTransaction(txId, { category_id: categoryId });
+      } catch (error) {
+        console.error("Failed to categorize:", error);
+        await loadData({ reset: true });
+      }
+    },
+    [pickerTxId, categories, loadData]
+  );
+
+
+  const renderItem = useCallback(
+    ({ item }: { item: FeedItem }) => {
+      if (item.type === "header") {
+        return (
+          <Text className={`mb-2 mt-4 ${SECTION_EYEBROW_CLASS}`}>
+            {formatDate(item.date, "EEEE, dd MMM")}
+          </Text>
+        );
+      }
+      return (
+        <MovimientosTransactionRow
+          transaction={item.tx}
+          onRequestCategoryPicker={handleRequestPicker}
+        />
+      );
+    },
+    [handleRequestPicker]
+  );
+
+  const listHeader = useMemo(
+    () => (
+      <View style={{ gap: 8, paddingBottom: 8 }}>
+        <View className="items-center">
+          <MonthSelector month={currentMonth} onChange={setCurrentMonth} />
+        </View>
+
+        <MovimientosLectura
+          count={count}
+          totalInflow={totalInflow}
+          totalOutflow={totalOutflow}
+          daysByDate={daysByDate}
+          currency={currency}
+          expanded={activeZone === "lectura"}
+          onToggle={() => toggle("lectura")}
+        />
+
+        <MovimientosHerramientas
+          uncategorizedTransactions={uncategorizedSample}
+          uncategorizedCount={uncategorizedCount}
+          categories={categories}
+          activeTool={activeTool}
+          onToggleTool={(tool) => toggle(`tool-${tool}`)}
+          onRequestCategoryPicker={handleRequestPicker}
+        />
+
+        <MovimientosUtilidades
+          accounts={accounts}
+          searchValue={searchQuery}
+          onSearchChange={setSearchQuery}
+          filters={filters}
+          onFiltersChange={setFilters}
+        />
+      </View>
+    ),
+    [
+      currentMonth,
+      count,
+      totalInflow,
+      totalOutflow,
+      daysByDate,
+      activeZone,
+      uncategorizedSample,
+      uncategorizedCount,
+      categories,
+      activeTool,
+      accounts,
+      searchQuery,
+      filters,
+      toggle,
+      handleRequestPicker,
+    ]
+  );
+
+  const listFooter = useMemo(() => {
+    if (loadingMore) {
+      return (
+        <View className="py-4 items-center">
+          <ActivityIndicator color={COLORS.brass} />
+        </View>
+      );
+    }
+    if (filteredTransactions.length === 0) {
+      return (
+        <View className="items-center justify-center py-16">
+          <Text className="text-muted-foreground font-inter text-sm">
+            {searchQuery
+              ? "No se encontraron transacciones"
+              : "Sin transacciones aún"}
+          </Text>
+        </View>
+      );
+    }
+    return null;
+  }, [loadingMore, filteredTransactions.length, searchQuery]);
 
   return (
     <View className="flex-1 bg-background">
@@ -95,9 +330,13 @@ export function MovimientosRoot() {
         right={<AvatarMenuTrigger />}
       />
 
-      <ScrollView
-        className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+      <FlatList
+        data={feedItems}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        ListHeaderComponent={listHeader}
+        ListFooterComponent={listFooter}
+        contentContainerStyle={{ padding: 16, paddingBottom: 100 }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -105,69 +344,26 @@ export function MovimientosRoot() {
             tintColor={COLORS.brass}
           />
         }
-      >
-        {/* Month navigation */}
-        <View className="items-center">
-          <MonthSelector month={currentMonth} onChange={setCurrentMonth} />
-        </View>
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.5}
+        initialNumToRender={12}
+        maxToRenderPerBatch={10}
+        windowSize={5}
+        removeClippedSubviews={Platform.OS === "android"}
+      />
 
-        {/* Lectura — month summary */}
-        <MovimientosLectura
-          count={count}
-          totalInflow={totalInflow}
-          totalOutflow={totalOutflow}
-          currency={currency}
-          expanded={activeZone === "lectura"}
-          onToggle={() => toggle("lectura")}
+      {pickerTxId !== null && (
+        <CategoryPickerSheet
+          categories={categories}
+          visible
+          onSelect={handleCategorySelect}
+          onClose={() => setPickerTxId(null)}
         />
-
-        {/* Herramientas — tools grid */}
-        <MovimientosHerramientas uncategorizedCount={uncategorizedCount} />
-
-        {/* Search — right above feed */}
-        <SearchBar onSearch={setSearchQuery} />
-
-        {/* Feed — date-grouped transaction rows */}
-        {transactions.length === 0 ? (
-          <View className="items-center justify-center py-16">
-            <Text className="text-muted-foreground font-inter text-sm">
-              {searchQuery
-                ? "No se encontraron transacciones"
-                : "Sin transacciones aun"}
-            </Text>
-          </View>
-        ) : (
-          <View className="gap-4">
-            {groupedByDate.map(([date, txs]) => (
-              <View key={date}>
-                <Text className={`mb-2 ${SECTION_EYEBROW_CLASS}`}>
-                  {formatDate(date, "dd MMM yyyy")}
-                </Text>
-                <View className="gap-0.5">
-                  {txs.map((tx) => (
-                    <MovimientosTransactionRow
-                      key={tx.id}
-                      transaction={{
-                        id: tx.id,
-                        description: tx.description,
-                        merchant_name: tx.merchant_name,
-                        amount: tx.amount,
-                        direction: tx.direction as "INFLOW" | "OUTFLOW",
-                        currency_code: tx.currency_code,
-                        transaction_date: tx.transaction_date,
-                        category_name_es: tx.category_name_es,
-                        category_color: tx.category_color,
-                        category_icon: tx.category_icon,
-                        account_type: tx.account_type,
-                      }}
-                    />
-                  ))}
-                </View>
-              </View>
-            ))}
-          </View>
-        )}
-      </ScrollView>
+      )}
     </View>
   );
+}
+
+function keyExtractor(item: FeedItem): string {
+  return item.type === "header" ? `h-${item.date}` : `r-${item.tx.id}`;
 }

--- a/mobile/components/movimientos/MovimientosTransactionRow.tsx
+++ b/mobile/components/movimientos/MovimientosTransactionRow.tsx
@@ -1,48 +1,37 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
-import { ArrowDownLeft, ArrowUpRight } from "lucide-react-native";
+import { ArrowDownLeft, ArrowUpRight, Pencil } from "lucide-react-native";
 import { useRouter } from "expo-router";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { COLORS } from "../../lib/constants/colors";
 import { AnimatedAccordion } from "../ui/AnimatedAccordion";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
-
-interface TransactionItem {
-  id: string;
-  description: string | null;
-  merchant_name: string | null;
-  amount: number;
-  direction: "INFLOW" | "OUTFLOW";
-  currency_code: string;
-  transaction_date: string;
-  category_name_es: string | null;
-  category_color: string | null;
-  category_icon: string | null;
-  account_type: string | null;
-}
+import type { TransactionListRow } from "../../lib/repositories/transactions";
 
 interface MovimientosTransactionRowProps {
-  transaction: TransactionItem;
+  transaction: TransactionListRow;
+  onRequestCategoryPicker: (txId: string) => void;
 }
 
-export function MovimientosTransactionRow({
+function MovimientosTransactionRowBase({
   transaction: tx,
+  onRequestCategoryPicker,
 }: MovimientosTransactionRowProps) {
   const [expanded, setExpanded] = useState(false);
   const router = useRouter();
 
-  const description = tx.merchant_name ?? tx.description ?? "Sin descripcion";
+  const description = tx.merchant_name ?? tx.description ?? "Sin descripción";
   const isInflow = tx.direction === "INFLOW";
+  const isExcluded = Boolean(tx.is_excluded);
+  const categoryName = tx.category_name_es ?? tx.category_name;
 
   return (
     <View className={expanded ? "border-l-2 border-l-z-brass pl-2" : ""}>
       <Pressable
-        onPress={() => setExpanded(!expanded)}
-        className="flex-row items-center gap-2 py-2 px-1"
+        onPress={() => setExpanded((prev) => !prev)}
+        className={`flex-row items-center gap-2 rounded-xl px-1.5 py-2 active:bg-white-5 ${isExcluded ? "opacity-40" : ""}`}
       >
-        {/* Direction icon */}
         <View
-          className={`h-[22px] w-[22px] items-center justify-center rounded-md ${isInflow ? "bg-green-500-10" : "bg-z-expense-12"}`}
+          className={`h-[22px] w-[22px] items-center justify-center rounded-md ${isInflow ? "bg-z-income-10" : "bg-z-expense-12"}`}
         >
           {isInflow ? (
             <ArrowDownLeft size={12} color={COLORS.income} />
@@ -51,31 +40,84 @@ export function MovimientosTransactionRow({
           )}
         </View>
 
-        {/* Description + category */}
         <View className="min-w-0 flex-1">
-          <Text className="text-xs font-inter-medium text-foreground" numberOfLines={1}>
+          <Text
+            className="text-sm font-inter-medium text-foreground"
+            numberOfLines={1}
+          >
             {description}
           </Text>
-          <Text className={`text-[10px] font-inter ${tx.category_name_es ? "text-muted-foreground" : "text-z-brass"}`} numberOfLines={1}>
-            {tx.category_name_es ?? "Sin categoria"}
-          </Text>
+          <View className="mt-0.5 flex-row items-center gap-1">
+            {tx.account_color && (
+              <View
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: tx.account_color }}
+              />
+            )}
+            <Text
+              className="text-[11px] font-inter text-muted-foreground"
+              numberOfLines={1}
+            >
+              {tx.account_name ?? "Cuenta"}
+            </Text>
+            <Text className="text-[11px] text-white-15">·</Text>
+            {categoryName ? (
+              <Text
+                className="text-[11px] font-inter text-muted-foreground"
+                numberOfLines={1}
+              >
+                {categoryName}
+              </Text>
+            ) : (
+              <Text className="text-[11px] font-inter text-z-brass">
+                Sin categoría
+              </Text>
+            )}
+          </View>
         </View>
 
-        {/* Amount */}
-        <Text className={`text-xs font-inter-medium ${isInflow ? "text-z-income" : "text-foreground"}`}>
-          {isInflow ? "+" : "-"}{formatCurrency(Math.abs(tx.amount), tx.currency_code as CurrencyCode)}
+        <Text
+          className={`text-sm font-inter-medium ${
+            isInflow ? "text-z-income" : "text-foreground"
+          } ${isExcluded ? "line-through" : ""}`}
+        >
+          {isInflow ? "+" : "-"}
+          {formatCurrency(Math.abs(tx.amount), tx.currency_code as CurrencyCode)}
         </Text>
       </Pressable>
 
-      {/* Expanded detail */}
-      <AnimatedAccordion expanded={expanded} estimatedHeight={60}>
-        <View className={`mb-1.5 ${PANEL_INSET_CLASS} border-z-brass-15 bg-black-20 p-2.5 flex-row items-center justify-between`}>
-          <Text className="text-[11px] font-inter text-muted-foreground">
-            {isInflow ? "Ingreso" : "Gasto"} · {formatCurrency(Math.abs(tx.amount), tx.currency_code as CurrencyCode)}
-          </Text>
-          <Pressable onPress={() => router.push(`/transaction/${tx.id}` as any)}>
-            <Text className="text-[11px] font-inter-semibold text-z-brass">
-              Ver detalle
+      <AnimatedAccordion expanded={expanded} estimatedHeight={52}>
+        <View className="flex-row flex-wrap items-center gap-1.5 px-2 pb-2 pt-0.5">
+          <Pressable
+            onPress={() => onRequestCategoryPicker(tx.id)}
+            className={`flex-row items-center gap-1 rounded-full border px-2.5 py-1 ${
+              categoryName
+                ? "border-z-brass-20 bg-z-brass-8"
+                : "border-white-8 bg-black-10"
+            }`}
+          >
+            {tx.category_color && (
+              <View
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: tx.category_color }}
+              />
+            )}
+            <Text
+              className={`text-[10px] font-inter-semibold ${categoryName ? "text-z-brass" : "text-muted-foreground"}`}
+            >
+              {categoryName ?? "Categoría"}
+            </Text>
+          </Pressable>
+
+          <View className="flex-1" />
+
+          <Pressable
+            onPress={() => router.push(`/transaction/${tx.id}` as any)}
+            className="flex-row items-center gap-1 rounded-full border border-white-8 bg-black-10 px-2.5 py-1 active:bg-white-5"
+          >
+            <Pencil size={10} color={COLORS.sageDark} />
+            <Text className="text-[10px] font-inter-semibold text-muted-foreground">
+              Editar
             </Text>
           </Pressable>
         </View>
@@ -83,3 +125,5 @@ export function MovimientosTransactionRow({
     </View>
   );
 }
+
+export const MovimientosTransactionRow = memo(MovimientosTransactionRowBase);

--- a/mobile/components/movimientos/MovimientosUtilidades.tsx
+++ b/mobile/components/movimientos/MovimientosUtilidades.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useRef, useState } from "react";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Check, Search, SlidersHorizontal, X } from "lucide-react-native";
+import { COLORS } from "../../lib/constants/colors";
+import { BRASS_BUTTON_CLASS, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
+import type { AccountRow } from "../../lib/repositories/accounts";
+
+export type DirectionFilter = "all" | "INFLOW" | "OUTFLOW";
+
+export interface MovimientosFilters {
+  accountId: string | null;
+  direction: DirectionFilter;
+  showExcluded: boolean;
+}
+
+interface MovimientosUtilidadesProps {
+  accounts: AccountRow[];
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  filters: MovimientosFilters;
+  onFiltersChange: (filters: MovimientosFilters) => void;
+}
+
+const PILL_BASE =
+  "flex-row items-center justify-center rounded-full border border-white-6 bg-black-10";
+
+const PILL_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+
+export function MovimientosUtilidades({
+  accounts,
+  searchValue,
+  onSearchChange,
+  filters,
+  onFiltersChange,
+}: MovimientosUtilidadesProps) {
+  const [searchOpen, setSearchOpen] = useState(searchValue.length > 0);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [localSearch, setLocalSearch] = useState(searchValue);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (localSearch === searchValue) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => onSearchChange(localSearch.trim()), 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [localSearch, searchValue, onSearchChange]);
+
+  const activeCount =
+    (filters.accountId ? 1 : 0) +
+    (filters.direction !== "all" ? 1 : 0) +
+    (filters.showExcluded ? 1 : 0);
+
+  return (
+    <View style={{ gap: 8 }}>
+      <View className="flex-row flex-wrap gap-1.5">
+        <Pressable
+          onPress={() => setSearchOpen((prev) => !prev)}
+          hitSlop={PILL_HIT_SLOP}
+          className={`${PILL_BASE} h-8 w-8 ${searchOpen ? "border-z-brass-30 bg-z-brass-10" : ""}`}
+          accessibilityLabel="Buscar"
+        >
+          <Search size={14} color={searchOpen ? COLORS.brass : COLORS.sageDark} />
+        </Pressable>
+
+        <Pressable
+          onPress={() => setFilterOpen(true)}
+          hitSlop={PILL_HIT_SLOP}
+          className={`${PILL_BASE} gap-1.5 px-3 py-1.5 ${activeCount > 0 ? "border-z-brass-30 bg-z-brass-10" : ""}`}
+        >
+          <SlidersHorizontal size={12} color={activeCount > 0 ? COLORS.brass : COLORS.sageDark} />
+          <Text
+            className={`text-[10px] font-inter-semibold ${activeCount > 0 ? "text-z-brass" : "text-muted-foreground"}`}
+          >
+            Filtrar{activeCount > 0 ? ` · ${activeCount}` : ""}
+          </Text>
+        </Pressable>
+
+        {activeCount > 0 && (
+          <Pressable
+            onPress={() =>
+              onFiltersChange({ accountId: null, direction: "all", showExcluded: false })
+            }
+            hitSlop={PILL_HIT_SLOP}
+            className="flex-row items-center gap-1 rounded-full border border-white-6 bg-black-10 px-3 py-1.5"
+          >
+            <X size={11} color={COLORS.sageDark} />
+            <Text className="text-[10px] font-inter-medium text-muted-foreground">
+              Limpiar
+            </Text>
+          </Pressable>
+        )}
+      </View>
+
+      {searchOpen && (
+        <TextInput
+          value={localSearch}
+          onChangeText={setLocalSearch}
+          placeholder="Buscar movimiento..."
+          placeholderTextColor={COLORS.sageDark}
+          autoFocus
+          autoCapitalize="none"
+          autoCorrect={false}
+          className="rounded-xl border border-white-6 bg-black-10 px-3 py-2 text-sm font-inter text-foreground"
+        />
+      )}
+
+      <MobileSheet visible={filterOpen} onClose={() => setFilterOpen(false)}>
+        <FilterDrawerBody
+          onClose={() => setFilterOpen(false)}
+          accounts={accounts}
+          filters={filters}
+          onChange={onFiltersChange}
+        />
+      </MobileSheet>
+    </View>
+  );
+}
+
+/* ─── Filter drawer body ──────────────────────────────────────────────── */
+
+function FilterDrawerBody({
+  onClose,
+  accounts,
+  filters,
+  onChange,
+}: {
+  onClose: () => void;
+  accounts: AccountRow[];
+  filters: MovimientosFilters;
+  onChange: (filters: MovimientosFilters) => void;
+}) {
+  return (
+    <View>
+      <View className="flex-row items-center justify-between px-4 pt-2 pb-2">
+        <Text className="text-[15px] font-inter-semibold text-foreground">
+          Filtros
+        </Text>
+        <Pressable
+          onPress={onClose}
+          hitSlop={PILL_HIT_SLOP}
+          className="h-8 w-8 items-center justify-center rounded-full"
+          accessibilityLabel="Cerrar"
+        >
+          <X size={16} color={COLORS.sageLight} />
+        </Pressable>
+      </View>
+
+      <ScrollView contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 12 }}>
+        <FilterSection label="Dirección">
+          <View className="flex-row gap-1.5">
+            {(
+              [
+                { id: "all", label: "Todas" },
+                { id: "INFLOW", label: "Ingresos" },
+                { id: "OUTFLOW", label: "Gastos" },
+              ] as const
+            ).map((opt) => {
+              const active = filters.direction === opt.id;
+              return (
+                <Pressable
+                  key={opt.id}
+                  onPress={() => onChange({ ...filters, direction: opt.id })}
+                  className={`flex-1 rounded-xl border px-3 py-2 items-center ${
+                    active
+                      ? "border-z-brass-30 bg-z-brass-10"
+                      : "border-white-6 bg-black-10"
+                  }`}
+                >
+                  <Text
+                    className={`text-xs font-inter-semibold ${active ? "text-z-brass" : "text-muted-foreground"}`}
+                  >
+                    {opt.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </FilterSection>
+
+        <FilterSection label="Cuenta">
+          <View className="rounded-2xl border border-white-6 bg-z-surface-2-55 overflow-hidden">
+            <AccountOption
+              label="Todas las cuentas"
+              active={filters.accountId === null}
+              onPress={() => onChange({ ...filters, accountId: null })}
+            />
+            {accounts.map((a) => (
+              <AccountOption
+                key={a.id}
+                label={a.name}
+                color={a.color}
+                active={filters.accountId === a.id}
+                onPress={() => onChange({ ...filters, accountId: a.id })}
+              />
+            ))}
+          </View>
+        </FilterSection>
+
+        <FilterSection label="Visibilidad">
+          <Pressable
+            onPress={() => onChange({ ...filters, showExcluded: !filters.showExcluded })}
+            className="flex-row items-center justify-between rounded-2xl border border-white-6 bg-z-surface-2-55 px-4 py-3"
+          >
+            <View className="flex-1">
+              <Text className="text-[13px] font-inter-medium text-foreground">
+                Mostrar excluidas
+              </Text>
+              <Text className="text-[10px] font-inter text-muted-foreground">
+                Incluye transacciones marcadas como excluidas del presupuesto.
+              </Text>
+            </View>
+            <View
+              className={`h-5 w-5 items-center justify-center rounded-md border ${
+                filters.showExcluded
+                  ? "border-z-brass bg-z-brass"
+                  : "border-white-8 bg-black-10"
+              }`}
+            >
+              {filters.showExcluded && <Check size={12} color={COLORS.ink} />}
+            </View>
+          </Pressable>
+        </FilterSection>
+
+        <Pressable
+          onPress={onClose}
+          className={`${BRASS_BUTTON_CLASS} mt-4 rounded-xl py-3 items-center active:opacity-80`}
+        >
+          <Text className="text-sm font-inter-semibold text-z-ink">Aplicar</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}
+
+function FilterSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View className="mb-4">
+      <Text className={`mb-2 ${SECTION_EYEBROW_CLASS}`}>{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+function AccountOption({
+  label,
+  color,
+  active,
+  onPress,
+}: {
+  label: string;
+  color?: string | null;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`flex-row items-center gap-3 px-3.5 py-2.5 border-b border-white-6 last:border-b-0 ${active ? "bg-z-brass-10" : ""} active:bg-white-5`}
+    >
+      {color ? (
+        <View className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+      ) : (
+        <View className="h-2.5 w-2.5 rounded-full bg-z-sage-20" />
+      )}
+      <Text
+        className={`flex-1 text-[13px] font-inter-medium ${active ? "text-z-brass" : "text-foreground"}`}
+      >
+        {label}
+      </Text>
+      {active && <Check size={14} color={COLORS.brass} />}
+    </Pressable>
+  );
+}
+

--- a/mobile/lib/demo-data.ts
+++ b/mobile/lib/demo-data.ts
@@ -1,9 +1,9 @@
 import * as Crypto from "expo-crypto";
 import {
-  CATEGORY_SALARIO,
+  CATEGORY_INGRESOS,
   CATEGORY_ALIMENTACION,
-  CATEGORY_SERVICIOS,
-  CATEGORY_PAGOS_DEUDA,
+  CATEGORY_HOGAR,
+  CATEGORY_OBLIGACIONES,
 } from "@zeta/shared";
 import { clearDatabase, getDatabase } from "./db/database";
 
@@ -11,7 +11,7 @@ const DEMO_USER_ID = "00000000-0000-4000-8000-000000000000";
 
 const DEMO_CATEGORIES = [
   {
-    id: CATEGORY_SALARIO,
+    id: CATEGORY_INGRESOS,
     name: "Salary",
     name_es: "Salario",
     color: "#16A34A",
@@ -29,7 +29,7 @@ const DEMO_CATEGORIES = [
     display_order: 2,
   },
   {
-    id: CATEGORY_SERVICIOS,
+    id: CATEGORY_HOGAR,
     name: "Services",
     name_es: "Servicios",
     color: "#3B82F6",
@@ -38,7 +38,7 @@ const DEMO_CATEGORIES = [
     display_order: 3,
   },
   {
-    id: CATEGORY_PAGOS_DEUDA,
+    id: CATEGORY_OBLIGACIONES,
     name: "Debt Payments",
     name_es: "Abonos a deuda",
     color: "#0EA5E9",
@@ -177,7 +177,7 @@ export async function seedDemoData(): Promise<void> {
       direction: "INFLOW",
       description: "Nomina Demo",
       date: dateShift(-15),
-      categoryId: CATEGORY_SALARIO,
+      categoryId: CATEGORY_INGRESOS,
     },
     {
       accountId: checkingId,
@@ -193,7 +193,7 @@ export async function seedDemoData(): Promise<void> {
       direction: "OUTFLOW",
       description: "Internet hogar",
       date: dateShift(-7),
-      categoryId: CATEGORY_SERVICIOS,
+      categoryId: CATEGORY_HOGAR,
     },
     {
       accountId: creditCardId,
@@ -201,7 +201,7 @@ export async function seedDemoData(): Promise<void> {
       direction: "INFLOW",
       description: "Pago tarjeta desde cuenta principal",
       date: dateShift(-5),
-      categoryId: CATEGORY_PAGOS_DEUDA,
+      categoryId: CATEGORY_OBLIGACIONES,
     },
     {
       accountId: loanId,
@@ -209,7 +209,7 @@ export async function seedDemoData(): Promise<void> {
       direction: "INFLOW",
       description: "Cuota credito vehiculo",
       date: dateShift(-2),
-      categoryId: CATEGORY_PAGOS_DEUDA,
+      categoryId: CATEGORY_OBLIGACIONES,
     },
   ];
 

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -53,6 +53,8 @@ export type TransactionListRow = TransactionRow & {
   category_color: string | null;
   category_icon: string | null;
   account_type: string | null;
+  account_name: string | null;
+  account_color: string | null;
 };
 
 export type CreateTransactionParams = {
@@ -239,7 +241,7 @@ export async function getTransactions(options?: {
 
   return db.getAllAsync<TransactionListRow>(
     `SELECT t.*, c.name as category_name, c.name_es as category_name_es, c.icon as category_icon, c.color as category_color,
-            a.account_type as account_type
+            a.account_type as account_type, a.name as account_name, a.color as account_color
      FROM transactions t
      LEFT JOIN categories c ON t.category_id = c.id
      LEFT JOIN accounts a ON t.account_id = a.id
@@ -247,6 +249,123 @@ export async function getTransactions(options?: {
      ORDER BY t.transaction_date DESC, t.created_at DESC
      LIMIT ? OFFSET ?`,
     [...params, limit, offset]
+  );
+}
+
+/**
+ * Month-scope aggregates for the Movimientos summary card — computed via SQL
+ * so the totals reflect the full month regardless of feed pagination. Matches
+ * webapp `getMonthlyCashflowCached` semantics: INFLOW to CREDIT_CARD / LOAN
+ * accounts is EXCLUDED from totalInflow (it's a debt payment, not income).
+ */
+export type MonthlyAggregates = {
+  count: number;
+  totalInflow: number;
+  totalOutflow: number;
+  uncategorizedCount: number;
+  daysByDate: { date: string; income: number; expense: number }[];
+};
+
+export async function getMonthlyAggregates(options: {
+  month: string;
+  accountId?: string;
+}): Promise<MonthlyAggregates> {
+  const db = await getDatabase();
+  const params: (string | number)[] = [`${options.month}%`];
+  let accountFilter = "";
+  if (options.accountId) {
+    accountFilter = " AND t.account_id = ?";
+    params.push(options.accountId);
+  }
+
+  // Totals + count. INFLOW to debt accounts excluded from totalInflow.
+  const totalsRow = await db.getFirstAsync<{
+    count: number;
+    total_inflow: number;
+    total_outflow: number;
+    uncategorized_count: number;
+  }>(
+    `SELECT
+       COUNT(*) AS count,
+       COALESCE(SUM(CASE WHEN t.direction = 'INFLOW'
+                          AND a.account_type NOT IN ('CREDIT_CARD','LOAN')
+                          AND t.is_excluded = 0
+                         THEN t.amount ELSE 0 END), 0) AS total_inflow,
+       COALESCE(SUM(CASE WHEN t.direction = 'OUTFLOW' AND t.is_excluded = 0
+                         THEN t.amount ELSE 0 END), 0) AS total_outflow,
+       SUM(CASE WHEN t.direction = 'OUTFLOW' AND t.category_id IS NULL AND t.is_excluded = 0
+                THEN 1 ELSE 0 END) AS uncategorized_count
+     FROM transactions t
+     LEFT JOIN accounts a ON t.account_id = a.id
+     WHERE t.transaction_date LIKE ?
+       AND t.reconciled_into_transaction_id IS NULL${accountFilter}`,
+    params
+  );
+
+  // Per-day income/expense aggregation for the flow chart.
+  const dayRows = await db.getAllAsync<{
+    transaction_date: string;
+    income: number;
+    expense: number;
+  }>(
+    `SELECT
+       t.transaction_date,
+       COALESCE(SUM(CASE WHEN t.direction = 'INFLOW'
+                          AND a.account_type NOT IN ('CREDIT_CARD','LOAN')
+                         THEN t.amount ELSE 0 END), 0) AS income,
+       COALESCE(SUM(CASE WHEN t.direction = 'OUTFLOW'
+                         THEN t.amount ELSE 0 END), 0) AS expense
+     FROM transactions t
+     LEFT JOIN accounts a ON t.account_id = a.id
+     WHERE t.transaction_date LIKE ?
+       AND t.is_excluded = 0
+       AND t.reconciled_into_transaction_id IS NULL${accountFilter}
+     GROUP BY t.transaction_date
+     ORDER BY t.transaction_date ASC`,
+    params
+  );
+
+  return {
+    count: totalsRow?.count ?? 0,
+    totalInflow: totalsRow?.total_inflow ?? 0,
+    totalOutflow: totalsRow?.total_outflow ?? 0,
+    uncategorizedCount: totalsRow?.uncategorized_count ?? 0,
+    daysByDate: dayRows.map((r) => ({
+      date: r.transaction_date,
+      income: r.income,
+      expense: r.expense,
+    })),
+  };
+}
+
+export async function getTopUncategorized(options: {
+  month: string;
+  accountId?: string;
+  limit?: number;
+}): Promise<TransactionListRow[]> {
+  const db = await getDatabase();
+  const params: (string | number)[] = [`${options.month}%`];
+  let accountFilter = "";
+  if (options.accountId) {
+    accountFilter = " AND t.account_id = ?";
+    params.push(options.accountId);
+  }
+  params.push(options.limit ?? 5);
+
+  return db.getAllAsync<TransactionListRow>(
+    `SELECT t.*, c.name as category_name, c.name_es as category_name_es, c.icon as category_icon, c.color as category_color,
+            a.account_type as account_type, a.name as account_name, a.color as account_color
+     FROM transactions t
+     LEFT JOIN categories c ON t.category_id = c.id
+     LEFT JOIN accounts a ON t.account_id = a.id
+     WHERE t.direction = 'OUTFLOW'
+       AND t.category_id IS NULL
+       AND t.is_excluded = 0
+       AND t.reconciled_into_transaction_id IS NULL
+       AND t.transaction_date LIKE ?${accountFilter}
+     ORDER BY t.transaction_date DESC, t.created_at DESC
+     LIMIT ?`,
+    params
   );
 }
 

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -338,11 +338,23 @@ export async function getMonthlyAggregates(options: {
   };
 }
 
+/** Narrow shape for the Categorizar panel — only the columns it renders. */
+export type UncategorizedSampleRow = Pick<
+  TransactionRow,
+  | "id"
+  | "amount"
+  | "direction"
+  | "currency_code"
+  | "description"
+  | "merchant_name"
+  | "transaction_date"
+>;
+
 export async function getTopUncategorized(options: {
   month: string;
   accountId?: string;
   limit?: number;
-}): Promise<TransactionListRow[]> {
+}): Promise<UncategorizedSampleRow[]> {
   const db = await getDatabase();
   const params: (string | number)[] = [`${options.month}%`];
   let accountFilter = "";
@@ -352,12 +364,9 @@ export async function getTopUncategorized(options: {
   }
   params.push(options.limit ?? 5);
 
-  return db.getAllAsync<TransactionListRow>(
-    `SELECT t.*, c.name as category_name, c.name_es as category_name_es, c.icon as category_icon, c.color as category_color,
-            a.account_type as account_type, a.name as account_name, a.color as account_color
+  return db.getAllAsync<UncategorizedSampleRow>(
+    `SELECT t.id, t.amount, t.direction, t.currency_code, t.description, t.merchant_name, t.transaction_date
      FROM transactions t
-     LEFT JOIN categories c ON t.category_id = c.id
-     LEFT JOIN accounts a ON t.account_id = a.id
      WHERE t.direction = 'OUTFLOW'
        AND t.category_id IS NULL
        AND t.is_excluded = 0


### PR DESCRIPTION
## Summary

- Mobile `/movimientos` now structurally matches the webapp mobile viewport: `MovimientosRoot` → `Lectura` (3-col summary + expandable flow chart) → `Herramientas` (Categorizar + Importar chips with inline panels) → `Utilidades` (search pill + filter drawer) → date-grouped feed → expandable row with Categoría + Editar chips.
- **Perf refactor**: `FlatList` + pagination, `React.memo`'d rows with stable `TransactionListRow` refs, hoisted + conditionally mounted `CategoryPickerSheet`, request-id race guard on `loadData`, summary totals computed via SQL (`getMonthlyAggregates`) instead of from the paginated feed.
- **New agent** `.claude/agents/mobile-perf-doctor.md` — specialized mobile-perf reviewer (memo prop-stability, FlatList config, Reanimated cost, AnimatedAccordion mount/close rules, NativeWind v3 tokens, Expo/RN gotchas). Registered in `CLAUDE.md` as review gate #6. Bible expanded during this PR's own review cycle with `§4.4 race guards on paginated loaders` and `§5.2 summary totals must come from SQL, not the paginated feed`.

## Deferred to slice 2 (tracked)

- Destinatario / tag / vincular-a-recurrente chips on the transaction row (need new picker sheets + `transaction_tags` JOIN).
- Email-pending detail inside Herramientas Importar chip (mobile doesn't sync `email_staging` yet).
- `categorization_source=null` on category clear — align with webapp (leaves prior value) when the edit form is wired up.
- Balance recalc on the `/transaction/:id` edit screen — out of scope; this PR's category chip only writes `category_id`, which is not a balance-relevant input.

## Review cycle (agents spawned + fixes applied)

- `zetas-front-guy` → stat-label `tracking-[3px] → [4px]` fixed. Rejected the toggle-label finding (intentionally matches `PulseWidget` `tracking-[2px]`) and two neutral-color warnings (match webapp mobile source of truth).
- `mobile-webapp-parity` → `uncategorizedCount` now truthful under `direction=INFLOW` filter; superseded by the SQL aggregate fix below.
- `feature-dev:code-reviewer` → **CRITICAL**: summary totals were computed from the paginated subset (numbers inflated as user scrolled). Fixed with `getMonthlyAggregates` SQL query + per-day buckets for the chart. **IMPORTANT**: pagination race on filter-change mid-flight. Fixed with `requestIdRef` guard + `txCountRef` so `loadData` doesn't retrigger on append.

## Test plan

- [ ] Open `/movimientos` on mobile — Lectura summary shows correct totals on first paint (not "grows as you scroll")
- [ ] Tap the Lectura card — chart expands smoothly from 0 → 180, content stays populated during both open and close animations
- [ ] Toggle between Categorizar and Importar chips in Herramientas — tool panel swaps instantly; closing fades the last-active panel
- [ ] Filter by account / direction / show-excluded — feed updates; summary stays correct; `uncategorizedCount` on Categorizar chip doesn't drop to 0 when direction=INFLOW
- [ ] Search + filter + pagination concurrency — change a filter mid-pagination and verify no stale rows are appended
- [ ] Tap a transaction row — Categoría chip opens hoisted picker; assign a category and confirm optimistic update without reload
- [ ] Scroll to end — more pages load via `onEndReached`

🤖 Generated with [Claude Code](https://claude.com/claude-code)