### PR TITLE
fix(plan): paid recurring occurrences no longer show as Pendiente in Periodo

### DIFF
--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -15,7 +15,7 @@ import { isDebtAccountType } from "@/lib/utils/account-balance";
 import { toColombiaDateString } from "@/lib/utils/date";
 import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 import type { ActionResult } from "@/types/actions";
-import type { TablesInsert } from "@/types/database";
+import type { TablesInsert, Database } from "@/types/database";
 import type {
   CurrencyCode,
   PlanningPeriod,
@@ -107,7 +107,10 @@ async function hydratePeriodData(
   const rawEntriesTyped = (rawEntries ?? []) as unknown as (Omit<PlanningEntryWithRelations, "converted_amount">)[];
   const assignments = (rawAssignments ?? []) as unknown as PlanningAssignment[];
 
-  const occurrenceStatusByKey = new Map<string, "pending" | "paid" | "skipped">();
+  const occurrenceStatusByKey = new Map<
+    string,
+    Database["public"]["Enums"]["occurrence_status"]
+  >();
   for (const occ of rawOccurrences ?? []) {
     occurrenceStatusByKey.set(`${occ.template_id}|${occ.occurrence_date}`, occ.status);
   }

--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -74,7 +74,7 @@ async function hydratePeriodData(
   const supabase = createCachedClient(accessToken);
   const periodCurrency = period.currency_code;
 
-  const [{ data: rawEntries }, { data: rawAssignments }] = await Promise.all([
+  const [{ data: rawEntries }, { data: rawAssignments }, { data: rawOccurrences }] = await Promise.all([
     supabase
       .from("planning_entries")
       .select(
@@ -92,10 +92,25 @@ async function hydratePeriodData(
       .select("*")
       .eq("period_id", period.id)
       .eq("user_id", userId),
+    // recurring_occurrences is the source of truth for recurring obligations.
+    // We reconcile each planning_entry's status with its matching occurrence
+    // so payments recorded outside the planning UI (PDF import, email,
+    // recurrentes tab, manual transactions) immediately reflect here.
+    supabase
+      .from("recurring_occurrences")
+      .select("template_id, occurrence_date, status")
+      .eq("user_id", userId)
+      .gte("occurrence_date", period.start_date)
+      .lte("occurrence_date", period.end_date),
   ]);
 
   const rawEntriesTyped = (rawEntries ?? []) as unknown as (Omit<PlanningEntryWithRelations, "converted_amount">)[];
   const assignments = (rawAssignments ?? []) as unknown as PlanningAssignment[];
+
+  const occurrenceStatusByKey = new Map<string, "pending" | "paid" | "skipped">();
+  for (const occ of rawOccurrences ?? []) {
+    occurrenceStatusByKey.set(`${occ.template_id}|${occ.occurrence_date}`, occ.status);
+  }
 
   const foreignCurrencies = new Set<CurrencyCode>();
   for (const e of rawEntriesTyped) {
@@ -126,7 +141,17 @@ async function hydratePeriodData(
       const rate = exchangeRates[e.currency_code];
       convertedAmount = rate != null ? amount * rate : amount;
     }
-    return { ...e, converted_amount: convertedAmount };
+    // For recurring entries, occurrence status overrides the entry's stored
+    // status — paid/skipped occurrences must not show as Pendiente.
+    let status = e.status;
+    if (e.recurring_template_id) {
+      const occStatus = occurrenceStatusByKey.get(
+        `${e.recurring_template_id}|${e.expected_date}`
+      );
+      if (occStatus === "paid") status = "COMPLETED";
+      else if (occStatus === "skipped") status = "SKIPPED";
+    }
+    return { ...e, status, converted_amount: convertedAmount };
   });
 
   const incomeEntries = entries.filter((e) => e.entry_type === "INCOME");

--- a/webapp/src/actions/occurrences.ts
+++ b/webapp/src/actions/occurrences.ts
@@ -596,6 +596,7 @@ export async function markOccurrencePaid(
   }
 
   revalidateFinancialViews();
+  updateTag("cashflow-planner");
   return { success: true, data: undefined };
 }
 
@@ -633,6 +634,7 @@ export async function skipOccurrence(occurrenceId: string): Promise<ActionResult
 
   revalidateFinancialViews();
   updateTag("occurrences");
+  updateTag("cashflow-planner");
   return { success: true, data: undefined };
 }
 
@@ -791,6 +793,7 @@ export async function revertOccurrence(occurrenceId: string): Promise<ActionResu
   revalidateFinancialViews();
   updateTag("occurrences");
   updateTag("recurring");
+  updateTag("cashflow-planner");
   return { success: true, data: undefined };
 }
 

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -1028,6 +1028,7 @@ export async function recordRecurringOccurrencePayment(input: {
   updateTag("occurrences");
   updateTag("recurring");
   updateTag("impact");
+  updateTag("cashflow-planner");
 
   return {
     success: true,


### PR DESCRIPTION
## Summary

The Periodo tab in `/plan` was rendering already-paid recurring obligations (e.g., `Pago NU Bank`, `Pago VISA`) as **Pendiente**, even though the same payments showed in the Recurrentes tab's **COMPLETADOS** section.

**Root cause:** `recurring_occurrences` is the documented source of truth for recurring obligations (per CLAUDE.md), but the Periodo view was reading `planning_entries.status` directly. Most occurrence-paying paths — `recordRecurringOccurrencePayment`, PDF import auto-link, email ingest auto-link, manual transaction matching — only update `recurring_occurrences.status`. They never touch the matching `planning_entries.status`. Only `payPlanningEntry` (paying through the Periodo UI itself) keeps both in sync.

**Fix:** In `hydratePeriodData`, fetch `recurring_occurrences` rows in the period's date range and override each recurring entry's status at read time:
- `paid` → `COMPLETED`
- `skipped` → `SKIPPED`
- `pending` → leave entry status untouched

Match key: `(planning_entries.recurring_template_id, expected_date) ↔ (recurring_occurrences.template_id, occurrence_date)` — both sides are seeded from the same `getOccurrencesBetween()` shared util, so they always align.

This approach was preferred over write-back from each mutation path because it:
- retroactively fixes already-inconsistent rows,
- covers every payment path (PDF, email, manual, recurrentes tab) without scattering planning_entry updates across the codebase,
- aligns with the CLAUDE.md principle that occurrences are the source of truth.

Standalone planning entries (`recurring_template_id = null`) are unaffected — they keep their stored status as before.

## Defensive cache invalidation

Added `updateTag("cashflow-planner")` to `recordRecurringOccurrencePayment`, `markOccurrencePaid`, `skipOccurrence`, and `revertOccurrence`. Today it's a no-op because `hydratePeriodData` is not `"use cache"`-wrapped (and `/plan` uses `connection()` for dynamic rendering), but it's cheap insurance: if anyone later wraps `hydratePeriodData` for performance, payments from outside the planning UI would otherwise silently go stale on Periodo.

## Review

Reviewed by `server-action-reviewer`, `recurring-doctor`, and `cache-doctor` agents — all PASS.

- ✅ Defense-in-depth: `.eq("user_id", userId)` on the new query
- ✅ Parallel fetch (no added latency)
- ✅ Typed enum (`Database["public"]["Enums"]["occurrence_status"]`) so the override map tracks the DB schema
- ✅ Source-of-truth alignment with the recurring obligations lifecycle
- ✅ Revert path correctly reverts entries back to `PLANNED`

## Test plan

- [ ] Pay a recurring occurrence via the **Recurrentes** tab → navigate to **Periodo** → entry shows `Pagado`, not `Pendiente`
- [ ] Skip a recurring occurrence → Periodo shows `Omitido`
- [ ] Pay an occurrence via PDF import (matching transaction auto-links) → Periodo reflects `Pagado`
- [ ] Click `Deshacer` in COMPLETADOS → occurrence returns to `pending` → Periodo entry returns to `Pendiente`
- [ ] Standalone (non-recurring) planning entry → status reflects what user set via `toggleEntryStatus` (no regression)
- [ ] Manually paying via Periodo's `Pagar` button still works end-to-end (no double-counting)

https://claude.ai/code/session_01SACsHowHo2TMNPFouqs9yE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SACsHowHo2TMNPFouqs9yE)_