### PR TITLE
Reset all my data + onboarding StepComplete fixes

### DIFF
--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -42,6 +42,8 @@ import { useBugReport } from "../../lib/bugReportMode";
 import { supabase } from "../../lib/supabase";
 import { clearDatabase, getDatabase } from "../../lib/db/database";
 import { disableDemoMode } from "../../lib/demo-mode";
+import { resetUserData } from "../../lib/reset-data";
+import { useOnboardingStatus } from "../../lib/onboarding-status";
 import { useTheme, type ThemeMode } from "../../lib/theme";
 import { COLORS } from "../../lib/constants/colors";
 import { LEGAL_URLS } from "../../lib/constants/urls";
@@ -363,7 +365,9 @@ export default function SettingsScreen() {
   const { status, lastSynced, sync } = useSync();
   const { profile, clear } = useAppStore();
   const { isFabEnabled, setFabEnabled } = useBugReport();
+  const { markIncomplete } = useOnboardingStatus();
   const [syncing, setSyncing] = useState(false);
+  const [resetting, setResetting] = useState(false);
   const [biometricsAvailable, setBiometricsAvailable] = useState(false);
   const [biometricsOn, setBiometricsOn] = useState(false);
   const [bgReauthOn, setBgReauthOn] = useState(false);
@@ -496,6 +500,53 @@ export default function SettingsScreen() {
       ]
     );
   }, [clear, sync]);
