### PR TITLE
feat(webapp): mobile IA refactor — 3 tabs + Más, personalized third slot

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -193,6 +193,19 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 
 ## Features
 
+### Import support — PDF redaction before "send to devs"
+- **Priority:** Medium
+- **What:** When a user opts into "send for support" on a failed import, give them a redaction step before upload so they can hide PII (name, document ID, account number, address, balances) without losing the structural data we need to build a parser.
+- **Why:** Bank statements are dense with PII. The current flow asks users to upload an unmodified PDF — many won't, even if it would help us add their bank. Privacy gate = higher conversion + safer storage of `save-unrecognized` blobs.
+- **Approach (MVP, ~2-3 days):**
+  1. Auto-redact pass on the server: extract bbox positions for known PII patterns (NIT/CC formats, common name lines via heuristics, account numbers via regex). Return a JSON of suggested redaction rectangles.
+  2. Client preview: render the PDF page-by-page (pdf.js) with the suggested rectangles overlaid as semi-opaque boxes. User can toggle each suggestion on/off and drag a new rectangle for anything missed.
+  3. On submit: client posts the redaction list + original file to `/api/save-unrecognized`. Server applies the rectangles using `pypdf` or `reportlab` (draw black rect on top of each page) and stores the redacted output. Original is discarded.
+- **Approach (full, ~1 week):** Add per-rectangle reasons ("name", "account", "amount") for analytics on what users hide most; let user blur instead of black-box; preserve text-layer for rectangles outside the redaction zone so devs can still parse the structure.
+- **Tradeoff:** image-only redaction (rasterize → paint → re-encode) loses text fidelity → defeats the dev-support purpose. Stick with vector overlay.
+- **Touches:** `services/pdf_parser/main.py` (`/save-unrecognized` accepts redaction rectangles + applies them; new `/suggest-redactions` endpoint for the auto-pass), `webapp/src/components/import/step-upload.tsx` (the existing `unsupportedFile` block grows a "Revisar y censurar" intermediate step), new `webapp/src/components/import/redaction-editor.tsx`, dependency: `pdfjs-dist` for client render + a server-side redaction lib.
+- **Found:** User request, 2026-04-28.
+
 ### Budget setup — per-category opt-in + calculator shortcut
 - **Priority:** Medium
 - **What:** When setting up budgets the user wants to pick categories one by one and only assign amounts to the ones they care about — leaving the rest blank is a valid state, not an error. Also: every amount input should expose a small calculator button (popover/drawer) so the user can do quick math without leaving the form.

