### PR TITLE
fix(recurring): update source account balance when marking occurrence paid

### DIFF
--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -30,8 +30,6 @@ import type {
   UpcomingRecurrence,
 } from "@/types/domain";
 
-const DEBT_ACCOUNT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
-
 const TEMPLATE_SELECT = `
   *,
   account:accounts!recurring_transaction_templates_account_id_fkey(id, name, icon, color, account_type, currency_code, mask, bank_key),
@@ -186,7 +184,7 @@ async function getRecurringSummaryCached(
   for (const t of templates) {
     const monthlyAmount = toMonthlyAmount(t.amount, t.frequency);
     const accountType = (t.accounts as { account_type?: string } | null)?.account_type;
-    const isDebtPayment = !!accountType && DEBT_ACCOUNT_TYPES.has(accountType);
+    const isDebtPayment = !!accountType && isDebtAccountType(accountType);
     if (t.direction === "OUTFLOW" || isDebtPayment) {
       totalMonthlyExpenses += monthlyAmount;
     } else {
@@ -274,7 +272,7 @@ async function insertRecurringTemplateFromFormData(
     return { success: false, error: "Cuenta inválida para este usuario." };
   }
 
-  if (DEBT_ACCOUNT_TYPES.has(account.account_type)) {
+  if (isDebtAccountType(account.account_type)) {
     payload.direction = "INFLOW";
     payload.category_id = payload.category_id ?? getDebtPaymentCategoryId(account.account_type);
     if (!payload.transfer_source_account_id) {
@@ -429,7 +427,7 @@ export async function updateRecurringTemplate(
     return { success: false, error: "Cuenta inválida para este usuario." };
   }
 
-  if (DEBT_ACCOUNT_TYPES.has(account.account_type)) {
+  if (isDebtAccountType(account.account_type)) {
     payload.direction = "INFLOW";
     payload.category_id = payload.category_id ?? getDebtPaymentCategoryId(account.account_type);
     if (!payload.transfer_source_account_id) {
@@ -613,7 +611,7 @@ function resolveSourceAccountSelection(params: {
   effectiveSourceAccountId: string | null;
   error: string | null;
 } {
-  const isDebtPaymentTemplate = DEBT_ACCOUNT_TYPES.has(params.template.account.account_type);
+  const isDebtPaymentTemplate = isDebtAccountType(params.template.account.account_type);
   const effectiveSourceAccountId =
     params.sourceAccountId ?? params.template.transfer_source_account_id ?? null;
 
@@ -1136,7 +1134,7 @@ export async function getRecurringTemplateImpact(
 
     // Resolve effective direction (debt accounts = INFLOW template but behaves as OUTFLOW obligation)
     const accountType = (template.account as { account_type?: string } | null)?.account_type;
-    const isDebtPayment = !!accountType && DEBT_ACCOUNT_TYPES.has(accountType);
+    const isDebtPayment = !!accountType && isDebtAccountType(accountType);
     const effectiveDirection: "INFLOW" | "OUTFLOW" = isDebtPayment ? "OUTFLOW" : template.direction;
 
     const nextDate = getNextOccurrence(

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -8,7 +8,7 @@ import { createCachedClient } from "@/lib/supabase/cached";
 import { recurringTemplateSchema } from "@/lib/validators/recurring-template";
 import { parseSubPayments } from "@/lib/utils/sub-payments";
 import { computeIdempotencyKey } from "@/lib/utils/idempotency";
-import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
+import { applyAccountBalanceDelta, isDebtAccountType } from "@/lib/utils/account-balance";
 import { toMonthlyAmount } from "@/lib/utils/recurring";
 import { ensureCurrentOccurrences, ensureOccurrencesForRange, linkTransactionToOccurrence } from "@/actions/occurrences";
 import {
@@ -552,6 +552,7 @@ type PaymentAccountRow = {
   name: string;
   account_type: string;
   current_balance: number;
+  credit_limit: number | null;
 };
 type RecurringTxDraft = {
   account_id: string;
@@ -671,7 +672,7 @@ async function loadPaymentAccounts(params: {
 
   const { data: accountRows, error } = await params.supabase
     .from("accounts")
-    .select("id, name, account_type, current_balance")
+    .select("id, name, account_type, current_balance, credit_limit")
     .in("id", accountIds)
     .eq("user_id", params.userId);
 
@@ -849,11 +850,24 @@ async function updateBalancesForCreatedTransactions(params: {
     });
 
     account.current_balance = nextBalance;
-    await params.supabase
+
+    const updatePayload: Record<string, number> = { current_balance: nextBalance };
+    if (isDebtAccountType(account.account_type) && account.credit_limit != null) {
+      updatePayload.available_balance = account.credit_limit - nextBalance;
+    }
+
+    const { error: balanceError } = await params.supabase
       .from("accounts")
-      .update({ current_balance: nextBalance })
+      .update(updatePayload)
       .eq("id", account.id)
       .eq("user_id", params.userId);
+
+    if (balanceError) {
+      console.error(
+        "[updateBalancesForCreatedTransactions] balance update failed",
+        { accountId: account.id, error: balanceError.message }
+      );
+    }
   }
 }
 


### PR DESCRIPTION
updateBalancesForCreatedTransactions silently swallowed DB errors and
omitted available_balance for debt accounts, so debt-payment recurrences
could leave the source account balance stale (no visible failure) and
the credit card's available credit out of sync with current_balance.

- Surface balance update errors via console.error so silent failures
  become visible (mirrors transfers.ts pattern).
- Recompute available_balance = credit_limit - current_balance for
  CREDIT_CARD/LOAN accounts on every balance write.
- Load credit_limit alongside the other account fields used during
  recurring payment posting.