### PR TITLE
fix(recurring): dedupe pending occurrences after template merge

### DIFF
--- a/supabase/migrations/20260429120000_cleanup_orphan_pending_occurrences.sql
+++ b/supabase/migrations/20260429120000_cleanup_orphan_pending_occurrences.sql
@@ -10,22 +10,29 @@
 -- code; this migration cleans up the data already corrupted by the old path.
 --
 -- Strategy (per template):
---   1. Compute the template's expected dates from start_date for the next 60
---      cycles, capped by end_date if set.
+--   1. Compute the template's expected dates from start_date stepping by its
+--      frequency, capped on the upper end by the lesser of end_date (if set)
+--      and (CURRENT_DATE + 90 days). The date-based cap is what matters — using
+--      a cycle-count cap (e.g. k <= 60) silently drops legitimate near-future
+--      pending rows when start_date is older than the cycle-count window
+--      (a WEEKLY template anchored 2 years ago needs >100 cycles to reach today).
 --   2. Delete any pending rows whose occurrence_date is NOT in the expected set.
 --   3. Paid/skipped rows are left untouched — they are historical records, even
 --      if their dates don't align with the current schedule.
 --
--- 60 cycles covers anything we'd realistically have stored (auto-generation
--- only goes month + 14 days ahead) without depending on the regeneration job
--- to refill a too-aggressive prune.
+-- The 5000-step generate_series upper bound is large enough for WEEKLY anchored
+-- in the 1930s to reach 2026; the date filter trims the result so per-template
+-- arrays stay small.
 -- =============================================================================
 
 DO $$
 DECLARE
   rec RECORD;
   expected_dates date[];
+  v_horizon date;
 BEGIN
+  v_horizon := (CURRENT_DATE + interval '90 days')::date;
+
   FOR rec IN
     SELECT id, start_date, end_date, frequency::text AS freq
     FROM recurring_transaction_templates_enc
@@ -44,9 +51,10 @@ BEGIN
             WHEN 'QUARTERLY' THEN interval '3 months'
             WHEN 'ANNUAL'    THEN interval '1 year'
           END))::date AS d
-        FROM generate_series(0, 60) AS k
+        FROM generate_series(0, 5000) AS k
       ) t
-      WHERE rec.end_date IS NULL OR t.d <= rec.end_date;
+      WHERE t.d <= v_horizon
+        AND (rec.end_date IS NULL OR t.d <= rec.end_date);
     END IF;
 
     IF expected_dates IS NULL OR array_length(expected_dates, 1) IS NULL THEN

