### PR TITLE
feat: in-app account deletion (Apple 5.1.1(v))

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ mobile/.idea/
 
 # PDF parser local scratch folder — sample statements, not shared
 /pdfs_to_review/
+
+# App Store screen recordings — large binary previews, uploaded directly to ASC
+/docs/app-store/previews/

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -47,7 +47,7 @@ import { deleteUserAccount } from "../lib/delete-account";
 import { useOnboardingStatus } from "../lib/onboarding-status";
 import { useTheme, type ThemeMode } from "../lib/theme";
 import { COLORS } from "../lib/constants/colors";
-import { LEGAL_URLS } from "../lib/constants/urls";
+import { LEGAL_URLS, SUPPORT_EMAIL } from "../lib/constants/urls";
 import {
   BRASS_GHOST_BUTTON_CLASS,
   PANEL_INSET_CLASS,
@@ -580,7 +580,7 @@ export default function SettingsScreen() {
                       console.error("Delete account error:", error);
                       Alert.alert(
                         "No se pudo eliminar",
-                        "Inténtalo de nuevo. Si persiste, contacta soporte en giraldo.0302@gmail.com.",
+                        `Inténtalo de nuevo. Si persiste, contacta soporte en ${SUPPORT_EMAIL}.`,
                       );
                     } finally {
                       setDeleting(false);

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -43,6 +43,7 @@ import { supabase } from "../lib/supabase";
 import { clearDatabase, getDatabase } from "../lib/db/database";
 import { disableDemoMode } from "../lib/demo-mode";
 import { resetUserData } from "../lib/reset-data";
+import { deleteUserAccount } from "../lib/delete-account";
 import { useOnboardingStatus } from "../lib/onboarding-status";
 import { useTheme, type ThemeMode } from "../lib/theme";
 import { COLORS } from "../lib/constants/colors";
@@ -367,6 +368,7 @@ export default function SettingsScreen() {
   const { markIncomplete } = useOnboardingStatus();
   const [syncing, setSyncing] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [biometricsAvailable, setBiometricsAvailable] = useState(false);
   const [biometricsOn, setBiometricsOn] = useState(false);
   const [bgReauthOn, setBgReauthOn] = useState(false);
@@ -546,6 +548,52 @@ export default function SettingsScreen() {
       ],
     );
   }, [clear, demoMode, markIncomplete, router, session?.user?.id]);
