### PR TITLE
feat(plan): show current balance of main accounts on monthly plan page

### DIFF
--- a/webapp/src/actions/exchange-rate.ts
+++ b/webapp/src/actions/exchange-rate.ts
@@ -28,7 +28,7 @@ export async function getExchangeRate(
   to: CurrencyCode
 ): Promise<ExchangeRateResult | null> {
   "use cache";
-  cacheTag(`exchange-rate:${from}_${to}`);
+  cacheTag("exchange-rates", `exchange-rate:${from}_${to}`);
   cacheLife({ stale: 3600, revalidate: 3600 * 6, expire: 3600 * 24 });
 
   if (from === to) return null;

--- a/webapp/src/actions/exchange-rate.ts
+++ b/webapp/src/actions/exchange-rate.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { cacheLife, cacheTag } from "next/cache";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { CurrencyCode } from "@/types/domain";
 import type { Database } from "@/types/database";
@@ -26,8 +27,11 @@ export async function getExchangeRate(
   from: CurrencyCode,
   to: CurrencyCode
 ): Promise<ExchangeRateResult | null> {
-  if (from === to) return null;
+  "use cache";
+  cacheTag(`exchange-rate:${from}_${to}`);
+  cacheLife({ stale: 3600, revalidate: 3600 * 6, expire: 3600 * 24 });
 
+  if (from === to) return null;
   const pair = `${from}_${to}`;
   const supabase = createAdminClient();
 

--- a/webapp/src/actions/plan.ts
+++ b/webapp/src/actions/plan.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { cache } from "react";
+import { getAccounts } from "@/actions/accounts";
 import { getCategoriesWithBudgetData } from "@/actions/categories";
 import { getDebtOverview } from "@/actions/debt";
 import { getDebtFreeCountdown, type DebtCountdownData } from "@/actions/debt-countdown";
 import { getEstimatedIncome, type IncomeEstimate } from "@/actions/income";
+import { getRatesForCurrencies } from "@/actions/exchange-rate";
 import { getPreferredCurrency } from "@/actions/profile";
 import {
   getRecurringSummary,
@@ -12,11 +14,68 @@ import {
 } from "@/actions/recurring-templates";
 import { get503020Allocation, type AllocationData } from "@/actions/allocation";
 import { getDashboardHeroData, type DashboardHeroData } from "@/actions/charts";
-import type { CurrencyCode } from "@/types/domain";
+import type { Account, AccountType, CurrencyCode } from "@/types/domain";
 import type {
   PlanHeroSummary,
+  PlanMainAccountsSummary,
   PlanPageData,
 } from "@/types/plan";
+
+const MAIN_ACCOUNT_TYPES: AccountType[] = ["CHECKING", "SAVINGS", "CASH"];
+
+async function buildMainAccountsSummary(
+  accounts: Account[],
+  baseCurrency: CurrencyCode
+): Promise<PlanMainAccountsSummary> {
+  const candidates = accounts.filter(
+    (a) => MAIN_ACCOUNT_TYPES.includes(a.account_type) && a.show_in_dashboard
+  );
+
+  const otherCurrencies = [
+    ...new Set(
+      candidates
+        .map((a) => a.currency_code as CurrencyCode)
+        .filter((c) => c !== baseCurrency)
+    ),
+  ];
+  const rates = otherCurrencies.length > 0
+    ? await getRatesForCurrencies(otherCurrencies, baseCurrency)
+    : new Map<CurrencyCode, number>();
+
+  let hasUnconvertibleAccounts = false;
+  const mainAccounts = candidates
+    .map((a) => {
+      const currency = a.currency_code as CurrencyCode;
+      const balance = a.current_balance ?? 0;
+      const rate = currency === baseCurrency ? 1 : rates.get(currency);
+      if (!rate) {
+        hasUnconvertibleAccounts = true;
+        return null;
+      }
+      return {
+        id: a.id,
+        name: a.name,
+        account_type: a.account_type,
+        current_balance: balance,
+        currency_code: currency,
+        balance_in_base: balance * rate,
+        icon: a.icon,
+        color: a.color,
+        bank_key: a.bank_key,
+        mask: a.mask,
+      };
+    })
+    .filter((a): a is NonNullable<typeof a> => a !== null)
+    .sort((a, b) => b.balance_in_base - a.balance_in_base);
+
+  const totalInBase = mainAccounts.reduce((sum, a) => sum + a.balance_in_base, 0);
+
+  return {
+    accounts: mainAccounts,
+    totalInBase,
+    hasUnconvertibleAccounts,
+  };
+}
 
 function buildHeroSummary({
   heroData,
@@ -116,6 +175,7 @@ export const getPlanPageData = cache(
       incomeEstimate,
       allocation,
       heroData,
+      accountsResult,
     ] = await Promise.all([
       getCategoriesWithBudgetData(month, baseCurrency),
       getDebtOverview(baseCurrency),
@@ -125,7 +185,13 @@ export const getPlanPageData = cache(
       getEstimatedIncome(baseCurrency, month),
       get503020Allocation(month, baseCurrency),
       getDashboardHeroData(month, baseCurrency),
+      getAccounts(),
     ]);
+
+    const mainAccounts = await buildMainAccountsSummary(
+      accountsResult.success ? accountsResult.data : [],
+      baseCurrency
+    );
 
     const categories = categoriesResult.success ? categoriesResult.data.filter((category) => category.direction === "OUTFLOW") : [];
     const overLimitCategories = categories.filter((category) => (category.budget ?? 0) > 0 && category.percentUsed > 100);
@@ -198,6 +264,7 @@ export const getPlanPageData = cache(
         dueSoonTotal,
         overdueCount: recurringSummary.overdueCount,
       },
+      mainAccounts,
       scenarios: {
         savedScenarios: [],
         latestScenario: null,

--- a/webapp/src/components/mobile/v2/plan/plan-mobile-accounts-card.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-mobile-accounts-card.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Wallet } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+import type { PlanMainAccountsSummary } from "@/types/plan";
+
+interface PlanMobileAccountsCardProps {
+  mainAccounts: PlanMainAccountsSummary;
+  currency: CurrencyCode;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function PlanMobileAccountsCard({
+  mainAccounts,
+  currency,
+  expanded,
+  onToggle,
+}: PlanMobileAccountsCardProps) {
+  const { accounts, totalInBase, hasUnconvertibleAccounts } = mainAccounts;
+  const hasAccounts = accounts.length > 0;
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className={cn(
+          "w-full rounded-xl border p-3 text-left transition-all",
+          expanded
+            ? "border-z-brass/50 bg-z-brass/10"
+            : "border-white/6 bg-z-brass/5"
+        )}
+      >
+        <div className="flex items-center justify-between">
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5 text-z-brass">
+              <Wallet className="size-3.5" />
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em]">
+                Saldo actual
+              </p>
+            </div>
+            <p className="mt-1 text-lg font-bold tabular-nums text-z-brass">
+              {formatCurrency(totalInBase, currency)}
+            </p>
+            <p className="text-[10px] text-muted-foreground">
+              {hasAccounts
+                ? `${accounts.length} ${accounts.length === 1 ? "cuenta principal" : "cuentas principales"}`
+                : "Sin cuentas principales"}
+            </p>
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="rounded-xl border border-z-brass/20 bg-z-brass/5 p-3">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+            Cuentas principales
+          </p>
+
+          {hasAccounts ? (
+            <>
+              <div className="divide-y divide-white/5">
+                {accounts.map((account) => {
+                  const showBaseConversion = account.currency_code !== currency;
+                  return (
+                    <div
+                      key={account.id}
+                      className="flex items-center justify-between py-2"
+                    >
+                      <div className="min-w-0 pr-2">
+                        <p className="truncate text-xs font-medium">{account.name}</p>
+                        <p className="text-[10px] text-muted-foreground">
+                          {account.mask ? `····${account.mask} · ` : ""}
+                          {account.currency_code}
+                        </p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-sm font-semibold tabular-nums text-z-brass">
+                          {formatCurrency(account.current_balance, account.currency_code)}
+                        </p>
+                        {showBaseConversion && (
+                          <p className="text-[10px] text-muted-foreground tabular-nums">
+                            ≈ {formatCurrency(account.balance_in_base, currency)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
+                <span className="text-muted-foreground">Total</span>
+                <span className="font-bold tabular-nums text-z-brass">
+                  {formatCurrency(totalInBase, currency)}
+                </span>
+              </div>
+              {hasUnconvertibleAccounts && (
+                <p className="mt-2 text-[10px] text-muted-foreground">
+                  Algunas cuentas en otra moneda no se pudieron convertir.
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="py-3 text-center">
+              <p className="mb-2 text-xs text-muted-foreground">
+                No tienes cuentas principales activas
+              </p>
+              <Link
+                href="/accounts"
+                className="inline-flex items-center gap-1 rounded-lg bg-z-brass/15 px-3 py-1.5 text-xs font-medium text-z-brass transition-colors hover:bg-z-brass/20"
+              >
+                Ver cuentas
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/plan-mobile-accounts-card.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-mobile-accounts-card.tsx
@@ -2,6 +2,7 @@
 
 import { Wallet } from "lucide-react";
 import Link from "next/link";
+import { MOBILE_ACTION_BUTTON_CLASS } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import type { CurrencyCode } from "@/types/domain";
@@ -29,6 +30,7 @@ export function PlanMobileAccountsCard({
         type="button"
         onClick={onToggle}
         aria-expanded={expanded}
+        aria-label={expanded ? "Ocultar saldos de cuentas principales" : "Mostrar saldos de cuentas principales"}
         className={cn(
           "w-full rounded-xl border p-3 text-left transition-all",
           expanded
@@ -64,7 +66,7 @@ export function PlanMobileAccountsCard({
 
           {hasAccounts ? (
             <>
-              <div className="divide-y divide-white/5">
+              <div className="divide-y divide-white/6">
                 {accounts.map((account) => {
                   const showBaseConversion = account.currency_code !== currency;
                   return (
@@ -93,7 +95,7 @@ export function PlanMobileAccountsCard({
                   );
                 })}
               </div>
-              <div className="mt-2 flex items-center justify-between border-t border-white/5 pt-2 text-xs">
+              <div className="mt-2 flex items-center justify-between border-t border-white/6 pt-2 text-xs">
                 <span className="text-muted-foreground">Total</span>
                 <span className="font-bold tabular-nums text-z-brass">
                   {formatCurrency(totalInBase, currency)}
@@ -112,7 +114,7 @@ export function PlanMobileAccountsCard({
               </p>
               <Link
                 href="/accounts"
-                className="inline-flex items-center gap-1 rounded-lg bg-z-brass/15 px-3 py-1.5 text-xs font-medium text-z-brass transition-colors hover:bg-z-brass/20"
+                className={cn(MOBILE_ACTION_BUTTON_CLASS, "inline-flex items-center gap-1")}
               >
                 Ver cuentas
               </Link>

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -5,6 +5,7 @@ import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { PlanNetHero } from "./plan-net-hero";
 import { PlanExpandableChips } from "./plan-expandable-chips";
 import { PlanDrillCards } from "./plan-drill-cards";
+import { PlanMobileAccountsCard } from "./plan-mobile-accounts-card";
 import { MonthSelector } from "@/components/month-selector";
 import { useExpandableZone } from "@/components/mobile/v2/use-expandable-zone";
 import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
@@ -59,6 +60,14 @@ export function PlanRoot({
         currency={currency}
         daysRemaining={daysInMonth - dayOfMonth}
         timelineData={timelineData}
+      />
+
+      {/* Saldo actual — main accounts current balance */}
+      <PlanMobileAccountsCard
+        mainAccounts={planData.mainAccounts}
+        currency={currency}
+        expanded={activeZone === "chip-balance"}
+        onToggle={() => toggle("chip-balance")}
       />
 
       {/* Expandable chips — próximo ingreso / próximo pago */}

--- a/webapp/src/components/mobile/v2/plan/plan-root.tsx
+++ b/webapp/src/components/mobile/v2/plan/plan-root.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useCallback } from "react";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { PlanNetHero } from "./plan-net-hero";
 import { PlanExpandableChips } from "./plan-expandable-chips";
@@ -37,6 +37,7 @@ export function PlanRoot({
   const { activeZone, toggle } = useExpandableZone<string>();
   const incomes = planData.recurring.upcomingIncome;
   const payments = planData.recurring.upcoming;
+  const toggleBalance = useCallback(() => toggle("chip-balance"), [toggle]);
 
   return (
     <div className={`space-y-2 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
@@ -67,7 +68,7 @@ export function PlanRoot({
         mainAccounts={planData.mainAccounts}
         currency={currency}
         expanded={activeZone === "chip-balance"}
-        onToggle={() => toggle("chip-balance")}
+        onToggle={toggleBalance}
       />
 
       {/* Expandable chips — próximo ingreso / próximo pago */}

--- a/webapp/src/components/plan/plan-main-accounts-section.tsx
+++ b/webapp/src/components/plan/plan-main-accounts-section.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+import { ArrowRight, Wallet } from "lucide-react";
+import { AccountIcon } from "@/components/accounts/account-icon";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
+import type { PlanMainAccountsSummary } from "@/types/plan";
+
+interface PlanMainAccountsSectionProps {
+  mainAccounts: PlanMainAccountsSummary;
+  currency: CurrencyCode;
+}
+
+export function PlanMainAccountsSection({
+  mainAccounts,
+  currency,
+}: PlanMainAccountsSectionProps) {
+  const { accounts, totalInBase, hasUnconvertibleAccounts } = mainAccounts;
+  const hasAccounts = accounts.length > 0;
+
+  return (
+    <Card className="border-white/6 bg-card/90">
+      <CardHeader className="space-y-2">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          <Wallet className="size-4" />
+          Saldos actuales
+        </div>
+        <div className="flex items-end justify-between gap-3">
+          <CardTitle className="text-xl">El dinero con el que cuentas hoy</CardTitle>
+          {hasAccounts && (
+            <span className="text-2xl font-semibold tabular-nums">
+              {formatCurrency(totalInBase, currency)}
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {hasAccounts ? (
+          <div className="space-y-2">
+            {accounts.map((account) => {
+              const showBaseConversion = account.currency_code !== currency;
+              return (
+                <div
+                  key={account.id}
+                  className="flex items-center justify-between rounded-2xl border border-white/6 bg-z-surface-2/30 px-4 py-3"
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <AccountIcon
+                      bank_key={account.bank_key}
+                      account_type={account.account_type}
+                      color={account.color}
+                      size="md"
+                    />
+                    <div className="min-w-0 space-y-0.5">
+                      <p className="truncate font-medium">{account.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {account.mask ? `····${account.mask} · ` : ""}
+                        {account.currency_code}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold tabular-nums">
+                      {formatCurrency(account.current_balance, account.currency_code)}
+                    </p>
+                    {showBaseConversion && (
+                      <p className="text-xs text-muted-foreground tabular-nums">
+                        ≈ {formatCurrency(account.balance_in_base, currency)}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-white/6 bg-z-surface-2/30 px-4 py-4 text-sm text-muted-foreground">
+            No tienes cuentas principales activas en la moneda del plan. Activa
+            «Mostrar en panel» en alguna cuenta de ahorros, corriente o efectivo.
+          </div>
+        )}
+
+        {hasUnconvertibleAccounts && (
+          <p className="text-xs text-muted-foreground">
+            Algunas cuentas en otra moneda no se pudieron convertir y no se
+            incluyen en el total.
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          <Button asChild variant="outline" className={GHOST_BUTTON_CLASS}>
+            <Link href="/accounts">
+              Ver cuentas
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/webapp/src/components/plan/zones/plan-resumen-zone.tsx
+++ b/webapp/src/components/plan/zones/plan-resumen-zone.tsx
@@ -4,6 +4,7 @@ import { PlanHero } from "@/components/plan/plan-hero";
 import { PlanBudgetSection } from "@/components/plan/plan-budget-section";
 import { PlanBudgetToggle } from "@/components/plan/plan-budget-toggle";
 import { PlanDebtSection } from "@/components/plan/plan-debt-section";
+import { PlanMainAccountsSection } from "@/components/plan/plan-main-accounts-section";
 import { PlanRecurringSection } from "@/components/plan/plan-recurring-section";
 import { PlanScenarioPreview } from "@/components/plan/plan-scenario-preview";
 import { PlanTabNav, type PlanTab } from "@/components/plan/plan-tab-nav";
@@ -53,8 +54,12 @@ export async function PlanResumenZone({
           currency={planData.currency}
         />
         <div className="space-y-6">
-          <PlanDebtSection debt={planData.debt} currency={planData.currency} />
+          <PlanMainAccountsSection
+            mainAccounts={planData.mainAccounts}
+            currency={planData.currency}
+          />
           <PlanRecurringSection recurring={planData.recurring} currency={planData.currency} />
+          <PlanDebtSection debt={planData.debt} currency={planData.currency} />
         </div>
       </div>
 

--- a/webapp/src/types/plan.ts
+++ b/webapp/src/types/plan.ts
@@ -2,7 +2,7 @@ import type { AllocationData } from "@/actions/allocation";
 import type { DashboardHeroData } from "@/actions/charts";
 import type { DebtCountdownData } from "@/actions/debt-countdown";
 import type { IncomeEstimate } from "@/actions/income";
-import type { CategoryBudgetData, CurrencyCode, UpcomingRecurrence } from "@/types/domain";
+import type { AccountType, CategoryBudgetData, CurrencyCode, UpcomingRecurrence } from "@/types/domain";
 import type { Database } from "@/types/database";
 import type { DebtOverview } from "@zeta/shared";
 
@@ -57,6 +57,26 @@ export interface PlanScenarioSummary {
   count: number;
 }
 
+export interface PlanMainAccount {
+  id: string;
+  name: string;
+  account_type: AccountType;
+  current_balance: number;
+  currency_code: CurrencyCode;
+  /** Balance converted to the active plan currency (same as current_balance when currency matches). */
+  balance_in_base: number;
+  icon: string | null;
+  color: string | null;
+  bank_key: string | null;
+  mask: string | null;
+}
+
+export interface PlanMainAccountsSummary {
+  accounts: PlanMainAccount[];
+  totalInBase: number;
+  hasUnconvertibleAccounts: boolean;
+}
+
 export interface PlanPageData {
   currency: CurrencyCode;
   month?: string;
@@ -65,6 +85,7 @@ export interface PlanPageData {
   budget: PlanBudgetSummary;
   debt: PlanDebtSummary;
   recurring: PlanRecurringSummary;
+  mainAccounts: PlanMainAccountsSummary;
   scenarios: PlanScenarioSummary;
   incomeEstimate: IncomeEstimate | null;
 }


### PR DESCRIPTION
Adds a "Saldos actuales" card to the Plan resumen, listing CHECKING,
SAVINGS and CASH accounts marked show_in_dashboard with their current
balance and a converted total in the active currency. Pairs with the
recurring section so the user sees the full month picture: what they
have now, what's coming in, what's going out.