### PR TITLE
feat(plan): sync recurring templates into existing period

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,6 +12,12 @@
 
 ## Bugs
 
+### `seedPeriodFromRecurring` — reminder dedup is title/amount-fragile
+- **Priority:** Low
+- **What:** `webapp/src/actions/cashflow-planner.ts` dedups reminder-derived `planning_entries` by `(label, due_date, amount)` since reminders have no FK in `planning_entries`. If a user renames a reminder-derived entry or changes the reminder's amount, the dedup key drifts and the next "Sincronizar recurrentes" click re-inserts the row.
+- **Fix:** Add a `source_reminder_id uuid REFERENCES financial_reminders(id) ON DELETE SET NULL` column to `planning_entries`, populate it on insert, dedup by it.
+- **Found:** server-action-reviewer on PR #244, 2026-05-02
+
 ### Telegram webhook — capture_tokens label updates via admin client never worked
 - **Priority:** Medium
 - **What:** `webapp/src/app/api/webhooks/telegram/route.ts` lines 27–35 (SELECT by encrypted `token`/`label`) and 99–102, 140–143 (UPDATE `label`) go through the `capture_tokens` view with the admin client (no JWT). Before PR #186's `has_auth` guard, the UPDATE silently NULLed the label via unguarded `zeta_encrypt()`. After the guard, the UPDATE preserves whatever was there (usually NULL). Either way, `findTokenByChatId` also decrypts via admin client → `zeta_decrypt(label)` returns NULL → `.like("label", "telegram:...")` never matches. End-to-end: the `/start <token>` deep-link and `/vincular <token>` flows never actually link a chat.

--- a/webapp/src/actions/cashflow-planner.ts
+++ b/webapp/src/actions/cashflow-planner.ts
@@ -382,10 +382,9 @@ export async function seedPeriodFromRecurring(
         .eq("is_active", true),
       supabase
         .from("planning_entries")
-        .select("recurring_template_id, expected_date")
+        .select("recurring_template_id, expected_date, label, amount")
         .eq("period_id", periodId)
-        .eq("user_id", user.id)
-        .not("recurring_template_id", "is", null),
+        .eq("user_id", user.id),
       supabase
         .from("financial_reminders")
         .select("*")
@@ -395,11 +394,17 @@ export async function seedPeriodFromRecurring(
         .lte("due_date", period.end_date),
     ]);
 
-  const existingKeys = new Set(
-    (existingEntries ?? []).map(
-      (e) => `${e.recurring_template_id}|${e.expected_date}`
-    )
-  );
+  // Templates dedup by (template_id, date); reminders have no FK so we
+  // signature them by (label, date, amount) against template-less rows.
+  const existingKeys = new Set<string>();
+  const existingReminderKeys = new Set<string>();
+  for (const e of existingEntries ?? []) {
+    if (e.recurring_template_id) {
+      existingKeys.add(`${e.recurring_template_id}|${e.expected_date}`);
+    } else {
+      existingReminderKeys.add(`${e.label}|${e.expected_date}|${e.amount}`);
+    }
+  }
 
   const rangeStart = parseISO(period.start_date);
   const rangeEnd = parseISO(period.end_date);