+
+  const handleResetAllData = useCallback(() => {
+    if (demoMode || !session?.user?.id) return;
+    const userId = session.user.id;
+
+    Alert.alert(
+      "Borrar todos mis datos",
+      "Se eliminarán cuentas, transacciones, presupuestos, deudas, recurrentes y categorías personalizadas. Tu cuenta y tu sesión se mantienen: volverás al onboarding. Esta acción no se puede deshacer.",
+      [
+        { text: "Cancelar", style: "cancel" },
+        {
+          text: "Continuar",
+          style: "destructive",
+          onPress: () => {
+            Alert.alert(
+              "¿Seguro?",
+              "Última confirmación. Tus datos se borrarán del servidor y del dispositivo.",
+              [
+                { text: "Cancelar", style: "cancel" },
+                {
+                  text: "Borrar todo",
+                  style: "destructive",
+                  onPress: async () => {
+                    setResetting(true);
+                    try {
+                      await resetUserData(userId);
+                      clear();
+                      markIncomplete();
+                      router.replace("/onboarding" as never);
+                    } catch (error) {
+                      console.error("Reset user data error:", error);
+                      Alert.alert(
+                        "No se pudo borrar",
+                        "Inténtalo de nuevo. Si persiste, cierra sesión y vuelve a entrar.",
+                      );
+                    } finally {
+                      setResetting(false);
+                    }
+                  },
+                },
+              ],
+            );
+          },
+        },
+      ],
+    );
+  }, [clear, demoMode, markIncomplete, router, session?.user?.id]);
 
   const handleSignOut = useCallback(() => {
     Alert.alert("Cerrar sesión", "Se eliminarán los datos locales.", [
@@ -683,6 +734,29 @@ export default function SettingsScreen() {
             />
           </View>
         </View>
+
+        {!demoMode && (
+          <View>
+            <SectionHeading label="Zona de peligro" />
+            <View className="gap-2">
+              <Pressable
+                className={`${PANEL_INSET_CLASS} flex-row items-center gap-3 px-4 py-3 active:bg-black-10`}
+                onPress={handleResetAllData}
+                disabled={resetting}
+              >
+                <Trash2 size={16} color={COLORS.debt} />
+                <View className="flex-1">
+                  <Text className="text-sm font-inter-semibold text-z-debt">
+                    {resetting ? "Borrando datos…" : "Borrar todos mis datos"}
+                  </Text>
+                  <Text className="mt-0.5 text-xs font-inter text-muted-foreground">
+                    Mantén tu cuenta y vuelve al onboarding
+                  </Text>
+                </View>
+              </Pressable>
+            </View>
+          </View>
+        )}
 
         {demoMode && (
           <View className="gap-2">

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -17,7 +17,7 @@ import {
 import { Kalam_700Bold } from "@expo-google-fonts/kalam";
 import { Stack, useRootNavigationState, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, AppState, StyleSheet, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import "react-native-reanimated";
@@ -34,6 +34,7 @@ import {
 } from "../lib/biometrics";
 import { BiometricLockScreen } from "../components/common/BiometricLockScreen";
 import { ZetaThemeProvider } from "../lib/theme";
+import { OnboardingStatusContext } from "../lib/onboarding-status";
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -204,6 +205,11 @@ function RootLayoutNav() {
     setBiometricLocked(false);
   }, []);
 
+  const onboardingStatusValue = useMemo(
+    () => ({ markComplete: () => setNeedsOnboarding(false) }),
+    [],
+  );
+
   const handleBiometricFallback = useCallback(async () => {
     setBiometricLocked(false);
     await supabase.auth.signOut();
@@ -215,6 +221,7 @@ function RootLayoutNav() {
     <SafeAreaProvider>
       <ZetaThemeProvider>
       <ThemeProvider value={DarkTheme}>
+        <OnboardingStatusContext.Provider value={onboardingStatusValue}>
         <BugReportViewShot>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -326,6 +333,7 @@ function RootLayoutNav() {
             <ActivityIndicator size="large" color="#937844" />
           </View>
         )}
+        </OnboardingStatusContext.Provider>
       </ThemeProvider>
       </ZetaThemeProvider>
     </SafeAreaProvider>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -170,7 +170,13 @@ function RootLayoutNav() {
       return;
     }
 
-    if (!needsOnboarding && (inAuthGroup || inOnboarding)) {
+    // Kick users out of the auth group once they're signed-in and complete.
+    // Do NOT auto-kick from /onboarding: the onboarding screen navigates
+    // itself out via its CTAs (calling markComplete() first). Without this
+    // guardrail, a session/token refresh during persistOnboarding flips
+    // `needsOnboarding=false` and yanks the user off StepComplete before
+    // they can choose an onward path.
+    if (!needsOnboarding && inAuthGroup) {
       router.replace("/(tabs)");
     }
   }, [session, demoMode, loading, checkingOnboarding, needsOnboarding, segments, router, rootNavigationState?.key]);

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -212,7 +212,10 @@ function RootLayoutNav() {
   }, []);
 
   const onboardingStatusValue = useMemo(
-    () => ({ markComplete: () => setNeedsOnboarding(false) }),
+    () => ({
+      markComplete: () => setNeedsOnboarding(false),
+      markIncomplete: () => setNeedsOnboarding(true),
+    }),
     [],
   );
 

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -29,6 +29,7 @@ import { useTheme, themeSurfaceClasses } from "../lib/theme";
 import { parseMoney } from "../lib/utils/money";
 import { supabase } from "../lib/supabase";
 import { useAuth } from "../lib/auth";
+import { useOnboardingStatus } from "../lib/onboarding-status";
 
 const TOTAL_STEPS = 5;
 type StepIndex = 1 | 2 | 3 | 4 | 5;
@@ -71,6 +72,7 @@ const STEP_META: Record<StepIndex, StepMeta> = {
 export default function MobileOnboardingScreen() {
   const router = useRouter();
   const { session } = useAuth();
+  const { markComplete } = useOnboardingStatus();
   const insets = useSafeAreaInsets();
   const topInset = Math.max(insets.top, 12);
   const bottomInset = Math.max(insets.bottom + 8, 20);
@@ -237,6 +239,10 @@ export default function MobileOnboardingScreen() {
   }
 
   function handleFinishPrimary() {
+    // Flip the root layout's onboarding gate BEFORE navigating. Otherwise its
+    // cached `needsOnboarding=true` redirects us straight back to /onboarding
+    // on the next segment change.
+    markComplete();
     switch (data.purpose) {
       case "manage_debt":
       case "track_spending":
@@ -252,6 +258,7 @@ export default function MobileOnboardingScreen() {
   }
 
   function handleExplore() {
+    markComplete();
     router.replace("/(tabs)");
   }
 

--- a/mobile/lib/db/database.ts
+++ b/mobile/lib/db/database.ts
@@ -59,6 +59,9 @@ export async function clearDatabase(): Promise<void> {
     DELETE FROM tags;
     DELETE FROM tag_groups;
     DELETE FROM transactions;
+    DELETE FROM planning_assignments;
+    DELETE FROM planning_entries;
+    DELETE FROM planning_periods;
     DELETE FROM accounts;
     DELETE FROM categories;
     DELETE FROM budgets;

--- a/mobile/lib/db/database.ts
+++ b/mobile/lib/db/database.ts
@@ -49,24 +49,33 @@ async function runMigrations(database: SQLite.SQLiteDatabase): Promise<void> {
 
 export async function clearDatabase(): Promise<void> {
   const database = await getDatabase();
+  // Order matters: `PRAGMA foreign_keys = ON` (set in runMigrations) rejects
+  // deletes that would orphan referenced rows. Delete dependent rows first,
+  // parents last. Specifically:
+  //   budgets.default_category_id → categories (budgets before categories)
+  //   statement_snapshots.account_id → accounts (snapshots before accounts)
+  //   transactions.account_id/category_id → accounts/categories
+  //   recurring_occurrences → recurring_transaction_templates → accounts
+  //   tags.group_id → tag_groups
+  //   planning_assignments → planning_entries → planning_periods
   await database.execAsync(`
     DELETE FROM wishlist_items;
     DELETE FROM transaction_tags;
     DELETE FROM recurring_occurrences;
-    DELETE FROM recurring_transaction_templates;
-    DELETE FROM destinatario_rules;
-    DELETE FROM destinatarios;
-    DELETE FROM tags;
-    DELETE FROM tag_groups;
-    DELETE FROM transactions;
     DELETE FROM planning_assignments;
     DELETE FROM planning_entries;
     DELETE FROM planning_periods;
+    DELETE FROM recurring_transaction_templates;
+    DELETE FROM destinatario_rules;
+    DELETE FROM destinatarios;
+    DELETE FROM statement_snapshots;
+    DELETE FROM budgets;
+    DELETE FROM transactions;
     DELETE FROM accounts;
     DELETE FROM categories;
-    DELETE FROM budgets;
+    DELETE FROM tags;
+    DELETE FROM tag_groups;
     DELETE FROM profiles;
-    DELETE FROM statement_snapshots;
     DELETE FROM sync_queue;
     DELETE FROM sync_metadata;
   `);

--- a/mobile/lib/onboarding-status.tsx
+++ b/mobile/lib/onboarding-status.tsx
@@ -2,11 +2,13 @@ import { createContext, useContext } from "react";
 
 type OnboardingStatusContextValue = {
   markComplete: () => void;
+  markIncomplete: () => void;
 };
 
 export const OnboardingStatusContext =
   createContext<OnboardingStatusContextValue>({
     markComplete: () => {},
+    markIncomplete: () => {},
   });
 
 export function useOnboardingStatus() {

--- a/mobile/lib/onboarding-status.tsx
+++ b/mobile/lib/onboarding-status.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react";
+
+type OnboardingStatusContextValue = {
+  markComplete: () => void;
+};
+
+export const OnboardingStatusContext =
+  createContext<OnboardingStatusContextValue>({
+    markComplete: () => {},
+  });
+
+export function useOnboardingStatus() {
+  return useContext(OnboardingStatusContext);
+}

--- a/mobile/lib/reset-data.ts
+++ b/mobile/lib/reset-data.ts
@@ -1,7 +1,8 @@
 import * as SecureStore from "expo-secure-store";
 import { supabase } from "./supabase";
-import { clearDatabase } from "./db/database";
+import { clearDatabase, getDatabase } from "./db/database";
 import { getAllAccounts } from "./repositories/accounts";
+import { beginReset, endReset } from "./sync/engine";
 
 const PDF_PASSWORD_KEY_PREFIX = "zeta_pdf_password";
 const DEFAULT_ACCOUNT_STORAGE_KEY = "zeta.default_capture_account_id";
@@ -18,22 +19,43 @@ function pdfPasswordKey(userId: string, accountId: string) {
 //
 // Intentionally preserved locally: the Supabase session (user stays signed
 // in), biometric credentials, theme, bug-report FAB preference.
+//
+// Ordering matters. Any concurrent `syncAll()` would either (a) push
+// `sync_queue` rows to the just-wiped server, partially resurrecting data,
+// or (b) pull a stale pre-wipe snapshot back into SQLite. We therefore:
+//   1. Set a global reset flag that `syncAll` checks and bails on.
+//   2. Drain `sync_queue` locally BEFORE the RPC — even if the RPC fails
+//      we leave no stale mutations behind.
+//   3. Call the RPC.
+//   4. Wipe local SQLite.
+//   5. Clear device-bound SecureStore entries.
+//   6. Release the reset flag.
 export async function resetUserData(userId: string): Promise<void> {
-  // Capture account IDs BEFORE the wipe so we know which PDF-password
-  // SecureStore keys to clear.
-  const accounts = await getAllAccounts().catch(() => []);
-  const pdfKeys = accounts.map((a) => pdfPasswordKey(userId, a.id));
+  beginReset();
+  try {
+    const accounts = await getAllAccounts().catch(() => []);
+    const pdfKeys = accounts.map((a) => pdfPasswordKey(userId, a.id));
 
-  const { error } = await supabase.rpc("reset_user_data");
-  if (error) {
-    throw new Error(error.message || "No se pudo borrar los datos remotos.");
+    const db = await getDatabase();
+    await db
+      .execAsync("DELETE FROM sync_queue")
+      .catch((err) => {
+        console.warn("[reset] sync_queue drain failed (non-fatal):", err);
+      });
+
+    const { error } = await supabase.rpc("reset_user_data");
+    if (error) {
+      throw new Error(error.message || "No se pudo borrar los datos remotos.");
+    }
+
+    await clearDatabase();
+
+    await Promise.all(
+      [...pdfKeys, DEFAULT_ACCOUNT_STORAGE_KEY].map((key) =>
+        SecureStore.deleteItemAsync(key).catch(() => {}),
+      ),
+    );
+  } finally {
+    endReset();
   }
-
-  await clearDatabase();
-
-  await Promise.all(
-    [...pdfKeys, DEFAULT_ACCOUNT_STORAGE_KEY].map((key) =>
-      SecureStore.deleteItemAsync(key).catch(() => {}),
-    ),
-  );
 }

--- a/mobile/lib/reset-data.ts
+++ b/mobile/lib/reset-data.ts
@@ -1,0 +1,39 @@
+import * as SecureStore from "expo-secure-store";
+import { supabase } from "./supabase";
+import { clearDatabase } from "./db/database";
+import { getAllAccounts } from "./repositories/accounts";
+
+const PDF_PASSWORD_KEY_PREFIX = "zeta_pdf_password";
+const DEFAULT_ACCOUNT_STORAGE_KEY = "zeta.default_capture_account_id";
+
+function pdfPasswordKey(userId: string, accountId: string) {
+  const sanitized = `${userId}_${accountId}`.replace(/[^a-zA-Z0-9.,_]/g, "_");
+  return `${PDF_PASSWORD_KEY_PREFIX}_${sanitized}`;
+}
+
+// Wipes all of the user's data but keeps their account: calls the
+// server-side `reset_user_data` RPC (scoped to `auth.uid()`), then clears
+// local SQLite and device-bound preferences that only make sense alongside
+// real data (saved PDF passwords, default capture account).
+//
+// Intentionally preserved locally: the Supabase session (user stays signed
+// in), biometric credentials, theme, bug-report FAB preference.
+export async function resetUserData(userId: string): Promise<void> {
+  // Capture account IDs BEFORE the wipe so we know which PDF-password
+  // SecureStore keys to clear.
+  const accounts = await getAllAccounts().catch(() => []);
+  const pdfKeys = accounts.map((a) => pdfPasswordKey(userId, a.id));
+
+  const { error } = await supabase.rpc("reset_user_data");
+  if (error) {
+    throw new Error(error.message || "No se pudo borrar los datos remotos.");
+  }
+
+  await clearDatabase();
+
+  await Promise.all(
+    [...pdfKeys, DEFAULT_ACCOUNT_STORAGE_KEY].map((key) =>
+      SecureStore.deleteItemAsync(key).catch(() => {}),
+    ),
+  );
+}

--- a/mobile/lib/sync/engine.ts
+++ b/mobile/lib/sync/engine.ts
@@ -4,10 +4,34 @@ import { supabase } from "../supabase";
 
 export type SyncStatus = "idle" | "syncing" | "error";
 
+// Global reset lock. When the user taps "Borrar todos mis datos", the reset
+// flow flips this on before calling the server-side RPC and only clears it
+// after the local wipe + navigation. Any `syncAll()` invocation during that
+// window (from the initial-sync listener, the pull-to-refresh hook, the
+// manual sync button, etc.) must bail out immediately — otherwise a push
+// can replay queued mutations against the now-empty server, or a pull can
+// re-seed SQLite from a stale snapshot captured before the wipe.
+let resetInProgress = false;
+
+export function beginReset(): void {
+  resetInProgress = true;
+}
+
+export function endReset(): void {
+  resetInProgress = false;
+}
+
+export function isResetInProgress(): boolean {
+  return resetInProgress;
+}
+
 export async function syncAll(): Promise<{
   pushed: number;
   pulled: Record<string, number>;
 }> {
+  if (resetInProgress) {
+    return { pushed: 0, pulled: {} };
+  }
   let session = null;
   try {
     const {

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -744,7 +744,10 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      reset_user_data: {
+        Args: Record<string, never>
+        Returns: undefined
+      }
     }
     Enums: {
       account_type:

--- a/supabase/migrations/20260422221529_add_reset_user_data_rpc.sql
+++ b/supabase/migrations/20260422221529_add_reset_user_data_rpc.sql
@@ -1,0 +1,175 @@
+-- ============================================================================
+-- public.reset_user_data() — wipe all user-scoped data for the calling user
+--
+-- Keeps auth.users, user_encryption_keys, and the profile row (reset) so the
+-- user can re-run onboarding from the same account. The webapp and mobile
+-- clients call this via `supabase.rpc('reset_user_data')` from a "Reset
+-- account" action in Settings.
+--
+-- Ordering strategy:
+--   1. Delete from dependent / leaf tables first (tags join tables, rules,
+--      email ingest, planning, debt, reminders, etc.).
+--   2. Delete from `destinatarios` (cascades to destinatario_rules,
+--      destinatario_tags) — must run BEFORE accounts because
+--      recurring_transaction_templates has destinatario_id ON DELETE SET NULL
+--      and we want a clean cascade from accounts next.
+--   3. Delete from `accounts` (view → accounts_enc) which cascades to
+--      transactions_enc, statement_snapshots, recurring_transaction_templates_enc
+--      (→ recurring_occurrences, recurring_occurrence_skips,
+--      recurring_template_tags), pdf_passwords_enc. It also SET NULLs
+--      account_id on email_ingest rows, planning_entries, wishlist_items,
+--      capture_tokens — but we've already deleted those above.
+--   4. Delete user tag rows (is_system = false) — system tags stay intact.
+--   5. Reset the profile via the `profiles` view so the INSTEAD OF UPDATE
+--      trigger re-encrypts cleared fields under the user's DEK.
+--
+-- Categories are NOT re-seeded: they are system rows (user_id NULL) shared
+-- across all users. No per-user seed function exists in this project, so
+-- once transactions/budgets/etc. are gone the user starts from a clean slate.
+--
+-- Granted to `authenticated` only so PostgREST exposes it via rpc(). All
+-- deletes run under SECURITY DEFINER but each DELETE is scoped by
+-- `user_id = v_user_id`, so a caller can only wipe their own data.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reset_user_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  -- --------------------------------------------------------------------------
+  -- 1. Leaf tables / tag joins (no inbound user cascades to wait for)
+  -- --------------------------------------------------------------------------
+
+  -- Tag join tables: these don't all have a user_id column, so scope via
+  -- the parent. category_tags has no user_id — it references `categories`
+  -- (shared) AND `tags` (user-owned); clear rows where the tag is the user's.
+  DELETE FROM public.category_tags
+    WHERE tag_id IN (
+      SELECT id FROM public.tags WHERE user_id = v_user_id
+    );
+
+  -- transaction_tags, destinatario_tags, recurring_template_tags: these
+  -- cascade from transactions / destinatarios / recurring_templates and
+  -- will be wiped when we delete those parents. We still delete explicitly
+  -- (defensive, cheap, and guards against missing cascades):
+  DELETE FROM public.transaction_tags       WHERE user_id = v_user_id;
+  DELETE FROM public.destinatario_tags
+    WHERE destinatario_id IN (
+      SELECT id FROM public.destinatarios WHERE user_id = v_user_id
+    );
+  DELETE FROM public.recurring_template_tags WHERE user_id = v_user_id;
+
+  -- --------------------------------------------------------------------------
+  -- 2. Planning / budgets / debt / reminders / wishlist
+  -- --------------------------------------------------------------------------
+  DELETE FROM public.planning_assignments     WHERE user_id = v_user_id;
+  DELETE FROM public.planning_entries         WHERE user_id = v_user_id;
+  DELETE FROM public.planning_periods         WHERE user_id = v_user_id;
+
+  DELETE FROM public.budgets                  WHERE user_id = v_user_id;
+
+  DELETE FROM public.debt_scenarios           WHERE user_id = v_user_id;
+
+  DELETE FROM public.financial_reminders      WHERE user_id = v_user_id;
+
+  DELETE FROM public.obligation_skips         WHERE user_id = v_user_id;
+  -- recurring_occurrence_skips + recurring_occurrences cascade from the
+  -- recurring template delete (via accounts), but delete defensively:
+  DELETE FROM public.recurring_occurrence_skips WHERE user_id = v_user_id;
+  DELETE FROM public.recurring_occurrences    WHERE user_id = v_user_id;
+
+  DELETE FROM public.wishlist_reflections     WHERE user_id = v_user_id;
+  DELETE FROM public.wishlist_items           WHERE user_id = v_user_id;
+
+  -- --------------------------------------------------------------------------
+  -- 3. Email ingest / capture / unrecognized
+  -- --------------------------------------------------------------------------
+  DELETE FROM public.pending_email_transactions  WHERE user_id = v_user_id;
+  DELETE FROM public.pending_email_statements    WHERE user_id = v_user_id;
+  DELETE FROM public.email_ingest_allowed_senders WHERE user_id = v_user_id;
+  -- email_ingest_logs.user_id is nullable (ON DELETE SET NULL) — still clear:
+  DELETE FROM public.email_ingest_logs           WHERE user_id = v_user_id;
+  DELETE FROM public.email_ingest_addresses      WHERE user_id = v_user_id;
+
+  DELETE FROM public.unrecognized_emails         WHERE user_id = v_user_id;
+
+  DELETE FROM public.capture_tokens              WHERE user_id = v_user_id;
+
+  -- Analytics — clear to keep the reset clean. bug_reports intentionally
+  -- preserved (support value).
+  DELETE FROM public.product_events              WHERE user_id = v_user_id;
+
+  -- --------------------------------------------------------------------------
+  -- 4. Destinatarios (cascades to destinatario_rules + destinatario_tags)
+  --    Must run before accounts so recurring_template.destinatario_id
+  --    references are cleared before the templates themselves are cascade-
+  --    deleted (SET NULL would fire otherwise — harmless but noisier).
+  -- --------------------------------------------------------------------------
+  DELETE FROM public.destinatarios               WHERE user_id = v_user_id;
+
+  -- Any orphan category_rules (user-owned regex rules) — predates destinatarios
+  DELETE FROM public.category_rules              WHERE user_id = v_user_id;
+
+  -- --------------------------------------------------------------------------
+  -- 5. Accounts (view → accounts_enc). Cascade chain:
+  --      accounts_enc
+  --        → transactions_enc (→ transaction_tags)
+  --        → statement_snapshots
+  --        → recurring_transaction_templates_enc
+  --            → recurring_occurrences
+  --            → recurring_occurrence_skips
+  --            → recurring_template_tags
+  --        → pdf_passwords_enc
+  -- --------------------------------------------------------------------------
+  DELETE FROM public.accounts                    WHERE user_id = v_user_id;
+
+  -- --------------------------------------------------------------------------
+  -- 6. User-owned tags + tag groups (preserve system rows where
+  --    is_system = true and user_id IS NULL)
+  -- --------------------------------------------------------------------------
+  DELETE FROM public.tags        WHERE user_id = v_user_id AND is_system = false;
+  DELETE FROM public.tag_groups  WHERE user_id = v_user_id AND is_system = false;
+
+  -- --------------------------------------------------------------------------
+  -- 7. Reset profile via the view — INSTEAD OF UPDATE trigger handles the
+  --    re-encryption under the caller's DEK. PRESERVE: id, email, created_at,
+  --    demo_mode, monthly_salary (ambiguous — cleared for clean slate too).
+  -- --------------------------------------------------------------------------
+  UPDATE public.profiles SET
+    full_name                   = NULL,
+    app_purpose                 = NULL,
+    avatar_url                  = NULL,
+    budget_mode                 = NULL,
+    estimated_monthly_income    = NULL,
+    estimated_monthly_expenses  = NULL,
+    monthly_salary              = NULL,
+    preferred_currency          = 'COP',
+    timezone                    = NULL,
+    locale                      = NULL,
+    onboarding_completed        = false,
+    dashboard_config            = NULL,
+    mobile_dashboard_config     = NULL,
+    updated_at                  = now()::text
+  WHERE id = v_user_id;
+END;
+$$;
+
+-- Expose to authenticated clients only. Deny public/anon explicitly.
+REVOKE ALL ON FUNCTION public.reset_user_data() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reset_user_data() FROM anon;
+GRANT  EXECUTE ON FUNCTION public.reset_user_data() TO authenticated;
+
+COMMENT ON FUNCTION public.reset_user_data() IS
+  'Wipes all user-scoped data for the calling user (auth.uid()) and resets '
+  'the profile to onboarding defaults. Keeps auth.users + encryption DEK so '
+  'the user can re-run onboarding from the same account. Callable from '
+  'clients via supabase.rpc(''reset_user_data'').';

--- a/supabase/migrations/20260422222441_fix_reset_user_data_obligation_skips.sql
+++ b/supabase/migrations/20260422222441_fix_reset_user_data_obligation_skips.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- Fix: `public.reset_user_data()` referenced `public.obligation_skips`, which
+-- was removed in `20260409205916_recurring_occurrences.sql` in favour of
+-- `recurring_occurrence_skips`. Running the RPC raised
+--     relation "public.obligation_skips" does not exist
+-- Re-create the function without that DELETE. Everything else is unchanged.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reset_user_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  -- Tag join tables
+  DELETE FROM public.category_tags
+    WHERE tag_id IN (
+      SELECT id FROM public.tags WHERE user_id = v_user_id
+    );
+  DELETE FROM public.transaction_tags       WHERE user_id = v_user_id;
+  DELETE FROM public.destinatario_tags
+    WHERE destinatario_id IN (
+      SELECT id FROM public.destinatarios WHERE user_id = v_user_id
+    );
+  DELETE FROM public.recurring_template_tags WHERE user_id = v_user_id;
+
+  -- Planning / budgets / debt / reminders / wishlist
+  DELETE FROM public.planning_assignments     WHERE user_id = v_user_id;
+  DELETE FROM public.planning_entries         WHERE user_id = v_user_id;
+  DELETE FROM public.planning_periods         WHERE user_id = v_user_id;
+
+  DELETE FROM public.budgets                  WHERE user_id = v_user_id;
+
+  DELETE FROM public.debt_scenarios           WHERE user_id = v_user_id;
+
+  DELETE FROM public.financial_reminders      WHERE user_id = v_user_id;
+
+  -- `obligation_skips` was dropped upstream; `recurring_occurrence_skips`
+  -- is the current table.
+  DELETE FROM public.recurring_occurrence_skips WHERE user_id = v_user_id;
+  DELETE FROM public.recurring_occurrences    WHERE user_id = v_user_id;
+
+  DELETE FROM public.wishlist_reflections     WHERE user_id = v_user_id;
+  DELETE FROM public.wishlist_items           WHERE user_id = v_user_id;
+
+  -- Email ingest / capture / unrecognized
+  DELETE FROM public.pending_email_transactions  WHERE user_id = v_user_id;
+  DELETE FROM public.pending_email_statements    WHERE user_id = v_user_id;
+  DELETE FROM public.email_ingest_allowed_senders WHERE user_id = v_user_id;
+  DELETE FROM public.email_ingest_logs           WHERE user_id = v_user_id;
+  DELETE FROM public.email_ingest_addresses      WHERE user_id = v_user_id;
+
+  DELETE FROM public.unrecognized_emails         WHERE user_id = v_user_id;
+
+  DELETE FROM public.capture_tokens              WHERE user_id = v_user_id;
+
+  DELETE FROM public.product_events              WHERE user_id = v_user_id;
+
+  -- Destinatarios (cascades destinatario_rules + destinatario_tags)
+  DELETE FROM public.destinatarios               WHERE user_id = v_user_id;
+
+  DELETE FROM public.category_rules              WHERE user_id = v_user_id;
+
+  -- Accounts (cascades transactions, snapshots, recurring templates, etc.)
+  DELETE FROM public.accounts                    WHERE user_id = v_user_id;
+
+  -- User-owned tags + tag groups (preserve system rows)
+  DELETE FROM public.tags        WHERE user_id = v_user_id AND is_system = false;
+  DELETE FROM public.tag_groups  WHERE user_id = v_user_id AND is_system = false;
+
+  -- Reset profile via the view (INSTEAD OF UPDATE trigger re-encrypts)
+  UPDATE public.profiles SET
+    full_name                   = NULL,
+    app_purpose                 = NULL,
+    avatar_url                  = NULL,
+    budget_mode                 = NULL,
+    estimated_monthly_income    = NULL,
+    estimated_monthly_expenses  = NULL,
+    monthly_salary              = NULL,
+    preferred_currency          = 'COP',
+    timezone                    = NULL,
+    locale                      = NULL,
+    onboarding_completed        = false,
+    dashboard_config            = NULL,
+    mobile_dashboard_config     = NULL,
+    updated_at                  = now()::text
+  WHERE id = v_user_id;
+END;
+$$;

--- a/supabase/migrations/20260422222804_reset_user_data_resilient.sql
+++ b/supabase/migrations/20260422222804_reset_user_data_resilient.sql
@@ -1,0 +1,120 @@
+-- ============================================================================
+-- Replace `public.reset_user_data()` with a version that guards every DELETE
+-- with `to_regclass()`, so renamed/dropped tables (like the skips tables that
+-- went through the obligation_skips rename and were later deleted entirely)
+-- don't abort the whole wipe.
+--
+-- Parent-scoped join tables (`category_tags`, `destinatario_tags`) get their
+-- own branch. Everything else is a simple `WHERE user_id = $1` delete driven
+-- by a single array so future schema additions are a one-line change.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reset_user_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_table   text;
+  -- Ordered so parent tables come AFTER their dependents where it matters,
+  -- but cascades do most of the heavy lifting — we only enumerate tables we
+  -- want to wipe explicitly so nothing is left behind by a missing cascade.
+  v_user_scoped_tables constant text[] := ARRAY[
+    -- Tag joins scoped by user_id directly
+    'transaction_tags',
+    'recurring_template_tags',
+
+    -- Planning / budgets / debt / reminders
+    'planning_assignments',
+    'planning_entries',
+    'planning_periods',
+    'budgets',
+    'debt_scenarios',
+    'financial_reminders',
+
+    -- Recurring occurrences & any legacy skip tables (historical churn)
+    'recurring_occurrence_skips',
+    'obligation_skips',
+    'recurring_occurrences',
+
+    -- Wishlist
+    'wishlist_reflections',
+    'wishlist_items',
+
+    -- Email ingest / capture / analytics
+    'pending_email_transactions',
+    'pending_email_statements',
+    'email_ingest_allowed_senders',
+    'email_ingest_logs',
+    'email_ingest_addresses',
+    'unrecognized_emails',
+    'capture_tokens',
+    'product_events',
+
+    -- Destinatarios (cascades destinatario_rules + destinatario_tags)
+    'destinatarios',
+    'category_rules',
+
+    -- Accounts last: cascades transactions_enc, statement_snapshots,
+    -- recurring_transaction_templates_enc, pdf_passwords_enc, etc.
+    'accounts'
+  ];
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  -- Parent-scoped joins (no user_id column of their own)
+  IF to_regclass('public.category_tags') IS NOT NULL THEN
+    DELETE FROM public.category_tags
+      WHERE tag_id IN (
+        SELECT id FROM public.tags WHERE user_id = v_user_id
+      );
+  END IF;
+
+  IF to_regclass('public.destinatario_tags') IS NOT NULL THEN
+    DELETE FROM public.destinatario_tags
+      WHERE destinatario_id IN (
+        SELECT id FROM public.destinatarios WHERE user_id = v_user_id
+      );
+  END IF;
+
+  -- Simple user_id-scoped deletes
+  FOREACH v_table IN ARRAY v_user_scoped_tables LOOP
+    IF to_regclass('public.' || v_table) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_table)
+        USING v_user_id;
+    END IF;
+  END LOOP;
+
+  -- User-owned tags + tag groups (preserve is_system rows)
+  IF to_regclass('public.tags') IS NOT NULL THEN
+    DELETE FROM public.tags
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+  IF to_regclass('public.tag_groups') IS NOT NULL THEN
+    DELETE FROM public.tag_groups
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+
+  -- Reset profile via the view (INSTEAD OF UPDATE trigger re-encrypts).
+  UPDATE public.profiles SET
+    full_name                   = NULL,
+    app_purpose                 = NULL,
+    avatar_url                  = NULL,
+    budget_mode                 = NULL,
+    estimated_monthly_income    = NULL,
+    estimated_monthly_expenses  = NULL,
+    monthly_salary              = NULL,
+    preferred_currency          = 'COP',
+    timezone                    = NULL,
+    locale                      = NULL,
+    onboarding_completed        = false,
+    dashboard_config            = NULL,
+    mobile_dashboard_config     = NULL,
+    updated_at                  = now()::text
+  WHERE id = v_user_id;
+END;
+$$;

--- a/supabase/migrations/20260422222913_reset_user_data_updated_at_type.sql
+++ b/supabase/migrations/20260422222913_reset_user_data_updated_at_type.sql
@@ -1,0 +1,92 @@
+-- Fix: `profiles.updated_at` is `timestamptz`, not `text`. The previous
+-- revisions of `reset_user_data()` cast `now()::text` which Postgres
+-- rejected as a type mismatch. Drop the cast.
+
+CREATE OR REPLACE FUNCTION public.reset_user_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_table   text;
+  v_user_scoped_tables constant text[] := ARRAY[
+    'transaction_tags',
+    'recurring_template_tags',
+    'planning_assignments',
+    'planning_entries',
+    'planning_periods',
+    'budgets',
+    'debt_scenarios',
+    'financial_reminders',
+    'recurring_occurrence_skips',
+    'obligation_skips',
+    'recurring_occurrences',
+    'wishlist_reflections',
+    'wishlist_items',
+    'pending_email_transactions',
+    'pending_email_statements',
+    'email_ingest_allowed_senders',
+    'email_ingest_logs',
+    'email_ingest_addresses',
+    'unrecognized_emails',
+    'capture_tokens',
+    'product_events',
+    'destinatarios',
+    'category_rules',
+    'accounts'
+  ];
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  IF to_regclass('public.category_tags') IS NOT NULL THEN
+    DELETE FROM public.category_tags
+      WHERE tag_id IN (
+        SELECT id FROM public.tags WHERE user_id = v_user_id
+      );
+  END IF;
+
+  IF to_regclass('public.destinatario_tags') IS NOT NULL THEN
+    DELETE FROM public.destinatario_tags
+      WHERE destinatario_id IN (
+        SELECT id FROM public.destinatarios WHERE user_id = v_user_id
+      );
+  END IF;
+
+  FOREACH v_table IN ARRAY v_user_scoped_tables LOOP
+    IF to_regclass('public.' || v_table) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_table)
+        USING v_user_id;
+    END IF;
+  END LOOP;
+
+  IF to_regclass('public.tags') IS NOT NULL THEN
+    DELETE FROM public.tags
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+  IF to_regclass('public.tag_groups') IS NOT NULL THEN
+    DELETE FROM public.tag_groups
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+
+  UPDATE public.profiles SET
+    full_name                   = NULL,
+    app_purpose                 = NULL,
+    avatar_url                  = NULL,
+    budget_mode                 = NULL,
+    estimated_monthly_income    = NULL,
+    estimated_monthly_expenses  = NULL,
+    monthly_salary              = NULL,
+    preferred_currency          = 'COP',
+    timezone                    = NULL,
+    locale                      = NULL,
+    onboarding_completed        = false,
+    dashboard_config            = NULL,
+    mobile_dashboard_config     = NULL,
+    updated_at                  = now()
+  WHERE id = v_user_id;
+END;
+$$;

--- a/supabase/migrations/20260422223057_reset_user_data_defaults_not_nulls.sql
+++ b/supabase/migrations/20260422223057_reset_user_data_defaults_not_nulls.sql
@@ -1,0 +1,97 @@
+-- Fix: `profiles_enc.locale` (and likely `timezone`) carry NOT NULL
+-- constraints inherited from the pre-encryption schema. Setting them to
+-- NULL during reset raised:
+--     null value in column "locale" of relation "profiles_enc" violates
+--     not-null constraint
+-- Use the same defaults the onboarding flow writes on first run —
+-- locale `es-CO`, timezone `America/Bogota`, preferred_currency `COP` —
+-- so post-reset the account looks identical to a freshly signed-up user.
+
+CREATE OR REPLACE FUNCTION public.reset_user_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_table   text;
+  v_user_scoped_tables constant text[] := ARRAY[
+    'transaction_tags',
+    'recurring_template_tags',
+    'planning_assignments',
+    'planning_entries',
+    'planning_periods',
+    'budgets',
+    'debt_scenarios',
+    'financial_reminders',
+    'recurring_occurrence_skips',
+    'obligation_skips',
+    'recurring_occurrences',
+    'wishlist_reflections',
+    'wishlist_items',
+    'pending_email_transactions',
+    'pending_email_statements',
+    'email_ingest_allowed_senders',
+    'email_ingest_logs',
+    'email_ingest_addresses',
+    'unrecognized_emails',
+    'capture_tokens',
+    'product_events',
+    'destinatarios',
+    'category_rules',
+    'accounts'
+  ];
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  IF to_regclass('public.category_tags') IS NOT NULL THEN
+    DELETE FROM public.category_tags
+      WHERE tag_id IN (
+        SELECT id FROM public.tags WHERE user_id = v_user_id
+      );
+  END IF;
+
+  IF to_regclass('public.destinatario_tags') IS NOT NULL THEN
+    DELETE FROM public.destinatario_tags
+      WHERE destinatario_id IN (
+        SELECT id FROM public.destinatarios WHERE user_id = v_user_id
+      );
+  END IF;
+
+  FOREACH v_table IN ARRAY v_user_scoped_tables LOOP
+    IF to_regclass('public.' || v_table) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_table)
+        USING v_user_id;
+    END IF;
+  END LOOP;
+
+  IF to_regclass('public.tags') IS NOT NULL THEN
+    DELETE FROM public.tags
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+  IF to_regclass('public.tag_groups') IS NOT NULL THEN
+    DELETE FROM public.tag_groups
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+
+  UPDATE public.profiles SET
+    full_name                   = NULL,
+    app_purpose                 = NULL,
+    avatar_url                  = NULL,
+    budget_mode                 = NULL,
+    estimated_monthly_income    = NULL,
+    estimated_monthly_expenses  = NULL,
+    monthly_salary              = NULL,
+    preferred_currency          = 'COP',
+    timezone                    = 'America/Bogota',
+    locale                      = 'es-CO',
+    onboarding_completed        = false,
+    dashboard_config            = NULL,
+    mobile_dashboard_config     = NULL,
+    updated_at                  = now()
+  WHERE id = v_user_id;
+END;
+$$;

--- a/supabase/migrations/20260422223709_reset_user_data_design_reviews.sql
+++ b/supabase/migrations/20260422223709_reset_user_data_design_reviews.sql
@@ -1,0 +1,94 @@
+-- Add `design_reviews` to the resilient reset_user_data table list. It has
+-- a `user_id uuid REFERENCES auth.users(id)` column and survives the
+-- cascade from `accounts`, so it needs an explicit wipe. Guarded by
+-- to_regclass() so environments without the table still run cleanly.
+
+CREATE OR REPLACE FUNCTION public.reset_user_data()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_table   text;
+  v_user_scoped_tables constant text[] := ARRAY[
+    'transaction_tags',
+    'recurring_template_tags',
+    'planning_assignments',
+    'planning_entries',
+    'planning_periods',
+    'budgets',
+    'debt_scenarios',
+    'financial_reminders',
+    'recurring_occurrence_skips',
+    'obligation_skips',
+    'recurring_occurrences',
+    'wishlist_reflections',
+    'wishlist_items',
+    'pending_email_transactions',
+    'pending_email_statements',
+    'email_ingest_allowed_senders',
+    'email_ingest_logs',
+    'email_ingest_addresses',
+    'unrecognized_emails',
+    'capture_tokens',
+    'product_events',
+    'design_reviews',
+    'destinatarios',
+    'category_rules',
+    'accounts'
+  ];
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  IF to_regclass('public.category_tags') IS NOT NULL THEN
+    DELETE FROM public.category_tags
+      WHERE tag_id IN (
+        SELECT id FROM public.tags WHERE user_id = v_user_id
+      );
+  END IF;
+
+  IF to_regclass('public.destinatario_tags') IS NOT NULL THEN
+    DELETE FROM public.destinatario_tags
+      WHERE destinatario_id IN (
+        SELECT id FROM public.destinatarios WHERE user_id = v_user_id
+      );
+  END IF;
+
+  FOREACH v_table IN ARRAY v_user_scoped_tables LOOP
+    IF to_regclass('public.' || v_table) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_table)
+        USING v_user_id;
+    END IF;
+  END LOOP;
+
+  IF to_regclass('public.tags') IS NOT NULL THEN
+    DELETE FROM public.tags
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+  IF to_regclass('public.tag_groups') IS NOT NULL THEN
+    DELETE FROM public.tag_groups
+      WHERE user_id = v_user_id AND is_system = false;
+  END IF;
+
+  UPDATE public.profiles SET
+    full_name                   = NULL,
+    app_purpose                 = NULL,
+    avatar_url                  = NULL,
+    budget_mode                 = NULL,
+    estimated_monthly_income    = NULL,
+    estimated_monthly_expenses  = NULL,
+    monthly_salary              = NULL,
+    preferred_currency          = 'COP',
+    timezone                    = 'America/Bogota',
+    locale                      = 'es-CO',
+    onboarding_completed        = false,
+    dashboard_config            = NULL,
+    mobile_dashboard_config     = NULL,
+    updated_at                  = now()
+  WHERE id = v_user_id;
+END;
+$$;

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -158,6 +158,150 @@ export type Database = {
           },
         ]
       }
+      accounts: {
+        Row: {
+          account_type: Database["public"]["Enums"]["account_type"]
+          available_balance: number | null
+          bank_key: string | null
+          card_brand: string | null
+          color: string | null
+          connection_status: Database["public"]["Enums"]["connection_status"]
+          created_at: string
+          credit_limit: number | null
+          currency_balances: Json | null
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          current_balance: number
+          cutoff_day: number | null
+          debit_card_mask: string | null
+          display_order: number
+          expected_return_rate: number | null
+          icon: string | null
+          id: string
+          initial_investment: number | null
+          institution_name: string | null
+          interest_rate: number | null
+          is_active: boolean
+          is_demo: boolean
+          is_payroll_deducted: boolean
+          last_synced_at: string | null
+          loan_amount: number | null
+          loan_end_date: string | null
+          loan_start_date: string | null
+          mask: string | null
+          mask_hmac: string | null
+          maturity_date: string | null
+          monthly_payment: number | null
+          name: string
+          payment_day: number | null
+          pdf_password: string | null
+          provider: Database["public"]["Enums"]["data_provider"]
+          provider_account_id: string | null
+          provider_account_id_hmac: string | null
+          show_in_dashboard: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_type: Database["public"]["Enums"]["account_type"]
+          available_balance?: number | null
+          bank_key?: string | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?: Database["public"]["Enums"]["connection_status"]
+          created_at?: string
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          current_balance?: number
+          cutoff_day?: number | null
+          debit_card_mask?: string | null
+          display_order?: number
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string
+          initial_investment?: number | null
+          institution_name?: string | null
+          interest_rate?: number | null
+          is_active?: boolean
+          is_demo?: boolean
+          is_payroll_deducted?: boolean
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: string | null
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name: string
+          payment_day?: number | null
+          pdf_password?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_type?: Database["public"]["Enums"]["account_type"]
+          available_balance?: number | null
+          bank_key?: string | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?: Database["public"]["Enums"]["connection_status"]
+          created_at?: string
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          current_balance?: number
+          cutoff_day?: number | null
+          debit_card_mask?: string | null
+          display_order?: number
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string
+          initial_investment?: number | null
+          institution_name?: string | null
+          interest_rate?: number | null
+          is_active?: boolean
+          is_demo?: boolean
+          is_payroll_deducted?: boolean
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: string | null
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: string
+          payment_day?: number | null
+          pdf_password?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_account_id?: string | null
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       admin_config: {
         Row: {
           id: string
@@ -297,7 +441,7 @@ export type Database = {
           last_used_at?: string | null
           revoked_at?: string | null
           token: string
-          token_hash: string
+          token_hash?: string
           user_id: string
         }
         Update: {
@@ -324,6 +468,57 @@ export type Database = {
             columns: ["default_account_id"]
             isOneToOne: false
             referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      capture_tokens: {
+        Row: {
+          created_at: string
+          default_account_id: string | null
+          id: string
+          label: string
+          last_used_at: string | null
+          revoked_at: string | null
+          token: string
+          token_hash: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_account_id?: string | null
+          id?: string
+          label: string
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token: string
+          token_hash?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_account_id?: string | null
+          id?: string
+          label?: string
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: string
+          token_hash?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
             referencedColumns: ["id"]
           },
         ]
@@ -743,6 +938,88 @@ export type Database = {
           },
         ]
       }
+      destinatarios: {
+        Row: {
+          created_at: string
+          default_category_id: string | null
+          id: string
+          is_active: boolean
+          name: string
+          name_hmac: string | null
+          notes: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_category_id?: string | null
+          id?: string
+          is_active?: boolean
+          name: string
+          name_hmac?: string | null
+          notes?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_category_id?: string | null
+          id?: string
+          is_active?: boolean
+          name?: string
+          name_hmac?: string | null
+          notes?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "destinatarios_default_category_id_fkey"
+            columns: ["default_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      email_ingest_allowed_senders: {
+        Row: {
+          created_at: string
+          id: string
+          label: string | null
+          sender_email: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          label?: string | null
+          sender_email: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          label?: string | null
+          sender_email?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       email_ingest_addresses_enc: {
         Row: {
           account_id: string | null
@@ -814,29 +1091,76 @@ export type Database = {
           },
         ]
       }
-      email_ingest_allowed_senders: {
+      email_ingest_addresses: {
         Row: {
+          account_id: string | null
+          address_key: string
+          allowed_sender: string | null
+          auto_import: boolean
           created_at: string
+          gmail_verification_at: string | null
+          gmail_verification_url: string | null
           id: string
-          label: string | null
-          sender_email: string
+          is_active: boolean
+          pdf_import_enabled: boolean
           user_id: string
         }
         Insert: {
+          account_id?: string | null
+          address_key: string
+          allowed_sender?: string | null
+          auto_import?: boolean
           created_at?: string
+          gmail_verification_at?: string | null
+          gmail_verification_url?: string | null
           id?: string
-          label?: string | null
-          sender_email: string
+          is_active?: boolean
+          pdf_import_enabled?: boolean
           user_id: string
         }
         Update: {
+          account_id?: string | null
+          address_key?: string
+          allowed_sender?: string | null
+          auto_import?: boolean
           created_at?: string
+          gmail_verification_at?: string | null
+          gmail_verification_url?: string | null
           id?: string
-          label?: string | null
-          sender_email?: string
+          is_active?: boolean
+          pdf_import_enabled?: boolean
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       email_ingest_logs: {
         Row: {
@@ -959,57 +1283,6 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
-      }
-      pdf_passwords_enc: {
-        Row: {
-          account_id: string | null
-          alias: string
-          bank_key: string | null
-          created_at: string
-          id: string
-          password: string
-          scope: string
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id?: string | null
-          alias: string
-          bank_key?: string | null
-          created_at?: string
-          id?: string
-          password: string
-          scope: string
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string | null
-          alias?: string
-          bank_key?: string | null
-          created_at?: string
-          id?: string
-          password?: string
-          scope?: string
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
       }
       pending_email_statements: {
         Row: {
@@ -1172,6 +1445,108 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pdf_passwords_enc: {
+        Row: {
+          account_id: string | null
+          alias: string
+          bank_key: string | null
+          created_at: string
+          id: string
+          password: string
+          scope: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id?: string | null
+          alias: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password: string
+          scope: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string | null
+          alias?: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password?: string
+          scope?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pdf_passwords: {
+        Row: {
+          account_id: string | null
+          alias: string
+          bank_key: string | null
+          created_at: string
+          id: string
+          password: string
+          scope: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id?: string | null
+          alias: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password: string
+          scope: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string | null
+          alias?: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password?: string
+          scope?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1452,6 +1827,66 @@ export type Database = {
           budget_mode: string | null
           created_at: string
           dashboard_config: Json | null
+          email: string
+          estimated_monthly_expenses: number | null
+          estimated_monthly_income: number | null
+          full_name: string | null
+          id: string
+          locale: string
+          mobile_dashboard_config: Json | null
+          monthly_salary: number | null
+          onboarding_completed: boolean
+          preferred_currency: Database["public"]["Enums"]["currency_code"]
+          timezone: string
+          updated_at: string
+        }
+        Insert: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string
+          dashboard_config?: Json | null
+          email: string
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: string | null
+          id: string
+          locale?: string
+          mobile_dashboard_config?: Json | null
+          monthly_salary?: number | null
+          onboarding_completed?: boolean
+          preferred_currency?: Database["public"]["Enums"]["currency_code"]
+          timezone?: string
+          updated_at?: string
+        }
+        Update: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string
+          dashboard_config?: Json | null
+          email?: string
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: string | null
+          id?: string
+          locale?: string
+          mobile_dashboard_config?: Json | null
+          monthly_salary?: number | null
+          onboarding_completed?: boolean
+          preferred_currency?: Database["public"]["Enums"]["currency_code"]
+          timezone?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          app_purpose: string | null
+          avatar_url: string | null
+          budget_mode: string | null
+          created_at: string
+          dashboard_config: Json | null
           demo_mode: boolean
           email: string
           estimated_monthly_expenses: number | null
@@ -1603,13 +2038,6 @@ export type Database = {
             foreignKeyName: "recurring_template_tags_recurring_template_id_fkey"
             columns: ["recurring_template_id"]
             isOneToOne: false
-            referencedRelation: "recurring_transaction_templates"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_template_tags_recurring_template_id_fkey"
-            columns: ["recurring_template_id"]
-            isOneToOne: false
             referencedRelation: "recurring_transaction_templates_enc"
             referencedColumns: ["id"]
           },
@@ -1755,6 +2183,139 @@ export type Database = {
           },
         ]
       }
+      recurring_transaction_templates: {
+        Row: {
+          account_id: string
+          amount: number
+          category_id: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          day_of_month: number | null
+          day_of_week: number | null
+          description: string | null
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id: string
+          is_active: boolean
+          merchant_name: string | null
+          start_date: string
+          sub_payments: Json | null
+          transfer_source_account_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          destinatario_id?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date: string
+          sub_payments?: Json | null
+          transfer_source_account_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          category_id?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: string | null
+          destinatario_id?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"]
+          id?: string
+          is_active?: boolean
+          merchant_name?: string | null
+          start_date?: string
+          sub_payments?: Json | null
+          transfer_source_account_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       statement_snapshots_enc: {
         Row: {
           account_id: string
@@ -1876,6 +2437,131 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      statement_snapshots: {
+        Row: {
+          account_id: string
+          available_credit: number | null
+          created_at: string
+          credit_limit: number | null
+          currency_code: string
+          final_balance: number | null
+          id: string
+          imported_count: number
+          initial_amount: number | null
+          installments_in_default: number | null
+          interest_charged: number | null
+          interest_rate: number | null
+          late_interest_rate: number | null
+          loan_number: string | null
+          minimum_payment: number | null
+          payment_due_date: string | null
+          period_from: string | null
+          period_to: string | null
+          previous_balance: number | null
+          purchases_and_charges: number | null
+          remaining_balance: number | null
+          skipped_count: number
+          source_filename: string | null
+          total_credits: number | null
+          total_debits: number | null
+          total_payment_due: number | null
+          transaction_count: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          available_credit?: number | null
+          created_at?: string
+          credit_limit?: number | null
+          currency_code?: string
+          final_balance?: number | null
+          id?: string
+          imported_count?: number
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: string | null
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number
+          source_filename?: string | null
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          available_credit?: number | null
+          created_at?: string
+          credit_limit?: number | null
+          currency_code?: string
+          final_balance?: number | null
+          id?: string
+          imported_count?: number
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: string | null
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number
+          source_filename?: string | null
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -2235,6 +2921,215 @@ export type Database = {
           },
         ]
       }
+      transactions: {
+        Row: {
+          account_id: string
+          amount: number
+          amount_in_base_currency: number | null
+          capture_input_text: string | null
+          capture_method: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence: number | null
+          categorization_source: Database["public"]["Enums"]["categorization_source"]
+          category_id: string | null
+          clean_description: string | null
+          clean_description_hmac: string | null
+          created_at: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate: number
+          id: string
+          idempotency_key: string
+          installment_current: number | null
+          installment_group_id: string | null
+          installment_total: number | null
+          is_excluded: boolean
+          is_recurring: boolean
+          is_subscription: boolean
+          merchant_category_code: string | null
+          merchant_logo_url: string | null
+          merchant_name: string | null
+          merchant_name_hmac: string | null
+          notes: string | null
+          original_amount: number | null
+          posting_date: string | null
+          provider: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id: string | null
+          raw_description: string | null
+          reconciled_into_transaction_id: string | null
+          reconciliation_score: number | null
+          recurrence_group_id: string | null
+          secondary_category_id: string | null
+          status: Database["public"]["Enums"]["transaction_status"]
+          tags: string[] | null
+          transaction_date: string
+          transfer_group_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id: string
+          amount: number
+          amount_in_base_currency?: number | null
+          capture_input_text?: string | null
+          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence?: number | null
+          categorization_source?: Database["public"]["Enums"]["categorization_source"]
+          category_id?: string | null
+          clean_description?: string | null
+          clean_description_hmac?: string | null
+          created_at?: string
+          currency_code: Database["public"]["Enums"]["currency_code"]
+          destinatario_id?: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate?: number
+          id?: string
+          idempotency_key: string
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean
+          is_recurring?: boolean
+          is_subscription?: boolean
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: string | null
+          merchant_name_hmac?: string | null
+          notes?: string | null
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id?: string | null
+          raw_description?: string | null
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"]
+          tags?: string[] | null
+          transaction_date: string
+          transfer_group_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number
+          amount_in_base_currency?: number | null
+          capture_input_text?: string | null
+          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
+          categorization_confidence?: number | null
+          categorization_source?: Database["public"]["Enums"]["categorization_source"]
+          category_id?: string | null
+          clean_description?: string | null
+          clean_description_hmac?: string | null
+          created_at?: string
+          currency_code?: Database["public"]["Enums"]["currency_code"]
+          destinatario_id?: string | null
+          direction?: Database["public"]["Enums"]["transaction_direction"]
+          exchange_rate?: number
+          id?: string
+          idempotency_key?: string
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean
+          is_recurring?: boolean
+          is_subscription?: boolean
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: string | null
+          merchant_name_hmac?: string | null
+          notes?: string | null
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"]
+          provider_transaction_id?: string | null
+          raw_description?: string | null
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"]
+          tags?: string[] | null
+          transaction_date?: string
+          transfer_group_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_secondary_category_id_fkey"
+            columns: ["secondary_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       unrecognized_emails: {
         Row: {
           created_at: string
@@ -2441,6 +3336,129 @@ export type Database = {
           },
         ]
       }
+      wishlist_items: {
+        Row: {
+          account_id: string | null
+          amount: number
+          bought_at: string | null
+          category_id: string | null
+          created_at: string
+          currency_code: string
+          desire_type: string | null
+          enriched: boolean
+          enriched_at: string | null
+          funding_type: string | null
+          id: string
+          image_url: string | null
+          installments: number | null
+          last_nudge_dismissed_at: string | null
+          last_score: number | null
+          last_scored_at: string | null
+          last_verdict: string | null
+          name: string
+          ready_at: string | null
+          status: string
+          transaction_id: string | null
+          updated_at: string
+          urgency: string | null
+          url: string | null
+          user_id: string
+          why: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount: number
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string
+          currency_code?: string
+          desire_type?: string | null
+          enriched?: boolean
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name: string
+          ready_at?: string | null
+          status?: string
+          transaction_id?: string | null
+          updated_at?: string
+          urgency?: string | null
+          url?: string | null
+          user_id: string
+          why?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string
+          currency_code?: string
+          desire_type?: string | null
+          enriched?: boolean
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: string
+          ready_at?: string | null
+          status?: string
+          transaction_id?: string | null
+          updated_at?: string
+          urgency?: string | null
+          url?: string | null
+          user_id?: string
+          why?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       wishlist_reflections: {
         Row: {
           days_since_purchase: number
@@ -2494,1106 +3512,25 @@ export type Database = {
       }
     }
     Views: {
-      accounts: {
-        Row: {
-          account_type: Database["public"]["Enums"]["account_type"] | null
-          available_balance: number | null
-          bank_key: string | null
-          card_brand: string | null
-          color: string | null
-          connection_status:
-            | Database["public"]["Enums"]["connection_status"]
-            | null
-          created_at: string | null
-          credit_limit: number | null
-          currency_balances: Json | null
-          currency_code: Database["public"]["Enums"]["currency_code"] | null
-          current_balance: number | null
-          cutoff_day: number | null
-          debit_card_mask: string | null
-          display_order: number | null
-          expected_return_rate: number | null
-          icon: string | null
-          id: string | null
-          initial_investment: number | null
-          institution_name: string | null
-          interest_rate: number | null
-          is_active: boolean | null
-          is_demo: boolean | null
-          is_payroll_deducted: boolean | null
-          last_synced_at: string | null
-          loan_amount: number | null
-          loan_end_date: string | null
-          loan_start_date: string | null
-          mask: string | null
-          mask_hmac: string | null
-          maturity_date: string | null
-          monthly_payment: number | null
-          name: string | null
-          payment_day: number | null
-          pdf_password: string | null
-          provider: Database["public"]["Enums"]["data_provider"] | null
-          provider_account_id: string | null
-          provider_account_id_hmac: string | null
-          show_in_dashboard: boolean | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_type?: Database["public"]["Enums"]["account_type"] | null
-          available_balance?: number | null
-          bank_key?: string | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?:
-            | Database["public"]["Enums"]["connection_status"]
-            | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          current_balance?: number | null
-          cutoff_day?: number | null
-          debit_card_mask?: never
-          display_order?: number | null
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string | null
-          initial_investment?: number | null
-          institution_name?: never
-          interest_rate?: number | null
-          is_active?: boolean | null
-          is_demo?: boolean | null
-          is_payroll_deducted?: boolean | null
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: never
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name?: never
-          payment_day?: number | null
-          pdf_password?: never
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_account_id?: never
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_type?: Database["public"]["Enums"]["account_type"] | null
-          available_balance?: number | null
-          bank_key?: string | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?:
-            | Database["public"]["Enums"]["connection_status"]
-            | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          current_balance?: number | null
-          cutoff_day?: number | null
-          debit_card_mask?: never
-          display_order?: number | null
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string | null
-          initial_investment?: number | null
-          institution_name?: never
-          interest_rate?: number | null
-          is_active?: boolean | null
-          is_demo?: boolean | null
-          is_payroll_deducted?: boolean | null
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: never
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name?: never
-          payment_day?: number | null
-          pdf_password?: never
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_account_id?: never
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      capture_tokens: {
-        Row: {
-          created_at: string | null
-          default_account_id: string | null
-          id: string | null
-          label: string | null
-          last_used_at: string | null
-          revoked_at: string | null
-          token: string | null
-          token_hash: string | null
-          user_id: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          default_account_id?: string | null
-          id?: string | null
-          label?: never
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token?: never
-          token_hash?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          default_account_id?: string | null
-          id?: string | null
-          label?: never
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token?: never
-          token_hash?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      destinatarios: {
-        Row: {
-          created_at: string | null
-          default_category_id: string | null
-          id: string | null
-          is_active: boolean | null
-          name: string | null
-          name_hmac: string | null
-          notes: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          default_category_id?: string | null
-          id?: string | null
-          is_active?: boolean | null
-          name?: never
-          name_hmac?: string | null
-          notes?: never
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          default_category_id?: string | null
-          id?: string | null
-          is_active?: boolean | null
-          name?: never
-          name_hmac?: string | null
-          notes?: never
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "destinatarios_default_category_id_fkey"
-            columns: ["default_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      email_ingest_addresses: {
-        Row: {
-          account_id: string | null
-          address_key: string | null
-          allowed_sender: string | null
-          auto_import: boolean | null
-          created_at: string | null
-          gmail_verification_at: string | null
-          gmail_verification_url: string | null
-          id: string | null
-          is_active: boolean | null
-          pdf_import_enabled: boolean | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          address_key?: string | null
-          allowed_sender?: never
-          auto_import?: boolean | null
-          created_at?: string | null
-          gmail_verification_at?: string | null
-          gmail_verification_url?: never
-          id?: string | null
-          is_active?: boolean | null
-          pdf_import_enabled?: boolean | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          address_key?: string | null
-          allowed_sender?: never
-          auto_import?: boolean | null
-          created_at?: string | null
-          gmail_verification_at?: string | null
-          gmail_verification_url?: never
-          id?: string | null
-          is_active?: boolean | null
-          pdf_import_enabled?: boolean | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      pdf_passwords: {
-        Row: {
-          account_id: string | null
-          alias: string | null
-          bank_key: string | null
-          created_at: string | null
-          id: string | null
-          password: string | null
-          scope: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          alias?: never
-          bank_key?: string | null
-          created_at?: string | null
-          id?: string | null
-          password?: never
-          scope?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          alias?: never
-          bank_key?: string | null
-          created_at?: string | null
-          id?: string | null
-          password?: never
-          scope?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      profiles: {
-        Row: {
-          app_purpose: string | null
-          avatar_url: string | null
-          budget_mode: string | null
-          created_at: string | null
-          dashboard_config: Json | null
-          demo_mode: boolean | null
-          email: string | null
-          estimated_monthly_expenses: number | null
-          estimated_monthly_income: number | null
-          full_name: string | null
-          id: string | null
-          locale: string | null
-          mobile_dashboard_config: Json | null
-          monthly_salary: number | null
-          onboarding_completed: boolean | null
-          preferred_currency:
-            | Database["public"]["Enums"]["currency_code"]
-            | null
-          timezone: string | null
-          updated_at: string | null
-        }
-        Insert: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string | null
-          dashboard_config?: Json | null
-          demo_mode?: boolean | null
-          email?: never
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: never
-          id?: string | null
-          locale?: string | null
-          mobile_dashboard_config?: Json | null
-          monthly_salary?: number | null
-          onboarding_completed?: boolean | null
-          preferred_currency?:
-            | Database["public"]["Enums"]["currency_code"]
-            | null
-          timezone?: string | null
-          updated_at?: string | null
-        }
-        Update: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string | null
-          dashboard_config?: Json | null
-          demo_mode?: boolean | null
-          email?: never
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: never
-          id?: string | null
-          locale?: string | null
-          mobile_dashboard_config?: Json | null
-          monthly_salary?: number | null
-          onboarding_completed?: boolean | null
-          preferred_currency?:
-            | Database["public"]["Enums"]["currency_code"]
-            | null
-          timezone?: string | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
-      recurring_transaction_templates: {
-        Row: {
-          account_id: string | null
-          amount: number | null
-          category_id: string | null
-          created_at: string | null
-          currency_code: Database["public"]["Enums"]["currency_code"] | null
-          day_of_month: number | null
-          day_of_week: number | null
-          description: string | null
-          destinatario_id: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"] | null
-          end_date: string | null
-          frequency: Database["public"]["Enums"]["recurrence_frequency"] | null
-          id: string | null
-          is_active: boolean | null
-          merchant_name: string | null
-          start_date: string | null
-          sub_payments: Json | null
-          transfer_source_account_id: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount?: number | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: never
-          destinatario_id?: string | null
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          end_date?: string | null
-          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
-          id?: string | null
-          is_active?: boolean | null
-          merchant_name?: never
-          start_date?: string | null
-          sub_payments?: Json | null
-          transfer_source_account_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: never
-          destinatario_id?: string | null
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          end_date?: string | null
-          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
-          id?: string | null
-          is_active?: boolean | null
-          merchant_name?: never
-          start_date?: string | null
-          sub_payments?: Json | null
-          transfer_source_account_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      statement_snapshots: {
-        Row: {
-          account_id: string | null
-          available_credit: number | null
-          created_at: string | null
-          credit_limit: number | null
-          currency_code: string | null
-          final_balance: number | null
-          id: string | null
-          imported_count: number | null
-          initial_amount: number | null
-          installments_in_default: number | null
-          interest_charged: number | null
-          interest_rate: number | null
-          late_interest_rate: number | null
-          loan_number: string | null
-          minimum_payment: number | null
-          payment_due_date: string | null
-          period_from: string | null
-          period_to: string | null
-          previous_balance: number | null
-          purchases_and_charges: number | null
-          remaining_balance: number | null
-          skipped_count: number | null
-          source_filename: string | null
-          total_credits: number | null
-          total_debits: number | null
-          total_payment_due: number | null
-          transaction_count: number | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          available_credit?: number | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_code?: string | null
-          final_balance?: number | null
-          id?: string | null
-          imported_count?: number | null
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: never
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number | null
-          source_filename?: never
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          available_credit?: number | null
-          created_at?: string | null
-          credit_limit?: number | null
-          currency_code?: string | null
-          final_balance?: number | null
-          id?: string | null
-          imported_count?: number | null
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: never
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number | null
-          source_filename?: never
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      transactions: {
-        Row: {
-          account_id: string | null
-          amount: number | null
-          amount_in_base_currency: number | null
-          capture_input_text: string | null
-          capture_method:
-            | Database["public"]["Enums"]["transaction_capture_method"]
-            | null
-          categorization_confidence: number | null
-          categorization_source:
-            | Database["public"]["Enums"]["categorization_source"]
-            | null
-          category_id: string | null
-          clean_description: string | null
-          clean_description_hmac: string | null
-          created_at: string | null
-          currency_code: Database["public"]["Enums"]["currency_code"] | null
-          destinatario_id: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"] | null
-          exchange_rate: number | null
-          id: string | null
-          idempotency_key: string | null
-          installment_current: number | null
-          installment_group_id: string | null
-          installment_total: number | null
-          is_excluded: boolean | null
-          is_recurring: boolean | null
-          is_subscription: boolean | null
-          merchant_category_code: string | null
-          merchant_logo_url: string | null
-          merchant_name: string | null
-          merchant_name_hmac: string | null
-          notes: string | null
-          original_amount: number | null
-          posting_date: string | null
-          provider: Database["public"]["Enums"]["data_provider"] | null
-          provider_transaction_id: string | null
-          raw_description: string | null
-          reconciled_into_transaction_id: string | null
-          reconciliation_score: number | null
-          recurrence_group_id: string | null
-          secondary_category_id: string | null
-          status: Database["public"]["Enums"]["transaction_status"] | null
-          tags: string[] | null
-          transaction_date: string | null
-          transfer_group_id: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount?: number | null
-          amount_in_base_currency?: number | null
-          capture_input_text?: never
-          capture_method?:
-            | Database["public"]["Enums"]["transaction_capture_method"]
-            | null
-          categorization_confidence?: number | null
-          categorization_source?:
-            | Database["public"]["Enums"]["categorization_source"]
-            | null
-          category_id?: string | null
-          clean_description?: never
-          clean_description_hmac?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          destinatario_id?: string | null
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          exchange_rate?: number | null
-          id?: string | null
-          idempotency_key?: string | null
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean | null
-          is_recurring?: boolean | null
-          is_subscription?: boolean | null
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: never
-          merchant_name_hmac?: string | null
-          notes?: never
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_transaction_id?: string | null
-          raw_description?: never
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"] | null
-          tags?: string[] | null
-          transaction_date?: string | null
-          transfer_group_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number | null
-          amount_in_base_currency?: number | null
-          capture_input_text?: never
-          capture_method?:
-            | Database["public"]["Enums"]["transaction_capture_method"]
-            | null
-          categorization_confidence?: number | null
-          categorization_source?:
-            | Database["public"]["Enums"]["categorization_source"]
-            | null
-          category_id?: string | null
-          clean_description?: never
-          clean_description_hmac?: string | null
-          created_at?: string | null
-          currency_code?: Database["public"]["Enums"]["currency_code"] | null
-          destinatario_id?: string | null
-          direction?:
-            | Database["public"]["Enums"]["transaction_direction"]
-            | null
-          exchange_rate?: number | null
-          id?: string | null
-          idempotency_key?: string | null
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean | null
-          is_recurring?: boolean | null
-          is_subscription?: boolean | null
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: never
-          merchant_name_hmac?: string | null
-          notes?: never
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"] | null
-          provider_transaction_id?: string | null
-          raw_description?: never
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"] | null
-          tags?: string[] | null
-          transaction_date?: string | null
-          transfer_group_id?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_secondary_category_id_fkey"
-            columns: ["secondary_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      wishlist_items: {
-        Row: {
-          account_id: string | null
-          amount: number | null
-          bought_at: string | null
-          category_id: string | null
-          created_at: string | null
-          currency_code: string | null
-          desire_type: string | null
-          enriched: boolean | null
-          enriched_at: string | null
-          funding_type: string | null
-          id: string | null
-          image_url: string | null
-          installments: number | null
-          last_nudge_dismissed_at: string | null
-          last_score: number | null
-          last_scored_at: string | null
-          last_verdict: string | null
-          name: string | null
-          ready_at: string | null
-          status: string | null
-          transaction_id: string | null
-          updated_at: string | null
-          urgency: string | null
-          url: string | null
-          user_id: string | null
-          why: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount?: number | null
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: string | null
-          desire_type?: string | null
-          enriched?: boolean | null
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string | null
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name?: never
-          ready_at?: string | null
-          status?: string | null
-          transaction_id?: string | null
-          updated_at?: string | null
-          urgency?: string | null
-          url?: never
-          user_id?: string | null
-          why?: never
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number | null
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string | null
-          currency_code?: string | null
-          desire_type?: string | null
-          enriched?: boolean | null
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string | null
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name?: never
-          ready_at?: string | null
-          status?: string | null
-          transaction_id?: string | null
-          updated_at?: string | null
-          urgency?: string | null
-          url?: never
-          user_id?: string | null
-          why?: never
-        }
-        Relationships: [
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+      [_ in never]: never
     }
     Functions: {
-      cleanup_anonymous_demo_users: {
-        Args: { p_older_than?: string }
-        Returns: number
-      }
-      generate_occurrences_for_template: {
-        Args: { p_template_id: string }
+      reset_user_data: {
+        Args: Record<string, never>
         Returns: undefined
       }
       get_accounts_with_masks: {
         Args: { p_user_id: string }
         Returns: {
+          id: string
+          mask: string | null
+          debit_card_mask: string | null
+          pdf_password: string | null
           account_type: Database["public"]["Enums"]["account_type"]
           currency_code: Database["public"]["Enums"]["currency_code"]
           current_balance: number
-          debit_card_mask: string
-          id: string
           is_demo: boolean
-          mask: string
-          pdf_password: string
         }[]
-      }
-      get_email_ingest_settings: {
-        Args: { p_address_key: string }
-        Returns: {
-          account_id: string
-          address_key: string
-          allowed_sender: string
-          allowed_senders: string[]
-          auto_import: boolean
-          id: string
-          pdf_import_enabled: boolean
-          user_id: string
-        }[]
-      }
-      reset_user_data: { Args: never; Returns: undefined }
-      set_gmail_verification: {
-        Args: { p_ingest_id: string; p_url: string; p_user_id: string }
-        Returns: undefined
       }
       zeta_decrypt: { Args: { ciphertext: string }; Returns: string }
       zeta_decrypt_as: {
@@ -3645,7 +3582,6 @@ export type Database = {
         | "CSV_IMPORT"
         | "OCR"
         | "EMAIL"
-      occurrence_status: "pending" | "paid" | "skipped"
       planning_entry_status: "PLANNED" | "COMPLETED" | "SKIPPED"
       planning_entry_type: "INCOME" | "EXPENSE"
       planning_period_preset: "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "CUSTOM"
@@ -3664,6 +3600,7 @@ export type Database = {
         | "OCR_SINGLE"
         | "EMAIL_IMPORT"
         | "EMAIL_PDF_IMPORT"
+      occurrence_status: "pending" | "paid" | "skipped"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
     }
@@ -3821,7 +3758,6 @@ export const Constants = {
         "OCR",
         "EMAIL",
       ],
-      occurrence_status: ["pending", "paid", "skipped"],
       planning_entry_status: ["PLANNED", "COMPLETED", "SKIPPED"],
       planning_entry_type: ["INCOME", "EXPENSE"],
       planning_period_preset: ["WEEKLY", "BIWEEKLY", "MONTHLY", "CUSTOM"],
@@ -3842,6 +3778,7 @@ export const Constants = {
         "EMAIL_IMPORT",
         "EMAIL_PDF_IMPORT",
       ],
+      occurrence_status: ["pending", "paid", "skipped"],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],
     },

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -158,150 +158,6 @@ export type Database = {
           },
         ]
       }
-      accounts: {
-        Row: {
-          account_type: Database["public"]["Enums"]["account_type"]
-          available_balance: number | null
-          bank_key: string | null
-          card_brand: string | null
-          color: string | null
-          connection_status: Database["public"]["Enums"]["connection_status"]
-          created_at: string
-          credit_limit: number | null
-          currency_balances: Json | null
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          current_balance: number
-          cutoff_day: number | null
-          debit_card_mask: string | null
-          display_order: number
-          expected_return_rate: number | null
-          icon: string | null
-          id: string
-          initial_investment: number | null
-          institution_name: string | null
-          interest_rate: number | null
-          is_active: boolean
-          is_demo: boolean
-          is_payroll_deducted: boolean
-          last_synced_at: string | null
-          loan_amount: number | null
-          loan_end_date: string | null
-          loan_start_date: string | null
-          mask: string | null
-          mask_hmac: string | null
-          maturity_date: string | null
-          monthly_payment: number | null
-          name: string
-          payment_day: number | null
-          pdf_password: string | null
-          provider: Database["public"]["Enums"]["data_provider"]
-          provider_account_id: string | null
-          provider_account_id_hmac: string | null
-          show_in_dashboard: boolean
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_type: Database["public"]["Enums"]["account_type"]
-          available_balance?: number | null
-          bank_key?: string | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?: Database["public"]["Enums"]["connection_status"]
-          created_at?: string
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          current_balance?: number
-          cutoff_day?: number | null
-          debit_card_mask?: string | null
-          display_order?: number
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string
-          initial_investment?: number | null
-          institution_name?: string | null
-          interest_rate?: number | null
-          is_active?: boolean
-          is_demo?: boolean
-          is_payroll_deducted?: boolean
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: string | null
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name: string
-          payment_day?: number | null
-          pdf_password?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_account_id?: string | null
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_type?: Database["public"]["Enums"]["account_type"]
-          available_balance?: number | null
-          bank_key?: string | null
-          card_brand?: string | null
-          color?: string | null
-          connection_status?: Database["public"]["Enums"]["connection_status"]
-          created_at?: string
-          credit_limit?: number | null
-          currency_balances?: Json | null
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          current_balance?: number
-          cutoff_day?: number | null
-          debit_card_mask?: string | null
-          display_order?: number
-          expected_return_rate?: number | null
-          icon?: string | null
-          id?: string
-          initial_investment?: number | null
-          institution_name?: string | null
-          interest_rate?: number | null
-          is_active?: boolean
-          is_demo?: boolean
-          is_payroll_deducted?: boolean
-          last_synced_at?: string | null
-          loan_amount?: number | null
-          loan_end_date?: string | null
-          loan_start_date?: string | null
-          mask?: string | null
-          mask_hmac?: string | null
-          maturity_date?: string | null
-          monthly_payment?: number | null
-          name?: string
-          payment_day?: number | null
-          pdf_password?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_account_id?: string | null
-          provider_account_id_hmac?: string | null
-          show_in_dashboard?: boolean
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "accounts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       admin_config: {
         Row: {
           id: string
@@ -441,7 +297,7 @@ export type Database = {
           last_used_at?: string | null
           revoked_at?: string | null
           token: string
-          token_hash?: string
+          token_hash: string
           user_id: string
         }
         Update: {
@@ -468,57 +324,6 @@ export type Database = {
             columns: ["default_account_id"]
             isOneToOne: false
             referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      capture_tokens: {
-        Row: {
-          created_at: string
-          default_account_id: string | null
-          id: string
-          label: string
-          last_used_at: string | null
-          revoked_at: string | null
-          token: string
-          token_hash: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          default_account_id?: string | null
-          id?: string
-          label: string
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token: string
-          token_hash?: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          default_account_id?: string | null
-          id?: string
-          label?: string
-          last_used_at?: string | null
-          revoked_at?: string | null
-          token?: string
-          token_hash?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "capture_tokens_default_account_id_fkey"
-            columns: ["default_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
             referencedColumns: ["id"]
           },
         ]
@@ -938,88 +743,6 @@ export type Database = {
           },
         ]
       }
-      destinatarios: {
-        Row: {
-          created_at: string
-          default_category_id: string | null
-          id: string
-          is_active: boolean
-          name: string
-          name_hmac: string | null
-          notes: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          default_category_id?: string | null
-          id?: string
-          is_active?: boolean
-          name: string
-          name_hmac?: string | null
-          notes?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          default_category_id?: string | null
-          id?: string
-          is_active?: boolean
-          name?: string
-          name_hmac?: string | null
-          notes?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "destinatarios_default_category_id_fkey"
-            columns: ["default_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "destinatarios_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      email_ingest_allowed_senders: {
-        Row: {
-          created_at: string
-          id: string
-          label: string | null
-          sender_email: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          label?: string | null
-          sender_email: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          label?: string | null
-          sender_email?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
       email_ingest_addresses_enc: {
         Row: {
           account_id: string | null
@@ -1091,76 +814,29 @@ export type Database = {
           },
         ]
       }
-      email_ingest_addresses: {
+      email_ingest_allowed_senders: {
         Row: {
-          account_id: string | null
-          address_key: string
-          allowed_sender: string | null
-          auto_import: boolean
           created_at: string
-          gmail_verification_at: string | null
-          gmail_verification_url: string | null
           id: string
-          is_active: boolean
-          pdf_import_enabled: boolean
+          label: string | null
+          sender_email: string
           user_id: string
         }
         Insert: {
-          account_id?: string | null
-          address_key: string
-          allowed_sender?: string | null
-          auto_import?: boolean
           created_at?: string
-          gmail_verification_at?: string | null
-          gmail_verification_url?: string | null
           id?: string
-          is_active?: boolean
-          pdf_import_enabled?: boolean
+          label?: string | null
+          sender_email: string
           user_id: string
         }
         Update: {
-          account_id?: string | null
-          address_key?: string
-          allowed_sender?: string | null
-          auto_import?: boolean
           created_at?: string
-          gmail_verification_at?: string | null
-          gmail_verification_url?: string | null
           id?: string
-          is_active?: boolean
-          pdf_import_enabled?: boolean
+          label?: string | null
+          sender_email?: string
           user_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "email_ingest_addresses_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
       email_ingest_logs: {
         Row: {
@@ -1283,6 +959,57 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      pdf_passwords_enc: {
+        Row: {
+          account_id: string | null
+          alias: string
+          bank_key: string | null
+          created_at: string
+          id: string
+          password: string
+          scope: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          account_id?: string | null
+          alias: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password: string
+          scope: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          account_id?: string | null
+          alias?: string
+          bank_key?: string | null
+          created_at?: string
+          id?: string
+          password?: string
+          scope?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       pending_email_statements: {
         Row: {
@@ -1445,108 +1172,6 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      pdf_passwords_enc: {
-        Row: {
-          account_id: string | null
-          alias: string
-          bank_key: string | null
-          created_at: string
-          id: string
-          password: string
-          scope: string
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id?: string | null
-          alias: string
-          bank_key?: string | null
-          created_at?: string
-          id?: string
-          password: string
-          scope: string
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string | null
-          alias?: string
-          bank_key?: string | null
-          created_at?: string
-          id?: string
-          password?: string
-          scope?: string
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      pdf_passwords: {
-        Row: {
-          account_id: string | null
-          alias: string
-          bank_key: string | null
-          created_at: string
-          id: string
-          password: string
-          scope: string
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id?: string | null
-          alias: string
-          bank_key?: string | null
-          created_at?: string
-          id?: string
-          password: string
-          scope: string
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string | null
-          alias?: string
-          bank_key?: string | null
-          created_at?: string
-          id?: string
-          password?: string
-          scope?: string
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts_enc"
             referencedColumns: ["id"]
           },
         ]
@@ -1827,66 +1452,6 @@ export type Database = {
           budget_mode: string | null
           created_at: string
           dashboard_config: Json | null
-          email: string
-          estimated_monthly_expenses: number | null
-          estimated_monthly_income: number | null
-          full_name: string | null
-          id: string
-          locale: string
-          mobile_dashboard_config: Json | null
-          monthly_salary: number | null
-          onboarding_completed: boolean
-          preferred_currency: Database["public"]["Enums"]["currency_code"]
-          timezone: string
-          updated_at: string
-        }
-        Insert: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string
-          dashboard_config?: Json | null
-          email: string
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: string | null
-          id: string
-          locale?: string
-          mobile_dashboard_config?: Json | null
-          monthly_salary?: number | null
-          onboarding_completed?: boolean
-          preferred_currency?: Database["public"]["Enums"]["currency_code"]
-          timezone?: string
-          updated_at?: string
-        }
-        Update: {
-          app_purpose?: string | null
-          avatar_url?: string | null
-          budget_mode?: string | null
-          created_at?: string
-          dashboard_config?: Json | null
-          email?: string
-          estimated_monthly_expenses?: number | null
-          estimated_monthly_income?: number | null
-          full_name?: string | null
-          id?: string
-          locale?: string
-          mobile_dashboard_config?: Json | null
-          monthly_salary?: number | null
-          onboarding_completed?: boolean
-          preferred_currency?: Database["public"]["Enums"]["currency_code"]
-          timezone?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      profiles: {
-        Row: {
-          app_purpose: string | null
-          avatar_url: string | null
-          budget_mode: string | null
-          created_at: string
-          dashboard_config: Json | null
           demo_mode: boolean
           email: string
           estimated_monthly_expenses: number | null
@@ -2038,6 +1603,13 @@ export type Database = {
             foreignKeyName: "recurring_template_tags_recurring_template_id_fkey"
             columns: ["recurring_template_id"]
             isOneToOne: false
+            referencedRelation: "recurring_transaction_templates"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_template_tags_recurring_template_id_fkey"
+            columns: ["recurring_template_id"]
+            isOneToOne: false
             referencedRelation: "recurring_transaction_templates_enc"
             referencedColumns: ["id"]
           },
@@ -2183,139 +1755,6 @@ export type Database = {
           },
         ]
       }
-      recurring_transaction_templates: {
-        Row: {
-          account_id: string
-          amount: number
-          category_id: string | null
-          created_at: string
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          day_of_month: number | null
-          day_of_week: number | null
-          description: string | null
-          destinatario_id: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          end_date: string | null
-          frequency: Database["public"]["Enums"]["recurrence_frequency"]
-          id: string
-          is_active: boolean
-          merchant_name: string | null
-          start_date: string
-          sub_payments: Json | null
-          transfer_source_account_id: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id: string
-          amount: number
-          category_id?: string | null
-          created_at?: string
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: string | null
-          destinatario_id?: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          end_date?: string | null
-          frequency: Database["public"]["Enums"]["recurrence_frequency"]
-          id?: string
-          is_active?: boolean
-          merchant_name?: string | null
-          start_date: string
-          sub_payments?: Json | null
-          transfer_source_account_id?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string
-          amount?: number
-          category_id?: string | null
-          created_at?: string
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          day_of_month?: number | null
-          day_of_week?: number | null
-          description?: string | null
-          destinatario_id?: string | null
-          direction?: Database["public"]["Enums"]["transaction_direction"]
-          end_date?: string | null
-          frequency?: Database["public"]["Enums"]["recurrence_frequency"]
-          id?: string
-          is_active?: boolean
-          merchant_name?: string | null
-          start_date?: string
-          sub_payments?: Json | null
-          transfer_source_account_id?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios_enc"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
-            columns: ["transfer_source_account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       statement_snapshots_enc: {
         Row: {
           account_id: string
@@ -2437,131 +1876,6 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles_enc"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      statement_snapshots: {
-        Row: {
-          account_id: string
-          available_credit: number | null
-          created_at: string
-          credit_limit: number | null
-          currency_code: string
-          final_balance: number | null
-          id: string
-          imported_count: number
-          initial_amount: number | null
-          installments_in_default: number | null
-          interest_charged: number | null
-          interest_rate: number | null
-          late_interest_rate: number | null
-          loan_number: string | null
-          minimum_payment: number | null
-          payment_due_date: string | null
-          period_from: string | null
-          period_to: string | null
-          previous_balance: number | null
-          purchases_and_charges: number | null
-          remaining_balance: number | null
-          skipped_count: number
-          source_filename: string | null
-          total_credits: number | null
-          total_debits: number | null
-          total_payment_due: number | null
-          transaction_count: number
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id: string
-          available_credit?: number | null
-          created_at?: string
-          credit_limit?: number | null
-          currency_code?: string
-          final_balance?: number | null
-          id?: string
-          imported_count?: number
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: string | null
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number
-          source_filename?: string | null
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string
-          available_credit?: number | null
-          created_at?: string
-          credit_limit?: number | null
-          currency_code?: string
-          final_balance?: number | null
-          id?: string
-          imported_count?: number
-          initial_amount?: number | null
-          installments_in_default?: number | null
-          interest_charged?: number | null
-          interest_rate?: number | null
-          late_interest_rate?: number | null
-          loan_number?: string | null
-          minimum_payment?: number | null
-          payment_due_date?: string | null
-          period_from?: string | null
-          period_to?: string | null
-          previous_balance?: number | null
-          purchases_and_charges?: number | null
-          remaining_balance?: number | null
-          skipped_count?: number
-          source_filename?: string | null
-          total_credits?: number | null
-          total_debits?: number | null
-          total_payment_due?: number | null
-          transaction_count?: number
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "statement_snapshots_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -2921,215 +2235,6 @@ export type Database = {
           },
         ]
       }
-      transactions: {
-        Row: {
-          account_id: string
-          amount: number
-          amount_in_base_currency: number | null
-          capture_input_text: string | null
-          capture_method: Database["public"]["Enums"]["transaction_capture_method"]
-          categorization_confidence: number | null
-          categorization_source: Database["public"]["Enums"]["categorization_source"]
-          category_id: string | null
-          clean_description: string | null
-          clean_description_hmac: string | null
-          created_at: string
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          destinatario_id: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          exchange_rate: number
-          id: string
-          idempotency_key: string
-          installment_current: number | null
-          installment_group_id: string | null
-          installment_total: number | null
-          is_excluded: boolean
-          is_recurring: boolean
-          is_subscription: boolean
-          merchant_category_code: string | null
-          merchant_logo_url: string | null
-          merchant_name: string | null
-          merchant_name_hmac: string | null
-          notes: string | null
-          original_amount: number | null
-          posting_date: string | null
-          provider: Database["public"]["Enums"]["data_provider"]
-          provider_transaction_id: string | null
-          raw_description: string | null
-          reconciled_into_transaction_id: string | null
-          reconciliation_score: number | null
-          recurrence_group_id: string | null
-          secondary_category_id: string | null
-          status: Database["public"]["Enums"]["transaction_status"]
-          tags: string[] | null
-          transaction_date: string
-          transfer_group_id: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          account_id: string
-          amount: number
-          amount_in_base_currency?: number | null
-          capture_input_text?: string | null
-          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
-          categorization_confidence?: number | null
-          categorization_source?: Database["public"]["Enums"]["categorization_source"]
-          category_id?: string | null
-          clean_description?: string | null
-          clean_description_hmac?: string | null
-          created_at?: string
-          currency_code: Database["public"]["Enums"]["currency_code"]
-          destinatario_id?: string | null
-          direction: Database["public"]["Enums"]["transaction_direction"]
-          exchange_rate?: number
-          id?: string
-          idempotency_key: string
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean
-          is_recurring?: boolean
-          is_subscription?: boolean
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: string | null
-          merchant_name_hmac?: string | null
-          notes?: string | null
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_transaction_id?: string | null
-          raw_description?: string | null
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"]
-          tags?: string[] | null
-          transaction_date: string
-          transfer_group_id?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          account_id?: string
-          amount?: number
-          amount_in_base_currency?: number | null
-          capture_input_text?: string | null
-          capture_method?: Database["public"]["Enums"]["transaction_capture_method"]
-          categorization_confidence?: number | null
-          categorization_source?: Database["public"]["Enums"]["categorization_source"]
-          category_id?: string | null
-          clean_description?: string | null
-          clean_description_hmac?: string | null
-          created_at?: string
-          currency_code?: Database["public"]["Enums"]["currency_code"]
-          destinatario_id?: string | null
-          direction?: Database["public"]["Enums"]["transaction_direction"]
-          exchange_rate?: number
-          id?: string
-          idempotency_key?: string
-          installment_current?: number | null
-          installment_group_id?: string | null
-          installment_total?: number | null
-          is_excluded?: boolean
-          is_recurring?: boolean
-          is_subscription?: boolean
-          merchant_category_code?: string | null
-          merchant_logo_url?: string | null
-          merchant_name?: string | null
-          merchant_name_hmac?: string | null
-          notes?: string | null
-          original_amount?: number | null
-          posting_date?: string | null
-          provider?: Database["public"]["Enums"]["data_provider"]
-          provider_transaction_id?: string | null
-          raw_description?: string | null
-          reconciled_into_transaction_id?: string | null
-          reconciliation_score?: number | null
-          recurrence_group_id?: string | null
-          secondary_category_id?: string | null
-          status?: Database["public"]["Enums"]["transaction_status"]
-          tags?: string[] | null
-          transaction_date?: string
-          transfer_group_id?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_destinatario_id_fkey"
-            columns: ["destinatario_id"]
-            isOneToOne: false
-            referencedRelation: "destinatarios"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
-            columns: ["reconciled_into_transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_secondary_category_id_fkey"
-            columns: ["secondary_category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "transactions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       unrecognized_emails: {
         Row: {
           created_at: string
@@ -3336,129 +2441,6 @@ export type Database = {
           },
         ]
       }
-      wishlist_items: {
-        Row: {
-          account_id: string | null
-          amount: number
-          bought_at: string | null
-          category_id: string | null
-          created_at: string
-          currency_code: string
-          desire_type: string | null
-          enriched: boolean
-          enriched_at: string | null
-          funding_type: string | null
-          id: string
-          image_url: string | null
-          installments: number | null
-          last_nudge_dismissed_at: string | null
-          last_score: number | null
-          last_scored_at: string | null
-          last_verdict: string | null
-          name: string
-          ready_at: string | null
-          status: string
-          transaction_id: string | null
-          updated_at: string
-          urgency: string | null
-          url: string | null
-          user_id: string
-          why: string | null
-        }
-        Insert: {
-          account_id?: string | null
-          amount: number
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string
-          currency_code?: string
-          desire_type?: string | null
-          enriched?: boolean
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name: string
-          ready_at?: string | null
-          status?: string
-          transaction_id?: string | null
-          updated_at?: string
-          urgency?: string | null
-          url?: string | null
-          user_id: string
-          why?: string | null
-        }
-        Update: {
-          account_id?: string | null
-          amount?: number
-          bought_at?: string | null
-          category_id?: string | null
-          created_at?: string
-          currency_code?: string
-          desire_type?: string | null
-          enriched?: boolean
-          enriched_at?: string | null
-          funding_type?: string | null
-          id?: string
-          image_url?: string | null
-          installments?: number | null
-          last_nudge_dismissed_at?: string | null
-          last_score?: number | null
-          last_scored_at?: string | null
-          last_verdict?: string | null
-          name?: string
-          ready_at?: string | null
-          status?: string
-          transaction_id?: string | null
-          updated_at?: string
-          urgency?: string | null
-          url?: string | null
-          user_id?: string
-          why?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_account_id_fkey"
-            columns: ["account_id"]
-            isOneToOne: false
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "categories"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "wishlist_items_transaction_id_fkey"
-            columns: ["transaction_id"]
-            isOneToOne: false
-            referencedRelation: "transactions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       wishlist_reflections: {
         Row: {
           days_since_purchase: number
@@ -3512,21 +2494,1106 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      accounts: {
+        Row: {
+          account_type: Database["public"]["Enums"]["account_type"] | null
+          available_balance: number | null
+          bank_key: string | null
+          card_brand: string | null
+          color: string | null
+          connection_status:
+            | Database["public"]["Enums"]["connection_status"]
+            | null
+          created_at: string | null
+          credit_limit: number | null
+          currency_balances: Json | null
+          currency_code: Database["public"]["Enums"]["currency_code"] | null
+          current_balance: number | null
+          cutoff_day: number | null
+          debit_card_mask: string | null
+          display_order: number | null
+          expected_return_rate: number | null
+          icon: string | null
+          id: string | null
+          initial_investment: number | null
+          institution_name: string | null
+          interest_rate: number | null
+          is_active: boolean | null
+          is_demo: boolean | null
+          is_payroll_deducted: boolean | null
+          last_synced_at: string | null
+          loan_amount: number | null
+          loan_end_date: string | null
+          loan_start_date: string | null
+          mask: string | null
+          mask_hmac: string | null
+          maturity_date: string | null
+          monthly_payment: number | null
+          name: string | null
+          payment_day: number | null
+          pdf_password: string | null
+          provider: Database["public"]["Enums"]["data_provider"] | null
+          provider_account_id: string | null
+          provider_account_id_hmac: string | null
+          show_in_dashboard: boolean | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_type?: Database["public"]["Enums"]["account_type"] | null
+          available_balance?: number | null
+          bank_key?: string | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?:
+            | Database["public"]["Enums"]["connection_status"]
+            | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          current_balance?: number | null
+          cutoff_day?: number | null
+          debit_card_mask?: never
+          display_order?: number | null
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string | null
+          initial_investment?: number | null
+          institution_name?: never
+          interest_rate?: number | null
+          is_active?: boolean | null
+          is_demo?: boolean | null
+          is_payroll_deducted?: boolean | null
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: never
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: never
+          payment_day?: number | null
+          pdf_password?: never
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_account_id?: never
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_type?: Database["public"]["Enums"]["account_type"] | null
+          available_balance?: number | null
+          bank_key?: string | null
+          card_brand?: string | null
+          color?: string | null
+          connection_status?:
+            | Database["public"]["Enums"]["connection_status"]
+            | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_balances?: Json | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          current_balance?: number | null
+          cutoff_day?: number | null
+          debit_card_mask?: never
+          display_order?: number | null
+          expected_return_rate?: number | null
+          icon?: string | null
+          id?: string | null
+          initial_investment?: number | null
+          institution_name?: never
+          interest_rate?: number | null
+          is_active?: boolean | null
+          is_demo?: boolean | null
+          is_payroll_deducted?: boolean | null
+          last_synced_at?: string | null
+          loan_amount?: number | null
+          loan_end_date?: string | null
+          loan_start_date?: string | null
+          mask?: never
+          mask_hmac?: string | null
+          maturity_date?: string | null
+          monthly_payment?: number | null
+          name?: never
+          payment_day?: number | null
+          pdf_password?: never
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_account_id?: never
+          provider_account_id_hmac?: string | null
+          show_in_dashboard?: boolean | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      capture_tokens: {
+        Row: {
+          created_at: string | null
+          default_account_id: string | null
+          id: string | null
+          label: string | null
+          last_used_at: string | null
+          revoked_at: string | null
+          token: string | null
+          token_hash: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          default_account_id?: string | null
+          id?: string | null
+          label?: never
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: never
+          token_hash?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          default_account_id?: string | null
+          id?: string | null
+          label?: never
+          last_used_at?: string | null
+          revoked_at?: string | null
+          token?: never
+          token_hash?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "capture_tokens_default_account_id_fkey"
+            columns: ["default_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      destinatarios: {
+        Row: {
+          created_at: string | null
+          default_category_id: string | null
+          id: string | null
+          is_active: boolean | null
+          name: string | null
+          name_hmac: string | null
+          notes: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          default_category_id?: string | null
+          id?: string | null
+          is_active?: boolean | null
+          name?: never
+          name_hmac?: string | null
+          notes?: never
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          default_category_id?: string | null
+          id?: string | null
+          is_active?: boolean | null
+          name?: never
+          name_hmac?: string | null
+          notes?: never
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "destinatarios_default_category_id_fkey"
+            columns: ["default_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "destinatarios_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      email_ingest_addresses: {
+        Row: {
+          account_id: string | null
+          address_key: string | null
+          allowed_sender: string | null
+          auto_import: boolean | null
+          created_at: string | null
+          gmail_verification_at: string | null
+          gmail_verification_url: string | null
+          id: string | null
+          is_active: boolean | null
+          pdf_import_enabled: boolean | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          address_key?: string | null
+          allowed_sender?: never
+          auto_import?: boolean | null
+          created_at?: string | null
+          gmail_verification_at?: string | null
+          gmail_verification_url?: never
+          id?: string | null
+          is_active?: boolean | null
+          pdf_import_enabled?: boolean | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          address_key?: string | null
+          allowed_sender?: never
+          auto_import?: boolean | null
+          created_at?: string | null
+          gmail_verification_at?: string | null
+          gmail_verification_url?: never
+          id?: string | null
+          is_active?: boolean | null
+          pdf_import_enabled?: boolean | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "email_ingest_addresses_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pdf_passwords: {
+        Row: {
+          account_id: string | null
+          alias: string | null
+          bank_key: string | null
+          created_at: string | null
+          id: string | null
+          password: string | null
+          scope: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          alias?: never
+          bank_key?: string | null
+          created_at?: string | null
+          id?: string | null
+          password?: never
+          scope?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          alias?: never
+          bank_key?: string | null
+          created_at?: string | null
+          id?: string | null
+          password?: never
+          scope?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pdf_passwords_enc_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          app_purpose: string | null
+          avatar_url: string | null
+          budget_mode: string | null
+          created_at: string | null
+          dashboard_config: Json | null
+          demo_mode: boolean | null
+          email: string | null
+          estimated_monthly_expenses: number | null
+          estimated_monthly_income: number | null
+          full_name: string | null
+          id: string | null
+          locale: string | null
+          mobile_dashboard_config: Json | null
+          monthly_salary: number | null
+          onboarding_completed: boolean | null
+          preferred_currency:
+            | Database["public"]["Enums"]["currency_code"]
+            | null
+          timezone: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string | null
+          dashboard_config?: Json | null
+          demo_mode?: boolean | null
+          email?: never
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: never
+          id?: string | null
+          locale?: string | null
+          mobile_dashboard_config?: Json | null
+          monthly_salary?: number | null
+          onboarding_completed?: boolean | null
+          preferred_currency?:
+            | Database["public"]["Enums"]["currency_code"]
+            | null
+          timezone?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          app_purpose?: string | null
+          avatar_url?: string | null
+          budget_mode?: string | null
+          created_at?: string | null
+          dashboard_config?: Json | null
+          demo_mode?: boolean | null
+          email?: never
+          estimated_monthly_expenses?: number | null
+          estimated_monthly_income?: number | null
+          full_name?: never
+          id?: string | null
+          locale?: string | null
+          mobile_dashboard_config?: Json | null
+          monthly_salary?: number | null
+          onboarding_completed?: boolean | null
+          preferred_currency?:
+            | Database["public"]["Enums"]["currency_code"]
+            | null
+          timezone?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      recurring_transaction_templates: {
+        Row: {
+          account_id: string | null
+          amount: number | null
+          category_id: string | null
+          created_at: string | null
+          currency_code: Database["public"]["Enums"]["currency_code"] | null
+          day_of_month: number | null
+          day_of_week: number | null
+          description: string | null
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"] | null
+          end_date: string | null
+          frequency: Database["public"]["Enums"]["recurrence_frequency"] | null
+          id: string | null
+          is_active: boolean | null
+          merchant_name: string | null
+          start_date: string | null
+          sub_payments: Json | null
+          transfer_source_account_id: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount?: number | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: never
+          destinatario_id?: string | null
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
+          id?: string | null
+          is_active?: boolean | null
+          merchant_name?: never
+          start_date?: string | null
+          sub_payments?: Json | null
+          transfer_source_account_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          day_of_month?: number | null
+          day_of_week?: number | null
+          description?: never
+          destinatario_id?: string | null
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          end_date?: string | null
+          frequency?: Database["public"]["Enums"]["recurrence_frequency"] | null
+          id?: string | null
+          is_active?: boolean | null
+          merchant_name?: never
+          start_date?: string | null
+          sub_payments?: Json | null
+          transfer_source_account_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_enc_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_transfer_source_account_id_fkey"
+            columns: ["transfer_source_account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_transaction_templates_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      statement_snapshots: {
+        Row: {
+          account_id: string | null
+          available_credit: number | null
+          created_at: string | null
+          credit_limit: number | null
+          currency_code: string | null
+          final_balance: number | null
+          id: string | null
+          imported_count: number | null
+          initial_amount: number | null
+          installments_in_default: number | null
+          interest_charged: number | null
+          interest_rate: number | null
+          late_interest_rate: number | null
+          loan_number: string | null
+          minimum_payment: number | null
+          payment_due_date: string | null
+          period_from: string | null
+          period_to: string | null
+          previous_balance: number | null
+          purchases_and_charges: number | null
+          remaining_balance: number | null
+          skipped_count: number | null
+          source_filename: string | null
+          total_credits: number | null
+          total_debits: number | null
+          total_payment_due: number | null
+          transaction_count: number | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          available_credit?: number | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_code?: string | null
+          final_balance?: number | null
+          id?: string | null
+          imported_count?: number | null
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: never
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number | null
+          source_filename?: never
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          available_credit?: number | null
+          created_at?: string | null
+          credit_limit?: number | null
+          currency_code?: string | null
+          final_balance?: number | null
+          id?: string | null
+          imported_count?: number | null
+          initial_amount?: number | null
+          installments_in_default?: number | null
+          interest_charged?: number | null
+          interest_rate?: number | null
+          late_interest_rate?: number | null
+          loan_number?: never
+          minimum_payment?: number | null
+          payment_due_date?: string | null
+          period_from?: string | null
+          period_to?: string | null
+          previous_balance?: number | null
+          purchases_and_charges?: number | null
+          remaining_balance?: number | null
+          skipped_count?: number | null
+          source_filename?: never
+          total_credits?: number | null
+          total_debits?: number | null
+          total_payment_due?: number | null
+          transaction_count?: number | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "statement_snapshots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      transactions: {
+        Row: {
+          account_id: string | null
+          amount: number | null
+          amount_in_base_currency: number | null
+          capture_input_text: string | null
+          capture_method:
+            | Database["public"]["Enums"]["transaction_capture_method"]
+            | null
+          categorization_confidence: number | null
+          categorization_source:
+            | Database["public"]["Enums"]["categorization_source"]
+            | null
+          category_id: string | null
+          clean_description: string | null
+          clean_description_hmac: string | null
+          created_at: string | null
+          currency_code: Database["public"]["Enums"]["currency_code"] | null
+          destinatario_id: string | null
+          direction: Database["public"]["Enums"]["transaction_direction"] | null
+          exchange_rate: number | null
+          id: string | null
+          idempotency_key: string | null
+          installment_current: number | null
+          installment_group_id: string | null
+          installment_total: number | null
+          is_excluded: boolean | null
+          is_recurring: boolean | null
+          is_subscription: boolean | null
+          merchant_category_code: string | null
+          merchant_logo_url: string | null
+          merchant_name: string | null
+          merchant_name_hmac: string | null
+          notes: string | null
+          original_amount: number | null
+          posting_date: string | null
+          provider: Database["public"]["Enums"]["data_provider"] | null
+          provider_transaction_id: string | null
+          raw_description: string | null
+          reconciled_into_transaction_id: string | null
+          reconciliation_score: number | null
+          recurrence_group_id: string | null
+          secondary_category_id: string | null
+          status: Database["public"]["Enums"]["transaction_status"] | null
+          tags: string[] | null
+          transaction_date: string | null
+          transfer_group_id: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount?: number | null
+          amount_in_base_currency?: number | null
+          capture_input_text?: never
+          capture_method?:
+            | Database["public"]["Enums"]["transaction_capture_method"]
+            | null
+          categorization_confidence?: number | null
+          categorization_source?:
+            | Database["public"]["Enums"]["categorization_source"]
+            | null
+          category_id?: string | null
+          clean_description?: never
+          clean_description_hmac?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          destinatario_id?: string | null
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          exchange_rate?: number | null
+          id?: string | null
+          idempotency_key?: string | null
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean | null
+          is_recurring?: boolean | null
+          is_subscription?: boolean | null
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: never
+          merchant_name_hmac?: string | null
+          notes?: never
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_transaction_id?: string | null
+          raw_description?: never
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"] | null
+          tags?: string[] | null
+          transaction_date?: string | null
+          transfer_group_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number | null
+          amount_in_base_currency?: number | null
+          capture_input_text?: never
+          capture_method?:
+            | Database["public"]["Enums"]["transaction_capture_method"]
+            | null
+          categorization_confidence?: number | null
+          categorization_source?:
+            | Database["public"]["Enums"]["categorization_source"]
+            | null
+          category_id?: string | null
+          clean_description?: never
+          clean_description_hmac?: string | null
+          created_at?: string | null
+          currency_code?: Database["public"]["Enums"]["currency_code"] | null
+          destinatario_id?: string | null
+          direction?:
+            | Database["public"]["Enums"]["transaction_direction"]
+            | null
+          exchange_rate?: number | null
+          id?: string | null
+          idempotency_key?: string | null
+          installment_current?: number | null
+          installment_group_id?: string | null
+          installment_total?: number | null
+          is_excluded?: boolean | null
+          is_recurring?: boolean | null
+          is_subscription?: boolean | null
+          merchant_category_code?: string | null
+          merchant_logo_url?: string | null
+          merchant_name?: never
+          merchant_name_hmac?: string | null
+          notes?: never
+          original_amount?: number | null
+          posting_date?: string | null
+          provider?: Database["public"]["Enums"]["data_provider"] | null
+          provider_transaction_id?: string | null
+          raw_description?: never
+          reconciled_into_transaction_id?: string | null
+          reconciliation_score?: number | null
+          recurrence_group_id?: string | null
+          secondary_category_id?: string | null
+          status?: Database["public"]["Enums"]["transaction_status"] | null
+          tags?: string[] | null
+          transaction_date?: string | null
+          transfer_group_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_reconciled_into_transaction_id_fkey"
+            columns: ["reconciled_into_transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_secondary_category_id_fkey"
+            columns: ["secondary_category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      wishlist_items: {
+        Row: {
+          account_id: string | null
+          amount: number | null
+          bought_at: string | null
+          category_id: string | null
+          created_at: string | null
+          currency_code: string | null
+          desire_type: string | null
+          enriched: boolean | null
+          enriched_at: string | null
+          funding_type: string | null
+          id: string | null
+          image_url: string | null
+          installments: number | null
+          last_nudge_dismissed_at: string | null
+          last_score: number | null
+          last_scored_at: string | null
+          last_verdict: string | null
+          name: string | null
+          ready_at: string | null
+          status: string | null
+          transaction_id: string | null
+          updated_at: string | null
+          urgency: string | null
+          url: string | null
+          user_id: string | null
+          why: string | null
+        }
+        Insert: {
+          account_id?: string | null
+          amount?: number | null
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: string | null
+          desire_type?: string | null
+          enriched?: boolean | null
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string | null
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: never
+          ready_at?: string | null
+          status?: string | null
+          transaction_id?: string | null
+          updated_at?: string | null
+          urgency?: string | null
+          url?: never
+          user_id?: string | null
+          why?: never
+        }
+        Update: {
+          account_id?: string | null
+          amount?: number | null
+          bought_at?: string | null
+          category_id?: string | null
+          created_at?: string | null
+          currency_code?: string | null
+          desire_type?: string | null
+          enriched?: boolean | null
+          enriched_at?: string | null
+          funding_type?: string | null
+          id?: string | null
+          image_url?: string | null
+          installments?: number | null
+          last_nudge_dismissed_at?: string | null
+          last_score?: number | null
+          last_scored_at?: string | null
+          last_verdict?: string | null
+          name?: never
+          ready_at?: string | null
+          status?: string | null
+          transaction_id?: string | null
+          updated_at?: string | null
+          urgency?: string | null
+          url?: never
+          user_id?: string | null
+          why?: never
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "wishlist_items_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Functions: {
+      cleanup_anonymous_demo_users: {
+        Args: { p_older_than?: string }
+        Returns: number
+      }
+      generate_occurrences_for_template: {
+        Args: { p_template_id: string }
+        Returns: undefined
+      }
       get_accounts_with_masks: {
         Args: { p_user_id: string }
         Returns: {
-          id: string
-          mask: string | null
-          debit_card_mask: string | null
-          pdf_password: string | null
           account_type: Database["public"]["Enums"]["account_type"]
           currency_code: Database["public"]["Enums"]["currency_code"]
           current_balance: number
+          debit_card_mask: string
+          id: string
           is_demo: boolean
+          mask: string
+          pdf_password: string
         }[]
+      }
+      get_email_ingest_settings: {
+        Args: { p_address_key: string }
+        Returns: {
+          account_id: string
+          address_key: string
+          allowed_sender: string
+          allowed_senders: string[]
+          auto_import: boolean
+          id: string
+          pdf_import_enabled: boolean
+          user_id: string
+        }[]
+      }
+      reset_user_data: { Args: never; Returns: undefined }
+      set_gmail_verification: {
+        Args: { p_ingest_id: string; p_url: string; p_user_id: string }
+        Returns: undefined
       }
       zeta_decrypt: { Args: { ciphertext: string }; Returns: string }
       zeta_decrypt_as: {
@@ -3578,6 +3645,7 @@ export type Database = {
         | "CSV_IMPORT"
         | "OCR"
         | "EMAIL"
+      occurrence_status: "pending" | "paid" | "skipped"
       planning_entry_status: "PLANNED" | "COMPLETED" | "SKIPPED"
       planning_entry_type: "INCOME" | "EXPENSE"
       planning_period_preset: "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "CUSTOM"
@@ -3596,7 +3664,6 @@ export type Database = {
         | "OCR_SINGLE"
         | "EMAIL_IMPORT"
         | "EMAIL_PDF_IMPORT"
-      occurrence_status: "pending" | "paid" | "skipped"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
     }
@@ -3754,6 +3821,7 @@ export const Constants = {
         "OCR",
         "EMAIL",
       ],
+      occurrence_status: ["pending", "paid", "skipped"],
       planning_entry_status: ["PLANNED", "COMPLETED", "SKIPPED"],
       planning_entry_type: ["INCOME", "EXPENSE"],
       planning_period_preset: ["WEEKLY", "BIWEEKLY", "MONTHLY", "CUSTOM"],
@@ -3774,7 +3842,6 @@ export const Constants = {
         "EMAIL_IMPORT",
         "EMAIL_PDF_IMPORT",
       ],
-      occurrence_status: ["pending", "paid", "skipped"],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],
     },


### PR DESCRIPTION
## Summary

- **Reset All Data feature** — Settings → Zona de peligro → *Borrar todos mis datos*. Wipes all user data (server + device) but keeps the account and session. User lands back at onboarding.
- **Onboarding StepComplete fixes** — the completion screen's CTAs previously either (a) bounced the user back to onboarding, or (b) never rendered because a session-refresh-triggered guard yanked them off mid-flow.

## Server side

New RPC `public.reset_user_data()` deployed across 5 migrations (iterative fixes applied live as each pre-existing schema quirk surfaced):

- `20260422221529_add_reset_user_data_rpc.sql` — initial
- `20260422222441_fix_reset_user_data_obligation_skips.sql` — remove DELETE for dropped table
- `20260422222804_reset_user_data_resilient.sql` — guard every DELETE with `to_regclass()`; collapse into array loop
- `20260422222913_reset_user_data_updated_at_type.sql` — `now()` not `now()::text`
- `20260422223057_reset_user_data_defaults_not_nulls.sql` — seed NOT NULL profile columns (`locale='es-CO'`, `timezone='America/Bogota'`)
- `20260422223709_reset_user_data_design_reviews.sql` — add `design_reviews` per review

Safety:
- `SECURITY DEFINER` but every DELETE is scoped by `WHERE user_id = auth.uid()` — defense-in-depth
- `REVOKE ALL FROM PUBLIC, anon; GRANT EXECUTE TO authenticated`
- PL/pgSQL — atomic, rolls back on any error
- Preserves: `auth.users`, `user_encryption_keys` (DEK), `bug_reports`, system categories/tags, profile row (reset, not deleted)

## Mobile side

- `mobile/lib/reset-data.ts` — orchestrates RPC → local SQLite wipe → SecureStore cleanup (PDF passwords per-account, default-capture-account key). Preserves session and biometrics.
- `OnboardingStatusContext` gains `markIncomplete()` / `markComplete()` so the root layout's `needsOnboarding` state can be driven from both directions.
- Settings screen: new "Zona de peligro" section with two-step destructive confirmation. Hidden in demo mode.

### Sync-race hardening (post-review)

`syncAll()` now bails out if a reset is in progress. The reset flow:
1. Toggle `beginReset()`
2. Drain `sync_queue` BEFORE calling the RPC (so a mid-reset failure can't replay stale mutations)
3. RPC
4. `clearDatabase()` — now also wipes `planning_periods / planning_entries / planning_assignments` (previously synced but not cleared)
5. SecureStore cleanup
6. `endReset()` in finally

## Onboarding fixes

- `markComplete()` called from StepComplete CTAs before `router.replace(...)` — prevents guard-167 from bouncing the user back to /onboarding after navigation.
- Auto-kick **out of** /onboarding removed from the layout guard — a token-refresh-driven `needsOnboarding=false` flip was yanking users off StepComplete before they could choose a path. The auth-group kick stays intact.

## Edge-to-edge (Android 15)

Plus the earlier edge-to-edge migration (expo-system-ui + react-native-edge-to-edge plugin) that silences Google Play deprecation warnings for `setStatusBarColor` / `setNavigationBarColor` / `LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`. Version bumped 1.1.1 → 1.1.2.

## Test plan

- [ ] New signup → onboarding → each of the 4 purpose paths at StepComplete → lands on chosen destination (no redirect loop).
- [ ] Existing user: Ajustes → Zona de peligro → Borrar todos mis datos → double confirm → lands at onboarding step 1 with zero accounts / transactions.
- [ ] Re-run onboarding from the same account → account works normally.
- [ ] Android: verify no `setStatusBarColor` warnings in Play Console after next EAS build upload.
- [ ] Portrait lock confirmed (rotation on tablet/foldable ignored per Android 16 — accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)