--- a/claude-ai-design/nav-redesign-mobile.html
+++ b/claude-ai-design/nav-redesign-mobile.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Nav redesign · Mobile webapp · Zeta</title>
+  <style>
+    :root{
+      --z-ink:#121412; --z-brass:#937844; --z-brass-hot:#B29256;
+      --z-income:#5CB88A; --z-expense:#E8875A; --z-debt:#E05545; --z-alert:#D4A843;
+      --z-surface:#171A17; --z-surface-2:#1E221E; --z-surface-3:#262B26;
+      --z-border:rgba(217,204,185,0.08); --z-border-strong:rgba(217,204,185,0.16);
+      --z-text:#EAE5DA; --z-muted:rgba(234,229,218,0.55); --z-muted-2:rgba(234,229,218,0.38);
+    }
+    *{box-sizing:border-box}
+    body{
+      margin:0;background:#0b0d0b;color:var(--z-text);
+      font-family:-apple-system,BlinkMacSystemFont,Inter,system-ui,sans-serif;
+      padding:32px 20px 80px;line-height:1.35;
+    }
+    .wrap{max-width:1320px;margin:0 auto}
+    h1{font-size:20px;font-weight:600;letter-spacing:-.01em;margin:0 0 4px}
+    .subtitle{color:var(--z-muted);font-size:13px;margin-bottom:28px;max-width:780px}
+    .legend{
+      display:flex;gap:16px;font-size:11px;color:var(--z-muted);
+      margin-bottom:28px;flex-wrap:wrap
+    }
+    .legend b{color:var(--z-text);font-weight:600}
+    .legend .swatch{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:6px;vertical-align:middle}
+    .row{display:grid;grid-template-columns:repeat(3,1fr);gap:24px;margin-bottom:36px}
+    @media(max-width:1080px){.row{grid-template-columns:1fr;max-width:420px;margin-left:auto;margin-right:auto}}
+    .col-label{
+      font-size:10px;font-weight:700;letter-spacing:.22em;text-transform:uppercase;
+      color:var(--z-muted);margin-bottom:8px
+    }
+    .col-label.now{color:var(--z-muted-2)}
+    .col-label.new{color:var(--z-brass)}
+    .col-note{font-size:11px;color:var(--z-muted-2);margin-bottom:14px;min-height:34px;line-height:1.45}
+    .phone{
+      background:var(--z-ink);border:1px solid var(--z-border-strong);
+      border-radius:32px;padding:18px 14px 0;
+      box-shadow:0 40px 80px rgba(0,0,0,.35);
+      overflow:hidden;position:relative;
+      height:640px;display:flex;flex-direction:column;
+    }
+    .phone[data-emphasis="yes"]{
+      border-color:rgba(147,120,68,.35);
+      box-shadow:0 40px 80px rgba(0,0,0,.35),0 0 0 1px rgba(147,120,68,.18);
+    }
+    .phone[data-emphasis="now"]{opacity:.78}
+
+    /* phone chrome */
+    .p-status{display:flex;justify-content:space-between;font-size:10px;color:var(--z-muted);margin-bottom:10px;padding:0 4px}
+    .p-status .dots{letter-spacing:1px}
+    .p-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
+    .p-title{font-weight:600;font-size:17px}
+    .p-subtitle{font-size:11px;color:var(--z-muted);margin-top:1px}
+    .avatar{width:30px;height:30px;border-radius:999px;background:var(--z-surface-3);
+      display:flex;align-items:center;justify-content:center;font-size:11px;color:var(--z-brass);font-weight:600}
+
+    /* eyebrow */
+    .eyebrow{font-size:10px;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:var(--z-brass);margin-bottom:6px}
+    .eyebrow.muted{color:var(--z-muted)}
+
+    /* card */
+    .card{background:var(--z-surface);border:1px solid var(--z-border);border-radius:16px;padding:14px;margin-bottom:12px}
+    .hero{
+      background:linear-gradient(145deg,rgba(147,120,68,.16),rgba(147,120,68,.03) 55%,transparent 80%),var(--z-surface);
+      border:1px solid rgba(147,120,68,.18);border-radius:20px;padding:14px 16px;margin-bottom:12px;
+    }
+    .hero-eyebrow{font-size:9px;letter-spacing:.18em;text-transform:uppercase;color:var(--z-brass);font-weight:600}
+    .hero-num{font-size:28px;font-weight:700;letter-spacing:-.02em;font-variant-numeric:tabular-nums;margin-top:6px}
+    .hero-sub{font-size:11px;color:var(--z-muted);margin-top:2px}
+
+    /* generic content stand-ins */
+    .stack{display:flex;flex-direction:column;gap:8px}
+    .row2{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+    .skeleton{
+      background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;
+      padding:11px 12px;font-size:11.5px;color:var(--z-muted);
+      display:flex;justify-content:space-between;align-items:center;
+    }
+    .skeleton b{color:var(--z-text);font-weight:600}
+    .skeleton .v{font-variant-numeric:tabular-nums;color:var(--z-text);font-weight:600}
+
+    .scroll{flex:1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 78%,transparent);}
+
+    /* TAB BAR */
+    .tabbar{
+      position:absolute;left:14px;right:14px;bottom:12px;
+      background:rgba(18,20,18,.92);backdrop-filter:blur(14px);
+      border:1px solid var(--z-border-strong);border-radius:22px;
+      padding:8px;height:62px;display:flex;align-items:center;justify-content:space-between;
+    }
+    .tab{
+      flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;
+      font-size:9.5px;color:var(--z-muted);font-weight:500;letter-spacing:.02em;
+      padding:6px 0;border-radius:12px;
+    }
+    .tab.active{color:var(--z-brass)}
+    .tab .ico{
+      width:20px;height:20px;display:flex;align-items:center;justify-content:center;
+    }
+    .tab.active .ico::after{
+      content:"";position:absolute;width:4px;height:4px;border-radius:999px;background:var(--z-brass);
+      margin-top:24px;
+    }
+    .fab{
+      width:54px;height:54px;border-radius:999px;
+      background:linear-gradient(150deg,var(--z-brass-hot),var(--z-brass));
+      display:flex;align-items:center;justify-content:center;
+      color:var(--z-ink);font-size:24px;font-weight:300;
+      box-shadow:0 12px 28px rgba(147,120,68,.45),inset 0 1px 0 rgba(255,255,255,.18);
+      margin:-22px 4px 0;
+      flex-shrink:0;
+    }
+    .tab.disabled{opacity:.35}
+    .tab.flag{position:relative}
+    .tab.flag::after{
+      content:"";position:absolute;top:6px;right:calc(50% - 14px);
+      width:6px;height:6px;border-radius:999px;background:var(--z-debt)
+    }
+
+    /* SVG icon helpers */
+    .ico svg{width:18px;height:18px;stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round}
+
+    /* MAS SHEET */
+    .sheet{
+      position:absolute;left:0;right:0;bottom:0;top:30%;
+      background:#10120f;border-top:1px solid var(--z-border-strong);
+      border-radius:24px 24px 0 0;padding:14px 16px 90px;
+      box-shadow:0 -20px 60px rgba(0,0,0,.6);
+      overflow:hidden;
+    }
+    .sheet-handle{width:36px;height:4px;border-radius:999px;background:var(--z-border-strong);margin:0 auto 12px}
+    .sheet h3{font-size:14px;font-weight:600;margin:0 0 12px;letter-spacing:-.01em}
+    .group-label{
+      font-size:9px;font-weight:700;letter-spacing:.22em;text-transform:uppercase;
+      color:var(--z-muted);margin:14px 0 6px;
+    }
+    .menu-row{
+      display:flex;align-items:center;gap:10px;padding:9px 8px;border-radius:10px;
+      font-size:12.5px;color:var(--z-text);
+    }
+    .menu-row .mi-ico{
+      width:28px;height:28px;border-radius:8px;background:var(--z-surface-2);
+      display:flex;align-items:center;justify-content:center;color:var(--z-brass)
+    }
+    .menu-row .mi-ico svg{width:14px;height:14px;stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round}
+    .menu-row .mi-name{flex:1}
+    .menu-row .mi-meta{font-size:10px;color:var(--z-muted-2)}
+    .menu-row .mi-badge{
+      background:var(--z-debt);color:white;font-size:9px;font-weight:700;
+      padding:2px 6px;border-radius:999px;
+    }
+
+    /* ONBOARDING */
+    .onboarding-step{
+      flex:1;display:flex;flex-direction:column;justify-content:center;
+      padding:0 6px;gap:14px;
+    }
+    .ob-title{font-size:22px;font-weight:600;letter-spacing:-.02em;line-height:1.18}
+    .ob-sub{font-size:12.5px;color:var(--z-muted);line-height:1.5}
+    .ob-card{
+      background:var(--z-surface);border:1px solid var(--z-border);border-radius:18px;
+      padding:14px;display:flex;gap:12px;align-items:flex-start;
+    }
+    .ob-card.selected{
+      border-color:rgba(147,120,68,.45);
+      background:linear-gradient(145deg,rgba(147,120,68,.12),transparent 80%),var(--z-surface);
+      box-shadow:0 0 0 1px rgba(147,120,68,.2);
+    }
+    .ob-card .glyph{
+      width:38px;height:38px;border-radius:11px;background:var(--z-surface-3);
+      display:flex;align-items:center;justify-content:center;color:var(--z-brass);
+      font-size:18px;flex-shrink:0;
+    }
+    .ob-card.selected .glyph{background:rgba(147,120,68,.18)}
+    .ob-card h4{font-size:14px;margin:0 0 3px;font-weight:600}
+    .ob-card p{font-size:11px;margin:0;color:var(--z-muted);line-height:1.45}
+    .ob-progress{
+      display:flex;gap:4px;margin-bottom:8px;
+    }
+    .ob-progress span{
+      flex:1;height:3px;border-radius:999px;background:var(--z-border-strong);
+    }
+    .ob-progress span.done{background:var(--z-brass)}
+    .ob-progress span.now{background:var(--z-brass);box-shadow:0 0 8px rgba(147,120,68,.6)}
+
+    /* CTA */
+    .cta-primary{
+      background:linear-gradient(150deg,var(--z-brass-hot),var(--z-brass));
+      color:var(--z-ink);font-weight:600;font-size:13px;
+      padding:12px;border-radius:14px;text-align:center;
+      box-shadow:inset 0 1px 0 rgba(255,255,255,.15);
+    }
+    .cta-secondary{
+      border:1px solid var(--z-border-strong);background:rgba(0,0,0,.2);
+      color:var(--z-text);font-size:12.5px;padding:11px;border-radius:14px;
+      text-align:center;font-weight:500;
+    }
+
+    /* Highlight callouts */
+    .annot{
+      margin-top:14px;padding:10px 12px;background:rgba(147,120,68,.06);
+      border:1px solid rgba(147,120,68,.18);border-radius:10px;
+      font-size:11px;color:var(--z-muted);line-height:1.5
+    }
+    .annot b{color:var(--z-brass);font-weight:600}
+
+    /* Empty state */
+    .empty-block{
+      border:1px dashed var(--z-border-strong);border-radius:18px;
+      padding:18px 14px;text-align:center;color:var(--z-muted);font-size:12px;
+      display:flex;flex-direction:column;gap:10px;align-items:center
+    }
+    .empty-block .glyph{
+      width:42px;height:42px;border-radius:12px;background:var(--z-surface-2);
+      display:flex;align-items:center;justify-content:center;color:var(--z-brass)
+    }
+    .empty-block h4{font-size:14px;color:var(--z-text);margin:0;font-weight:600}
+    .empty-block p{margin:0;font-size:11.5px;line-height:1.5;max-width:240px}
+
+    .row-h{
+      display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;
+    }
+    .row-h h2{font-size:13px;font-weight:600;margin:0;letter-spacing:-.01em}
+    .row-h .meta{font-size:10px;color:var(--z-muted-2);letter-spacing:.18em;text-transform:uppercase;font-weight:600}
+
+    .footer-note{
+      max-width:780px;margin:36px auto 0;font-size:11.5px;color:var(--z-muted-2);
+      line-height:1.6;padding:14px 16px;border:1px solid var(--z-border);
+      border-radius:12px;background:rgba(255,255,255,.01)
+    }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Nav redesign · mobile webapp</h1>
+  <p class="subtitle">
+    Comparativa visual del shell actual vs el propuesto: 3 tabs principales + Más + FAB,
+    con tercer slot personalizado según el foco del usuario (Plan o Deudas).
+    Solo cambia mobile webapp en este milestone — el sidebar de desktop queda fuera.
+  </p>
+
+  <div class="legend">
+    <span><span class="swatch" style="background:var(--z-muted-2)"></span> <b>Estado actual</b></span>
+    <span><span class="swatch" style="background:var(--z-brass)"></span> <b>Propuesta</b></span>
+    <span><span class="swatch" style="background:var(--z-debt)"></span> Punto rojo = badge / atención pendiente</span>
+  </div>
+
+  <!-- ROW 1: TAB BAR COMPARISON -->
+  <div class="row">
+    <!-- Phone 1: CURRENT -->
+    <div>
+      <div class="col-label now">Hoy</div>
+      <p class="col-note">4 tabs visibles + 4 tabs ocultos (import, accounts, budgets, settings). Bandeja, Cuentas y Categorías quedan invisibles para usuarios casuales.</p>
+      <div class="phone" data-emphasis="now">
+        <div class="p-status"><span>9:41</span><span class="dots">●●●●</span></div>
+        <div class="p-header">
+          <div>
+            <div class="p-title">Inicio</div>
+            <div class="p-subtitle">Abril · COP</div>
+          </div>
+          <div class="avatar">CG</div>
+        </div>
+        <div class="hero">
+          <div class="hero-eyebrow">Disponible</div>
+          <div class="hero-num">$2.480.500</div>
+          <div class="hero-sub">después de fijos · runway 2.4m</div>
+        </div>
+        <div class="card">
+          <div class="row-h"><h2>Atención</h2><span class="meta">3</span></div>
+          <div class="stack">
+            <div class="skeleton"><span><b>Sin categorizar</b><br><span style="font-size:10px;color:var(--z-muted-2)">12 movimientos</span></span><span class="v">→</span></div>
+            <div class="skeleton"><span><b>Recurrente vence</b><br><span style="font-size:10px;color:var(--z-muted-2)">Netflix · 2 días</span></span><span class="v">→</span></div>
+          </div>
+        </div>
+        <div class="scroll"><div class="card"><div class="row-h"><h2>Cuentas</h2></div><div class="stack"><div class="skeleton"><span>Bancolombia ahorros</span><span class="v">$1.840.500</span></div><div class="skeleton"><span>Nu débito</span><span class="v">$640.000</span></div></div></div></div>
+
+        <div class="tabbar">
+          <div class="tab active"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 12l9-9 9 9M5 10v10h14V10"/></svg></div>Inicio</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>Movim.</div>
+          <div class="fab">+</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 3v18h18M7 14l4-4 4 4 5-6"/></svg></div>Plan</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M2 7h20v10H2zM6 11h12"/></svg></div>Deudas</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Phone 2: NEW PLAN focus -->
+    <div>
+      <div class="col-label new">Propuesta · foco PLAN</div>
+      <p class="col-note">Usuario eligió "Construir mi plan" en onboarding. Tercer tab = Plan. Deudas y todo lo demás vive en Más.</p>
+      <div class="phone" data-emphasis="yes">
+        <div class="p-status"><span>9:41</span><span class="dots">●●●●</span></div>
+        <div class="p-header">
+          <div>
+            <div class="p-title">Inicio</div>
+            <div class="p-subtitle">Abril · COP</div>
+          </div>
+          <div class="avatar">CG</div>
+        </div>
+        <div class="hero">
+          <div class="hero-eyebrow">Disponible</div>
+          <div class="hero-num">$2.480.500</div>
+          <div class="hero-sub">después de fijos · runway 2.4m</div>
+        </div>
+        <div class="card">
+          <div class="row-h"><h2>Atención</h2><span class="meta">3</span></div>
+          <div class="stack">
+            <div class="skeleton"><span><b>Sin categorizar</b><br><span style="font-size:10px;color:var(--z-muted-2)">12 movimientos</span></span><span class="v">→</span></div>
+            <div class="skeleton"><span><b>Recurrente vence</b><br><span style="font-size:10px;color:var(--z-muted-2)">Netflix · 2 días</span></span><span class="v">→</span></div>
+          </div>
+        </div>
+        <div class="scroll"><div class="card"><div class="row-h"><h2>Plan del mes</h2></div><div class="stack"><div class="skeleton"><span>Comida</span><span class="v">62%</span></div><div class="skeleton"><span>Transporte</span><span class="v">88%</span></div></div></div></div>
+
+        <div class="tabbar">
+          <div class="tab active"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 12l9-9 9 9M5 10v10h14V10"/></svg></div>Inicio</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>Movim.</div>
+          <div class="fab">+</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 3v18h18M7 14l4-4 4 4 5-6"/></svg></div>Plan</div>
+          <div class="tab flag"><div class="ico"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="2"/><circle cx="5" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg></div>Más</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Phone 3: NEW DEBT focus -->
+    <div>
+      <div class="col-label new">Propuesta · foco DEUDAS</div>
+      <p class="col-note">Usuario eligió "Salir de deudas" en onboarding. Tercer tab = Deudas. Plan vive en Más. Misma estructura, distinto énfasis.</p>
+      <div class="phone" data-emphasis="yes">
+        <div class="p-status"><span>9:41</span><span class="dots">●●●●</span></div>
+        <div class="p-header">
+          <div>
+            <div class="p-title">Inicio</div>
+            <div class="p-subtitle">Abril · COP</div>
+          </div>
+          <div class="avatar">CG</div>
+        </div>
+        <div class="hero" style="background:linear-gradient(145deg,rgba(224,85,69,.14),rgba(224,85,69,.02) 55%,transparent 80%),var(--z-surface);border-color:rgba(224,85,69,.2)">
+          <div class="hero-eyebrow" style="color:var(--z-debt)">Deuda total</div>
+          <div class="hero-num" style="color:var(--z-debt)">$8.420.000</div>
+          <div class="hero-sub">payoff estimado · 14 meses</div>
+        </div>
+        <div class="card">
+          <div class="row-h"><h2>Próximo pago</h2><span class="meta">5d</span></div>
+          <div class="stack">
+            <div class="skeleton"><span><b>Falabella TC</b><br><span style="font-size:10px;color:var(--z-muted-2)">Mín · 3 mayo</span></span><span class="v">$420.000</span></div>
+          </div>
+        </div>
+        <div class="scroll"><div class="card"><div class="row-h"><h2>Tarjetas activas</h2></div><div class="stack"><div class="skeleton"><span>Bancolombia TC</span><span class="v">$3.1M</span></div><div class="skeleton"><span>Falabella TC</span><span class="v">$2.4M</span></div></div></div></div>
+
+        <div class="tabbar">
+          <div class="tab active"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 12l9-9 9 9M5 10v10h14V10"/></svg></div>Inicio</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>Movim.</div>
+          <div class="fab">+</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M2 7h20v10H2zM6 11h12"/></svg></div>Deudas</div>
+          <div class="tab flag"><div class="ico"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="2"/><circle cx="5" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg></div>Más</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 2: MAS SHEET, ONBOARDING, ACCOUNTS EMPTY -->
+  <div class="row">
+    <!-- Phone 4: MAS FULL PAGE (absorbs Bandeja) -->
+    <div>
+      <div class="col-label new">/mas · página completa (absorbe Bandeja)</div>
+      <p class="col-note">Página dedicada como /gestionar. Acción + sugerencias arriba (lo de Bandeja hoy), grid de capacidades abajo. Una sola superficie para "todo lo demás".</p>
+      <div class="phone" data-emphasis="yes">
+        <div class="p-status"><span>9:41</span><span class="dots">●●●●</span></div>
+        <div class="p-header">
+          <div style="display:flex;align-items:center;gap:10px">
+            <div style="width:24px;height:24px;color:var(--z-muted);font-size:18px">←</div>
+            <div class="p-title">Más</div>
+          </div>
+          <div class="avatar">CG</div>
+        </div>
+
+        <div class="scroll" style="mask-image:linear-gradient(to bottom,#000 90%,transparent)">
+          <div class="eyebrow muted" style="margin-top:4px">Requiere acción</div>
+          <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:14px">
+            <div style="background:rgba(147,120,68,.08);border:1px solid rgba(147,120,68,.22);border-radius:14px;padding:11px 12px;display:flex;justify-content:space-between;align-items:center">
+              <div>
+                <div style="background:var(--z-surface-3);color:var(--z-brass);font-size:10px;font-weight:600;padding:2px 8px;border-radius:999px;display:inline-block;margin-bottom:4px">581</div>
+                <div style="font-size:12px">581 sin categoría</div>
+              </div>
+              <span style="color:var(--z-brass);font-size:11px;font-weight:600">Resolver →</span>
+            </div>
+            <div style="background:rgba(147,120,68,.08);border:1px solid rgba(147,120,68,.22);border-radius:14px;padding:11px 12px;display:flex;justify-content:space-between;align-items:center">
+              <div>
+                <div style="background:var(--z-surface-3);color:var(--z-brass);font-size:10px;font-weight:600;padding:2px 8px;border-radius:999px;display:inline-block;margin-bottom:4px">3</div>
+                <div style="font-size:12px">recurrentes vencen pronto</div>
+              </div>
+              <span style="color:var(--z-brass);font-size:11px;font-weight:600">Ver →</span>
+            </div>
+          </div>
+
+          <div class="eyebrow muted">Sugerencias</div>
+          <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:14px;padding:11px 12px;display:flex;justify-content:space-between;align-items:center;margin-bottom:14px">
+            <div>
+              <div style="background:var(--z-surface-3);color:var(--z-muted);font-size:10px;font-weight:600;padding:2px 8px;border-radius:999px;display:inline-block;margin-bottom:4px">235</div>
+              <div style="font-size:12px">destinatarios sugeridos</div>
+            </div>
+            <span style="color:var(--z-muted);font-size:11px;font-weight:600">Ver →</span>
+          </div>
+
+          <div class="eyebrow muted">Cuentas y saldos</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px">
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M3 7h18v10H3zM3 11h18"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Cuentas</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M12 4v12M5 11l7 5 7-5"/><path d="M5 19h14"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Importar</div>
+            </div>
+          </div>
+
+          <div class="eyebrow muted">Organizar</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px">
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M3 6h18M3 12h18M3 18h12"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Categorizar</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M3 5h18v4H3zM3 13h18v6H3z"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Categorías</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 4-6 8-6s8 2 8 6"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Destinatarios</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M20 12L12 4H4v8l8 8z"/><circle cx="8" cy="8" r="1"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Etiquetas</div>
+            </div>
+          </div>
+
+          <div class="eyebrow muted">Planificar</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px">
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center;opacity:.85">
+              <div style="color:var(--z-muted);margin-bottom:4px;font-size:10px;letter-spacing:.18em;text-transform:uppercase;font-weight:700">Foco PLAN</div>
+              <div style="font-size:11px;font-weight:600">Deudas</div>
+              <div style="font-size:9px;color:var(--z-muted-2);margin-top:2px">tab no activo aquí</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Recurrentes</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px dashed rgba(147,120,68,.4);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M17 8a5 5 0 1 0-10 0"/><circle cx="12" cy="14" r="6"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Préstamos</div>
+              <div style="font-size:8px;color:var(--z-brass);letter-spacing:.18em;margin-top:2px;font-weight:600">FASE 3</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><path d="M12 2l3 6 7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1z"/></svg></div>
+              <div style="font-size:11px;font-weight:600">Deseos</div>
+            </div>
+            <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center;grid-column:span 2">
+              <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg></div>
+              <div style="font-size:11px;font-weight:600">¿Puedo pagarlo?</div>
+            </div>
+          </div>
+
+          <div class="eyebrow muted">Sistema</div>
+          <div style="background:var(--z-surface);border:1px solid var(--z-border);border-radius:12px;padding:14px 10px;text-align:center;margin-bottom:80px">
+            <div style="color:var(--z-brass);margin-bottom:4px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" style="margin:0 auto;display:block"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 0 0-.3-2l2-1.5-2-3.5-2.4.9a7 7 0 0 0-3.4-2L12.5 1h-1l-.4 2.4a7 7 0 0 0-3.4 2l-2.4-.9-2 3.5 2 1.5a7 7 0 0 0 0 4l-2 1.5 2 3.5 2.4-.9a7 7 0 0 0 3.4 2L11.5 23h1l.4-2.4a7 7 0 0 0 3.4-2l2.4.9 2-3.5-2-1.5a7 7 0 0 0 .3-2z"/></svg></div>
+            <div style="font-size:11px;font-weight:600">Ajustes</div>
+          </div>
+        </div>
+
+        <div class="tabbar">
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 12l9-9 9 9M5 10v10h14V10"/></svg></div>Inicio</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>Movim.</div>
+          <div class="fab">+</div>
+          <div class="tab"><div class="ico"><svg viewBox="0 0 24 24"><path d="M3 3v18h18M7 14l4-4 4 4 5-6"/></svg></div>Plan</div>
+          <div class="tab active"><div class="ico"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="2"/><circle cx="5" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg></div>Más</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Phone 5: ONBOARDING FOCUS STEP -->
+    <div>
+      <div class="col-label new">Onboarding · paso "foco"</div>
+      <p class="col-note">Nuevo paso entre nombre y cuenta. Define <code>profile.nav_focus</code> y configura el tercer tab. Configurable después en Ajustes.</p>
+      <div class="phone" data-emphasis="yes">
+        <div class="p-status"><span>9:41</span><span class="dots">●●●●</span></div>
+        <div class="ob-progress" style="margin-top:6px">
+          <span class="done"></span><span class="done"></span><span class="now"></span><span></span><span></span>
+        </div>
+        <div class="onboarding-step">
+          <div>
+            <div class="eyebrow">Paso 3 de 5</div>
+            <div class="ob-title">¿Qué te importa<br>más ahora?</div>
+            <div class="ob-sub" style="margin-top:6px">Adaptamos las pestañas a tu prioridad. Puedes cambiarlo cuando quieras desde Ajustes.</div>
+          </div>
+
+          <div class="ob-card selected">
+            <div class="glyph">📈</div>
+            <div>
+              <h4>Construir mi plan</h4>
+              <p>Presupuestos, metas y flujo del mes. Tercer tab = Plan.</p>
+            </div>
+          </div>
+
+          <div class="ob-card">
+            <div class="glyph">⚖︎</div>
+            <div>
+              <h4>Salir de deudas</h4>
+              <p>Tarjetas, pagos mínimos y simulación de pago. Tercer tab = Deudas.</p>
+            </div>
+          </div>
+
+          <div style="margin-top:auto;display:flex;flex-direction:column;gap:8px;padding-bottom:90px">
+            <div class="cta-primary">Continuar</div>
+            <div style="font-size:10px;color:var(--z-muted-2);text-align:center">Esto solo cambia qué pestaña ves primero — todo sigue accesible.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Phone 6: ACCOUNTS EMPTY w/ promoted manual -->
+    <div>
+      <div class="col-label new">Cuentas vacías · CTA manual primaria</div>
+      <p class="col-note">Caso Rappi: el usuario quiere agregar una tarjeta sin parser. La opción manual ahora es la principal; importar es secundaria.</p>
+      <div class="phone" data-emphasis="yes">
+        <div class="p-status"><span>9:41</span><span class="dots">●●●●</span></div>
+        <div class="p-header">
+          <div>
+            <div class="eyebrow">Cuentas</div>
+            <div class="p-title">Tus cuentas</div>
+          </div>
+          <div class="avatar">CG</div>
+        </div>
+
+        <div class="empty-block" style="margin-top:6px">
+          <div class="glyph"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M3 7h18v10H3zM3 11h18"/></svg></div>
+          <h4>Aún no tienes cuentas</h4>
+          <p>Agrega manualmente cualquier cuenta —tarjeta, app, efectivo— o importa un extracto de los bancos soportados.</p>
+        </div>
+
+        <div style="margin-top:14px;display:flex;flex-direction:column;gap:8px">
+          <div class="cta-primary">＋ Crear cuenta manual</div>
+          <div class="cta-secondary">Importar PDF / extracto</div>
+        </div>
+
+        <div class="annot">
+          <b>Solución Rappi:</b> el flujo de importar mantiene un CTA permanente "¿Tu banco no aparece? Crea la cuenta manualmente" que aterriza aquí. Ahora hay 3 superficies que llevan a creación manual: FAB, /accounts vacío, /import fallback.
+        </div>
+
+        <div class="tabbar">
+          <div class="tab"><div class="ico">⌂</div>Inicio</div>
+          <div class="tab"><div class="ico">≡</div>Movim.</div>
+          <div class="fab">+</div>
+          <div class="tab"><div class="ico">▲</div>Plan</div>
+          <div class="tab active"><div class="ico">⋯</div>Más</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer-note">
+    <b style="color:var(--z-text)">Notas de implementación.</b> Phase 1 toca solo mobile webapp:
+    nuevo <code>profile.nav_focus</code>, restructura de <code>mobile-nav.ts</code>, nuevo <code>more-menu-sheet.tsx</code> (vaul),
+    nuevo <code>StepFocus</code> en onboarding, CTA promocional en <code>/accounts</code> y <code>/import</code>.
+    El sidebar de desktop y la app nativa Expo quedan fuera de este milestone — se actualizarán después de validar este shell.
+    Phase 2 = onboarding polish (demo data, currency auto). Phase 3 = página de Préstamos con tabla propia.
+  </div>
+</div>
+</body>
+</html>