+
+  const handleDeleteAccount = useCallback(() => {
+    if (demoMode || !session?.user?.id) return;
+    const userId = session.user.id;
+
+    Alert.alert(
+      "Eliminar cuenta",
+      "Se eliminarán de forma permanente tu cuenta, transacciones, presupuestos, deudas, recurrentes, destinatarios y todas tus configuraciones. Esta acción no se puede deshacer.",
+      [
+        { text: "Cancelar", style: "cancel" },
+        {
+          text: "Continuar",
+          style: "destructive",
+          onPress: () => {
+            Alert.alert(
+              "Confirmación final",
+              "Tu cuenta y todos los datos se borrarán para siempre. ¿Seguro?",
+              [
+                { text: "Cancelar", style: "cancel" },
+                {
+                  text: "Eliminar cuenta",
+                  style: "destructive",
+                  onPress: async () => {
+                    setDeleting(true);
+                    try {
+                      await deleteUserAccount(userId);
+                      clear();
+                      router.replace("/(auth)/login");
+                    } catch (error) {
+                      console.error("Delete account error:", error);
+                      Alert.alert(
+                        "No se pudo eliminar",
+                        "Inténtalo de nuevo. Si persiste, contacta soporte en giraldo.0302@gmail.com.",
+                      );
+                    } finally {
+                      setDeleting(false);
+                    }
+                  },
+                },
+              ],
+            );
+          },
+        },
+      ],
+    );
+  }, [clear, demoMode, router, session?.user?.id]);
 
   const handleSignOut = useCallback(() => {
     Alert.alert("Cerrar sesión", "Se eliminarán los datos locales.", [
@@ -750,6 +798,23 @@ export default function SettingsScreen() {
                   </Text>
                   <Text className="mt-0.5 text-xs font-inter text-muted-foreground">
                     Mantén tu cuenta y vuelve al onboarding
+                  </Text>
+                </View>
+              </Pressable>
+              <Pressable
+                className={`${PANEL_INSET_CLASS} flex-row items-center gap-3 px-4 py-3 active:bg-black-10`}
+                onPress={handleDeleteAccount}
+                disabled={deleting}
+                accessibilityRole="button"
+                accessibilityLabel="Eliminar cuenta"
+              >
+                <Trash2 size={16} color={COLORS.debt} />
+                <View className="flex-1">
+                  <Text className="text-sm font-inter-semibold text-z-debt">
+                    {deleting ? "Eliminando cuenta…" : "Eliminar cuenta"}
+                  </Text>
+                  <Text className="mt-0.5 text-xs font-inter text-muted-foreground">
+                    Borra tu cuenta y todos tus datos. Permanente.
                   </Text>
                 </View>
               </Pressable>

--- a/mobile/lib/constants/urls.ts
+++ b/mobile/lib/constants/urls.ts
@@ -11,3 +11,5 @@ export const LEGAL_URLS = {
   privacy: `${WEBAPP_URL}/privacy`,
   terms: `${WEBAPP_URL}/terms`,
 };
+
+export const SUPPORT_EMAIL = "giraldo.0302@gmail.com";

--- a/mobile/lib/delete-account.ts
+++ b/mobile/lib/delete-account.ts
@@ -1,0 +1,59 @@
+import * as SecureStore from "expo-secure-store";
+import { supabase } from "./supabase";
+import { clearDatabase, getDatabase } from "./db/database";
+import { getAllAccounts } from "./repositories/accounts";
+import { beginReset, endReset } from "./sync/engine";
+import { disableBiometrics, setBackgroundReauth } from "./biometrics";
+
+const PDF_PASSWORD_KEY_PREFIX = "zeta_pdf_password";
+const DEFAULT_ACCOUNT_STORAGE_KEY = "zeta.default_capture_account_id";
+
+function pdfPasswordKey(userId: string, accountId: string) {
+  const sanitized = `${userId}_${accountId}`.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return `${PDF_PASSWORD_KEY_PREFIX}_${sanitized}`;
+}
+
+// Permanently deletes the calling user's account and ALL associated data.
+// Required by Apple App Store Guideline 5.1.1(v).
+//
+// Server: `delete_user_account` RPC wipes app tables via reset_user_data()
+// then deletes the auth.users row (cascades the rest).
+//
+// Local cleanup mirrors resetUserData() but additionally:
+//   - signs the session out
+//   - disables biometrics (Face ID bound to a deleted user is a re-login loop)
+export async function deleteUserAccount(userId: string): Promise<void> {
+  beginReset();
+  try {
+    const accounts = await getAllAccounts().catch(() => []);
+    const pdfKeys = accounts.map((a) => pdfPasswordKey(userId, a.id));
+
+    const db = await getDatabase();
+    await db
+      .execAsync("DELETE FROM sync_queue")
+      .catch((err) => {
+        console.warn("[delete-account] sync_queue drain failed (non-fatal):", err);
+      });
+
+    const { error } = await supabase.rpc("delete_user_account");
+    if (error) {
+      throw new Error(error.message || "No se pudo eliminar la cuenta.");
+    }
+
+    await supabase.auth.signOut().catch((err) => {
+      console.warn("[delete-account] signOut failed (non-fatal):", err);
+    });
+
+    await clearDatabase();
+
+    await Promise.all([
+      ...[...pdfKeys, DEFAULT_ACCOUNT_STORAGE_KEY].map((key) =>
+        SecureStore.deleteItemAsync(key).catch(() => {}),
+      ),
+      setBackgroundReauth(false).catch(() => {}),
+      disableBiometrics().catch(() => {}),
+    ]);
+  } finally {
+    endReset();
+  }
+}

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -748,6 +748,10 @@ export type Database = {
         Args: Record<string, never>
         Returns: undefined
       }
+      delete_user_account: {
+        Args: Record<string, never>
+        Returns: undefined
+      }
     }
     Enums: {
       account_type:

--- a/supabase/migrations/20260429192328_add_delete_user_account_rpc.sql
+++ b/supabase/migrations/20260429192328_add_delete_user_account_rpc.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- public.delete_user_account() — self-service account deletion for the
+-- calling user. Required by Apple App Review Guideline 5.1.1(v): apps that
+-- support account creation must offer in-app account deletion (not just an
+-- email-based request flow).
+--
+-- Strategy:
+--   1. Reuse public.reset_user_data() to wipe app-scoped tables that don't
+--      have ON DELETE CASCADE from auth.users (defense in depth).
+--   2. DELETE the auth.users row. Cascades handle profiles_enc, accounts,
+--      transactions_enc, budgets, destinatarios_enc, recurring_*, etc.
+--
+-- SECURITY DEFINER + ownership stays with the migration runner (postgres /
+-- supabase_admin) so the function has privilege to DELETE from auth.users.
+-- The body re-checks `auth.uid()` so a caller can only delete THEIR OWN
+-- account — never another user's.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.delete_user_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth, pg_catalog
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuario no autenticado';
+  END IF;
+
+  -- Wipe app-scoped tables (idempotent; safe to call before delete).
+  PERFORM public.reset_user_data();
+
+  -- Cascade-delete the auth row. profiles_enc, accounts, transactions_enc,
+  -- budgets, etc. all REFERENCE auth.users(id) ON DELETE CASCADE.
+  DELETE FROM auth.users WHERE id = v_user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.delete_user_account() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_user_account() FROM anon;
+GRANT  EXECUTE ON FUNCTION public.delete_user_account() TO authenticated;
+
+COMMENT ON FUNCTION public.delete_user_account() IS
+  'Self-service account deletion for the calling auth.uid(). Wipes app data '
+  'via reset_user_data() then deletes the auth.users row (cascades the rest). '
+  'Required by Apple App Store Guideline 5.1.1(v).';

--- a/webapp/src/actions/auth.ts
+++ b/webapp/src/actions/auth.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { redirect } from "next/navigation";
 import { loginSchema, signupSchema, forgotPasswordSchema, resetPasswordSchema } from "@/lib/validators/auth";
 import { trackProductEvent, trackProductEventForUser } from "@/actions/product-events";
@@ -179,6 +180,38 @@ export async function signOut(): Promise<void> {
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect("/login");
+}
+
+// Permanently deletes the calling user's account and ALL associated data.
+// Required by Apple App Store Guideline 5.1.1(v) and Google Play Data
+// Safety. Wipes app tables via reset_user_data() and deletes the
+// auth.users row (cascades the rest).
+export async function deleteAccount(): Promise<AuthActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { error: "No autenticado" };
+
+  // Anonymous demo sessions: the "Eliminar cuenta" affordance is for real
+  // accounts. Demo users are cleaned up by the daily cron — letting them
+  // hit this RPC works at the DB level but is a UX footgun.
+  if (user.is_anonymous) {
+    return {
+      error:
+        "Estás en modo demo. Cierra sesión y crea una cuenta real para gestionar tus datos.",
+    };
+  }
+
+  // RPC is `SECURITY DEFINER` and re-checks `auth.uid()` server-side, so
+  // a caller can only delete their own account.
+  const { error } = await supabase.rpc("delete_user_account");
+  if (error) {
+    console.error("[deleteAccount] RPC failed:", error);
+    return {
+      error: "No se pudo eliminar la cuenta. Intenta de nuevo.",
+    };
+  }
+
+  await supabase.auth.signOut();
+  redirect("/login?deleted=1");
 }
 
 export async function resetPasswordRequest(

--- a/webapp/src/app/(dashboard)/settings/perfil/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/perfil/page.tsx
@@ -4,13 +4,17 @@ import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { PageHeaderRow } from "@/components/ui/page-header-row";
 import { ProfileForm } from "@/components/settings/profile-form";
 import { SettingsBackLink } from "@/components/settings/settings-back-link";
+import { DeleteAccountSection } from "@/components/settings/delete-account-section";
 import { getProfile } from "@/actions/profile";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
 
 export default async function PerfilSettingsPage() {
   await connection();
   const profileResult = await getProfile();
   if (!profileResult.success) redirect("/login");
   const profile = profileResult.data;
+  const { user } = await getAuthenticatedClient();
+  const isAnonymous = !!user?.is_anonymous;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 lg:space-y-8">
@@ -23,6 +27,7 @@ export default async function PerfilSettingsPage() {
         />
       </div>
       <ProfileForm profile={profile} />
+      {!isAnonymous && <DeleteAccountSection />}
     </div>
   );
 }

--- a/webapp/src/app/eliminar-cuenta/page.tsx
+++ b/webapp/src/app/eliminar-cuenta/page.tsx
@@ -17,40 +17,51 @@ export default function EliminarCuentaPage() {
       lastUpdated="22 de abril de 2026"
     >
       <p>
-        Esta página explica cómo puedes solicitar la eliminación de tu cuenta
-        de Zeta y de todos los datos asociados. Cumple con los requisitos de
-        Google Play Console y App Store sobre gestión de datos del usuario.
+        Esta página explica cómo puedes eliminar tu cuenta de Zeta y todos
+        los datos asociados. Cumple con los requisitos de Google Play Console
+        y App Store sobre gestión de datos del usuario.
       </p>
 
-      <h2>1. Cómo solicitar la eliminación</h2>
+      <h2>1. Eliminación dentro de la app (recomendado)</h2>
       <p>
-        Envíanos un correo a{" "}
+        Puedes eliminar tu cuenta directamente desde la app, sin enviar
+        correos ni esperas. La eliminación es inmediata.
+      </p>
+      <ul>
+        <li>
+          <strong>Web:</strong> Abre{" "}
+          <Link
+            href="/settings/perfil"
+            className="text-foreground underline decoration-dotted underline-offset-2"
+          >
+            Ajustes → Perfil
+          </Link>{" "}
+          y pulsa <em>Eliminar cuenta</em> al final de la página.
+        </li>
+        <li>
+          <strong>iOS / Android:</strong> Abre <em>Ajustes</em> en la app,
+          baja a <em>Zona de peligro</em> y toca <em>Eliminar cuenta</em>.
+        </li>
+      </ul>
+      <p>
+        Confirma la acción cuando se te pida. Tu cuenta y todos tus datos se
+        borrarán de forma permanente del servidor.
+      </p>
+
+      <h2>2. Eliminación por correo (alternativa)</h2>
+      <p>
+        Si no puedes acceder a la app, también puedes escribirnos a{" "}
         <a
           href={`mailto:${CONTACT_EMAIL}?subject=Solicitud%20de%20eliminaci%C3%B3n%20de%20cuenta%20Zeta`}
           className="text-foreground underline decoration-dotted underline-offset-2"
         >
           {CONTACT_EMAIL}
         </a>{" "}
-        con:
-      </p>
-      <ul>
-        <li>Asunto: <em>Solicitud de eliminación de cuenta Zeta</em>.</li>
-        <li>
-          El correo electrónico con el que te registraste (debe coincidir con
-          el remitente del mensaje).
-        </li>
-        <li>
-          Opcional: motivo de la solicitud (nos ayuda a mejorar, pero no es
-          requerido).
-        </li>
-      </ul>
-      <p>
-        Verificaremos tu identidad comparando el correo remitente con la
-        cuenta en nuestro sistema. Procesamos las solicitudes en un plazo
-        máximo de <strong>7 días hábiles</strong>.
+        desde el correo con el que te registraste. Procesamos las solicitudes
+        manuales en un plazo máximo de <strong>7 días hábiles</strong>.
       </p>
 
-      <h2>2. Qué datos se eliminan</h2>
+      <h2>3. Qué datos se eliminan</h2>
       <p>Al eliminar tu cuenta borramos de forma permanente:</p>
       <ul>
         <li>Tu perfil, correo electrónico y credenciales de autenticación.</li>
@@ -70,7 +81,7 @@ export default function EliminarCuentaPage() {
         </li>
       </ul>
 
-      <h2>3. Qué datos se retienen y por qué</h2>
+      <h2>4. Qué datos se retienen y por qué</h2>
       <p>
         Por obligaciones legales y de integridad del servicio, algunos datos
         pueden conservarse de forma desidentificada tras la eliminación:
@@ -91,7 +102,7 @@ export default function EliminarCuentaPage() {
         </li>
       </ul>
 
-      <h2>4. Reversibilidad</h2>
+      <h2>5. Reversibilidad</h2>
       <p>
         La eliminación es <strong>permanente e irreversible</strong>. No
         podemos recuperar una cuenta eliminada ni sus datos. Si solo quieres
@@ -99,7 +110,7 @@ export default function EliminarCuentaPage() {
         vez de eliminar.
       </p>
 
-      <h2>5. Contacto</h2>
+      <h2>6. Contacto</h2>
       <p>
         Si tienes dudas sobre el proceso o el estado de tu solicitud,
         escríbenos a{" "}

--- a/webapp/src/components/settings/delete-account-section.tsx
+++ b/webapp/src/components/settings/delete-account-section.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { deleteAccount } from "@/actions/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  DESTRUCTIVE_BUTTON_CLASS,
+  DESTRUCTIVE_GHOST_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+  PANEL_SURFACE_SUBTLE_CLASS,
+} from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+const CONFIRMATION_PHRASE = "ELIMINAR";
+
+export function DeleteAccountSection() {
+  const [open, setOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const canConfirm = confirmation.trim().toUpperCase() === CONFIRMATION_PHRASE;
+
+  function handleDelete() {
+    if (!canConfirm) return;
+    startTransition(async () => {
+      const result = await deleteAccount();
+      // `deleteAccount` redirects on success — only reach here on error.
+      if (result?.error) {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <section
+      className={cn(PANEL_SURFACE_SUBTLE_CLASS, "surface-debt p-4 sm:p-5")}
+      aria-labelledby="delete-account-heading"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="space-y-1">
+          <h2
+            id="delete-account-heading"
+            className="text-sm font-semibold text-z-debt"
+          >
+            Eliminar cuenta
+          </h2>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Borra tu cuenta y todos tus datos (transacciones, presupuestos,
+            deudas, recurrentes, destinatarios, configuración). Esta acción es
+            permanente y no se puede deshacer.
+          </p>
+        </div>
+
+        <AlertDialog
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            if (!next) setConfirmation("");
+          }}
+        >
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS, "shrink-0")}
+            >
+              <Trash2 className="size-4" aria-hidden />
+              Eliminar cuenta
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>¿Eliminar tu cuenta?</AlertDialogTitle>
+              <AlertDialogDescription className="space-y-2">
+                <span className="block">
+                  Tu cuenta y todos los datos asociados se borrarán de forma
+                  permanente. No podrás recuperarlos.
+                </span>
+                <span className="block">
+                  Para confirmar, escribe{" "}
+                  <span className="font-semibold text-foreground">
+                    {CONFIRMATION_PHRASE}
+                  </span>{" "}
+                  abajo.
+                </span>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+
+            <div className="space-y-2 pt-2">
+              <Label htmlFor="delete-confirmation" className="text-xs">
+                Confirmación
+              </Label>
+              <Input
+                id="delete-confirmation"
+                value={confirmation}
+                onChange={(e) => setConfirmation(e.target.value)}
+                placeholder={CONFIRMATION_PHRASE}
+                autoComplete="off"
+                autoCapitalize="characters"
+                disabled={isPending}
+              />
+            </div>
+
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                className={GHOST_BUTTON_CLASS}
+                disabled={isPending}
+              >
+                Cancelar
+              </AlertDialogCancel>
+              <AlertDialogAction
+                className={DESTRUCTIVE_BUTTON_CLASS}
+                onClick={handleDelete}
+                disabled={!canConfirm || isPending}
+              >
+                {isPending ? "Eliminando…" : "Eliminar cuenta"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -3525,6 +3525,10 @@ export type Database = {
         Args: Record<string, never>
         Returns: undefined
       }
+      delete_user_account: {
+        Args: Record<string, never>
+        Returns: undefined
+      }
       get_accounts_with_masks: {
         Args: { p_user_id: string }
         Returns: {


### PR DESCRIPTION
## Why

Apple rejected the App Store submission (Guideline 5.1.1(v)) because email-only account deletion is insufficient. Apps that support account creation must offer self-service in-app deletion. This PR adds the flow on both mobile and web, and updates the legal page to point users at it.

## Summary

- **New RPC `public.delete_user_account()`** (`supabase/migrations/20260429192328_*.sql`) — `SECURITY DEFINER`, re-checks `auth.uid()`, calls `reset_user_data()` then `DELETE FROM auth.users WHERE id = v_user_id`. Cascades wipe `profiles_enc`, `accounts`, `transactions_enc`, etc. Same privilege pattern as the existing `cleanup_anonymous_demo_users()` cron.
- **Mobile** — "Eliminar cuenta" row in *Zona de peligro* with two-step `Alert.alert` confirmation. Post-RPC: `auth.signOut()` → `clearDatabase()` → wipe SecureStore (PDF passwords, default account) → disable biometrics → `router.replace("/(auth)/login")`.
- **Webapp** — `DeleteAccountSection` on `/settings/perfil` with typed-confirmation ("ELIMINAR") AlertDialog. Hidden for anonymous demo sessions. Server action uses `getAuthenticatedClient()` + `is_anonymous` guard + sanitized error response.
- **Legal page** — `/eliminar-cuenta` now points to the in-app flow first; email contact kept as fallback.

## Files

- `supabase/migrations/20260429192328_add_delete_user_account_rpc.sql` (new)
- `webapp/src/actions/auth.ts` — `deleteAccount()` action
- `webapp/src/components/settings/delete-account-section.tsx` (new)
- `webapp/src/app/(dashboard)/settings/perfil/page.tsx` — mounts section, hides for anonymous
- `webapp/src/app/eliminar-cuenta/page.tsx` — legal copy update
- `webapp/src/types/database.ts`, `packages/shared/src/types/database.ts` — `delete_user_account` Function stub (manual; full regen avoided to dodge the encrypted-views footgun)
- `mobile/app/settings.tsx` — UI row + handler
- `mobile/lib/delete-account.ts` (new) — local cleanup helper

## Reviewed by agents

- ✅ `supabase-migrator` — safe to ship; cascades audited; single-tx rollback prevents partial-wipe
- ✅ `server-action-reviewer` — fixed: now uses `getAuthenticatedClient()` + sanitized error
- ✅ `mobile-webapp-parity` — fixed: webapp now guards anonymous users + hides UI for them
- ✅ `zetas-front-guy` — fixed: `surface-debt` utility + `text-z-debt` heading

## Migration

Already applied to remote (`supabase db push` succeeded). The migration is idempotent (uses `CREATE OR REPLACE FUNCTION`) so no rollback risk if re-run.

## Test plan

- [ ] Local web: `pnpm build` ✅ passes (verified)
- [ ] Local mobile: `pnpm exec tsc --noEmit -p mobile` ✅ passes (verified)
- [ ] On real device: sign in → Ajustes → Eliminar cuenta → confirm twice → routes to /login
- [ ] On web: /settings/perfil → Eliminar cuenta → type "ELIMINAR" → confirm → routes to /login
- [ ] Anonymous demo session on web does NOT see the section
- [ ] Re-sign-up with same email succeeds (proves auth row gone, not just disabled)
- [ ] Build new EAS production-ios → upload to TestFlight → record screen video → resubmit to Apple with video in App Review notes

## Out of scope / known

- `?deleted=1` toast on `/login` is not yet wired (harmless query param).
- Pre-existing audit advisory: `@xmldom/xmldom <0.8.13` via `expo>@expo/cli>@expo/plist` (4 high). Build-time only, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)