### PR TITLE
feat(plan): main account balances as planning envelopes in Periodo

### DIFF
--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -502,29 +502,33 @@ export async function upsertBalanceEnvelopes(
   if (periodErr || !period)
     return { success: false, error: "Periodo no encontrado" };
 
-  const { data: accounts, error: accErr } = await supabase
-    .from("accounts")
-    .select("id, name, current_balance, currency_code, account_type")
-    .eq("user_id", user.id)
-    .eq("is_active", true)
-    .eq("show_in_dashboard", true)
-    .in("account_type", MAIN_ACCOUNT_TYPES);
+  // Accounts and existing seed entries are independent reads — fetch in parallel.
+  const [
+    { data: accounts, error: accErr },
+    { data: existing, error: existingErr },
+  ] = await Promise.all([
+    supabase
+      .from("accounts")
+      .select("id, name, current_balance, currency_code, account_type")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .eq("show_in_dashboard", true)
+      .in("account_type", MAIN_ACCOUNT_TYPES),
+    supabase
+      .from("planning_entries")
+      .select("id, account_id")
+      .eq("period_id", periodId)
+      .eq("user_id", user.id)
+      .eq("entry_type", "INCOME")
+      .eq("notes", BALANCE_SEED_NOTES),
+  ]);
 
   if (accErr) return { success: false, error: accErr.message };
+  if (existingErr) return { success: false, error: existingErr.message };
 
   if (!accounts || accounts.length === 0) {
     return { success: true, data: { created: 0, updated: 0 } };
   }
-
-  const { data: existing, error: existingErr } = await supabase
-    .from("planning_entries")
-    .select("id, account_id")
-    .eq("period_id", periodId)
-    .eq("user_id", user.id)
-    .eq("entry_type", "INCOME")
-    .eq("notes", BALANCE_SEED_NOTES);
-
-  if (existingErr) return { success: false, error: existingErr.message };
 
   const existingByAccount = new Map<string, string>();
   for (const row of existing ?? []) {
@@ -535,14 +539,17 @@ export async function upsertBalanceEnvelopes(
   let updated = 0;
   let firstError: string | null = null;
 
-  await Promise.all(
-    accounts.map(async (account) => {
-      const balance = Number(account.current_balance ?? 0);
-      const label = `Saldo · ${account.name}`;
-      const existingId = existingByAccount.get(account.id);
+  const toInsert: TablesInsert<"planning_entries">[] = [];
+  const updatePromises: PromiseLike<void>[] = [];
 
-      if (existingId) {
-        const { error } = await supabase
+  for (const account of accounts) {
+    const balance = Number(account.current_balance ?? 0);
+    const label = `Saldo · ${account.name}`;
+    const existingId = existingByAccount.get(account.id);
+
+    if (existingId) {
+      updatePromises.push(
+        supabase
           .from("planning_entries")
           .update({
             amount: balance,
@@ -550,41 +557,46 @@ export async function upsertBalanceEnvelopes(
             currency_code: account.currency_code,
           })
           .eq("id", existingId)
-          .eq("user_id", user.id);
-        if (error) {
-          firstError ??= error.message;
-        } else {
-          updated += 1;
-        }
-      } else {
-        const { error } = await supabase
-          .from("planning_entries")
-          .insert({
-            user_id: user.id,
-            period_id: periodId,
-            entry_type: "INCOME",
-            label,
-            amount: balance,
-            currency_code: account.currency_code,
-            expected_date: period.start_date,
-            account_id: account.id,
-            status: "PLANNED",
-            notes: BALANCE_SEED_NOTES,
-          });
-        if (error) {
-          firstError ??= error.message;
-        } else {
-          created += 1;
-        }
-      }
-    })
-  );
+          .eq("user_id", user.id)
+          .then(({ error }) => {
+            if (error) firstError ??= error.message;
+            else updated += 1;
+          })
+      );
+    } else {
+      toInsert.push({
+        user_id: user.id,
+        period_id: periodId,
+        entry_type: "INCOME",
+        label,
+        amount: balance,
+        currency_code: account.currency_code,
+        expected_date: period.start_date,
+        account_id: account.id,
+        status: "PLANNED",
+        notes: BALANCE_SEED_NOTES,
+      });
+    }
+  }
 
-  updateTag(TAG);
+  // Bulk insert in one round trip; updates remain per-row but run in parallel.
+  const insertPromise =
+    toInsert.length > 0
+      ? supabase
+          .from("planning_entries")
+          .insert(toInsert)
+          .then(({ error }) => {
+            if (error) firstError ??= error.message;
+            else created = toInsert.length;
+          })
+      : Promise.resolve();
+
+  await Promise.all([insertPromise, ...updatePromises]);
 
   if (firstError) {
     return { success: false, error: firstError };
   }
+  updateTag(TAG);
   return { success: true, data: { created, updated } };
 }
 

--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -22,11 +22,12 @@ import type {
   PlanningEntry,
   PlanningAssignment,
 } from "@/types/domain";
-import type {
-  PlanningEntryWithRelations,
-  IncomeEnvelope,
-  AssignmentDetail,
-  PeriodPlanData,
+import {
+  BALANCE_SEED_NOTES,
+  type PlanningEntryWithRelations,
+  type IncomeEnvelope,
+  type AssignmentDetail,
+  type PeriodPlanData,
 } from "@/types/cashflow-planner";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -466,6 +467,125 @@ export async function seedPeriodFromRecurring(
 
   updateTag(TAG);
   return { success: true, data: { created: entriesToInsert.length } };
+}
+
+// ─── Balance envelopes (seed + refresh) ──────────────────────────────────────
+
+const MAIN_ACCOUNT_TYPES: Database["public"]["Enums"]["account_type"][] = [
+  "CHECKING",
+  "SAVINGS",
+  "CASH",
+];
+
+/**
+ * Seeds (first run) or refreshes (subsequent runs) one INCOME planning entry
+ * per main liquid account (`CHECKING`/`SAVINGS`/`CASH` with
+ * `show_in_dashboard = true`). Each entry mirrors the account's
+ * `current_balance` so the user can assign expenses against it.
+ *
+ * On refresh, the amount and label are overwritten — to "promote" an entry
+ * to user-managed, change its notes to anything other than `[saldo]`.
+ */
+export async function upsertBalanceEnvelopes(
+  periodId: string
+): Promise<ActionResult<{ created: number; updated: number }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const { data: period, error: periodErr } = await supabase
+    .from("planning_periods")
+    .select("id, start_date, currency_code")
+    .eq("id", periodId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (periodErr || !period)
+    return { success: false, error: "Periodo no encontrado" };
+
+  const { data: accounts, error: accErr } = await supabase
+    .from("accounts")
+    .select("id, name, current_balance, currency_code, account_type")
+    .eq("user_id", user.id)
+    .eq("is_active", true)
+    .eq("show_in_dashboard", true)
+    .in("account_type", MAIN_ACCOUNT_TYPES);
+
+  if (accErr) return { success: false, error: accErr.message };
+
+  if (!accounts || accounts.length === 0) {
+    return { success: true, data: { created: 0, updated: 0 } };
+  }
+
+  const { data: existing, error: existingErr } = await supabase
+    .from("planning_entries")
+    .select("id, account_id")
+    .eq("period_id", periodId)
+    .eq("user_id", user.id)
+    .eq("entry_type", "INCOME")
+    .eq("notes", BALANCE_SEED_NOTES);
+
+  if (existingErr) return { success: false, error: existingErr.message };
+
+  const existingByAccount = new Map<string, string>();
+  for (const row of existing ?? []) {
+    if (row.account_id) existingByAccount.set(row.account_id, row.id);
+  }
+
+  let created = 0;
+  let updated = 0;
+  let firstError: string | null = null;
+
+  await Promise.all(
+    accounts.map(async (account) => {
+      const balance = Number(account.current_balance ?? 0);
+      const label = `Saldo · ${account.name}`;
+      const existingId = existingByAccount.get(account.id);
+
+      if (existingId) {
+        const { error } = await supabase
+          .from("planning_entries")
+          .update({
+            amount: balance,
+            label,
+            currency_code: account.currency_code,
+          })
+          .eq("id", existingId)
+          .eq("user_id", user.id);
+        if (error) {
+          firstError ??= error.message;
+        } else {
+          updated += 1;
+        }
+      } else {
+        const { error } = await supabase
+          .from("planning_entries")
+          .insert({
+            user_id: user.id,
+            period_id: periodId,
+            entry_type: "INCOME",
+            label,
+            amount: balance,
+            currency_code: account.currency_code,
+            expected_date: period.start_date,
+            account_id: account.id,
+            status: "PLANNED",
+            notes: BALANCE_SEED_NOTES,
+          });
+        if (error) {
+          firstError ??= error.message;
+        } else {
+          created += 1;
+        }
+      }
+    })
+  );
+
+  updateTag(TAG);
+
+  if (firstError) {
+    return { success: false, error: firstError };
+  }
+  return { success: true, data: { created, updated } };
 }
 
 // ─── Entry CRUD ──────────────────────────────────────────────────────────────

--- a/webapp/src/components/cashflow-planner/balance-seed-button.tsx
+++ b/webapp/src/components/cashflow-planner/balance-seed-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTransition } from "react";
+import { Wallet } from "lucide-react";
+import { toast } from "sonner";
+import { upsertBalanceEnvelopes } from "@/actions/cashflow-planner";
+import { Button } from "@/components/ui/button";
+
+interface BalanceSeedButtonProps {
+  periodId: string;
+  hasExistingBalances: boolean;
+}
+
+export function BalanceSeedButton({
+  periodId,
+  hasExistingBalances,
+}: BalanceSeedButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(async () => {
+      const result = await upsertBalanceEnvelopes(periodId);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      const { created, updated } = result.data;
+      if (created === 0 && updated === 0) {
+        toast.info("No hay cuentas principales para cargar");
+        return;
+      }
+      const parts: string[] = [];
+      if (created > 0) parts.push(`${created} ${created === 1 ? "creado" : "creados"}`);
+      if (updated > 0) parts.push(`${updated} ${updated === 1 ? "actualizado" : "actualizados"}`);
+      toast.success(`Saldos: ${parts.join(" · ")}`);
+    });
+  }
+
+  const idleLabel = hasExistingBalances ? "Actualizar saldos" : "Cargar saldos";
+  const pendingLabel = hasExistingBalances ? "Actualizando..." : "Cargando...";
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={isPending}
+    >
+      <Wallet className="mr-1.5 h-3.5 w-3.5" />
+      {isPending ? pendingLabel : idleLabel}
+    </Button>
+  );
+}

--- a/webapp/src/components/cashflow-planner/envelope-board.tsx
+++ b/webapp/src/components/cashflow-planner/envelope-board.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { IncomeEnvelopeCard } from "./income-envelope-card";
 import { ExpenseEntryRow } from "./expense-entry-row";
 import { AssignmentDialog } from "./assignment-dialog";
+import { BalanceSeedButton } from "./balance-seed-button";
 import { EntryFormDialog } from "./entry-form-dialog";
 import { EditEntryDialog } from "./edit-entry-dialog";
 import { AutoAssignButton } from "./auto-assign-button";
@@ -11,7 +12,11 @@ import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { buildEnvelopeMaps } from "@/lib/utils/cashflow-planner";
 import { Wallet, Receipt } from "lucide-react";
 import type { Account, Category } from "@/types/domain";
-import type { PeriodPlanData, PlanningEntryWithRelations } from "@/types/cashflow-planner";
+import {
+  BALANCE_SEED_NOTES,
+  type PeriodPlanData,
+  type PlanningEntryWithRelations,
+} from "@/types/cashflow-planner";
 
 interface EnvelopeBoardProps {
   data: PeriodPlanData;
@@ -31,6 +36,11 @@ export function EnvelopeBoard({ data, accounts = [], categories = [] }: Envelope
     [income_envelopes],
   );
 
+  const hasBalanceEnvelopes = useMemo(
+    () => income_envelopes.some((env) => env.entry.notes === BALANCE_SEED_NOTES),
+    [income_envelopes],
+  );
+
   function openAssignDialog(expense: PlanningEntryWithRelations) {
     setAssignTarget(expense);
     setAssignDialogOpen(true);
@@ -46,18 +56,24 @@ export function EnvelopeBoard({ data, accounts = [], categories = [] }: Envelope
       <div className="grid gap-4 sm:gap-6 lg:grid-cols-2">
         {/* Income envelopes */}
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <Wallet className="h-4 w-4 text-z-income" />
               <SectionEyebrow>Ingresos</SectionEyebrow>
             </div>
-            <EntryFormDialog
-              periodId={period.id}
-              currency={currency}
-              defaultType="INCOME"
-              accounts={accounts}
-              categories={categories}
-            />
+            <div className="flex items-center gap-2">
+              <BalanceSeedButton
+                periodId={period.id}
+                hasExistingBalances={hasBalanceEnvelopes}
+              />
+              <EntryFormDialog
+                periodId={period.id}
+                currency={currency}
+                defaultType="INCOME"
+                accounts={accounts}
+                categories={categories}
+              />
+            </div>
           </div>
 
           {income_envelopes.length === 0 ? (

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { getEnvelopeColor } from "@/lib/constants/envelope-colors";
 import { buildEnvelopeMaps, nextExpenseStatus, nextIncomeStatus } from "@/lib/utils/cashflow-planner";
 import { PlanFlowChart } from "./plan-flow-chart";
+import { BalanceSeedButton } from "@/components/cashflow-planner/balance-seed-button";
 import { EntryFormDialog } from "@/components/cashflow-planner/entry-form-dialog";
 import { EditEntryDialog } from "@/components/cashflow-planner/edit-entry-dialog";
 import { AssignmentDialog } from "@/components/cashflow-planner/assignment-dialog";
@@ -28,10 +29,11 @@ import {
   Trash2,
 } from "lucide-react";
 import type { PlanTimelineData } from "@/actions/plan-timeline";
-import type {
-  PeriodPlanData,
-  IncomeEnvelope,
-  PlanningEntryWithRelations,
+import {
+  BALANCE_SEED_NOTES,
+  type PeriodPlanData,
+  type IncomeEnvelope,
+  type PlanningEntryWithRelations,
 } from "@/types/cashflow-planner";
 import type { PlanningEntryStatus, CurrencyCode, Account, Category } from "@/types/domain";
 
@@ -95,6 +97,11 @@ export function MobilePeriodoView({
   /* ── Computed data ── */
   const { assignedPerExpense, incomeColorMap, expenseAssignmentChips } = useMemo(
     () => buildEnvelopeMaps(income_envelopes),
+    [income_envelopes],
+  );
+
+  const hasBalanceEnvelopes = useMemo(
+    () => income_envelopes.some((env) => env.entry.notes === BALANCE_SEED_NOTES),
     [income_envelopes],
   );
 
@@ -219,17 +226,23 @@ export function MobilePeriodoView({
 
       {/* ── Ingresos section ── */}
       <div>
-        <div className="flex items-center justify-between mb-2">
-          <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <p className="min-w-0 truncate text-[9px] font-bold uppercase tracking-[0.22em] text-z-sage-dark">
             Ingresos
           </p>
-          <EntryFormDialog
-            periodId={period.id}
-            currency={currency}
-            defaultType="INCOME"
-            accounts={accounts}
-            categories={categories}
-          />
+          <div className="flex shrink-0 items-center gap-2">
+            <BalanceSeedButton
+              periodId={period.id}
+              hasExistingBalances={hasBalanceEnvelopes}
+            />
+            <EntryFormDialog
+              periodId={period.id}
+              currency={currency}
+              defaultType="INCOME"
+              accounts={accounts}
+              categories={categories}
+            />
+          </div>
         </div>
         {income_envelopes.length > 0 && (
           <div className="space-y-2">

--- a/webapp/src/types/cashflow-planner.ts
+++ b/webapp/src/types/cashflow-planner.ts
@@ -8,6 +8,13 @@ import type {
   RecurringTemplate,
 } from "./domain";
 
+/**
+ * Sentinel stored in `planning_entries.notes` to flag entries that mirror an
+ * account's current balance (managed by `upsertBalanceEnvelopes`). If the user
+ * edits the notes, the entry stops being treated as balance-managed.
+ */
+export const BALANCE_SEED_NOTES = "[saldo]";
+
 export interface PlanningEntryWithRelations extends PlanningEntry {
   account: Pick<Account, "id" | "name" | "icon" | "color"> | null;
   category: Pick<Category, "id" | "name" | "name_es" | "icon" | "color"> | null;


### PR DESCRIPTION
## Summary

Lets users plan with their current liquid balances as **envelopes** in the Periodo (cashflow planner) tab, not just see them as a read-only stat. This is the missing half of #242 — that PR added the Saldo card to the resumen; this one makes the same balances actionable inside the planning flow.

- New server action `upsertBalanceEnvelopes(periodId)` seeds (first run) or refreshes (subsequent runs) one INCOME `planning_entries` row per main liquid account (`CHECKING`/`SAVINGS`/`CASH` with `show_in_dashboard = true`). Amount mirrors the account's `current_balance`; label is `Saldo · {account name}`.
- Marker: `notes = "[saldo]"`. If the user edits the notes, the entry stops being treated as balance-managed and refresh skips it (entry is "promoted" to user-managed).
- Single button "Cargar saldos" → "Actualizar saldos" wired into the income column header on both desktop `EnvelopeBoard` and mobile `mobile-periodo-view`. Reuses the entire existing envelope/assignment UI — balances become first-class envelopes you can assign expenses against.
- First-error short-circuit: if any DB write fails the action returns `{ success: false }` instead of silently green-toasting a partial result (server-action-reviewer finding).
- Cache invalidation via `updateTag("cashflow-planner")` — already covers both `cashflow-planner.ts` and `plan-timeline.ts` readers.

Builds cleanly (21s). Reviewed with `server-action-reviewer` and `zetas-front-guy` agents; their HIGH findings (silent failures, marker constant duplication, narrow-width mobile layout) are addressed. Concurrency guard for double-clicks is handled by `useTransition`'s `disabled` state on the button.

## Test plan

- [ ] Active Periodo with no main account balance entries → "Cargar saldos" appears next to "+" in Ingresos column
- [ ] Click → toast "Saldos: N creados" and one INCOME envelope per active main account appears with correct balance and label `Saldo · {name}`
- [ ] Click again → button now reads "Actualizar saldos"; clicking it overwrites amounts with current `current_balance` (toast "Saldos: N actualizados")
- [ ] Edit one entry's notes manually → next click only refreshes the others (the edited one is "promoted")
- [ ] Account with `show_in_dashboard = false` is **not** seeded
- [ ] CREDIT_CARD/LOAN/INVESTMENT accounts are **not** seeded
- [ ] Mobile: same flow at 375px width — header doesn't overflow (button group has `shrink-0`)
- [ ] Multi-currency: an account in USD shows `Saldo · X` with `currency_code = USD`; period header shows the converted amount per existing FX path
- [ ] Assign an expense to a balance envelope → standard `planning_assignments` flow works unchanged
- [ ] Period changes (delete + re-create) → `Cargar saldos` works on the fresh period

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015gB9XbgnU3GxngWfuWAaF5)_