### PR TITLE
Add recurring transaction linking and phantom swap logic

### DIFF
--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -314,6 +314,58 @@ export async function isTransactionLinkedToOccurrence(
   return !!data;
 }
 
+export interface LinkedRecurringInfo {
+  occurrenceId: string;
+  occurrenceDate: string;
+  templateId: string;
+  templateMerchant: string;
+  expectedAmount: number;
+  currencyCode: string;
+}
+
+/**
+ * Returns the recurring template/occurrence linked to this transaction, if any.
+ * Used by transaction detail and row badges to navigate the user to the source.
+ */
+export async function getLinkedRecurringForTransaction(
+  transactionId: string,
+): Promise<LinkedRecurringInfo | null> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return null;
+
+  if (!UUID_RE.test(transactionId)) return null;
+
+  const { data } = await supabase
+    .from("recurring_occurrences")
+    .select(`
+      id, occurrence_date, template_id, expected_amount,
+      template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
+        merchant_name, description, currency_code
+      )
+    `)
+    .eq("transaction_id", transactionId)
+    .eq("user_id", user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (!data) return null;
+  const t = data.template as {
+    merchant_name: string | null;
+    description: string | null;
+    currency_code: string;
+  } | null;
+  if (!t) return null;
+
+  return {
+    occurrenceId: data.id,
+    occurrenceDate: data.occurrence_date,
+    templateId: data.template_id,
+    templateMerchant: t.merchant_name ?? t.description ?? "Recurrente",
+    expectedAmount: data.expected_amount,
+    currencyCode: t.currency_code,
+  };
+}
+
 // ─── Public actions ───────────────────────────────────────────────────────────
 
 /**
@@ -455,8 +507,12 @@ async function deactivateOnceTemplate(
 }
 
 /**
- * Mark an occurrence as paid and link it to the created transaction.
+ * Mark an occurrence as paid and link it to a pre-existing transaction (auto-link path).
  * Only transitions from 'pending'.
+ *
+ * Stamps `recurrence_group_id` on the transaction so the "Vincular" button hides,
+ * and sets `linked_manually = true` on the occurrence so revertOccurrence unlinks
+ * the imported/manual transaction instead of deleting it.
  */
 export async function markOccurrencePaid(
   occurrenceId: string,
@@ -475,14 +531,51 @@ export async function markOccurrencePaid(
       status: "paid",
       transaction_id: transactionId,
       paid_at: new Date().toISOString(),
+      linked_manually: true,
     })
     .eq("id", occurrenceId)
     .eq("user_id", user.id)
     .eq("status", "pending")
-    .select("template_id, template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(frequency)")
+    .select("template_id, occurrence_date, template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(frequency, category_id)")
     .single();
 
   if (error) return { success: false, error: error.message };
+
+  // Stamp recurrence_group_id on the linked transaction so visibility predicates
+  // (movimientos / inicio "Vincular" button) correctly hide it. Use the same
+  // deterministic UUID scheme as linkExistingTransactionToOccurrence so both
+  // paths share group identity.
+  if (occurrence?.template_id && occurrence?.occurrence_date) {
+    const { computeRecurringGroupUuid } = await import("@/actions/recurring-templates");
+    const recurrenceGroupId = await computeRecurringGroupUuid(
+      occurrence.template_id,
+      occurrence.occurrence_date,
+    );
+    const template = occurrence.template as { frequency: string; category_id: string | null } | null;
+
+    // Read existing tx to decide if we should backfill the category
+    const { data: tx } = await supabase
+      .from("transactions")
+      .select("category_id")
+      .eq("id", transactionId)
+      .eq("user_id", user.id)
+      .single();
+
+    const update: Record<string, unknown> = { recurrence_group_id: recurrenceGroupId };
+    if (tx && !tx.category_id && template?.category_id) {
+      update.category_id = template.category_id;
+      update.categorization_source = "RECURRING_TEMPLATE";
+    }
+
+    const { error: txUpdateErr } = await supabase
+      .from("transactions")
+      .update(update)
+      .eq("id", transactionId)
+      .eq("user_id", user.id);
+    if (txUpdateErr) {
+      console.error("[markOccurrencePaid] tx group stamp failed:", txUpdateErr.message);
+    }
+  }
 
   // Auto-deactivate ONCE templates after their single occurrence is resolved
   const freq = (occurrence?.template as { frequency: string } | null)?.frequency;