@@ -446,6 +451,8 @@ export async function seedPeriodFromRecurring(
 
   for (const reminder of reminders ?? []) {
     if (!reminder.due_date || !reminder.amount || reminder.amount <= 0) continue;
+    const dedupKey = `${reminder.title}|${reminder.due_date}|${reminder.amount}`;
+    if (existingReminderKeys.has(dedupKey)) continue;
     entriesToInsert.push({
       user_id: user.id,
       period_id: periodId,

--- a/webapp/src/components/cashflow-planner/envelope-board.tsx
+++ b/webapp/src/components/cashflow-planner/envelope-board.tsx
@@ -8,6 +8,7 @@ import { BalanceSeedButton } from "./balance-seed-button";
 import { EntryFormDialog } from "./entry-form-dialog";
 import { EditEntryDialog } from "./edit-entry-dialog";
 import { AutoAssignButton } from "./auto-assign-button";
+import { SyncRecurringButton } from "./sync-recurring-button";
 import { SectionEyebrow } from "@/components/ui/section-eyebrow";
 import { buildEnvelopeMaps } from "@/lib/utils/cashflow-planner";
 import { Wallet, Receipt } from "lucide-react";
@@ -111,6 +112,7 @@ export function EnvelopeBoard({ data, accounts = [], categories = [] }: Envelope
               {unassigned_expenses.length > 0 && income_envelopes.length > 0 && (
                 <AutoAssignButton periodId={period.id} />
               )}
+              <SyncRecurringButton periodId={period.id} />
               <EntryFormDialog
                 periodId={period.id}
                 currency={currency}

--- a/webapp/src/components/cashflow-planner/sync-recurring-button.tsx
+++ b/webapp/src/components/cashflow-planner/sync-recurring-button.tsx
@@ -41,7 +41,9 @@ export function SyncRecurringButton({ periodId }: SyncRecurringButtonProps) {
       aria-label="Sincronizar recurrentes"
       className={cn(GHOST_BUTTON_CLASS, "border")}
     >
-      <RefreshCw className="h-3.5 w-3.5 sm:mr-1.5" />
+      <RefreshCw
+        className={cn("h-3.5 w-3.5 sm:mr-1.5", isPending && "animate-spin")}
+      />
       <span className="hidden sm:inline">
         {isPending ? "Sincronizando..." : "Sincronizar recurrentes"}
       </span>

--- a/webapp/src/components/cashflow-planner/sync-recurring-button.tsx
+++ b/webapp/src/components/cashflow-planner/sync-recurring-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTransition } from "react";
+import { RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { seedPeriodFromRecurring } from "@/actions/cashflow-planner";
+import { Button } from "@/components/ui/button";
+import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+interface SyncRecurringButtonProps {
+  periodId: string;
+}
+
+export function SyncRecurringButton({ periodId }: SyncRecurringButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(async () => {
+      const result = await seedPeriodFromRecurring(periodId);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      const { created } = result.data;
+      if (created === 0) {
+        toast.info("Nada nuevo que sincronizar");
+        return;
+      }
+      toast.success(
+        `${created} ${created === 1 ? "recurrente agregado" : "recurrentes agregados"}`,
+      );
+    });
+  }
+
+  return (
+    <Button
+      size="sm"
+      onClick={handleClick}
+      disabled={isPending}
+      aria-label="Sincronizar recurrentes"
+      className={cn(GHOST_BUTTON_CLASS, "border")}
+    >
+      <RefreshCw className="h-3.5 w-3.5 sm:mr-1.5" />
+      <span className="hidden sm:inline">
+        {isPending ? "Sincronizando..." : "Sincronizar recurrentes"}
+      </span>
+    </Button>
+  );
+}

--- a/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
+++ b/webapp/src/components/mobile/v2/plan/mobile-periodo-view.tsx
@@ -14,6 +14,7 @@ import { EditEntryDialog } from "@/components/cashflow-planner/edit-entry-dialog
 import { AssignmentDialog } from "@/components/cashflow-planner/assignment-dialog";
 import { PayExpenseDialog } from "@/components/cashflow-planner/pay-expense-dialog";
 import { AutoAssignButton } from "@/components/cashflow-planner/auto-assign-button";
+import { SyncRecurringButton } from "@/components/cashflow-planner/sync-recurring-button";
 import {
   toggleEntryStatus,
   deletePlanningEntry,
@@ -281,6 +282,7 @@ export function MobilePeriodoView({
             {hasUnassigned && income_envelopes.length > 0 && (
               <AutoAssignButton periodId={period.id} />
             )}
+            <SyncRecurringButton periodId={period.id} />
             <EntryFormDialog
               periodId={period.id}
               currency={currency}


### PR DESCRIPTION
## Summary
- New **Sincronizar recurrentes** button in the Periodo expense header (desktop + mobile) wired to the existing `seedPeriodFromRecurring(periodId)` action.
- Lets users pull active recurring templates into an already-created monthly plan — closes the gap where only ad-hoc expenses could be added post-setup.
- Existing dedup on `(recurring_template_id, expected_date)` prevents duplicates on repeated clicks.
- Mobile button collapses to icon-only below `sm:` to keep the AutoAssign + Sync + Agregar row from overflowing.

## Test plan
- [ ] Create a monthly plan, then activate a new recurring template → click "Sincronizar recurrentes" → entry appears.
- [ ] Click again → toast says "Nada nuevo que sincronizar"; no duplicates inserted.
- [ ] Mobile (<640px): button shows icon only; row does not wrap.
- [ ] Desktop: button shows full label, sits next to "Agregar".

## Agent reviews
- `zetas-front-guy`: NEEDS_FIXES → applied (`GHOST_BUTTON_CLASS` + responsive icon-only).
- `cache-doctor`: PASS — `seedPeriodFromRecurring` already calls `updateTag("cashflow-planner")`; button uses `startTransition`.
- `recurring-doctor`: PASS — flagged risks (template-edit drift, planning_entries ↔ recurring_occurrences disconnect) are pre-existing in the action, not introduced here.