### PR TITLE
fix(mobile): align categorization_source clear with webapp + BACKLOG handoff

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -655,7 +655,7 @@ Gate pipeline: implement → `/simplify` (3 reviewers en paralelo) → aplicar (
 - **`.github/workflows/mobile-pr-verify.yml`** — new CI workflow. Runs `pnpm install --frozen-lockfile` + `npx tsc --noEmit` against `mobile/` on every PR touching `mobile/**`, `packages/shared/**`, or root lockfile. Proven green on PR #221. Mobile now has the same pre-merge gate the webapp has via `pr-build-images.yml`.
 
 ### Parity/infra follow-ups committed on branch `chore/movimientos-followups`
-- `categorization_source` alignment: mobile `updateTransaction` no longer writes `null` to `categorization_source` when clearing a category. Matches webapp (`actions/transactions.ts:841` — only flags `USER_OVERRIDE` when assigning, not when clearing). Prior behavior was silently overwriting prior-source values.
+- `categorization_source` alignment: mobile `updateTransaction` now flags `USER_OVERRIDE` on any category change (assign OR clear), matching webapp (`actions/transactions.ts:841` uses `categoryChanged`, true in both directions). Prior mobile behavior wrote `null` on clear — diverged from webapp.
 - `getTransactions SELECT t.*` narrowing was considered, **declined for now**: 6 callers each consume many columns; narrowing is a real refactor with marginal perf gain (mobile SQLite rows are plaintext, no encrypted-column parse cost). Filed as a low-priority follow-up below.
 
 ### Triage candidates for next session

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -643,3 +643,31 @@ Gate pipeline: implement → `/simplify` (3 reviewers en paralelo) → aplicar (
 4. **Consolidar helpers de formato de monto en `@zeta/shared`** — `formatAmountInput`/`parseFormattedAmount` (mobile) y `formatDisplay`/`stripFormatting` (webapp `currency-input.tsx`) hacen lo mismo. Subir uno al shared package. Low priority.
 5. **Mobile stubs** — `subscriptions.tsx`, `bug-report.tsx`, `annotate-screenshot.tsx`, `purchase-decision.tsx` (usuario indica: bug-report + annotate no se usan, bajar prioridad o eliminar).
 6. **PR #190 drag-envelope UX review** — aún pendiente.
+
+## Session handoff — 2026-04-22 (late night)
+
+### Shipped this session
+- **PR #221** — `feat(mobile): Movimientos parity slice 1 + perf refactor + mobile-perf-doctor agent`. *Merged* (commit `81229c3`).
+  - Movimientos parity: `MovimientosRoot` (FlatList + pagination), `Lectura` (3-col summary + expandable SVG flow-by-day chart + rotating ChevronDown affordance), `Herramientas` (Categorizar + Importar chips with expandable inline panel, retain-last-tool close animation), `Utilidades` (search pill + MobileSheet filter drawer), `TransactionRow` (memoized, account dot + name, Categoría + Editar chips).
+  - Perf: React.memo'd rows with stable `TransactionListRow` refs (no toItem wrapper), hoisted + conditionally mounted `CategoryPickerSheet`, request-id race guard, `txCountRef` to stop `loadData` recreation on append, summary totals via new `getMonthlyAggregates` SQL rollup (prev: summed paginated feed, numbers grew as user scrolled).
+  - New agent `.claude/agents/mobile-perf-doctor.md` + `CLAUDE.md` review-gate entry. Bible sections §3.2 (AnimatedAccordion scale/close/affordance rules), §4.4 (race guards), §5.2 (summary totals from SQL) added during this PR's own review cycle.
+- **PR #221 follow-up commit** — Gemini review fixes: `toISOString` timezone bug, useFocusEffect dep simplification, React.memo on Lectura/Herramientas + stabilized callbacks to stop chart re-render on search typing, narrowed `getTopUncategorized` SELECT. Also fixed pre-existing `mobile/lib/demo-data.ts` broken imports (category constants renamed in shared package; demo mode had been compile-broken).
+- **`.github/workflows/mobile-pr-verify.yml`** — new CI workflow. Runs `pnpm install --frozen-lockfile` + `npx tsc --noEmit` against `mobile/` on every PR touching `mobile/**`, `packages/shared/**`, or root lockfile. Proven green on PR #221. Mobile now has the same pre-merge gate the webapp has via `pr-build-images.yml`.
+
+### Parity/infra follow-ups committed on branch `chore/movimientos-followups`
+- `categorization_source` alignment: mobile `updateTransaction` no longer writes `null` to `categorization_source` when clearing a category. Matches webapp (`actions/transactions.ts:841` — only flags `USER_OVERRIDE` when assigning, not when clearing). Prior behavior was silently overwriting prior-source values.
+- `getTransactions SELECT t.*` narrowing was considered, **declined for now**: 6 callers each consume many columns; narrowing is a real refactor with marginal perf gain (mobile SQLite rows are plaintext, no encrypted-column parse cost). Filed as a low-priority follow-up below.
+
+### Triage candidates for next session
+1. **Dogfood `mobile-perf-doctor` on main** — agent was registered during PR #221 so existing sessions can't see it. Next session will have it. Spawn as a retroactive audit against `mobile/components/movimientos/*` to validate the bible rules on the merged code, then on whatever tab we polish next.
+2. **Mobile tab polish — pick one:** Budgets (smallest; still pre-v2 tokens `bg-z-surface-2-55`), Plan (`PlanRoot` parity vs `/plan` webapp; high-traffic), Deudas (`DeudasRoot` parity vs `/deudas`; high-visibility), or Movimientos slice 2 (destinatario/tag/vincular chips + email-pending sync — large, reopens recently-shipped files).
+3. **Narrow `getTransactions` SELECT** (deferred from PR #221 Gemini review) — 6 callers, marginal gain. Do only when refactoring the repo anyway.
+4. **Anonymous demo cleanup cron** — still pending from 2026-04-21.
+5. **Flow 02 PR 3** — drag-to-reorder + S/M/L resize for the dashboard widget zone.
+6. **Mobile stubs** — `subscriptions.tsx`, `bug-report.tsx`, `annotate-screenshot.tsx`, `purchase-decision.tsx` (user: bug-report + annotate unused — consider delete).
+7. **PR #190 drag-envelope UX review** — still pending.
+8. **Backfill drifted `recurring_occurrences`** — opt-in migration.
+
+### Memory added / updated
+- `feedback_mobile_perf_doctor.md` — commitment to grow the agent's bible after every mobile perf bug debugged.
+- `.claude/agents/mobile-perf-doctor.md` — added §3.2 AnimatedAccordion close-animation + scale rules, §4.4 race guards on paginated loaders, §5.2 summary totals from SQL.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -4,7 +4,7 @@
 
 ## 1. Session Summary
 
-Shipped **PR #221** (merged, commit `81229c3`): mobile `/movimientos` tab structural parity with the webapp mobile viewport + a large perf refactor + a new `mobile-perf-doctor` review-gate agent. Addressed 5 Gemini review comments in a follow-up commit on that PR (timezone bug, useFocusEffect deps, `React.memo` + stable callbacks, narrowed `getTopUncategorized` SELECT, fixed pre-existing broken imports in `lib/demo-data.ts`). Added **`.github/workflows/mobile-pr-verify.yml`** — a new CI workflow that runs `pnpm install --frozen-lockfile` + `npx tsc --noEmit` on mobile-touching PRs; proven green on PR #221 itself. Opened **PR #222** (open at handoff) with a parity fix (don't null `categorization_source` on category clear — matches webapp) + BACKLOG handoff entry.
+Shipped **PR #221** (merged, commit `81229c3`): mobile `/movimientos` tab structural parity with the webapp mobile viewport + a large perf refactor + a new `mobile-perf-doctor` review-gate agent. Addressed 5 Gemini review comments in a follow-up commit on that PR (timezone bug, useFocusEffect deps, `React.memo` + stable callbacks, narrowed `getTopUncategorized` SELECT, fixed pre-existing broken imports in `lib/demo-data.ts`). Added **`.github/workflows/mobile-pr-verify.yml`** — a new CI workflow that runs `pnpm install --frozen-lockfile` + `npx tsc --noEmit` on mobile-touching PRs; proven green on PR #221 itself. Opened **PR #222** (open at handoff) with a parity fix (`categorization_source` is flagged `USER_OVERRIDE` on any category change — assign or clear — matching webapp `categoryChanged`) + BACKLOG handoff entry.
 
 The session's highest-value pattern went into the agent bible: prop-reference stability is the #1 mobile perf footgun. A `toItem()` "view-model" wrapper we initially wrote rebuilt objects per render → broke `React.memo` on paginated rows → every row re-rendered on every pagination. Fix is passing the repo row directly. Encoded as agent §1.1 "Golden rule".
 
@@ -30,7 +30,7 @@ Demo data unblock:
 
 ### PR #222 (open — commit `610b177`, branch `chore/movimientos-followups`)
 
-- `mobile/lib/repositories/transactions.ts` — `updateTransaction`: on category clear (`category_id → null`), no longer writes `categorization_source = null`. Matches webapp (`webapp/src/actions/transactions.ts:841` only flags `USER_OVERRIDE` when assigning; leaves prior source intact on clear). Applied to both the SQLite UPDATE branch AND the `syncPayload` sent to Supabase.
+- `mobile/lib/repositories/transactions.ts` — `updateTransaction`: whenever the caller passes `category_id` (assign OR clear), `categorization_source` is now set to `USER_OVERRIDE`. Matches webapp (`webapp/src/actions/transactions.ts:841`) which uses `categoryChanged` (true on both assign and clear). Applied to both the SQLite UPDATE branch AND the `syncPayload` sent to Supabase. Previous implementation wrote `null` on clear (incorrect); initial PR #222 attempt left prior value intact (also incorrect — Gemini caught it, see review on PR #222).
 - `BACKLOG.md` — appended "Session handoff — 2026-04-22 (late night)" entry.
 
 ### Memory additions (user-scope, persist across sessions)

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,85 +1,107 @@
-# Session Handover — 2026-04-22 (Mobile capture ungate + Cuentas v2)
+# HANDOVER — 2026-04-22 (late night) — Movimientos parity + mobile-perf-doctor + mobile CI
 
 > Supersedes prior handovers. For earlier handovers see git history (`HANDOVER.md@HEAD~N`).
 
 ## 1. Session Summary
 
-Shipped **PR #212** (merged as `5d22762`): mobile capture screen now creates destinatarios + recurring templates alongside a transaction save, and the Cuentas tab + forms migrated from pre-v2 light-mode classes to the design-system tokens used everywhere else. Also landed a Supabase trigger that auto-generates `recurring_occurrences` for newly created/reactivated templates — closing a webapp/mobile divergence where mobile-created templates were invisible in Plan until a webapp user visited the page. Session ran the full pipeline: audit (Explore agent) → implement → gate agents (`mobile-webapp-parity`, `mobile-sync-doctor`) → fix findings → `/simplify` (3 review agents in parallel) → apply → Gemini review → reply + backlog.
+Shipped **PR #221** (merged, commit `81229c3`): mobile `/movimientos` tab structural parity with the webapp mobile viewport + a large perf refactor + a new `mobile-perf-doctor` review-gate agent. Addressed 5 Gemini review comments in a follow-up commit on that PR (timezone bug, useFocusEffect deps, `React.memo` + stable callbacks, narrowed `getTopUncategorized` SELECT, fixed pre-existing broken imports in `lib/demo-data.ts`). Added **`.github/workflows/mobile-pr-verify.yml`** — a new CI workflow that runs `pnpm install --frozen-lockfile` + `npx tsc --noEmit` on mobile-touching PRs; proven green on PR #221 itself. Opened **PR #222** (open at handoff) with a parity fix (don't null `categorization_source` on category clear — matches webapp) + BACKLOG handoff entry.
 
-## 2. Changes Made (shipped in PR #212, now on main)
+The session's highest-value pattern went into the agent bible: prop-reference stability is the #1 mobile perf footgun. A `toItem()` "view-model" wrapper we initially wrote rebuilt objects per render → broke `React.memo` on paginated rows → every row re-rendered on every pagination. Fix is passing the repo row directly. Encoded as agent §1.1 "Golden rule".
 
-### Mobile — capture + new repo writes
-- **`mobile/app/capture.tsx`** (modified) — replaced two `Alert("Próximamente")` Pressables under "Opciones relacionadas" with Switch toggles. On save, optionally calls `createDestinatarioWithPattern` + `createRecurringTemplate` alongside `createTransaction`. DEBT account guard at UI + repo; repo throws surfaced via Alert.
-- **`mobile/lib/repositories/destinatarios.ts`** (modified) — added `createDestinatarioWithPattern({ user_id, name, default_category_id?, notes?, pattern? })` — single SQLite transaction inserting destinatario + optional rule + both sync_queue entries.
-- **`mobile/lib/repositories/recurring.ts`** (modified) — added `createRecurringTemplate(params)` + `CreateRecurringTemplateParams` type. Uses shared `TransactionDirection` / `RecurrenceFrequency` from `@zeta/shared` (not hand-rolled unions — fixes `ONCE` drift). Defense-in-depth DEBT guard. Uses `effectiveDirection` const (no param reassignment, per Gemini review).
-- **`mobile/lib/sync/queue.ts`** (created) — `enqueueInsert` / `enqueueUpdate` / `enqueueDelete` helpers. Replaces 3 duplicated `INSERT INTO sync_queue ...` blocks.
-- **`mobile/lib/db/schema.ts`** (modified) — migration v10 adds `destinatario_id TEXT` to `recurring_transaction_templates` so capture can link both when toggled together.
+## 2. Changes Made
 
-### Mobile — Cuentas v2 migration
-- **`mobile/app/(tabs)/accounts.tsx`** (modified) — `MobileHeader` (narrator title font), `PANEL_SURFACE_SUBTLE_CLASS` net-worth card, `BRASS_BUTTON_CLASS`, `SECTION_EYEBROW_CLASS`, `MOBILE_TAB_BAR_CLEARANCE`. Dropped per-item `<View className="px-4">` wrapper (padding moved to `contentContainerStyle`).
-- **`mobile/app/account/create.tsx`** (modified) — `MobileHeader variant="sub"`, `PANEL_INSET_CLASS` inputs, `BRASS_BUTTON_CLASS` submit, dark-mode `DayPicker`. Imports shared form primitives from `AccountFormFields.tsx`.
-- **`mobile/app/account/edit/[id].tsx`** (modified) — same treatment.
-- **`mobile/components/accounts/AccountFormFields.tsx`** (created) — extracted `FormField`, `NumericInput`, `DayPicker` (were duplicated byte-for-byte between create + edit).
-- **`mobile/components/accounts/AccountTypeGrid.tsx`** (modified) — dark tiles + brass selection; replaced undefined `bg-primary` class.
-- **`mobile/components/accounts/CurrencyPicker.tsx`** (modified) — same.
-- **`mobile/lib/constants/styles.ts`** (modified) — added `FORM_INPUT_CLASS` token.
+### PR #221 (merged — commit `81229c3`)
 
-### Supabase migrations (applied to remote `tgkhaxipfgskxydotdtu`)
-- **`supabase/migrations/20260422003433_auto_generate_recurring_occurrences.sql`** (created) — AFTER INSERT + AFTER UPDATE triggers on `recurring_transaction_templates_enc`. `generate_occurrences_for_template(uuid)` SECURITY DEFINER function materializes pending occurrences for current-month + 14 days. `ON CONFLICT DO NOTHING` for idempotency. `SET search_path = public`. Reversible.
-- **`supabase/migrations/20260422010000_refine_recurring_occurrence_trigger.sql`** (created) — refinement: moves the "should we regenerate?" predicate into the UPDATE trigger's `WHEN` clause so the SECURITY DEFINER function isn't invoked for `updated_at`-only touches.
+Movimientos parity:
+- `mobile/components/movimientos/MovimientosRoot.tsx` — rewritten. FlatList + pagination (`PAGE_SIZE=25`), memoized list header, hoisted `CategoryPickerSheet` at Root (conditionally mounted), `getMonthlyAggregates` SQL rollup for summary totals (was summing paginated feed), request-id race guard on `loadData`, `txCountRef` so loadData callback doesn't recreate on append.
+- `mobile/components/movimientos/MovimientosLectura.tsx` — rewritten. 3-col summary (Movimientos / Ingresos / Gastos) + expandable SVG flow-by-day chart via `react-native-svg`. Rotating `ChevronDown` + "Ocultar / Ver flujo por día" at `tracking-[2px]` matches `PulseWidget` affordance. `React.memo` wrapper. Local-timezone date helper (not `toISOString()`).
+- `mobile/components/movimientos/MovimientosHerramientas.tsx` — rewritten. Categorizar + Importar chips with expandable inline panel. Retain-last-tool pattern (260ms timeout, see `feedback_expand_animation_keep_content_mounted.md`). `React.memo` wrapper.
+- `mobile/components/movimientos/MovimientosUtilidades.tsx` — **created**. Search-icon pill + `MobileSheet` filter drawer (Dirección / Cuenta / Mostrar excluidas).
+- `mobile/components/movimientos/MovimientosTransactionRow.tsx` — rewritten. `React.memo` row, receives `TransactionListRow` directly (prior `toItem()` wrapper broke memo), account dot + name, expanded chips: Categoría picker + Editar link.
+- `mobile/lib/repositories/transactions.ts` — added `getMonthlyAggregates` (SQL `SUM + CASE WHEN`, debt-filtered inflow, per-day `GROUP BY`), `getTopUncategorized` (narrowed SELECT + new `UncategorizedSampleRow` type), extended `TransactionListRow` with `account_name` + `account_color`.
 
-### .mcp.json (project-level)
-- Added `ios-simulator` server via `npx -y ios-simulator-mcp`. Allows `ui_tap`, `ui_swipe`, `screenshot`, `ui_describe_all`, etc. from future sessions.
+Agent + CI:
+- `.claude/agents/mobile-perf-doctor.md` — **created**. 8 sections: prop-reference stability (§1), list virtualization (§2), animation cost (§3, incl. §3.2 AnimatedAccordion scale/close/affordance rules), mount/lifecycle (§4, incl. §4.4 race guards on paginated loaders), SQLite data layer (§5, incl. §5.2 summary totals from SQL), NativeWind v3 tokens (§6), Expo/RN gotchas (§7), verification (§8). Refined during this PR's own review cycle.
+- `CLAUDE.md` — registered `mobile-perf-doctor` as review gate #6 ("every mobile list screen or animated surface").
+- `.github/workflows/mobile-pr-verify.yml` — **created**. Pre-merge typecheck on mobile changes.
 
-### Memory (`~/.claude/projects/.../memory/`)
-- **`feedback_webapp_source_of_truth.md`** (created) — principle that webapp is canonical; mobile mirrors validation/shapes/side effects. Parity gate before any mobile Supabase mutation.
-- **`MEMORY.md`** (modified) — indexed the above.
+Demo data unblock:
+- `mobile/lib/demo-data.ts` — fixed broken imports (shared package renamed category constants: `SALARIO → INGRESOS`, `SERVICIOS → HOGAR`, `PAGOS_DEUDA → OBLIGACIONES`). Demo mode had been compile-broken for a while; required for new CI to pass.
 
-### Post-merge (uncommitted)
-- **`BACKLOG.md`** (modified) — removed resolved "Mobile capture ungate" entry, added new "Recurrence end-of-month drift" bug entry (paired `@zeta/shared` + trigger fix), added 2026-04-22 session handoff section.
-- **`.claude/worktrees/agent-a29c6afc`** (staged deletion) — stale worktree dir, unrelated to this session but picked up by `git status`.
+### PR #222 (open — commit `610b177`, branch `chore/movimientos-followups`)
+
+- `mobile/lib/repositories/transactions.ts` — `updateTransaction`: on category clear (`category_id → null`), no longer writes `categorization_source = null`. Matches webapp (`webapp/src/actions/transactions.ts:841` only flags `USER_OVERRIDE` when assigning; leaves prior source intact on clear). Applied to both the SQLite UPDATE branch AND the `syncPayload` sent to Supabase.
+- `BACKLOG.md` — appended "Session handoff — 2026-04-22 (late night)" entry.
+
+### Memory additions (user-scope, persist across sessions)
+
+- `~/.claude/projects/-Users-cristian-Documents-developing-current-projects-zeta/memory/feedback_mobile_perf_doctor.md` — commitment to keep appending learnings to the agent file after every mobile perf bug debugged.
+- `MEMORY.md` index entry under `### Performance` pointing to the new feedback file.
 
 ## 3. Key Decisions
 
-- **Toggles-on-save UX** for the two "Opciones relacionadas" actions instead of dedicated modal routes. Ships in one slice; matches user intent ("also create X alongside this tx").
-- **DEBT guard duplicated** at UI + repo. UI surfaces a Spanish Alert pointing to Recurrentes; repo throws for defense-in-depth against future callers. Both branches hit the same invariant.
-- **Occurrence generation via DB trigger**, not mobile sync-push hook. Single invariant for all clients. Beats mobile-side RPC because (a) offline-then-sync would leave a gap, (b) future-proofs against any other write path.
-- **Drift bug left as-is.** Gemini flagged Jan 31 → Feb 28 drift. Webapp `getOccurrencesBetween` (date-fns `addMonths`) has identical drift. Per the source-of-truth principle, fixing the trigger alone would silently diverge. Logged on BACKLOG as a paired fix.
-- **Types regen skipped.** `npx supabase gen types` output showed `| null` on every Row field (CLI 2.90.0 breakage, per memory). Tracked `webapp/src/types/database.ts` is manually maintained and already has `destinatario_id`.
-- **sync_queue payload for destinatarios omits `name_hmac`** — supabase-migrator confirmed INSTEAD OF INSERT trigger on view hardcodes `zeta_hmac(NEW.name)`.
-- **SQLite migration v10** instead of schema rewrite — additive `ALTER TABLE ADD COLUMN` runs non-destructively on existing installs.
+- **Slice Movimientos parity into two PRs.** Slice 1 (shipped): structural parity without new picker sheets. Slice 2 (deferred): destinatario + tag + vincular-a-recurrente chips on rows + email-pending detail panel. Reason: slice 2 needs 2–3 new sheet components + `transaction_tags` JOIN extension — too wide to bundle with the perf refactor.
+- **Pass `TransactionListRow` directly to the memoized row; no view-model wrapper.** The `toItem()` wrapper we initially wrote was the root cause of the "gets slow after 2–3 paginations" bug — it created new object refs on every feedItems rebuild, breaking memo. Direct pass keeps refs stable.
+- **Keep `AnimatedAccordion` chart always-mounted, aggregation conditionally computed.** Initially wrapped chart in `{expanded && <FlowChart/>}` for perf. That caused pop-in tear on expand + blank close animation. Reverted per the `feedback_expand_animation_keep_content_mounted` rule + the "one-per-screen content always mounts, per-row content mounts conditionally" guidance (encoded in agent §3.2).
+- **Summary totals via SQL aggregate, not from paginated feed.** Code-reviewer agent caught that Lectura's count / ingresos / gastos / `uncategorizedCount` were summing only the loaded rows, so totals inflated as the user scrolled. Added `getMonthlyAggregates` repository function with SQL `SUM + CASE WHEN` and per-day `GROUP BY`. Added `getTopUncategorized` for the Categorizar sample.
+- **Request-id race guard on `loadData`.** Code-reviewer also caught that if the user toggles a filter while a `loadData({ reset: false })` page fetch is in flight, the stale page appends to the freshly-reset state. Added `requestIdRef` pattern from agent §4.4. Also moved `transactions.length` out of `loadData`'s dep list via `txCountRef` so it doesn't recreate on every append.
+- **Declined narrowing `getTransactions SELECT t.*`** (Gemini deferred comment). 6 callers consume many columns; mobile SQLite rows are plaintext (no encrypted-column parse cost); gain is marginal. Filed in BACKLOG.
+- **Declined re-review from zetas-front-guy on toggle label `tracking-[2px]`.** Agent flagged it as non-canonical vs `SECTION_EYEBROW_CLASS` `[4px]`. But `PulseWidget` (the reference dashboard pattern the user asked us to match) uses `tracking-[2px]` for the exact same toggle label. Kept as-is. Lesson: Zeta has TWO eyebrow tracking values — `[4px]` for section eyebrows, `[2px]` for toggle-label eyebrows. Don't let an agent "normalize" the latter.
+- **`mobile-perf-doctor` will grow over time.** Commitment saved as feedback memory + first learning encoded in the agent file during the same PR's review cycle. Future: every mobile perf bug → append to the matching section.
 
 ## 4. Current State
 
-- **Build:** webapp `pnpm build` passed at end of session. Mobile `npx tsc --noEmit` clean on touched files (pre-existing `demo-data.ts` errors unrelated, on main).
-- **Branch:** `main`, 0 commits ahead of origin/main. PR #212 merged (`5d22762`).
-- **Uncommitted:** `BACKLOG.md` modified, `.claude/worktrees/agent-a29c6afc` deletion staged.
-- **Remote DB:** both 20260422 migrations applied. Trigger fires on view INSERT via INSTEAD OF forwarding to `_enc`.
-- **Simulator:** iPhone 17 Pro (UDID `AFBA8440-2959-4DC9-8B8D-ABD7CFE5B14A`) booted with dev-client installed; Metro bundler was running in background task `bg212ini3` (check before assuming alive).
+- **Branch**: `chore/movimientos-followups` (PR #222 open, waiting on CI + review). `main` contains PR #221 (merged).
+- **Build**: `cd mobile && npx tsc --noEmit` → 0 errors. `mobile-pr-verify` CI workflow proven green on PR #221.
+- **Uncommitted**: only `D .claude/worktrees/agent-a19574cf` (unrelated worktree cleanup, not ours).
+- **Agents loaded in current session**: `mobile-perf-doctor` is on `main` but **sessions started before the merge do not see it in their registry** — the agent list locks at session start. First post-session-restart run should dogfood it.
 
 ## 5. Open Issues & Gotchas
 
-- **Recurrence engine end-of-month drift** (BACKLOG, Medium) — `packages/shared/src/utils/recurrence.ts:68-106` `getOccurrencesBetween` + `supabase/migrations/20260422003433_auto_generate_recurring_occurrences.sql` both drift. Fix together: use `day_of_month` column as anchor with end-of-month clamping.
-- **Mobile capture amount live-formatting** (BACKLOG, Medium) — `mobile/app/capture.tsx:420-433` TextInput shows raw digits. Want COP thousand grouping. Formula prototyped in 2026-04-20 session (see BACKLOG entry).
-- **Mobile stubs from audit** — `subscriptions.tsx`, `bug-report.tsx`, `annotate-screenshot.tsx`, `purchase-decision.tsx` still partial/stub. Not yet in BACKLOG.
-- **Gemini PR #212 replies** sent via `gh api` on comments 3121025656, 3121025657, 3121025661.
+### Non-blocking for PR #222
+
+- **`mobile-perf-doctor` not dogfooded yet.** Agent was registered mid-session; current session's registry is frozen. First order of business next session: spawn it against `mobile/components/movimientos/*` + whatever tab is being polished next.
+- **`SELECT t.*` in `getTransactions`** (`mobile/lib/repositories/transactions.ts:242`) — flagged by Gemini on PR #221, declined. Do during the next repo-scope refactor.
+
+### Pre-existing, deferred
+
+- **`@zeta/shared` has 2 pre-existing TS errors** in test files / dev deps: `@vitest/spy` `Disposable` missing, `DebtAccount` missing in `scenario-engine.test.ts`. Not caught by mobile tsc (they're in shared's own `tsconfig`). Mobile CI intentionally only typechecks `mobile/` for this reason (documented in the workflow).
+- **Slice 2 Movimientos gaps** (tracked in BACKLOG):
+  - Row expanded chips: destinatario picker, tag picker, vincular-a-recurrente. All need new sheet components + repo extensions (`transaction_tags` JOIN, pending-occurrences by account).
+  - Herramientas Importar chip: email-pending detail. Requires `email_staging` SQLite sync (not currently synced on mobile; `pendingEmails` is hardcoded `0`).
+
+### Gotchas for next session
+
+- **Agent registry locks at session start.** Any agent added mid-session is invisible until `/clear` or new session.
+- **`mobile/lib/demo-data.ts` category IDs were remapped**: `CATEGORY_SALARIO → CATEGORY_INGRESOS`, `CATEGORY_SERVICIOS → CATEGORY_HOGAR`, `CATEGORY_PAGOS_DEUDA → CATEGORY_OBLIGACIONES`. Any script that seeds demo data assuming the old IDs will land in wrong buckets.
+- **Mobile SQLite is plaintext** — no encryption layer — so the `SELECT t.*` concerns from the webapp don't apply to the same degree. Parse cost is small.
+- **`useFocusEffect` in RN fires on every tab refocus**, not just mount. Kept simple with `[loadData]` dep list (PR #221's Gemini fix). Watch for double-load on slow tabs.
 
 ## 6. Suggested Next Steps
 
-1. **Commit pending BACKLOG.md + stale worktree deletion** — small housekeeping.
-2. **Mobile capture amount live-formatting** — ~30 min, finishes the capture polish arc.
-3. **Recurrence engine drift fix** — medium lift, paired `@zeta/shared` + Supabase trigger. Gate: test covers Jan 31 → Mar 31 chain.
-4. **Flow 02 PR 3** — drag-to-reorder + S/M/L resize for dashboard widget zone (Reanimated + gesture-handler). Pending from 2026-04-21.
-5. **Next mobile stub** — `subscriptions.tsx` or similar from the 2026-04-22 audit.
+1. **`/clear` → dogfood `mobile-perf-doctor`** against `mobile/components/movimientos/*` to validate the agent catches what we think it catches on a fresh target. First real test of the agent.
+2. **Merge PR #222** once CI + any review returns. Single simple fix, low risk.
+3. **Next mobile tab polish.** User's stated priority was "continue polishing mobile based on webapp". Candidates ranked by ROI:
+   - **Budgets** — smallest scope, biggest token-compliance debt (still uses `bg-z-surface-2-55` pre-v2 tokens). Good first tab to ship after the agent is loaded — validates the agent on a small surface.
+   - **Plan** — high-traffic; Flow 05 backlog open ("decide: PR #170 polish sufficient or full Variant A?"). Medium scope.
+   - **Deudas** — high-visibility; debt is core to Zeta value. Medium scope.
+   - **Movimientos slice 2** — large scope, reopens recently-shipped files. Only pursue if user wants continuity.
+4. **Flow 02 PR 3** (dashboard widget drag-to-reorder + S/M/L resize) — still pending from several sessions back. Reanimated + gesture-handler work; medium-large.
+5. **Anonymous demo cleanup cron** (Tech Debt, Medium) — still pending since 2026-04-21.
 
 ## 7. Context for Claude
 
-- **PR #212 diff:** 751 insertions / 287 deletions / 16 files.
-- **Route audit** for mobile lives in this session's Explore agent transcript. Re-run on `mobile/app/**/*.tsx` + `mobile/lib/repositories/*.ts` if needed.
-- **ios-simulator MCP** loaded from `.mcp.json` — requires `idb-companion` (brew) + `fb-idb` via `uv tool install --python 3.11 fb-idb`. Python 3.14 breaks it.
-- **Simulator deep-link scheme** is `zeta://<path>` (e.g. `xcrun simctl openurl <UDID> "zeta://capture"`). Useful when FAB sheets are fragile in the a11y tree.
-- **Expo dev-client** needs Metro running separately (`npx expo start --dev-client` in `mobile/`). No Metro → "No development servers found".
-- **Unapplied migration picked up** — `supabase/migrations/20260421180000_anonymous_cleanup_cron.sql` was applied during this session's first `db push` (pre-existing, not from PR #212).
-- **Webapp-is-source-of-truth** is the governing principle. Before any mobile Supabase mutation, read the webapp action and port verbatim. If webapp has a bug, fix both or neither — never diverge.
-- **Gate pipeline order** this session: Explore audit → implement → `mobile-webapp-parity` + `mobile-sync-doctor` in parallel → fix → `pnpm build` → commit → PR → `/simplify` (3 reviewers parallel) → fix → push → Gemini reply.
-- **Auto mode + caveman lite** active throughout. Code/commits write normally; prose stays tight.
+- **Mobile webapp viewport is the design source of truth.** Every mobile parity slice should open `webapp/src/components/mobile/v2/<feature>/*` first and mirror the shape. Deviations need justification (usually: "picker sheet doesn't exist on mobile yet — slice 2").
+- **`WidgetGridRow` at `mobile/components/inicio/WidgetGrid.tsx`** is the canonical reference implementation for the retain-last-detail pattern (shared accordion that swaps children by active id). Copy its timer + cleanup pattern whenever you wire an `AnimatedAccordion` with swappable children.
+- **`MobileSheet` at `mobile/components/ui/MobileSheet.tsx`** is the canonical bottom-sheet Modal wrapper — handles safe-area inset, scrim, drag handle. Never use raw `<Modal>` + custom scrim — duplicates the safe-area logic.
+- **Mobile pre-computed opacity tokens**: NativeWind v3 cannot consume `color/opacity` syntax. Use `bg-black-10`, `text-white-15`, `border-white-6`, `bg-z-brass-10` etc. from `mobile/tailwind.config.js`. Arbitrary `/opacity` silently falls back on some targets.
+- **`PulseWidget` at `mobile/components/inicio/widgets/PulseWidget.tsx`** is the canonical dashboard expand/collapse affordance: rotating `ChevronDown` + "Ocultar / Ver …" label at `tracking-[2px]`. Zeta has TWO eyebrow tracking values: `[4px]` for section eyebrows (`SECTION_EYEBROW_CLASS`), `[2px]` for toggle-label eyebrows. Don't let an agent "normalize" the latter.
+- **Review gate order after any mobile feature**: `mobile-perf-doctor` + `mobile-webapp-parity` + `zetas-front-guy` + `feature-dev:code-reviewer`. Run foreground when findings are needed to proceed; background when independent.
+- **`mobile-perf-doctor` bible sections we added this session**:
+  - §1.1 Golden rule: pass the array item directly, don't rebuild it into a view model (the `toItem()` trap)
+  - §3.2 AnimatedAccordion scale/close/affordance rules (one-per-screen vs per-row mounting; retain-last-detail pattern; `ChevronDown` + toggle label)
+  - §3.3 SVG rendering gated on `expanded` without retention causes close-animation tear
+  - §4.4 Race guards on paginated loaders (`requestIdRef` + `txCountRef`)
+  - §5.2 Summary totals must come from SQL, not the paginated feed
+- **PR merge style**: squash merge via GitHub UI. Don't force-push to `main`. Dry-merge against `origin/main` before pushing any branch (Zeta `CLAUDE.md` rule).
+- **Pipeline** (proven across 2026-04-22 sessions): implement → gate agents (foreground when blocking) → apply findings → `/simplify` or equivalent → apply → Gemini review → reply + backlog. Works well; stick with it.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Zeta",
     "slug": "zeta",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "zeta",

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -593,9 +593,13 @@ export async function updateTransaction(
   if (params.category_id !== undefined) {
     setClauses.push("category_id = ?");
     values.push(params.category_id ?? null);
-    // Match webapp: track how the category was assigned
-    setClauses.push("categorization_source = ?");
-    values.push(params.category_id ? "USER_OVERRIDE" : null);
+    // Match webapp (actions/transactions.ts:841): only flag USER_OVERRIDE
+    // when ASSIGNING a category. On clear, leave the prior source intact —
+    // webapp does not null it, so mobile must not either (parity).
+    if (params.category_id) {
+      setClauses.push("categorization_source = ?");
+      values.push("USER_OVERRIDE");
+    }
   }
   if (params.notes !== undefined) {
     setClauses.push("notes = ?");
@@ -631,7 +635,10 @@ export async function updateTransaction(
   if (params.transaction_date !== undefined) syncPayload.transaction_date = params.transaction_date;
   if (params.category_id !== undefined) {
     syncPayload.category_id = params.category_id ?? null;
-    syncPayload.categorization_source = params.category_id ? "USER_OVERRIDE" : null;
+    // Match webapp: don't overwrite categorization_source on clear.
+    if (params.category_id) {
+      syncPayload.categorization_source = "USER_OVERRIDE";
+    }
   }
   if (params.notes !== undefined) syncPayload.notes = params.notes ?? null;
   if (params.is_excluded !== undefined) syncPayload.is_excluded = params.is_excluded;

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -593,13 +593,12 @@ export async function updateTransaction(
   if (params.category_id !== undefined) {
     setClauses.push("category_id = ?");
     values.push(params.category_id ?? null);
-    // Match webapp (actions/transactions.ts:841): only flag USER_OVERRIDE
-    // when ASSIGNING a category. On clear, leave the prior source intact —
-    // webapp does not null it, so mobile must not either (parity).
-    if (params.category_id) {
-      setClauses.push("categorization_source = ?");
-      values.push("USER_OVERRIDE");
-    }
+    // Match webapp (actions/transactions.ts:841): flag USER_OVERRIDE on any
+    // category change — assign or clear. Webapp uses `categoryChanged` which
+    // is true in both directions; mobile mirrors by always setting the flag
+    // whenever the caller includes category_id in the update.
+    setClauses.push("categorization_source = ?");
+    values.push("USER_OVERRIDE");
   }
   if (params.notes !== undefined) {
     setClauses.push("notes = ?");
@@ -635,10 +634,7 @@ export async function updateTransaction(
   if (params.transaction_date !== undefined) syncPayload.transaction_date = params.transaction_date;
   if (params.category_id !== undefined) {
     syncPayload.category_id = params.category_id ?? null;
-    // Match webapp: don't overwrite categorization_source on clear.
-    if (params.category_id) {
-      syncPayload.categorization_source = "USER_OVERRIDE";
-    }
+    syncPayload.categorization_source = "USER_OVERRIDE";
   }
   if (params.notes !== undefined) syncPayload.notes = params.notes ?? null;
   if (params.is_excluded !== undefined) syncPayload.is_excluded = params.is_excluded;


### PR DESCRIPTION
## Summary

- **Parity fix**: `updateTransaction` no longer writes `categorization_source = null` when clearing a category. Matches webapp (`webapp/src/actions/transactions.ts:841` — only flags `USER_OVERRIDE` when assigning, leaves prior source intact on clear). Prior mobile behavior was silently overwriting prior values.
- **BACKLOG handoff** for 2026-04-22 (late night) — PR #221 shipped, follow-ups documented, triage candidates for next session queued.

## Declined (follow-up)

- Narrowing `getTransactions SELECT t.*` from Gemini's deferred comment on PR #221 — 6 callers, marginal gain (mobile SQLite has no encrypted columns so parse cost is small). Filed in BACKLOG for opportunistic cleanup.

## Test plan

- [ ] `pnpm tsc --noEmit` clean on mobile (verified locally)
- [ ] `mobile-pr-verify` CI workflow passes (second run of the newly added workflow)
- [ ] Manual: on `/transaction/:id`, clear a category — `categorization_source` stays whatever it was (observe via SQLite inspector or sync_queue payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)