@@ -833,6 +926,12 @@ export async function findMatchingOccurrence(
 /**
  * Convenience: find a matching pending occurrence and mark it paid.
  * Used by all transaction creation paths (FAB, email, PDF import).
+ *
+ * Also handles the "phantom-swap" race: if no PENDING occurrence matches but
+ * a recently-paid system-created occurrence does (i.e. the user clicked
+ * "Confirmar pago" before the bank-verified import arrived), the imported
+ * transaction supersedes the phantom — the phantom tx is deleted (balance
+ * reversed) and the occurrence is repointed at the imported transaction.
  */
 export async function linkTransactionToOccurrence(
   accountId: string,
@@ -851,7 +950,147 @@ export async function linkTransactionToOccurrence(
   );
   if (matchId) {
     await markOccurrencePaid(matchId, transactionId);
+    return;
   }
+
+  await swapPhantomOccurrenceIfMatched(
+    accountId,
+    transactionDate,
+    amount,
+    direction,
+    transactionId,
+  );
+}
+
+/**
+ * Phantom-swap fallback for `linkTransactionToOccurrence`.
+ *
+ * If a recently-paid, system-created (linked_manually=false) occurrence exists
+ * in the same account/direction window with a matching amount, replace its
+ * phantom transaction with the just-inserted bank-verified one.
+ *
+ * Restricted to single-tx recurrence groups — multi-leg debt-payment phantoms
+ * (CC inflow + source outflow) require human reconciliation.
+ */
+async function swapPhantomOccurrenceIfMatched(
+  accountId: string,
+  transactionDate: string,
+  amount: number,
+  direction: "INFLOW" | "OUTFLOW",
+  newTransactionId: string,
+): Promise<void> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return;
+
+  const baseDateObj = parseISO(transactionDate + "T12:00:00");
+  const rangeStart = toColombiaDateString(addDays(baseDateObj, -3));
+  const rangeEnd = toColombiaDateString(addDays(baseDateObj, 3));
+
+  const { data: candidates, error } = await supabase
+    .from("recurring_occurrences")
+    .select(
+      `id, transaction_id, expected_amount,
+       template:recurring_transaction_templates!recurring_occurrences_template_id_fkey!inner(
+         account_id, direction, is_active
+       )`,
+    )
+    .eq("user_id", user.id)
+    .eq("status", "paid")
+    .eq("linked_manually", false)
+    .eq("template.account_id", accountId)
+    .eq("template.direction", direction)
+    .eq("template.is_active", true)
+    .gte("occurrence_date", rangeStart)
+    .lte("occurrence_date", rangeEnd);
+
+  if (error || !candidates) return;
+
+  const tolerance = amount * 0.01;
+  const match = candidates.find(
+    (row) =>
+      row.transaction_id != null &&
+      Math.abs(row.expected_amount - amount) <= tolerance,
+  );
+  if (!match || !match.transaction_id) return;
+
+  // Read phantom tx — must be a single-tx recurrence group to swap safely
+  const { data: phantomTx } = await supabase
+    .from("transactions")
+    .select(
+      "id, recurrence_group_id, amount, direction, account_id, accounts!transactions_account_id_fkey(account_type, current_balance)",
+    )
+    .eq("id", match.transaction_id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!phantomTx || !phantomTx.recurrence_group_id) return;
+
+  const { data: groupTxs } = await supabase
+    .from("transactions")
+    .select("id")
+    .eq("recurrence_group_id", phantomTx.recurrence_group_id)
+    .eq("user_id", user.id);
+
+  if (!groupTxs || groupTxs.length !== 1) {
+    // Multi-leg phantom — leave for manual reconciliation
+    return;
+  }
+
+  // Reverse the phantom's balance, then delete it
+  const phantomAccount = phantomTx.accounts as
+    | { account_type: string; current_balance: number }
+    | null;
+
+  if (phantomAccount) {
+    const reversedBalance = reverseAccountBalanceDelta({
+      currentBalance: phantomAccount.current_balance,
+      accountType: phantomAccount.account_type,
+      direction: phantomTx.direction as "INFLOW" | "OUTFLOW",
+      amount: phantomTx.amount,
+    });
+    const { error: balErr } = await supabase
+      .from("accounts")
+      .update({ current_balance: reversedBalance })
+      .eq("id", phantomTx.account_id)
+      .eq("user_id", user.id);
+    if (balErr) {
+      console.error("[swapPhantomOccurrence] balance reverse failed:", balErr.message);
+      return;
+    }
+  }
+
+  const { error: delErr } = await supabase
+    .from("transactions")
+    .delete()
+    .eq("id", phantomTx.id)
+    .eq("user_id", user.id);
+  if (delErr) {
+    console.error("[swapPhantomOccurrence] phantom delete failed:", delErr.message);
+    return;
+  }
+
+  // Repoint the occurrence at the new tx, mark linked_manually so future
+  // reverts unlink (don't delete) the bank-verified transaction
+  await supabase
+    .from("recurring_occurrences")
+    .update({
+      transaction_id: newTransactionId,
+      linked_manually: true,
+      paid_at: new Date().toISOString(),
+    })
+    .eq("id", match.id)
+    .eq("user_id", user.id);
+
+  // Stamp the new tx with the existing recurrence_group_id so the Vincular
+  // button hides and downstream queries treat it as the canonical payment
+  await supabase
+    .from("transactions")
+    .update({ recurrence_group_id: phantomTx.recurrence_group_id })
+    .eq("id", newTransactionId)
+    .eq("user_id", user.id);
+
+  revalidateFinancialViews();
+  updateTag("occurrences");
 }
 
 // ─── Manual Linking ───────────────────────────────────────────────────────────

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -327,13 +327,16 @@ export interface LinkedRecurringInfo {
  * Returns the recurring template/occurrence linked to this transaction, if any.
  * Used by transaction detail and row badges to navigate the user to the source.
  */
-export async function getLinkedRecurringForTransaction(
+async function getLinkedRecurringForTransactionCached(
+  userId: string,
   transactionId: string,
+  accessToken: string,
 ): Promise<LinkedRecurringInfo | null> {
-  const { supabase, user } = await getAuthenticatedClient();
-  if (!user) return null;
+  "use cache";
+  cacheTag("occurrences");
+  cacheLife("zeta");
 
-  if (!UUID_RE.test(transactionId)) return null;
+  const supabase = createCachedClient(accessToken);
 
   const { data } = await supabase
     .from("recurring_occurrences")
@@ -344,7 +347,7 @@ export async function getLinkedRecurringForTransaction(
       )
     `)
     .eq("transaction_id", transactionId)
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .limit(1)
     .maybeSingle();
 
@@ -364,6 +367,15 @@ export async function getLinkedRecurringForTransaction(
     expectedAmount: data.expected_amount,
     currencyCode: t.currency_code,
   };
+}
+
+export async function getLinkedRecurringForTransaction(
+  transactionId: string,
+): Promise<LinkedRecurringInfo | null> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return null;
+  if (!UUID_RE.test(transactionId)) return null;
+  return getLinkedRecurringForTransactionCached(user.id, transactionId, accessToken);
 }
 
 // ─── Public actions ───────────────────────────────────────────────────────────
@@ -584,7 +596,6 @@ export async function markOccurrencePaid(
   }
 
   revalidateFinancialViews();
-  updateTag("occurrences");
   return { success: true, data: undefined };
 }
 
@@ -1036,10 +1047,24 @@ async function swapPhantomOccurrenceIfMatched(
     return;
   }
 
-  // Reverse the phantom's balance, then delete it
+  // Order: delete phantom first, then reverse balance. If the delete fails the
+  // balance is still correct; if the balance update fails after a successful
+  // delete, the account will be off by the phantom amount but the row is gone —
+  // recoverable via "recompute account balance". Without ACID transactions across
+  // PostgREST calls, this ordering minimizes the window of inconsistency.
   const phantomAccount = phantomTx.accounts as
     | { account_type: string; current_balance: number }
     | null;
+
+  const { error: delErr } = await supabase
+    .from("transactions")
+    .delete()
+    .eq("id", phantomTx.id)
+    .eq("user_id", user.id);
+  if (delErr) {
+    console.error("[swapPhantomOccurrence] phantom delete failed:", delErr.message);
+    return;
+  }
 
   if (phantomAccount) {
     const reversedBalance = reverseAccountBalanceDelta({
@@ -1054,24 +1079,16 @@ async function swapPhantomOccurrenceIfMatched(
       .eq("id", phantomTx.account_id)
       .eq("user_id", user.id);
     if (balErr) {
-      console.error("[swapPhantomOccurrence] balance reverse failed:", balErr.message);
-      return;
+      console.error("[swapPhantomOccurrence] balance reverse failed after delete:", balErr.message);
+      // Continue — phantom is gone, repoint the occurrence anyway so the user
+      // sees the import as the canonical payment. Account balance can be
+      // recomputed; leaving the orphan paid occurrence is worse UX.
     }
   }
 
-  const { error: delErr } = await supabase
-    .from("transactions")
-    .delete()
-    .eq("id", phantomTx.id)
-    .eq("user_id", user.id);
-  if (delErr) {
-    console.error("[swapPhantomOccurrence] phantom delete failed:", delErr.message);
-    return;
-  }
-
   // Repoint the occurrence at the new tx, mark linked_manually so future
-  // reverts unlink (don't delete) the bank-verified transaction
-  await supabase
+  // reverts unlink (don't delete) the bank-verified transaction.
+  const { error: occErr } = await supabase
     .from("recurring_occurrences")
     .update({
       transaction_id: newTransactionId,
@@ -1080,17 +1097,22 @@ async function swapPhantomOccurrenceIfMatched(
     })
     .eq("id", match.id)
     .eq("user_id", user.id);
+  if (occErr) {
+    console.error("[swapPhantomOccurrence] occurrence repoint failed:", occErr.message);
+  }
 
   // Stamp the new tx with the existing recurrence_group_id so the Vincular
-  // button hides and downstream queries treat it as the canonical payment
-  await supabase
+  // button hides and downstream queries treat it as the canonical payment.
+  const { error: txStampErr } = await supabase
     .from("transactions")
     .update({ recurrence_group_id: phantomTx.recurrence_group_id })
     .eq("id", newTransactionId)
     .eq("user_id", user.id);
+  if (txStampErr) {
+    console.error("[swapPhantomOccurrence] new tx group stamp failed:", txStampErr.message);
+  }
 
   revalidateFinancialViews();
-  updateTag("occurrences");
 }
 
 // ─── Manual Linking ───────────────────────────────────────────────────────────

--- a/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getDestinatarios } from "@/actions/destinatarios";
 import { getTagsForEntity } from "@/actions/tags";
 import {
   getAccountIdsWithPendingOccurrences,
+  getLinkedRecurringForTransaction,
   isTransactionLinkedToOccurrence,
 } from "@/actions/occurrences";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
@@ -38,10 +39,12 @@ export default async function TransactionDetailPage({
     [accountsResult, categoriesResult, destinatariosResult, linkableAccountIds],
     initialTags,
     isLinkedToOccurrence,
+    linkedRecurring,
   ] = await Promise.all([
     listFetchesPromise,
     getTagsForEntity("transaction", tx.id),
     isTransactionLinkedToOccurrence(tx.id),
+    getLinkedRecurringForTransaction(tx.id),
   ]);
 
   const accounts = accountsResult.success ? accountsResult.data : [];
@@ -62,6 +65,7 @@ export default async function TransactionDetailPage({
         categories={categories}
         initialTags={initialTags}
         isLinkedToOccurrence={isLinkedToOccurrence}
+        linkedRecurring={linkedRecurring}
         linkableAccountIds={linkableAccountIds}
       />
     </div>

--- a/webapp/src/app/(dashboard)/transactions/[id]/transaction-detail-client.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/transaction-detail-client.tsx
@@ -2,15 +2,18 @@
 
 import { startTransition, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import {
   ArrowDownLeft,
   ArrowUpRight,
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   EyeOff,
   Eye,
   Link2,
   Plus,
+  Repeat,
   Tag,
   Trash2,
   UserRound,
@@ -55,6 +58,7 @@ import {
   getCandidateOccurrencesForTransaction,
   linkExistingTransactionToOccurrence,
   type CandidateOccurrence,
+  type LinkedRecurringInfo,
 } from "@/actions/occurrences";
 import type {
   Account,
@@ -83,6 +87,8 @@ interface TransactionDetailClientProps {
   categories: CategoryWithChildren[];
   initialTags: TagType[];
   isLinkedToOccurrence: boolean;
+  /** Recurring template + occurrence linked to this tx, if any. */
+  linkedRecurring: LinkedRecurringInfo | null;
   /** Account IDs that have at least one pending occurrence — enables "Vincular". */
   linkableAccountIds: string[];
 }
@@ -117,6 +123,7 @@ export function TransactionDetailClient({
   categories,
   initialTags,
   isLinkedToOccurrence,
+  linkedRecurring,
   linkableAccountIds,
 }: TransactionDetailClientProps) {
   const router = useRouter();
@@ -487,6 +494,35 @@ export function TransactionDetailClient({
           />
         </div>
       </section>
+
+      {/* ── Vinculado a recurrente ─────────────────────────────────── */}
+      {linkedRecurring && (
+        <section className="px-4 pt-4">
+          <p className={cn(SECTION_EYEBROW_CLASS, "mb-2")}>Recurrente vinculada</p>
+          <Link
+            href={`/recurrentes/${linkedRecurring.templateId}/edit`}
+            className="flex items-center gap-3 rounded-xl border border-z-brass/20 bg-z-brass/8 px-3 py-2.5 transition-colors hover:bg-z-brass/12"
+          >
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-z-brass/15 text-z-brass">
+              <Repeat className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-semibold text-z-brass">
+                {linkedRecurring.templateMerchant}
+              </span>
+              <span className="block truncate text-[11px] text-muted-foreground">
+                Pago de {formatDate(linkedRecurring.occurrenceDate, "dd MMM yyyy")} ·
+                {" "}
+                {formatCurrency(
+                  linkedRecurring.expectedAmount,
+                  linkedRecurring.currencyCode as CurrencyCode,
+                )}{" "}esperado
+              </span>
+            </span>
+            <ChevronRight className="size-4 shrink-0 text-z-brass/60" />
+          </Link>
+        </section>
+      )}
 
       {/* ── Notas ──────────────────────────────────────────────────── */}
       <section className="px-4 pt-4">

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -13,6 +13,7 @@ import {
   Hash,
   Link2,
   MoreHorizontal,
+  Repeat,
   Tag,
   Trash2,
   UserRound,
@@ -309,7 +310,15 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                 </div>
 
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-xs font-medium">{tx.description}</p>
+                  <p className="flex items-center gap-1 truncate text-xs font-medium">
+                    {tx.recurrence_group_id && (
+                      <Repeat
+                        className="size-3 shrink-0 text-z-brass/70"
+                        aria-label="Vinculado a recurrente"
+                      />
+                    )}
+                    <span className="truncate">{tx.description}</span>
+                  </p>
                   <p className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
                     <AccountRowIdentity
                       account={{

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -312,10 +312,13 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
                 <div className="min-w-0 flex-1">
                   <p className="flex items-center gap-1 truncate text-xs font-medium">
                     {tx.recurrence_group_id && (
-                      <Repeat
-                        className="size-3 shrink-0 text-z-brass/70"
-                        aria-label="Vinculado a recurrente"
-                      />
+                      <>
+                        <Repeat
+                          className="size-3 shrink-0 text-z-brass/70"
+                          aria-hidden="true"
+                        />
+                        <span className="sr-only">Vinculado a recurrente:</span>
+                      </>
                     )}
                     <span className="truncate">{tx.description}</span>
                   </p>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -5,7 +5,7 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
-import { Pencil, ArrowDownLeft, ArrowUpRight, Link2 } from "lucide-react";
+import { Pencil, ArrowDownLeft, ArrowUpRight, Link2, Repeat } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
@@ -160,7 +160,15 @@ export function MovimientosTransactionRow({
           {tx.direction === "INFLOW" ? <ArrowDownLeft className="size-3" /> : <ArrowUpRight className="size-3" />}
         </div>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium">{description}</p>
+          <p className="truncate text-sm font-medium flex items-center gap-1">
+            {tx.recurrence_group_id && (
+              <Repeat
+                className="size-3 shrink-0 text-z-brass/70"
+                aria-label="Vinculado a recurrente"
+              />
+            )}
+            <span className="truncate">{description}</span>
+          </p>
           <p className="text-[11px] text-muted-foreground flex items-center gap-1">
             <span
               className="inline-block h-1.5 w-1.5 rounded-full shrink-0"

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -162,10 +162,13 @@ export function MovimientosTransactionRow({
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium flex items-center gap-1">
             {tx.recurrence_group_id && (
-              <Repeat
-                className="size-3 shrink-0 text-z-brass/70"
-                aria-label="Vinculado a recurrente"
-              />
+              <>
+                <Repeat
+                  className="size-3 shrink-0 text-z-brass/70"
+                  aria-hidden="true"
+                />
+                <span className="sr-only">Vinculado a recurrente:</span>
+              </>
             )}
             <span className="truncate">{description}</span>
           </p>

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Check, Tag } from "lucide-react";
+import Link from "next/link";
+import { Check, ExternalLink, Tag } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MobileRecurrentesTemplatesStrip } from "./mobile-recurrentes-templates-strip";
 import { AccountRowIdentity } from "@/components/accounts/account-row-identity";
@@ -540,6 +541,16 @@ function CompletedSection({
                 <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                   {formatCurrency(item.plannedAmount, item.currencyCode as CurrencyCode)}
                 </span>
+                {item.transactionId && (
+                  <Link
+                    href={`/transactions/${item.transactionId}`}
+                    aria-label={`Ver transacción de ${item.merchant}`}
+                    className="shrink-0 inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] text-z-brass active:bg-white/5"
+                  >
+                    <ExternalLink className="size-3" />
+                    Ver
+                  </Link>
+                )}
                 <button
                   type="button"
                   onClick={() => handleRevert(item)}

--- a/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-recurrentes-view.tsx
@@ -11,6 +11,7 @@ import { formatDate } from "@/lib/utils/date";
 import {
   PANEL_INSET_CLASS,
   HERO_CARD_GRADIENT_CLASS,
+  MOBILE_ACTION_BUTTON_CLASS,
   MOBILE_EYEBROW_CLASS,
   MOBILE_TAB_BAR_CLEARANCE_CLASS,
 } from "@/lib/constants/styles";
@@ -545,7 +546,10 @@ function CompletedSection({
                   <Link
                     href={`/transactions/${item.transactionId}`}
                     aria-label={`Ver transacción de ${item.merchant}`}
-                    className="shrink-0 inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] text-z-brass active:bg-white/5"
+                    className={cn(
+                      MOBILE_ACTION_BUTTON_CLASS,
+                      "shrink-0 inline-flex items-center gap-0.5",
+                    )}
                   >
                     <ExternalLink className="size-3" />
                     Ver

--- a/webapp/src/components/recurring/recurring-completed-section.tsx
+++ b/webapp/src/components/recurring/recurring-completed-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { CheckCircle2, ExternalLink, SkipForward, Undo2, Pencil } from "lucide-react";
+import { CheckCircle2, ExternalLink, SkipForward, Undo2, Pencil, ChevronDown } from "lucide-react";
+import Link from "next/link";
 import {
   Collapsible,
   CollapsibleContent,
@@ -8,23 +9,18 @@ import {
 } from "@/components/ui/collapsible";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
+import { cn } from "@/lib/utils";
+import { PANEL_INSET_CLASS } from "@/lib/constants/styles";
 import type { OccurrenceItem } from "./use-recurring-month";
 import type { CurrencyCode } from "@/types/domain";
-import { ChevronDown } from "lucide-react";
-import Link from "next/link";
-
-/* ------------------------------------------------------------------ */
-/*  Types                                                              */
-/* ------------------------------------------------------------------ */
 
 interface RecurringCompletedSectionProps {
   completed: OccurrenceItem[];
   onRevert?: (item: OccurrenceItem) => void;
 }
 
-/* ------------------------------------------------------------------ */
-/*  Component                                                          */
-/* ------------------------------------------------------------------ */
+const ICON_BUTTON_CLASS =
+  "rounded-md p-1.5 text-z-sage-dark transition-colors hover:bg-white/5 hover:text-z-white";
 
 export function RecurringCompletedSection({
   completed,
@@ -34,7 +30,7 @@ export function RecurringCompletedSection({
 
   return (
     <Collapsible>
-      <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-lg bg-green-50 px-3 py-2.5 text-sm font-medium text-green-700 transition-colors hover:bg-green-100 dark:bg-green-950/30 dark:text-green-400 dark:hover:bg-green-950/50">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-lg border border-z-income/20 bg-z-income/8 px-3 py-2.5 text-sm font-medium text-z-income transition-colors hover:bg-z-income/12">
         <CheckCircle2 className="size-4" />
         <span>
           {completed.length}{" "}
@@ -45,50 +41,48 @@ export function RecurringCompletedSection({
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <div className="mt-1 divide-y divide-green-200/50 rounded-lg border border-green-200/50 bg-green-50/50 dark:divide-green-900/30 dark:border-green-900/30 dark:bg-green-950/20">
+        <div className={cn(PANEL_INSET_CLASS, "mt-1 divide-y divide-white/6")}>
           {completed.map((item) => (
-            <div
-              key={item.key}
-              className="flex items-center gap-2 px-3 py-2"
-            >
+            <div key={item.key} className="flex items-center gap-2 px-3 py-2">
               {item.status === "paid" ? (
-                <CheckCircle2 className="size-4 shrink-0 text-green-600 dark:text-green-500" />
+                <CheckCircle2 className="size-4 shrink-0 text-z-income" />
               ) : (
-                <SkipForward className="size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+                <SkipForward className="size-4 shrink-0 text-z-alert" />
               )}
 
               <div className="min-w-0 flex-1">
-                <span className="truncate text-sm font-medium text-green-800 dark:text-green-300">
+                <span className="truncate text-sm font-medium text-z-white">
                   {item.merchant}
                 </span>
-                <span className="ml-1.5 text-xs text-green-600/70 dark:text-green-500/70">
+                <span className="ml-1.5 text-xs text-muted-foreground">
                   {formatDate(item.date, "d MMM")}
                   {item.status === "skipped" && " · Omitido"}
                 </span>
               </div>
 
-              <span className="shrink-0 text-sm font-medium tabular-nums text-green-700 dark:text-green-400">
+              <span className="shrink-0 text-sm font-medium tabular-nums text-z-white">
                 {formatCurrency(
                   item.plannedAmount,
-                  item.currencyCode as CurrencyCode
+                  item.currencyCode as CurrencyCode,
                 )}
               </span>
 
-              {/* Actions */}
               <div className="flex shrink-0 items-center gap-1 ml-1">
                 {item.transactionId && (
                   <Link
                     href={`/transactions/${item.transactionId}`}
-                    className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"
+                    className={ICON_BUTTON_CLASS}
                     title="Ver transacción"
+                    aria-label={`Ver transacción de ${item.merchant}`}
                   >
                     <ExternalLink className="size-3.5" />
                   </Link>
                 )}
                 <Link
                   href={`/recurrentes/${item.templateId}/edit`}
-                  className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"
+                  className={ICON_BUTTON_CLASS}
                   title="Editar plantilla"
+                  aria-label={`Editar plantilla ${item.merchant}`}
                 >
                   <Pencil className="size-3.5" />
                 </Link>
@@ -96,8 +90,9 @@ export function RecurringCompletedSection({
                   <button
                     type="button"
                     onClick={() => onRevert(item)}
-                    className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"
+                    className={ICON_BUTTON_CLASS}
                     title="Deshacer — volver a pendiente"
+                    aria-label={`Deshacer ${item.merchant}`}
                   >
                     <Undo2 className="size-3.5" />
                   </button>

--- a/webapp/src/components/recurring/recurring-completed-section.tsx
+++ b/webapp/src/components/recurring/recurring-completed-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCircle2, SkipForward, Undo2, Pencil } from "lucide-react";
+import { CheckCircle2, ExternalLink, SkipForward, Undo2, Pencil } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -76,6 +76,15 @@ export function RecurringCompletedSection({
 
               {/* Actions */}
               <div className="flex shrink-0 items-center gap-1 ml-1">
+                {item.transactionId && (
+                  <Link
+                    href={`/transactions/${item.transactionId}`}
+                    className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"
+                    title="Ver transacción"
+                  >
+                    <ExternalLink className="size-3.5" />
+                  </Link>
+                )}
                 <Link
                   href={`/recurrentes/${item.templateId}/edit`}
                   className="rounded-md p-1.5 text-green-600/70 transition-colors hover:bg-green-200/50 hover:text-green-800 dark:text-green-500/70 dark:hover:bg-green-900/40 dark:hover:text-green-300"


### PR DESCRIPTION
## Summary
This PR enhances the recurring transaction system with improved linking capabilities and a "phantom swap" mechanism to handle race conditions when bank-verified imports arrive after user-created phantom transactions.

## Key Changes

### Core Linking Improvements
- **New `getLinkedRecurringForTransaction()` function**: Retrieves the recurring template/occurrence linked to a transaction, enabling navigation from transaction detail to the source recurring template
- **Enhanced `markOccurrencePaid()` function**: Now stamps `recurrence_group_id` on linked transactions and sets `linked_manually = true` to distinguish user-linked occurrences from system-created ones. Also backfills category from template if transaction lacks one
- **New `LinkedRecurringInfo` interface**: Provides structured data about linked recurring occurrences for UI consumption

### Phantom Swap Mechanism
- **New `swapPhantomOccurrenceIfMatched()` function**: Implements fallback logic for `linkTransactionToOccurrence()` to handle the race condition where:
  - User clicks "Confirmar pago" creating a phantom transaction
  - Bank-verified import arrives before the phantom is reconciled
  - The imported transaction supersedes the phantom (phantom deleted, balance reversed, occurrence repointed)
- Restricted to single-transaction recurrence groups for safety; multi-leg phantoms (e.g., CC inflow + source outflow) require manual reconciliation
- Includes careful error handling with balance reversal ordering to minimize inconsistency windows

### UI Enhancements
- **Transaction Detail**: Added "Recurrente vinculada" section showing linked recurring template with merchant, date, and expected amount
- **Recurring Completed Section**: 
  - Updated styling to use design system colors (z-income, z-brass)
  - Added external link icon to navigate to linked transactions
  - Improved accessibility with aria-labels
- **Transaction Rows** (movimientos & inicio): Added recurring badge (Repeat icon) to visually indicate transactions linked to recurring templates
- **Mobile Recurrentes View**: Added "Ver" button in completed section to navigate to linked transactions

### Implementation Details
- Uses deterministic UUID scheme (`computeRecurringGroupUuid`) to ensure both manual and auto-linking paths share group identity
- Implements tolerance-based amount matching (±1%) for phantom swap detection
- Leverages `linked_manually` flag to control revert behavior (unlink vs. delete)
- Includes comprehensive error logging for debugging phantom swap failures
- Maintains financial view revalidation for consistency

https://claude.ai/code/session_01MaSA6hxXSe8fk8sTGAWPNk