--- a/supabase/migrations/20260429120000_cleanup_orphan_pending_occurrences.sql
+++ b/supabase/migrations/20260429120000_cleanup_orphan_pending_occurrences.sql
@@ -1,0 +1,62 @@
+-- =============================================================================
+-- One-shot cleanup of orphan pending recurring_occurrences left behind by past
+-- mergeRecurringTemplates() runs.
+--
+-- The previous merge implementation reassigned the absorbed template's pending
+-- occurrences to the surviving template without aligning them to the survivor's
+-- own start_date/frequency. The result: a single template ended up with two
+-- pending rows per cycle on different days (e.g. "Pago VISA" on 4 MAY and 6 MAY
+-- both pointing at the same template). The merge function has been fixed in
+-- code; this migration cleans up the data already corrupted by the old path.
+--
+-- Strategy (per template):
+--   1. Compute the template's expected dates from start_date for the next 60
+--      cycles, capped by end_date if set.
+--   2. Delete any pending rows whose occurrence_date is NOT in the expected set.
+--   3. Paid/skipped rows are left untouched — they are historical records, even
+--      if their dates don't align with the current schedule.
+--
+-- 60 cycles covers anything we'd realistically have stored (auto-generation
+-- only goes month + 14 days ahead) without depending on the regeneration job
+-- to refill a too-aggressive prune.
+-- =============================================================================
+
+DO $$
+DECLARE
+  rec RECORD;
+  expected_dates date[];
+BEGIN
+  FOR rec IN
+    SELECT id, start_date, end_date, frequency::text AS freq
+    FROM recurring_transaction_templates_enc
+  LOOP
+    IF rec.freq = 'ONCE' THEN
+      expected_dates := ARRAY[rec.start_date];
+    ELSE
+      SELECT array_agg(d)
+      INTO expected_dates
+      FROM (
+        SELECT (rec.start_date + (k *
+          CASE rec.freq
+            WHEN 'WEEKLY'    THEN interval '7 days'
+            WHEN 'BIWEEKLY'  THEN interval '14 days'
+            WHEN 'MONTHLY'   THEN interval '1 month'
+            WHEN 'QUARTERLY' THEN interval '3 months'
+            WHEN 'ANNUAL'    THEN interval '1 year'
+          END))::date AS d
+        FROM generate_series(0, 60) AS k
+      ) t
+      WHERE rec.end_date IS NULL OR t.d <= rec.end_date;
+    END IF;
+
+    IF expected_dates IS NULL OR array_length(expected_dates, 1) IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    DELETE FROM recurring_occurrences
+    WHERE template_id = rec.id
+      AND status = 'pending'
+      AND NOT (occurrence_date = ANY(expected_dates));
+  END LOOP;
+END;
+$$;

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -110,56 +110,33 @@ async function getUpcomingRecurrencesCached(
 
   const now = new Date(`${todayStr}T00:00:00`);
   const rangeEnd = addDays(now, days);
-  const rangeStartStr = todayStr;
   const rangeEndStr = toISODateString(rangeEnd);
 
-  const occurrenceKey = (templateId: string, date: string) => `${templateId}|${date}`;
+  // Read pending occurrences directly — the materialized table is the source
+  // of truth. Computing dates in JS from active templates would silently
+  // drift after merges or schedule edits.
+  const { data, error } = await supabase
+    .from("recurring_occurrences")
+    .select(`
+      occurrence_date,
+      template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
+        ${TEMPLATE_SELECT}
+      )
+    `)
+    .eq("user_id", userId)
+    .eq("status", "pending")
+    .gte("occurrence_date", todayStr)
+    .lte("occurrence_date", rangeEndStr)
+    .order("occurrence_date");
 
-  const [templatesRes, resolvedRes] = await Promise.all([
-    supabase
-      .from("recurring_transaction_templates")
-      .select(TEMPLATE_SELECT)
-      .eq("user_id", userId)
-      .eq("is_active", true),
-    supabase
-      .from("recurring_occurrences")
-      .select("template_id, occurrence_date")
-      .eq("user_id", userId)
-      .in("status", ["paid", "skipped"])
-      .gte("occurrence_date", rangeStartStr)
-      .lte("occurrence_date", rangeEndStr),
-  ]);
-
-  if (templatesRes.error) throw templatesRes.error;
-  if (resolvedRes.error) throw resolvedRes.error;
-
-  const templates = templatesRes.data;
-  const resolvedOccurrences = resolvedRes.data;
-
-  if (!templates || templates.length === 0) return [];
-
-  const resolvedKeys = new Set(
-    (resolvedOccurrences ?? []).map((o) => occurrenceKey(o.template_id, o.occurrence_date))
-  );
+  if (error) throw error;
 
   const upcoming: UpcomingRecurrence[] = [];
-
-  for (const template of templates as RecurringTemplateWithRelations[]) {
-    const dates = getOccurrencesBetween(
-      template.start_date,
-      template.frequency,
-      template.end_date,
-      now,
-      rangeEnd
-    );
-
-    for (const date of dates) {
-      if (resolvedKeys.has(occurrenceKey(template.id, date))) continue;
-      upcoming.push({ template, next_date: date });
-    }
+  for (const row of data ?? []) {
+    const template = row.template as RecurringTemplateWithRelations | null;
+    if (!template || template.is_active === false) continue;
+    upcoming.push({ template, next_date: row.occurrence_date });
   }
-
-  upcoming.sort((a, b) => a.next_date.localeCompare(b.next_date));
 
   return upcoming;
 }
@@ -1047,15 +1024,20 @@ export async function recordRecurringOccurrencePayment(input: {
 }
 
 /**
- * Get upcoming recurring payments for the next N days.
- * Computes occurrences on the fly from active templates.
+ * Get upcoming recurring payments for the next N days, sourced from the
+ * materialized recurring_occurrences table.
  */
 export async function getUpcomingRecurrences(
   days: number = 30
 ): Promise<UpcomingRecurrence[]> {
   const { user, accessToken } = await getAuthenticatedClient();
   if (!user || !accessToken) return [];
-  return getUpcomingRecurrencesCached(user.id, days, toISODateString(new Date()), accessToken);
+
+  // Make sure pending rows exist for the lookahead window before reading.
+  const now = new Date();
+  await ensureOccurrencesForRange(now, addDays(now, days));
+
+  return getUpcomingRecurrencesCached(user.id, days, toISODateString(now), accessToken);
 }
 
 /**
@@ -1299,6 +1281,60 @@ export async function mergeRecurringTemplates(
       .update({ template_id: keepId })
       .eq("template_id", absorbId)
       .eq("user_id", user.id);
+
+    // 3.5. Re-align keep's pending occurrences with its own schedule.
+    // The reassign in step 3 can move pending rows onto dates the absorbed
+    // template generated (e.g. day 6) that don't match the keep template's
+    // own day_of_month/frequency (e.g. day 4). Left untouched, the dashboard
+    // would show two upcoming entries per cycle instead of one.
+    // Paid/skipped rows are preserved as historical records regardless of
+    // date alignment — only pending rows are filtered against the schedule.
+    const { data: keepPendingRows } = await supabase
+      .from("recurring_occurrences")
+      .select("id, occurrence_date")
+      .eq("template_id", keepId)
+      .eq("user_id", user.id)
+      .eq("status", "pending");
+
+    if (keepPendingRows && keepPendingRows.length > 0) {
+      const sorted = [...keepPendingRows].sort((a, b) =>
+        a.occurrence_date.localeCompare(b.occurrence_date),
+      );
+      const earliest = new Date(`${sorted[0].occurrence_date}T12:00:00`);
+      const latest = new Date(`${sorted[sorted.length - 1].occurrence_date}T12:00:00`);
+      const lookaheadEnd = addDays(new Date(), 90);
+      const rangeEnd = latest > lookaheadEnd ? latest : lookaheadEnd;
+      const expectedDates = new Set(
+        getOccurrencesBetween(
+          keep.start_date,
+          keep.frequency,
+          keep.end_date,
+          earliest,
+          rangeEnd,
+        ),
+      );
+      const orphanIds = sorted
+        .filter((row) => !expectedDates.has(row.occurrence_date))
+        .map((row) => row.id);
+      if (orphanIds.length > 0) {
+        await supabase
+          .from("recurring_occurrences")
+          .delete()
+          .in("id", orphanIds)
+          .eq("user_id", user.id);
+      }
+    }
+
+    // Align expected_amount on every surviving pending row to the merged
+    // primary amount. The original keep pending still carry the pre-merge
+    // amount; without this they'd render the old number while the reassigned
+    // rows show the new merged amount.
+    await supabase
+      .from("recurring_occurrences")
+      .update({ expected_amount: primaryAmount })
+      .eq("template_id", keepId)
+      .eq("user_id", user.id)
+      .eq("status", "pending");
 
     // 4. Delete the absorbed template
     await supabase

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -115,16 +115,19 @@ async function getUpcomingRecurrencesCached(
   // Read pending occurrences directly — the materialized table is the source
   // of truth. Computing dates in JS from active templates would silently
   // drift after merges or schedule edits.
+  // !inner + template.is_active filter pushes the paused-template exclusion
+  // down to PostgREST so we don't ship rows we'd discard in JS.
   const { data, error } = await supabase
     .from("recurring_occurrences")
     .select(`
       occurrence_date,
-      template:recurring_transaction_templates!recurring_occurrences_template_id_fkey(
+      template:recurring_transaction_templates!recurring_occurrences_template_id_fkey!inner(
         ${TEMPLATE_SELECT}
       )
     `)
     .eq("user_id", userId)
     .eq("status", "pending")
+    .eq("template.is_active", true)
     .gte("occurrence_date", todayStr)
     .lte("occurrence_date", rangeEndStr)
     .order("occurrence_date");
@@ -134,7 +137,7 @@ async function getUpcomingRecurrencesCached(
   const upcoming: UpcomingRecurrence[] = [];
   for (const row of data ?? []) {
     const template = row.template as RecurringTemplateWithRelations | null;
-    if (!template || template.is_active === false) continue;
+    if (!template) continue;
     upcoming.push({ template, next_date: row.occurrence_date });
   }
 


### PR DESCRIPTION
## Summary

Fixes the duplicate "Próximos pagos" entries on the dashboard (e.g. two "Pago VISA" rows on different days under a single template). Caused by `mergeRecurringTemplates()` reassigning the absorbed template's pending occurrences to the survivor without aligning them to the survivor's own `start_date`/`frequency`.

- **`mergeRecurringTemplates()`**: after the absorb→keep reassign, prune keep's pending rows whose dates don't match keep's schedule (via `getOccurrencesBetween()`), then normalize `expected_amount` across all surviving pending rows. Paid/skipped rows are preserved as historical records.
- **`getUpcomingRecurrencesCached()`**: replace JS-side date computation from active templates with a direct query against `recurring_occurrences` (source of truth). Eliminates silent drift after merges and schedule edits. Public wrapper now calls `ensureOccurrencesForRange()` before reading.
- **Cleanup migration** (`20260429120000_cleanup_orphan_pending_occurrences.sql`): one-shot DO block that re-aligns every template's pending rows with its own schedule, fixing data already corrupted by the old merge path. Date-based cap (`CURRENT_DATE + 90 days`, capped further by `end_date`) ensures legitimate near-future rows are preserved regardless of how old the template's `start_date` is.

## Reviews

- `recurring-doctor` — flagged a HIGH bug in v1 of the migration (60-cycle cap silently dropped legitimate pending rows for old WEEKLY templates). Fixed in `a9abe36` with date-based cap.
- `server-action-reviewer` — PASS. Defense-in-depth, FK hint syntax, cache invalidation all correct.
- `supabase-migrator` — PASS. Encrypted base table is the right target; date arithmetic matches `generate_occurrences_for_template()`; idempotent re-run safe.

## Test plan

- [ ] Apply migration: `npx supabase db push`
- [ ] Verify dashboard "Por resolver" shows one "Pago VISA" per cycle (not two)
- [ ] Verify recurring admin page still shows the surviving template
- [ ] Merge two templates with different cadences (e.g. day 4 + day 6 monthly) and confirm only the survivor's schedule produces pending rows after the merge
- [ ] Verify `expected_amount` on surviving pending rows reflects the merged primary amount
- [ ] Confirm paid/skipped historical rows are preserved (no regression on past data)

## Out of scope

- `webapp/src/actions/cashflow-planner.ts:381` still computes occurrences in JS from active templates. Pre-existing source-of-truth violation, not a regression — flagged for a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)