--- a/services/pdf_parser/main.py
+++ b/services/pdf_parser/main.py
@@ -92,11 +92,26 @@ class ParseResponse(BaseModel):
     statements: list[ParsedStatement]
 
 
+def _statements_have_content(statements: list[ParsedStatement]) -> bool:
+    """A parse is useful only if at least one statement carries transactions or
+    structured metadata. An empty list — or statements with no transactions and
+    no summary/credit_card/loan metadata — means the detector matched but the
+    extractor produced nothing, which the frontend should treat the same as
+    "format not supported"."""
+    return any(
+        s.transactions
+        or s.summary is not None
+        or s.credit_card_metadata is not None
+        or s.loan_metadata is not None
+        for s in statements
+    )
+
+
 def _attempt_fallback_parse(
     tmp_path: str, password: str | None, filename: str, reason: str
 ) -> ParseResponse | None:
     fallback_statements = try_parse_with_opendataloader(tmp_path, password=password)
-    if not fallback_statements:
+    if not fallback_statements or not _statements_have_content(fallback_statements):
         return None
 
     logger.info(
@@ -160,6 +175,19 @@ async def parse_pdf(file: UploadFile, password: str | None = Form(None)):
 
     try:
         statements = detect_and_parse(tmp_path, password=password)
+        if not _statements_have_content(statements):
+            # Detector matched but extractor produced no usable data — treat as
+            # unsupported so the user gets the "send for support" CTA instead of
+            # a silent empty result.
+            logger.warning(
+                "Detector matched but produced no usable content: filename=%s statements=%s",
+                file.filename,
+                len(statements),
+            )
+            raise ValueError(
+                "El extracto fue reconocido pero no se pudieron extraer transacciones ni metadatos. "
+                "Probablemente el formato cambió o no es uno de los soportados."
+            )
         logger.info(
             "Parsing succeeded: filename=%s statements=%s",
             file.filename,

--- a/supabase/migrations/20260428120000_add_nav_focus_to_profiles.sql
+++ b/supabase/migrations/20260428120000_add_nav_focus_to_profiles.sql
@@ -1,0 +1,146 @@
+-- ============================================================================
+-- Add nav_focus to profiles
+--
+-- Plain enum column on profiles_enc, passed through unencrypted in the view +
+-- INSTEAD OF triggers. Drives mobile/web nav surfacing (PLAN vs DEBT focus).
+--
+-- Backfill: existing rows with app_purpose = 'manage_debt' get nav_focus = 'DEBT';
+-- everyone else stays at the default 'PLAN'.
+--
+-- Pattern (mirrors 20260419205737_add_mobile_dashboard_config_to_profiles.sql):
+--   1. CREATE TYPE for the enum.
+--   2. ALTER profiles_enc (real table) to add the column with NOT NULL default.
+--   3. Backfill existing rows from app_purpose.
+--   4. Drop INSTEAD OF triggers + view.
+--   5. Recreate view with the new column as a plain passthrough (no decrypt).
+--   6. Recreate INSERT + UPDATE trigger fns to include the column as a plain
+--      passthrough (no encrypt). Preserves the has_auth guard from 20260417193237
+--      and the SELECT INTO refactor from 20260417203708.
+--   7. Recreate triggers.
+-- ============================================================================
+
+CREATE TYPE public.nav_focus AS ENUM ('PLAN', 'DEBT');
+
+ALTER TABLE public.profiles_enc
+  ADD COLUMN nav_focus public.nav_focus NOT NULL DEFAULT 'PLAN';
+
+COMMENT ON COLUMN public.profiles_enc.nav_focus IS
+  'Primary navigation focus for the user (PLAN vs DEBT). Drives surfacing of plan/debt-centric tabs.';
+
+-- Backfill: users whose app_purpose is debt-focused get DEBT; rest stay PLAN.
+UPDATE public.profiles_enc
+  SET nav_focus = 'DEBT'
+  WHERE app_purpose = 'manage_debt';
+
+-- Drop triggers + view so we can recreate with the new column
+DROP TRIGGER IF EXISTS profiles_view_insert_trg ON public.profiles;
+DROP TRIGGER IF EXISTS profiles_view_update_trg ON public.profiles;
+DROP TRIGGER IF EXISTS profiles_view_delete_trg ON public.profiles;
+DROP VIEW IF EXISTS public.profiles;
+
+-- Recreate view including nav_focus (plain passthrough)
+CREATE VIEW public.profiles WITH (security_invoker = true) AS
+SELECT
+  app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+  mobile_dashboard_config,
+  demo_mode,
+  zeta_decrypt(email) AS email,
+  estimated_monthly_expenses, estimated_monthly_income,
+  zeta_decrypt(full_name) AS full_name,
+  id, locale, monthly_salary, nav_focus, onboarding_completed, preferred_currency,
+  timezone, updated_at
+FROM public.profiles_enc;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.profiles TO authenticated;
+GRANT ALL ON public.profiles TO postgres, service_role;
+
+-- Rebuild INSERT trigger fn — preserves has_auth guard from 20260417193237
+CREATE OR REPLACE FUNCTION public.profiles_view_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  has_auth BOOLEAN;
+BEGIN
+  has_auth := (SELECT auth.uid()) IS NOT NULL;
+
+  NEW.created_at := COALESCE(NEW.created_at, now()::text);
+  NEW.updated_at := COALESCE(NEW.updated_at, now()::text);
+  NEW.locale := COALESCE(NEW.locale, 'es-CO');
+  NEW.onboarding_completed := COALESCE(NEW.onboarding_completed, false);
+  NEW.preferred_currency := COALESCE(NEW.preferred_currency, 'COP');
+  NEW.timezone := COALESCE(NEW.timezone, 'America/Bogota');
+  NEW.demo_mode := COALESCE(NEW.demo_mode, false);
+  NEW.nav_focus := COALESCE(NEW.nav_focus, 'PLAN');
+
+  INSERT INTO public.profiles_enc (
+    app_purpose, avatar_url, budget_mode, created_at, dashboard_config,
+    mobile_dashboard_config,
+    demo_mode, email, estimated_monthly_expenses, estimated_monthly_income,
+    full_name, id, locale, monthly_salary, nav_focus, onboarding_completed,
+    preferred_currency, timezone, updated_at
+  ) VALUES (
+    NEW.app_purpose, NEW.avatar_url, NEW.budget_mode, NEW.created_at,
+    NEW.dashboard_config, NEW.mobile_dashboard_config, NEW.demo_mode,
+    CASE WHEN has_auth THEN zeta_encrypt(NEW.email) ELSE zeta_encrypt_as(NEW.email, NEW.id) END,
+    NEW.estimated_monthly_expenses, NEW.estimated_monthly_income,
+    CASE WHEN has_auth THEN zeta_encrypt(NEW.full_name) ELSE zeta_encrypt_as(NEW.full_name, NEW.id) END,
+    NEW.id, NEW.locale, NEW.monthly_salary, NEW.nav_focus, NEW.onboarding_completed,
+    NEW.preferred_currency, NEW.timezone, NEW.updated_at
+  );
+  RETURN NEW;
+END;
+$function$;
+
+-- Rebuild UPDATE trigger fn — preserves has_auth + SELECT INTO refactor
+-- from 20260417203708_has_auth_guard_select_into_refactor.sql
+CREATE OR REPLACE FUNCTION public.profiles_view_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  has_auth BOOLEAN;
+  _old profiles_enc;
+BEGIN
+  has_auth := (SELECT auth.uid()) IS NOT NULL;
+
+  IF NOT has_auth THEN
+    SELECT * INTO _old FROM public.profiles_enc WHERE id = OLD.id;
+  END IF;
+
+  UPDATE public.profiles_enc SET
+    app_purpose = NEW.app_purpose,
+    avatar_url = NEW.avatar_url,
+    budget_mode = NEW.budget_mode,
+    created_at = NEW.created_at,
+    dashboard_config = NEW.dashboard_config,
+    mobile_dashboard_config = NEW.mobile_dashboard_config,
+    demo_mode = NEW.demo_mode,
+    email = CASE WHEN has_auth THEN zeta_encrypt(NEW.email) ELSE _old.email END,
+    estimated_monthly_expenses = NEW.estimated_monthly_expenses,
+    estimated_monthly_income = NEW.estimated_monthly_income,
+    full_name = CASE WHEN has_auth THEN zeta_encrypt(NEW.full_name) ELSE _old.full_name END,
+    locale = NEW.locale,
+    monthly_salary = NEW.monthly_salary,
+    nav_focus = NEW.nav_focus,
+    onboarding_completed = NEW.onboarding_completed,
+    preferred_currency = NEW.preferred_currency,
+    timezone = NEW.timezone,
+    updated_at = NEW.updated_at
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$function$;
+
+-- DELETE fn unchanged — recreate triggers only
+CREATE TRIGGER profiles_view_insert_trg
+  INSTEAD OF INSERT ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.profiles_view_insert();
+
+CREATE TRIGGER profiles_view_update_trg
+  INSTEAD OF UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.profiles_view_update();
+
+CREATE TRIGGER profiles_view_delete_trg
+  INSTEAD OF DELETE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.profiles_view_delete();

--- a/webapp/src/actions/onboarding.ts
+++ b/webapp/src/actions/onboarding.ts
@@ -56,6 +56,11 @@ export async function finishOnboarding(
         throw new Error("Failed to create account. Please try again.");
     }
 
+    // Derive primary nav focus from purpose: debt-focused users get the Deudas
+    // tab promoted; everyone else gets Plan.
+    const navFocus: Database["public"]["Enums"]["nav_focus"] =
+        profileData.app_purpose === "manage_debt" ? "DEBT" : "PLAN";
+
     // 2. Update Profile to include onboarding preferences and mark completed
     const { error: profileError } = await supabase
         .from("profiles")
@@ -67,6 +72,7 @@ export async function finishOnboarding(
             preferred_currency: defaultCurrency,
             timezone: profileData.timezone,
             locale: profileData.locale,
+            nav_focus: navFocus,
             onboarding_completed: true,
             ...(dashboardConfig ? { dashboard_config: dashboardConfig as unknown as Json } : {}),
             ...(mobileDashboardConfig ? { mobile_dashboard_config: mobileDashboardConfig as unknown as Json } : {}),

--- a/webapp/src/actions/profile.ts
+++ b/webapp/src/actions/profile.ts
@@ -56,6 +56,7 @@ const profileSchema = z.object({
   preferred_currency: z.enum(["COP", "BRL", "MXN", "USD", "EUR", "PEN", "CLP", "ARS"]),
   locale: z.string().default("es-CO"),
   timezone: z.string().default("America/Bogota"),
+  nav_focus: z.enum(["PLAN", "DEBT"]).default("PLAN"),
   monthly_salary: z.preprocess(
     (v) => (v === "" || v === undefined || v === null ? null : Number(v)),
     z.number().int().positive("El salario debe ser positivo").nullable()
@@ -87,6 +88,7 @@ export async function updateProfile(
     preferred_currency: formData.get("preferred_currency"),
     locale: formData.get("locale") || "es-CO",
     timezone: formData.get("timezone") || "America/Bogota",
+    nav_focus: formData.get("nav_focus") || "PLAN",
     monthly_salary: formData.get("monthly_salary"),
   });
 

--- a/webapp/src/app/(dashboard)/accounts/page.tsx
+++ b/webapp/src/app/(dashboard)/accounts/page.tsx
@@ -126,10 +126,14 @@ export default async function AccountsPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-              Crea la primera cuenta o importa un extracto para empezar.
+              Crea cualquier cuenta a mano —tarjeta, app, efectivo— en segundos.
+              Si tu banco aparece en la lista de soportados, también puedes importar un extracto.
             </p>
             <div className="flex flex-wrap gap-3">
-              <AccountFormDialog />
+              <AccountFormDialog
+                triggerLabel="Crear cuenta manual"
+                triggerClassName={BRASS_BUTTON_CLASS}
+              />
               <Button
                 asChild
                 variant="outline"

--- a/webapp/src/app/(dashboard)/gestionar/page.tsx
+++ b/webapp/src/app/(dashboard)/gestionar/page.tsx
@@ -7,43 +7,35 @@ import { MobileLinkGrid } from "@/components/mobile/mobile-link-grid";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { PAGE_STACK_CLASS } from "@/lib/constants/styles";
 
-export default async function BandejaPage() {
+export default async function MasPage() {
   await connection();
   const snapshot = await getAttentionSnapshot();
 
+  const subtitle =
+    snapshot.totalAction > 0
+      ? `${snapshot.totalAction} pendientes`
+      : snapshot.totalSuggestion > 0
+        ? `${snapshot.totalSuggestion} sugerencias`
+        : "Todo al día";
+
   return (
     <div className={PAGE_STACK_CLASS}>
-      <MobileHeader variant="sub" title="Bandeja" />
+      <MobileHeader variant="sub" title="Más" />
 
       {/* Desktop */}
       <div className="hidden lg:block space-y-8">
         <div className="space-y-1">
           <SectionEyebrow>Gestionar</SectionEyebrow>
-          <PageHeaderRow
-            title="Bandeja"
-            subtitle={
-              snapshot.totalAction > 0
-                ? `${snapshot.totalAction} pendientes`
-                : snapshot.totalSuggestion > 0
-                  ? `${snapshot.totalSuggestion} sugerencias`
-                  : "Todo al día"
-            }
-          />
+          <PageHeaderRow title="Más" subtitle={subtitle} />
         </div>
         <AttentionHub signals={snapshot.signals} />
-        <div className="space-y-3">
-          <SectionEyebrow>Ir a</SectionEyebrow>
-          <MobileLinkGrid />
-        </div>
+        <MobileLinkGrid />
       </div>
 
       {/* Mobile */}
       <div className="lg:hidden space-y-6">
         <AttentionHub signals={snapshot.signals} />
-        <div className="space-y-3">
-          <SectionEyebrow>Ir a</SectionEyebrow>
-          <MobileLinkGrid />
-        </div>
+        <MobileLinkGrid />
       </div>
     </div>
   );

--- a/webapp/src/app/(dashboard)/layout.tsx
+++ b/webapp/src/app/(dashboard)/layout.tsx
@@ -12,6 +12,7 @@ import { getCategories } from "@/actions/categories";
 import { getDestinatarios } from "@/actions/destinatarios";
 import { getTagGroups } from "@/actions/tags";
 import { AppDataProvider } from "@/components/providers/app-data-provider";
+import { NavFocusProvider } from "@/components/providers/nav-focus-provider";
 import { MobileTabBar } from "@/components/mobile/v2/mobile-tab-bar";
 import { MobileShellProvider } from "@/components/mobile/v2/mobile-shell-provider";
 import { MobileSheetProvider } from "@/components/mobile/mobile-sheet-provider";
@@ -106,6 +107,7 @@ export default async function DashboardLayout({
             }}
           >
             <AppDataProvider data={appData}>
+              <NavFocusProvider value={profile.nav_focus}>
               <MobileSheetProvider>
                 <main className={cn("flex-1 overflow-x-hidden p-4 lg:p-6 lg:pb-6", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
                   {profile.demo_mode ? (
@@ -120,6 +122,7 @@ export default async function DashboardLayout({
 
                 <MobileTabBar />
               </MobileSheetProvider>
+              </NavFocusProvider>
             </AppDataProvider>
           </MobileShellProvider>
         </KeyboardInsetProvider>

--- a/webapp/src/components/accounts/account-form-dialog.tsx
+++ b/webapp/src/components/accounts/account-form-dialog.tsx
@@ -11,17 +11,27 @@ import {
 import { Button } from "@/components/ui/button";
 import { SpecializedAccountForm } from "./specialized-account-form";
 import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { Account } from "@/types/domain";
 
-export function AccountFormDialog({ account }: { account?: Account }) {
+export function AccountFormDialog({
+  account,
+  triggerLabel,
+  triggerClassName,
+}: {
+  account?: Account;
+  triggerLabel?: string;
+  triggerClassName?: string;
+}) {
   const [open, setOpen] = useState(false);
+  const label = triggerLabel ?? (account ? "Editar" : "Nueva cuenta");
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
+        <Button className={cn(triggerClassName)}>
           <Plus className="h-4 w-4 mr-2" />
-          {account ? "Editar" : "Nueva cuenta"}
+          {label}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-xl max-h-[85vh] overflow-y-auto">

--- a/webapp/src/components/mobile/mobile-link-grid.tsx
+++ b/webapp/src/components/mobile/mobile-link-grid.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import {
   Brain,
@@ -5,37 +7,90 @@ import {
   Contact,
   FileUp,
   Folder,
+  Heart,
   Landmark,
+  PiggyBank,
   Settings,
   Tags,
   Wallet,
   type LucideIcon,
 } from "lucide-react";
+import { useNavFocus } from "@/components/providers/nav-focus-provider";
+import { SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
 
-const LINKS: { href: string; icon: LucideIcon; label: string }[] = [
-  { href: "/accounts", icon: Wallet, label: "Cuentas" },
-  { href: "/plan?tab=presupuesto", icon: Folder, label: "Categorías" },
-  { href: "/plan?tab=recurrentes", icon: CalendarClock, label: "Recurrentes" },
-  { href: "/destinatarios", icon: Contact, label: "Destinatarios" },
-  { href: "/categorizar", icon: Tags, label: "Categorizar" },
-  { href: "/import", icon: FileUp, label: "Importar" },
-  { href: "/deudas", icon: Landmark, label: "Deudas" },
-  { href: "/puedo-pagar", icon: Brain, label: "¿Comprarlo?" },
-  { href: "/settings", icon: Settings, label: "Ajustes" },
-];
+type Tile = { href: string; icon: LucideIcon; label: string };
+type Group = { title: string; tiles: Tile[] };
+
+const CUENTAS_GROUP: Group = {
+  title: "Cuentas y saldos",
+  tiles: [
+    { href: "/accounts", icon: Wallet, label: "Cuentas" },
+    { href: "/import", icon: FileUp, label: "Importar" },
+  ],
+};
+
+const ORGANIZAR_GROUP: Group = {
+  title: "Organizar",
+  tiles: [
+    { href: "/categorizar", icon: Tags, label: "Categorizar" },
+    { href: "/plan?tab=presupuesto", icon: Folder, label: "Categorías" },
+    { href: "/destinatarios", icon: Contact, label: "Destinatarios" },
+    { href: "/etiquetas", icon: Tags, label: "Etiquetas" },
+  ],
+};
+
+const PLAN_TILE: Tile = { href: "/plan", icon: PiggyBank, label: "Plan" };
+const DEUDAS_TILE: Tile = { href: "/deudas", icon: Landmark, label: "Deudas" };
+const RECURRENTES_TILE: Tile = {
+  href: "/plan?tab=recurrentes",
+  icon: CalendarClock,
+  label: "Recurrentes",
+};
+const DESEOS_TILE: Tile = { href: "/deseos", icon: Heart, label: "Deseos" };
+const PUEDO_PAGAR_TILE: Tile = { href: "/puedo-pagar", icon: Brain, label: "¿Comprarlo?" };
+
+const SISTEMA_GROUP: Group = {
+  title: "Sistema",
+  tiles: [{ href: "/settings", icon: Settings, label: "Ajustes" }],
+};
 
 export function MobileLinkGrid() {
+  const focus = useNavFocus();
+
+  // The active third tab lives in the bottom nav — surface the OTHER one in the grid.
+  const planificarTiles: Tile[] = [
+    focus === "DEBT" ? PLAN_TILE : DEUDAS_TILE,
+    RECURRENTES_TILE,
+    DESEOS_TILE,
+    PUEDO_PAGAR_TILE,
+  ];
+  const planificarGroup: Group = { title: "Planificar", tiles: planificarTiles };
+
+  const groups: Group[] = [
+    CUENTAS_GROUP,
+    ORGANIZAR_GROUP,
+    planificarGroup,
+    SISTEMA_GROUP,
+  ];
+
   return (
-    <div className="grid grid-cols-3 gap-3 lg:grid-cols-4">
-      {LINKS.map(({ href, icon: Icon, label }) => (
-        <Link
-          key={href}
-          href={href}
-          className="flex flex-col items-center gap-2 rounded-2xl border border-white/6 bg-z-surface-2/80 px-3 py-4 transition-colors hover:bg-white/5"
-        >
-          <Icon className="size-5 text-muted-foreground" />
-          <span className="text-xs font-medium">{label}</span>
-        </Link>
+    <div className="space-y-5">
+      {groups.map((group) => (
+        <section key={group.title} className="space-y-2">
+          <h3 className={SECTION_EYEBROW_CLASS}>{group.title}</h3>
+          <div className="grid grid-cols-3 gap-3 lg:grid-cols-4">
+            {group.tiles.map(({ href, icon: Icon, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex flex-col items-center gap-2 rounded-2xl border border-white/6 bg-z-surface-2/80 px-3 py-4 transition-colors hover:bg-white/5"
+              >
+                <Icon className="size-5 text-muted-foreground" />
+                <span className="text-xs font-medium">{label}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
       ))}
     </div>
   );

--- a/webapp/src/components/mobile/mobile-link-grid.tsx
+++ b/webapp/src/components/mobile/mobile-link-grid.tsx
@@ -9,9 +9,10 @@ import {
   Folder,
   Heart,
   Landmark,
+  List,
   PiggyBank,
   Settings,
-  Tags,
+  Tag,
   Wallet,
   type LucideIcon,
 } from "lucide-react";
@@ -32,10 +33,10 @@ const CUENTAS_GROUP: Group = {
 const ORGANIZAR_GROUP: Group = {
   title: "Organizar",
   tiles: [
-    { href: "/categorizar", icon: Tags, label: "Categorizar" },
+    { href: "/categorizar", icon: List, label: "Categorizar" },
     { href: "/plan?tab=presupuesto", icon: Folder, label: "Categorías" },
     { href: "/destinatarios", icon: Contact, label: "Destinatarios" },
-    { href: "/etiquetas", icon: Tags, label: "Etiquetas" },
+    { href: "/etiquetas", icon: Tag, label: "Etiquetas" },
   ],
 };
 

--- a/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
+++ b/webapp/src/components/mobile/v2/mobile-tab-bar.tsx
@@ -5,15 +5,16 @@ import Link from "next/link";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useKeyboardInset } from "@/hooks/use-keyboard-inset";
-import { MOBILE_TABS, isMobileTabActive } from "@/lib/constants/mobile-nav";
+import { getMobileTabs, isMobileTabActive } from "@/lib/constants/mobile-nav";
 import { MOBILE_BG_CLASS } from "@/lib/constants/styles";
 import { useMobileActionMenu } from "@/components/mobile/mobile-sheet-provider";
+import { useNavFocus } from "@/components/providers/nav-focus-provider";
 
-const LEFT_TABS = MOBILE_TABS.slice(0, 2);
-const RIGHT_TABS = MOBILE_TABS.slice(2);
 const SAFE_AREA_BOTTOM_STYLE = { paddingBottom: "env(safe-area-inset-bottom)" } as const;
 
-function TabLinks({ tabs, pathname }: { tabs: typeof MOBILE_TABS; pathname: string }) {
+type Tab = ReturnType<typeof getMobileTabs>[number];
+
+function TabLinks({ tabs, pathname }: { tabs: Tab[]; pathname: string }) {
   return (
     <div className="flex flex-1 items-center justify-around">
       {tabs.map((tab) => {
@@ -40,9 +41,13 @@ export function MobileTabBar() {
   const pathname = usePathname();
   const { openActionMenu, isFabOpen } = useMobileActionMenu();
   const keyboardInset = useKeyboardInset();
+  const focus = useNavFocus();
 
-  // Hide tab bar when virtual keyboard is open to avoid overlapping input
   if (keyboardInset > 0) return null;
+
+  const tabs = getMobileTabs(focus);
+  const leftTabs = tabs.slice(0, 2);
+  const rightTabs = tabs.slice(2);
 
   return (
     <nav
@@ -56,7 +61,7 @@ export function MobileTabBar() {
           MOBILE_BG_CLASS
         )}
       >
-        <TabLinks tabs={LEFT_TABS} pathname={pathname} />
+        <TabLinks tabs={leftTabs} pathname={pathname} />
 
         <div className="relative flex shrink-0 items-center justify-center px-4 py-2">
           <button
@@ -69,7 +74,7 @@ export function MobileTabBar() {
           </button>
         </div>
 
-        <TabLinks tabs={RIGHT_TABS} pathname={pathname} />
+        <TabLinks tabs={rightTabs} pathname={pathname} />
       </div>
     </nav>
   );

--- a/webapp/src/components/providers/nav-focus-provider.tsx
+++ b/webapp/src/components/providers/nav-focus-provider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { Database } from "@/types/database";
+
+export type NavFocus = Database["public"]["Enums"]["nav_focus"];
+
+const NavFocusContext = createContext<NavFocus>("PLAN");
+
+export function NavFocusProvider({
+  value,
+  children,
+}: {
+  value: NavFocus | null | undefined;
+  children: React.ReactNode;
+}) {
+  return (
+    <NavFocusContext.Provider value={value ?? "PLAN"}>
+      {children}
+    </NavFocusContext.Provider>
+  );
+}
+
+export function useNavFocus(): NavFocus {
+  return useContext(NavFocusContext);
+}

--- a/webapp/src/components/settings/profile-form.tsx
+++ b/webapp/src/components/settings/profile-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
+import { PiggyBank, Landmark } from "lucide-react";
 import { updateProfile } from "@/actions/profile";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,11 +15,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { CURRENCIES } from "@/lib/constants/currencies";
+import { cn } from "@/lib/utils";
 import type { ActionResult } from "@/types/actions";
 import type { Profile } from "@/types/domain";
+import type { Database } from "@/types/database";
 import { toast } from "sonner";
 
+type NavFocus = Database["public"]["Enums"]["nav_focus"];
+
 export function ProfileForm({ profile }: { profile: Profile }) {
+  const [navFocus, setNavFocus] = useState<NavFocus>(profile.nav_focus ?? "PLAN");
   const [state, formAction, pending] = useActionState<
     ActionResult<Profile>,
     FormData
@@ -81,8 +87,44 @@ export function ProfileForm({ profile }: { profile: Profile }) {
         </p>
       </div>
 
+      <div className="space-y-2">
+        <Label>Foco principal</Label>
+        <p className="text-xs text-muted-foreground">
+          Define qué pestaña ves como tercera opción en la barra inferior. Cámbialo cuando quieras.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {([
+            { value: "PLAN" as const, label: "Plan", description: "Presupuestos y metas", Icon: PiggyBank },
+            { value: "DEBT" as const, label: "Deudas", description: "Tarjetas y pagos", Icon: Landmark },
+          ]).map(({ value, label, description, Icon }) => {
+            const active = navFocus === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setNavFocus(value)}
+                aria-pressed={active}
+                className={cn(
+                  "flex flex-col items-start gap-1 rounded-xl border px-3 py-3 text-left transition-colors",
+                  active
+                    ? "border-z-brass/40 bg-z-brass/10 text-foreground"
+                    : "border-white/6 bg-z-surface-2/60 text-muted-foreground hover:bg-white/5"
+                )}
+              >
+                <span className="flex items-center gap-2 text-sm font-semibold">
+                  <Icon className={cn("size-4", active ? "text-z-brass" : "text-muted-foreground")} />
+                  {label}
+                </span>
+                <span className="text-xs">{description}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
       <input type="hidden" name="locale" value={profile.locale} />
       <input type="hidden" name="timezone" value={profile.timezone} />
+      <input type="hidden" name="nav_focus" value={navFocus} />
 
       <Button type="submit" disabled={pending}>
         {pending ? "Guardando..." : "Guardar cambios"}

--- a/webapp/src/lib/constants/mobile-nav.ts
+++ b/webapp/src/lib/constants/mobile-nav.ts
@@ -3,8 +3,12 @@ import {
   ArrowLeftRight,
   PiggyBank,
   Landmark,
+  LayoutGrid,
   type LucideIcon,
 } from "lucide-react";
+import type { Database } from "@/types/database";
+
+type NavFocus = Database["public"]["Enums"]["nav_focus"];
 
 export type MobileTab = {
   title: string;
@@ -13,21 +17,41 @@ export type MobileTab = {
   matchHrefs?: string[];
 };
 
-export const MOBILE_TABS: MobileTab[] = [
-  { title: "Inicio", href: "/dashboard", icon: LayoutDashboard },
-  { title: "Movim.", href: "/transactions", icon: ArrowLeftRight },
-  {
-    title: "Plan",
-    href: "/plan",
-    icon: PiggyBank,
-  },
-  {
-    title: "Deudas",
-    href: "/deudas",
-    matchHrefs: ["/deudas/planificador"],
-    icon: Landmark,
-  },
-];
+const INICIO_TAB: MobileTab = {
+  title: "Inicio",
+  href: "/dashboard",
+  icon: LayoutDashboard,
+};
+
+const MOVIMIENTOS_TAB: MobileTab = {
+  title: "Movim.",
+  href: "/transactions",
+  icon: ArrowLeftRight,
+};
+
+const PLAN_TAB: MobileTab = {
+  title: "Plan",
+  href: "/plan",
+  icon: PiggyBank,
+};
+
+const DEUDAS_TAB: MobileTab = {
+  title: "Deudas",
+  href: "/deudas",
+  matchHrefs: ["/deudas/planificador"],
+  icon: Landmark,
+};
+
+const MAS_TAB: MobileTab = {
+  title: "Más",
+  href: "/gestionar",
+  icon: LayoutGrid,
+};
+
+export function getMobileTabs(focus: NavFocus): MobileTab[] {
+  const thirdTab = focus === "DEBT" ? DEUDAS_TAB : PLAN_TAB;
+  return [INICIO_TAB, MOVIMIENTOS_TAB, thirdTab, MAS_TAB];
+}
 
 export function isMobileTabActive(pathname: string, tab: MobileTab): boolean {
   const hrefs = [tab.href, ...(tab.matchHrefs ?? [])];

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -1835,6 +1835,7 @@ export type Database = {
           locale: string
           mobile_dashboard_config: Json | null
           monthly_salary: number | null
+          nav_focus: Database["public"]["Enums"]["nav_focus"]
           onboarding_completed: boolean
           preferred_currency: Database["public"]["Enums"]["currency_code"]
           timezone: string
@@ -1854,6 +1855,7 @@ export type Database = {
           locale?: string
           mobile_dashboard_config?: Json | null
           monthly_salary?: number | null
+          nav_focus?: Database["public"]["Enums"]["nav_focus"]
           onboarding_completed?: boolean
           preferred_currency?: Database["public"]["Enums"]["currency_code"]
           timezone?: string
@@ -1873,6 +1875,7 @@ export type Database = {
           locale?: string
           mobile_dashboard_config?: Json | null
           monthly_salary?: number | null
+          nav_focus?: Database["public"]["Enums"]["nav_focus"]
           onboarding_completed?: boolean
           preferred_currency?: Database["public"]["Enums"]["currency_code"]
           timezone?: string
@@ -1896,6 +1899,7 @@ export type Database = {
           locale: string
           mobile_dashboard_config: Json | null
           monthly_salary: number | null
+          nav_focus: Database["public"]["Enums"]["nav_focus"]
           onboarding_completed: boolean
           preferred_currency: Database["public"]["Enums"]["currency_code"]
           timezone: string
@@ -1916,6 +1920,7 @@ export type Database = {
           locale?: string
           mobile_dashboard_config?: Json | null
           monthly_salary?: number | null
+          nav_focus?: Database["public"]["Enums"]["nav_focus"]
           onboarding_completed?: boolean
           preferred_currency?: Database["public"]["Enums"]["currency_code"]
           timezone?: string
@@ -1936,6 +1941,7 @@ export type Database = {
           locale?: string
           mobile_dashboard_config?: Json | null
           monthly_salary?: number | null
+          nav_focus?: Database["public"]["Enums"]["nav_focus"]
           onboarding_completed?: boolean
           preferred_currency?: Database["public"]["Enums"]["currency_code"]
           timezone?: string
@@ -3601,6 +3607,7 @@ export type Database = {
         | "EMAIL_IMPORT"
         | "EMAIL_PDF_IMPORT"
       occurrence_status: "pending" | "paid" | "skipped"
+      nav_focus: "PLAN" | "DEBT"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
     }


### PR DESCRIPTION
## Summary

Phase 1 of the IA / onboarding / prestamos redesign. **Mobile webapp only** — desktop sidebar and Expo native app are out of scope this milestone.

- **Tab bar collapses to 3 + Más + FAB.** Third slot adapts to the user's stated focus (Plan vs Deudas) via new `profile.nav_focus` column. Default is `PLAN`; backfilled to `DEBT` for existing users with `app_purpose = 'manage_debt'`.
- **`/gestionar` becomes "Más"** — same route, retitled header, restructured into grouped sections (Cuentas y saldos · Organizar · Planificar · Sistema). The non-active third tab surfaces in the Planificar group so it's never more than one tap away.
- **NavFocusProvider** mounted in the dashboard layout exposes `useNavFocus()` to client components.
- **Settings → Perfil** gets a "Foco principal" toggle so users can flip without re-onboarding.
- **Onboarding action** derives `nav_focus` from `app_purpose` automatically — no new step UI in this PR (Phase 2 polishes onboarding).
- **Rappi fix.** /accounts empty state promotes manual creation as the primary brass CTA. PDF parser reliably classifies non-recoverable parses as `unsupported_format` so the existing "send for support" CTA fires for genuine unsupported-bank cases.
- **Backlog:** PDF redaction step before "send to devs" upload.

Visual mockup: `claude-ai-design/nav-redesign-mobile.html`.

## Migration

`supabase/migrations/20260428120000_add_nav_focus_to_profiles.sql` — adds `nav_focus` enum + column to `profiles_enc` via the standard 6-step view+trigger rebuild. Backfills `'DEBT'` for `app_purpose = 'manage_debt'`. **Already applied to remote.**

## Reviews

- supabase-migrator — PASS
- server-action-reviewer — PASS
- zetas-front-guy — PASS (after fixing eyebrow token + `cn()` over template literal)
- perf-auditor — PASS
- `pnpm build` — clean

## Test plan

- [ ] Existing user with `app_purpose = 'manage_debt'`: third tab is Deudas; Plan visible in Más > Planificar.
- [ ] Existing user with any other purpose: third tab is Plan; Deudas visible in Más > Planificar.
- [ ] Toggle Foco principal in Settings → Perfil: third tab swaps after save.
- [ ] Más page header reads "Más"; Bandeja's action items + suggestions still render.
- [ ] /accounts empty state: brass "Crear cuenta manual" is primary; "Importar extracto" is secondary.
- [ ] /import: "Si no tienes cuentas aún" panel still nudges manual creation in-flow.
- [ ] Upload an unsupported-bank PDF: support CTA appears at the failure step.
- [ ] Fresh signup → onboarding → land on dashboard: third tab matches the chosen purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)