### PR TITLE
feat(webapp): trim onboarding to 3 steps + Saltar configuración (Phase 2)

### DIFF
--- a/webapp/src/actions/onboarding.ts
+++ b/webapp/src/actions/onboarding.ts
@@ -1,9 +1,11 @@
 "use server";
 
+import { z } from "zod";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { updateTag } from "next/cache";
 import { Database, type Json } from "@/types/database";
 import type { DashboardConfig, MobileDashboardLayout } from "@/types/dashboard-config";
+import { inferCurrencyFromTimezone } from "@/lib/utils/currency-from-timezone";
 
 export type OnboardingProfileData = {
     app_purpose: string;
@@ -82,6 +84,91 @@ export async function finishOnboarding(
     if (profileError) {
         console.error("Failed to update profile:", profileError);
         throw new Error("Failed to finalize onboarding setup. Please try again.");
+    }
+
+    updateTag("profile");
+    updateTag("accounts");
+    updateTag("dashboard:hero");
+    updateTag("dashboard:accounts");
+}
+
+// ─── Skip onboarding with sensible defaults ────────────────────────────────
+//
+// Lets a signed-up user land on the dashboard without filling every step.
+// Creates a placeholder cuenta + sets minimal profile values; everything is
+// editable later in Settings → Perfil and /accounts. We mark `app_purpose`
+// as `track_spending` (the most generic) so `nav_focus` defaults to PLAN.
+//
+// Idempotent: if the profile already has `onboarding_completed = true`, we
+// return without re-inserting the placeholder account (handles double-click
+// or retry).
+
+const skipInputSchema = z.object({
+    // Permissive IANA shape (Region/City). Just a sanity guard against
+    // arbitrary client input — the value is stored verbatim.
+    timezone: z.string().regex(/^[A-Za-z]+\/[A-Za-z_/]+$/).optional(),
+    full_name: z.string().trim().min(1).max(120).optional(),
+});
+
+export async function skipOnboardingWithDefaults(input: {
+    full_name?: string;
+    timezone?: string;
+}): Promise<void> {
+    const { supabase, user } = await getAuthenticatedClient();
+    if (!user) throw new Error("Unauthorized");
+
+    const parsed = skipInputSchema.safeParse(input);
+    if (!parsed.success) {
+        throw new Error("Datos de configuración inválidos.");
+    }
+
+    // Idempotency guard: if onboarding already finished (e.g. double-submit
+    // or a retry after a network blip), short-circuit so we don't insert
+    // duplicate "Mi cuenta" rows or overwrite the user's later edits.
+    const { data: existing } = await supabase
+        .from("profiles")
+        .select("onboarding_completed")
+        .eq("id", user.id)
+        .single();
+    if (existing?.onboarding_completed) return;
+
+    const timezone = parsed.data.timezone || "America/Bogota";
+    const currency = inferCurrencyFromTimezone(timezone);
+    const fullName = parsed.data.full_name ?? null;
+
+    const { error: accountError } = await supabase
+        .from("accounts")
+        .insert({
+            user_id: user.id,
+            name: "Mi cuenta",
+            account_type: "CHECKING",
+            current_balance: 0,
+            currency_code: currency,
+            is_active: true,
+            display_order: 0,
+            provider: "MANUAL",
+            connection_status: "CONNECTED",
+        });
+    if (accountError) {
+        console.error("skipOnboardingWithDefaults account insert failed:", accountError);
+        throw new Error("No se pudo crear la cuenta inicial.");
+    }
+
+    const { error: profileError } = await supabase
+        .from("profiles")
+        .update({
+            app_purpose: "track_spending",
+            full_name: fullName,
+            preferred_currency: currency,
+            timezone,
+            locale: "es-CO",
+            nav_focus: "PLAN",
+            onboarding_completed: true,
+        })
+        .eq("id", user.id);
+    if (profileError) {
+        console.error("skipOnboardingWithDefaults profile update failed:", profileError);
+        throw new Error("No se pudo finalizar la configuración.");
     }
 
     updateTag("profile");

--- a/webapp/src/app/onboarding/page.tsx
+++ b/webapp/src/app/onboarding/page.tsx
@@ -135,6 +135,7 @@ export default function OnboardingPage() {
         if (skipping) return;
         setSkipping(true);
         try {
+            await skipOnboardingWithDefaults({ timezone });
             void trackClientEvent({
                 event_name: "onboarding_skipped",
                 flow: "onboarding",
@@ -143,7 +144,6 @@ export default function OnboardingPage() {
                 success: true,
                 duration_ms: Date.now() - startedAtRef.current,
             });
-            await skipOnboardingWithDefaults({ timezone });
             router.push("/dashboard");
         } catch (error) {
             void trackClientEvent({
@@ -155,6 +155,7 @@ export default function OnboardingPage() {
                 error_code: "skip_failed",
             });
             toast.error(error instanceof Error ? error.message : "No se pudo saltar la configuración.");
+        } finally {
             setSkipping(false);
         }
     };

--- a/webapp/src/app/onboarding/page.tsx
+++ b/webapp/src/app/onboarding/page.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { finishOnboarding } from "@/actions/onboarding";
+import { finishOnboarding, skipOnboardingWithDefaults } from "@/actions/onboarding";
 import { Button } from "@/components/ui/button";
 import { CurrencyInput } from "@/components/ui/currency-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SelectPill } from "@/components/ui/select-pill";
+import { SectionDivider } from "@/components/import/section-divider";
 import type { Database } from "@/types/database";
 import {
     BRASS_BUTTON_CLASS,
@@ -18,7 +19,7 @@ import {
 } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import type { CurrencyCode } from "@/types/domain";
+import { inferCurrencyFromTimezone } from "@/lib/utils/currency-from-timezone";
 import { toast } from "sonner";
 import {
     Loader2,
@@ -31,13 +32,12 @@ import {
     CheckCircle2,
     FileUp,
     Tags,
+    Sparkles,
 } from "lucide-react";
 import { trackClientEvent } from "@/lib/utils/analytics";
 import { getDefaultConfig } from "@/lib/dashboard-config-defaults";
 import { DEFAULT_LAYOUT as DEFAULT_MOBILE_LAYOUT } from "@zeta/shared";
 import type { AppPurpose } from "@/types/dashboard-config";
-
-const OPTIONAL_STEPS = new Set([1]);
 
 type QuickWin = { label: string; href: string; icon: typeof FileUp };
 
@@ -55,14 +55,6 @@ const PURPOSES = [
     { id: "improve_habits", label: "Mejorar hábitos financieros", icon: TrendingUp },
 ] as const;
 
-const CURRENCIES = [
-    { code: "COP", label: "COP" },
-    { code: "USD", label: "USD" },
-    { code: "MXN", label: "MXN" },
-    { code: "EUR", label: "EUR" },
-    { code: "BRL", label: "BRL" },
-] as const;
-
 const ACCOUNT_TYPES = [
     { code: "CHECKING", label: "Corriente" },
     { code: "SAVINGS", label: "Ahorros" },
@@ -70,27 +62,31 @@ const ACCOUNT_TYPES = [
     { code: "CASH", label: "Efectivo" },
 ] as const;
 
+// 4 step screens total. Step 4 is the final "Listo" celebration.
+// Progress bar excludes the celebration so it always reads "Paso N de 3".
+const TOTAL_STEPS = 4;
+const FUNCTIONAL_STEPS = TOTAL_STEPS - 1;
+
 const STEP_TITLES = {
-    1: { title: "¿Qué quieres lograr?", sub: "Tres taps. Esto moldea todo." },
-    2: { title: "Tu perfil", sub: "Personaliza cómo ves tu dinero." },
-    3: { title: "Pulso mensual", sub: "Una estimación rápida para arrancar." },
-    4: { title: "Primera cuenta", sub: "Luego puedes importar un extracto." },
-    5: { title: "¡Listo!", sub: "" },
+    1: { title: "Bienvenido a Zeta", sub: "Configurá lo esencial en menos de un minuto." },
+    2: { title: "Sobre ti", sub: "Lo justo para personalizar tu dashboard." },
+    3: { title: "Tu pulso y primera cuenta", sub: "Una estimación rápida y un saldo de partida." },
+    4: { title: "¡Listo!", sub: "" },
 } as const;
 
 export default function OnboardingPage() {
     const router = useRouter();
     const [step, setStep] = useState(1);
     const [loading, setLoading] = useState(false);
+    const [skipping, setSkipping] = useState(false);
 
     const [purpose, setPurpose] = useState<AppPurpose | "">("");
     const [fullName, setFullName] = useState("");
-    const [currency, setCurrency] = useState<CurrencyCode>("COP");
     const [timezone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    const currency = inferCurrencyFromTimezone(timezone);
 
     const [income, setIncome] = useState("");
     const [expenses, setExpenses] = useState("");
-    const [debtCount, setDebtCount] = useState("");
 
     const [accountName, setAccountName] = useState("");
     const [accountType, setAccountType] =
@@ -98,8 +94,7 @@ export default function OnboardingPage() {
     const [balance, setBalance] = useState("");
 
     const startedAtRef = useRef<number>(Date.now());
-    const totalSteps = 5;
-    const progressStep = Math.min(step, totalSteps);
+    const progressStep = Math.min(step, FUNCTIONAL_STEPS);
 
     useEffect(() => {
         void trackClientEvent({
@@ -108,22 +103,20 @@ export default function OnboardingPage() {
             step: "step_1",
             entry_point: "redirect",
             success: true,
-            metadata: { step_number: 1, total_steps: totalSteps },
+            metadata: { step_number: 1, total_steps: FUNCTIONAL_STEPS },
         });
     }, []);
 
     const nextStep = () => {
-        if (step === 1 && !purpose) {
-            toast.error("Elige un objetivo para continuar.");
-            return;
-        }
-        if (step === 2 && !fullName.trim()) {
-            toast.error("Ingresa tu nombre.");
-            return;
-        }
-        if (step === 3 && (!income || !expenses)) {
-            toast.error("Ingresa tus ingresos y gastos estimados.");
-            return;
+        if (step === 2) {
+            if (!fullName.trim()) {
+                toast.error("Ingresa tu nombre.");
+                return;
+            }
+            if (!purpose) {
+                toast.error("Elige un objetivo para continuar.");
+                return;
+            }
         }
         void trackClientEvent({
             event_name: "onboarding_step_completed",
@@ -131,29 +124,48 @@ export default function OnboardingPage() {
             step: `step_${step}`,
             entry_point: "cta",
             success: true,
-            metadata: { step_number: step, total_steps: totalSteps },
+            metadata: { step_number: step, total_steps: FUNCTIONAL_STEPS },
         });
-        setStep((prev) => Math.min(prev + 1, totalSteps));
-    };
-
-    const skipStep = (defaultAction: () => void) => {
-        void trackClientEvent({
-            event_name: "onboarding_step_skipped",
-            flow: "onboarding",
-            step: `step_${step}`,
-            entry_point: "skip",
-            success: true,
-            metadata: { step_number: step, total_steps: totalSteps },
-        });
-        defaultAction();
-        setStep((prev) => Math.min(prev + 1, totalSteps));
+        setStep((prev) => Math.min(prev + 1, TOTAL_STEPS));
     };
 
     const prevStep = () => setStep((prev) => Math.max(prev - 1, 1));
 
+    const onSkipAll = async () => {
+        if (skipping) return;
+        setSkipping(true);
+        try {
+            void trackClientEvent({
+                event_name: "onboarding_skipped",
+                flow: "onboarding",
+                step: "step_1",
+                entry_point: "skip",
+                success: true,
+                duration_ms: Date.now() - startedAtRef.current,
+            });
+            await skipOnboardingWithDefaults({ timezone });
+            router.push("/dashboard");
+        } catch (error) {
+            void trackClientEvent({
+                event_name: "onboarding_skipped",
+                flow: "onboarding",
+                step: "step_1",
+                entry_point: "skip",
+                success: false,
+                error_code: "skip_failed",
+            });
+            toast.error(error instanceof Error ? error.message : "No se pudo saltar la configuración.");
+            setSkipping(false);
+        }
+    };
+
     const onSubmit = async () => {
         if (!accountName.trim() || balance === "") {
             toast.error("Completa los datos de tu cuenta.");
+            return;
+        }
+        if (!income || !expenses) {
+            toast.error("Ingresa tus ingresos y gastos estimados.");
             return;
         }
         setLoading(true);
@@ -184,9 +196,9 @@ export default function OnboardingPage() {
                 entry_point: "cta",
                 success: true,
                 duration_ms: Date.now() - startedAtRef.current,
-                metadata: { total_steps: totalSteps },
+                metadata: { total_steps: FUNCTIONAL_STEPS },
             });
-            setStep(5);
+            setStep(TOTAL_STEPS);
         } catch (error) {
             void trackClientEvent({
                 event_name: "onboarding_completed",
@@ -212,22 +224,22 @@ export default function OnboardingPage() {
 
     return (
         <div className="space-y-5">
-            {step < 5 && (
+            {step < TOTAL_STEPS && step > 1 && (
                 <div className={cn(PANEL_SURFACE_CLASS, "p-4")}>
                     <div className="flex items-center justify-between">
                         <span className={SECTION_EYEBROW_CLASS}>Configuración</span>
                         <span className="text-[11px] font-semibold text-muted-foreground">
-                            Paso {progressStep} de {totalSteps - 1}
+                            Paso {progressStep} de {FUNCTIONAL_STEPS}
                         </span>
                     </div>
                     <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-white/5">
                         <div
                             className="h-full rounded-full bg-z-brass transition-all duration-300"
-                            style={{ width: `${(progressStep / (totalSteps - 1)) * 100}%` }}
+                            style={{ width: `${(progressStep / FUNCTIONAL_STEPS) * 100}%` }}
                         />
                     </div>
                     <div className="mt-3 flex items-center justify-center gap-2">
-                        {Array.from({ length: totalSteps - 1 }, (_, i) => i + 1).map((s) => (
+                        {Array.from({ length: FUNCTIONAL_STEPS }, (_, i) => i + 1).map((s) => (
                             <div
                                 key={s}
                                 className={cn(
@@ -236,9 +248,7 @@ export default function OnboardingPage() {
                                         ? "w-5 bg-z-brass"
                                         : s < step
                                             ? "w-2 bg-z-brass/60"
-                                            : OPTIONAL_STEPS.has(s)
-                                                ? "w-2 bg-white/10"
-                                                : "w-2 bg-white/15",
+                                            : "w-2 bg-white/15",
                                 )}
                             />
                         ))}
@@ -246,7 +256,7 @@ export default function OnboardingPage() {
                 </div>
             )}
 
-            {step < 5 && (
+            {step < TOTAL_STEPS && (
                 <div className="space-y-1">
                     <h2 className="text-2xl font-bold tracking-tight">{headerCopy.title}</h2>
                     {headerCopy.sub && (
@@ -256,47 +266,39 @@ export default function OnboardingPage() {
             )}
 
             {step === 1 && (
-                <div key="step1" className="animate-in fade-in slide-in-from-right-4 duration-200 space-y-4">
-                    <div className="grid gap-2">
-                        {PURPOSES.map((p) => {
-                            const Icon = p.icon;
-                            const active = purpose === p.id;
-                            return (
-                                <button
-                                    key={p.id}
-                                    type="button"
-                                    onClick={() => setPurpose(p.id)}
-                                    className={cn(
-                                        PANEL_INSET_INTERACTIVE_CLASS,
-                                        "flex items-center gap-3 p-4 text-left transition-colors",
-                                        active && "border-z-brass/40 bg-z-brass/10",
-                                    )}
-                                    aria-pressed={active}
-                                >
-                                    <span
-                                        className={cn(
-                                            "flex size-9 shrink-0 items-center justify-center rounded-xl bg-white/5",
-                                            active && "bg-z-brass/15 text-z-brass",
-                                        )}
-                                    >
-                                        <Icon className="size-4" />
-                                    </span>
-                                    <span className="text-sm font-medium text-foreground">{p.label}</span>
-                                </button>
-                            );
-                        })}
+                <div key="step1" className="animate-in fade-in slide-in-from-right-4 duration-200 space-y-6">
+                    <div className={cn(PANEL_SURFACE_CLASS, "p-5")}>
+                        <div className="flex items-start gap-3">
+                            <Sparkles className="mt-1 size-5 text-z-brass shrink-0" />
+                            <div className="space-y-2 text-sm leading-6 text-muted-foreground">
+                                <p>
+                                    Vamos a configurar lo mínimo para que tu dashboard tenga sentido:
+                                    tu nombre, qué quieres lograr y un saldo de partida.
+                                </p>
+                                <p>
+                                    Todo es editable después en <span className="font-medium text-foreground">Ajustes → Perfil</span>.
+                                </p>
+                            </div>
+                        </div>
                     </div>
-                    <div className="flex items-center justify-between pt-2">
+
+                    <div className="grid gap-3">
+                        <Button
+                            size="lg"
+                            onClick={nextStep}
+                            className={cn("w-full gap-2", BRASS_BUTTON_CLASS)}
+                        >
+                            Comenzar
+                            <ArrowRight className="size-4" />
+                        </Button>
                         <button
                             type="button"
-                            onClick={() => skipStep(() => setPurpose("track_spending"))}
-                            className="text-xs text-muted-foreground hover:text-foreground"
+                            onClick={onSkipAll}
+                            disabled={skipping}
+                            className="text-center text-xs text-muted-foreground hover:text-foreground disabled:opacity-60"
                         >
-                            Omitir
+                            {skipping ? "Configurando…" : "Saltar configuración y explorar"}
                         </button>
-                        <Button onClick={nextStep} disabled={!purpose} className={BRASS_BUTTON_CLASS}>
-                            Siguiente <ArrowRight className="ml-2 h-4 w-4" />
-                        </Button>
                     </div>
                 </div>
             )}
@@ -311,21 +313,47 @@ export default function OnboardingPage() {
                             value={fullName}
                             onChange={(e) => setFullName(e.target.value)}
                             autoComplete="name"
+                            autoFocus
                         />
                     </div>
+
                     <div className="space-y-2">
-                        <Label>Moneda principal</Label>
-                        <div className="flex flex-wrap gap-2">
-                            {CURRENCIES.map((c) => (
-                                <SelectPill
-                                    key={c.code}
-                                    label={c.label}
-                                    active={currency === c.code}
-                                    onClick={() => setCurrency(c.code)}
-                                />
-                            ))}
+                        <Label>¿Qué quieres lograr?</Label>
+                        <div className="grid gap-2">
+                            {PURPOSES.map((p) => {
+                                const Icon = p.icon;
+                                const active = purpose === p.id;
+                                return (
+                                    <button
+                                        key={p.id}
+                                        type="button"
+                                        onClick={() => setPurpose(p.id)}
+                                        className={cn(
+                                            PANEL_INSET_INTERACTIVE_CLASS,
+                                            "flex items-center gap-3 p-4 text-left transition-colors",
+                                            active && "border-z-brass/40 bg-z-brass/10",
+                                        )}
+                                        aria-pressed={active}
+                                    >
+                                        <span
+                                            className={cn(
+                                                "flex size-9 shrink-0 items-center justify-center rounded-xl bg-white/5",
+                                                active && "bg-z-brass/15 text-z-brass",
+                                            )}
+                                        >
+                                            <Icon className="size-4" />
+                                        </span>
+                                        <span className="text-sm font-medium text-foreground">{p.label}</span>
+                                    </button>
+                                );
+                            })}
                         </div>
+                        <p className="text-xs text-muted-foreground">
+                            La pestaña <span className="font-medium text-foreground">Deudas</span> aparece solo si eliges
+                            <span className="font-medium text-foreground"> Salir de deudas</span>. Siempre puedes cambiarlo en Ajustes.
+                        </p>
                     </div>
+
                     <div className="flex items-center justify-between pt-2">
                         <Button
                             variant="ghost"
@@ -334,7 +362,11 @@ export default function OnboardingPage() {
                         >
                             <ArrowLeft className="mr-2 h-4 w-4" /> Atrás
                         </Button>
-                        <Button onClick={nextStep} disabled={!fullName.trim()} className={BRASS_BUTTON_CLASS}>
+                        <Button
+                            onClick={nextStep}
+                            disabled={!fullName.trim() || !purpose}
+                            className={BRASS_BUTTON_CLASS}
+                        >
                             Siguiente <ArrowRight className="ml-2 h-4 w-4" />
                         </Button>
                     </div>
@@ -343,108 +375,85 @@ export default function OnboardingPage() {
 
             {step === 3 && (
                 <div key="step3" className="animate-in fade-in slide-in-from-right-4 duration-200 space-y-5">
-                    <div className="space-y-2">
-                        <Label htmlFor="income">Ingreso mensual estimado</Label>
-                        <CurrencyInput
-                            id="income"
-                            placeholder="Ej: 5.000.000"
-                            value={income}
-                            onChange={(e) => setIncome(e.target.value)}
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="expenses">Gasto mensual estimado</Label>
-                        <CurrencyInput
-                            id="expenses"
-                            placeholder="Ej: 4.000.000"
-                            value={expenses}
-                            onChange={(e) => setExpenses(e.target.value)}
-                        />
-                    </div>
-                    {incomeNumber > 0 && (
-                        <div className={cn(PANEL_INSET_INTERACTIVE_CLASS, "p-3 text-sm")}>
-                            <p className="font-semibold tabular-nums text-foreground">
-                                Disponible para presupuesto:{" "}
-                                {formatCurrency(availableToBudget, currency)}
-                            </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                                Nos ayuda a sugerirte límites desde el día 1.
-                            </p>
-                        </div>
-                    )}
-                    {purpose === "manage_debt" && (
+                    <div className="space-y-3">
+                        <span className={SECTION_EYEBROW_CLASS}>Tu pulso mensual</span>
                         <div className="space-y-2">
-                            <Label htmlFor="debtCount">Tarjetas o préstamos activos</Label>
-                            <Input
-                                id="debtCount"
-                                type="number"
-                                min="0"
-                                max="20"
-                                placeholder="Ej: 3"
-                                value={debtCount}
-                                onChange={(e) => setDebtCount(e.target.value)}
+                            <Label htmlFor="income">Ingreso mensual estimado</Label>
+                            <CurrencyInput
+                                id="income"
+                                placeholder="Ej: 5.000.000"
+                                value={income}
+                                onChange={(e) => setIncome(e.target.value)}
                             />
-                            {debtCount && parseInt(debtCount) > 0 && (
-                                <p className="text-xs text-z-income">
-                                    Zeta te ayudará a organizar tus {debtCount} deudas.
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="expenses">Gasto mensual estimado</Label>
+                            <CurrencyInput
+                                id="expenses"
+                                placeholder="Ej: 4.000.000"
+                                value={expenses}
+                                onChange={(e) => setExpenses(e.target.value)}
+                            />
+                        </div>
+                        {incomeNumber > 0 && expensesNumber > 0 && (
+                            <div className={cn(PANEL_INSET_INTERACTIVE_CLASS, "p-3 text-sm")}>
+                                <p className="font-semibold tabular-nums text-foreground">
+                                    Disponible para presupuesto:{" "}
+                                    {formatCurrency(availableToBudget, currency)}
                                 </p>
-                            )}
-                        </div>
-                    )}
-                    <div className="flex items-center justify-between pt-2">
-                        <Button variant="ghost" onClick={prevStep} className={GHOST_BUTTON_CLASS}>
-                            <ArrowLeft className="mr-2 h-4 w-4" /> Atrás
-                        </Button>
-                        <Button onClick={nextStep} disabled={!income || !expenses} className={BRASS_BUTTON_CLASS}>
-                            Siguiente <ArrowRight className="ml-2 h-4 w-4" />
-                        </Button>
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                    Nos ayuda a sugerirte límites desde el día 1.
+                                </p>
+                            </div>
+                        )}
                     </div>
-                </div>
-            )}
 
-            {step === 4 && (
-                <div key="step4" className="animate-in fade-in slide-in-from-right-4 duration-200 space-y-5">
-                    <div className="space-y-2">
-                        <Label htmlFor="accountName">Nombre de la cuenta</Label>
-                        <Input
-                            id="accountName"
-                            placeholder="Ej: Bancolombia ahorros"
-                            value={accountName}
-                            onChange={(e) => setAccountName(e.target.value)}
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label>Tipo</Label>
-                        <div className="flex flex-wrap gap-2">
-                            {ACCOUNT_TYPES.map((t) => (
-                                <SelectPill
-                                    key={t.code}
-                                    label={t.label}
-                                    active={accountType === t.code}
-                                    onClick={() => setAccountType(t.code)}
-                                />
-                            ))}
+                    <SectionDivider label="Primera cuenta" />
+
+                    <div className="space-y-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="accountName">Nombre de la cuenta</Label>
+                            <Input
+                                id="accountName"
+                                placeholder="Ej: Bancolombia ahorros"
+                                value={accountName}
+                                onChange={(e) => setAccountName(e.target.value)}
+                            />
                         </div>
+                        <div className="space-y-2">
+                            <Label>Tipo</Label>
+                            <div className="flex flex-wrap gap-2">
+                                {ACCOUNT_TYPES.map((t) => (
+                                    <SelectPill
+                                        key={t.code}
+                                        label={t.label}
+                                        active={accountType === t.code}
+                                        onClick={() => setAccountType(t.code)}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="balance">Saldo actual</Label>
+                            <CurrencyInput
+                                id="balance"
+                                placeholder="0"
+                                value={balance}
+                                onChange={(e) => setBalance(e.target.value)}
+                            />
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                            ¿Tienes un extracto PDF? Podrás importarlo después y tus cuentas aparecen automáticamente.
+                        </p>
                     </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="balance">Saldo actual</Label>
-                        <CurrencyInput
-                            id="balance"
-                            placeholder="0"
-                            value={balance}
-                            onChange={(e) => setBalance(e.target.value)}
-                        />
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                        ¿Tienes un extracto PDF? Podrás importarlo luego y tus cuentas aparecen automáticamente.
-                    </p>
+
                     <div className="flex items-center justify-between pt-2">
                         <Button variant="ghost" onClick={prevStep} disabled={loading} className={GHOST_BUTTON_CLASS}>
                             <ArrowLeft className="mr-2 h-4 w-4" /> Atrás
                         </Button>
                         <Button
                             onClick={onSubmit}
-                            disabled={loading || !accountName.trim() || balance === ""}
+                            disabled={loading || !income || !expenses || !accountName.trim() || balance === ""}
                             className={BRASS_BUTTON_CLASS}
                         >
                             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
@@ -454,8 +463,8 @@ export default function OnboardingPage() {
                 </div>
             )}
 
-            {step === 5 && (
-                <div key="step5" className="animate-in fade-in slide-in-from-right-4 duration-200 space-y-5 text-center">
+            {step === TOTAL_STEPS && (
+                <div key="step-done" className="animate-in fade-in slide-in-from-right-4 duration-200 space-y-5 text-center">
                     <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-z-income/10 text-z-income">
                         <CheckCircle2 className="size-9" />
                     </div>

--- a/webapp/src/lib/utils/currency-from-timezone.ts
+++ b/webapp/src/lib/utils/currency-from-timezone.ts
@@ -1,0 +1,59 @@
+import type { CurrencyCode } from "@/types/domain";
+
+/**
+ * Infer a sensible default currency from the browser's IANA timezone.
+ *
+ * Used during onboarding so we don't force a manual currency pick in the
+ * common case. Conservative — only maps countries we explicitly support
+ * (mirrors `CURRENCIES` in `lib/constants/currencies.ts`). Anything else
+ * falls back to COP (Zeta's primary market is Colombia).
+ *
+ * Users can still change the currency in Settings → Perfil after onboarding.
+ */
+const TIMEZONE_TO_CURRENCY: Record<string, CurrencyCode> = {
+  // Colombia
+  "America/Bogota": "COP",
+  // Mexico
+  "America/Mexico_City": "MXN",
+  "America/Cancun": "MXN",
+  "America/Monterrey": "MXN",
+  "America/Tijuana": "MXN",
+  "America/Mazatlan": "MXN",
+  "America/Chihuahua": "MXN",
+  "America/Hermosillo": "MXN",
+  // Brazil
+  "America/Sao_Paulo": "BRL",
+  "America/Bahia": "BRL",
+  "America/Fortaleza": "BRL",
+  "America/Recife": "BRL",
+  "America/Manaus": "BRL",
+  // Peru
+  "America/Lima": "PEN",
+  // Chile
+  "America/Santiago": "CLP",
+  // Argentina
+  "America/Argentina/Buenos_Aires": "ARS",
+  "America/Argentina/Cordoba": "ARS",
+  "America/Argentina/Mendoza": "ARS",
+  // United States
+  "America/New_York": "USD",
+  "America/Chicago": "USD",
+  "America/Denver": "USD",
+  "America/Los_Angeles": "USD",
+  "America/Phoenix": "USD",
+  "America/Anchorage": "USD",
+  "Pacific/Honolulu": "USD",
+  // Eurozone (a small subset — most-used by Spanish speakers)
+  "Europe/Madrid": "EUR",
+  "Europe/Paris": "EUR",
+  "Europe/Berlin": "EUR",
+  "Europe/Rome": "EUR",
+  "Europe/Lisbon": "EUR",
+};
+
+const DEFAULT_CURRENCY: CurrencyCode = "COP";
+
+export function inferCurrencyFromTimezone(timezone: string | undefined | null): CurrencyCode {
+  if (!timezone) return DEFAULT_CURRENCY;
+  return TIMEZONE_TO_CURRENCY[timezone] ?? DEFAULT_CURRENCY;
+}


### PR DESCRIPTION
## Summary

Phase 2 of the IA / onboarding / prestamos plan. Mobile webapp only.

Reduces required onboarding from **5 mandatory steps to 3 functional + final celebration**, and adds a **"Saltar configuración"** path for users who want to land on the dashboard immediately and configure later.

### Step-by-step changes

| Step | Before | After |
|---|---|---|
| 1 | Purpose picker (4 options) | NEW Welcome: intro panel + "Comenzar" + "Saltar configuración" text link |
| 2 | Name + Currency picker | Combined "Sobre ti": name + purpose (currency auto from timezone) |
| 3 | Income + Expenses | Combined "Tu pulso y primera cuenta": income + expenses + cuenta name/type/balance with `SectionDivider` between halves |
| 4 | First account form | (now part of step 3) |
| 5 | Listo celebration | Unchanged, renumbered as step 4 |

### Why no demo CTA inside `/onboarding`

`startDemoSession` requires either an anonymous user or no session. By the time a user reaches `/onboarding` they've already signed up with a real email — calling demo would either redirect them with no effect or orphan their email. The demo path stays where it semantically belongs: the landing page hero and the auth shortcuts. The new "Saltar configuración" link inside onboarding gives the same outcome (fast path to a usable dashboard) without the semantic conflict.

### New `skipOnboardingWithDefaults` server action

- Idempotency guard: short-circuits if `onboarding_completed` already true (no duplicate "Mi cuenta" on double-click).
- Zod-validated `timezone` + `full_name`.
- Sets minimal defaults: `app_purpose=track_spending`, `nav_focus=PLAN`, `preferred_currency` inferred from timezone, `locale=es-CO`, `full_name=null` (no "Tu nombre" placeholder bleeding into greetings).
- Inserts "Mi cuenta" CHECKING with $0 balance.
- Fires the same `updateTag()` set as `finishOnboarding`.

### New `inferCurrencyFromTimezone()` helper

`webapp/src/lib/utils/currency-from-timezone.ts` — maps IANA timezones (`America/Bogota` → COP, `America/Mexico_City` → MXN, `America/Sao_Paulo` → BRL, etc.) to currency codes. Defaults to COP. Editable later in Settings → Perfil.

## Reviews

- **server-action-reviewer:** 3 fixes applied (idempotency guard, Zod schema, null over `"Tu nombre"`).
- **zetas-front-guy:** my regression fixed (replaced ad-hoc `border-t` with `SectionDivider` per TOKENS.md §5; tightened the focus-hint copy). Pre-existing patterns (`h-1.5` progress bar, `font-bold` titles) flagged but out of scope — separate TOKENS conformance pass.
- **Build:** clean.

## Test plan

- [ ] Fresh signup → lands on welcome step → "Comenzar" advances to "Sobre ti".
- [ ] Welcome → "Saltar configuración y explorar" → lands on `/dashboard` with "Mi cuenta" pre-created and currency matching timezone.
- [ ] Double-click skip → only one "Mi cuenta" exists (idempotency).
- [ ] Step 2 → name + purpose required, hint copy explains the Deudas tab rule.
- [ ] Step 3 → income, expenses, cuenta name, balance all required to enable Finalizar.
- [ ] After finalizar → quick-win CTA matches purpose (manage_debt → /import, others → /transactions/new etc.).
- [ ] Existing users with `onboarding_completed=true` still bounce to /dashboard (layout guard untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)