### PR TITLE
feat(settings): expose "Borrar todos mis datos" en webapp

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -47,13 +47,6 @@
 - **What:** Today "Crear nueva recurrente" navigates to `/transactions/[id]?promote=1` instead of opening the dialog inline in the drawer. Code cost is small (`RecurringFormDialog` already accepts `controlledOpen`). Would remove the full-page detour. Drawback: dialog-in-drawer is visually awkward on mobile and the detail page detour gives the user a landing destination.
 - **Found:** ux-analyst review, 2026-04-17
 
-### Recurring templates — review the unran template-merge from 20260416
-- **Priority:** Medium
-- **What:** Migration `20260416120000_add_sub_payments_to_recurring_templates.sql` was stamped as applied on the remote project but its DDL never ran. `20260418130000_fix_missing_sub_payments.sql` recovers the column + view + triggers, but **intentionally skips the original step 5** (merge duplicate INFLOW/MONTHLY templates into one with `sub_payments`) to avoid destroying occurrence→tx links created over the past ~2 days. Decide: either run the merge manually via the UI, or ship a fresh migration that replicates step 5 after an audit of which dupes remain.
-- **Latent risk until merged:** `syncCreditCardRecurringTemplate` / `syncLoanRecurringTemplate` in `webapp/src/actions/import-transactions.ts` pick "the" active template by account — if two duplicates still exist, re-importing a statement may populate `sub_payments` on the non-canonical one. Non-crash, only a data-quality issue until the merge runs.
-- **Audit SQL:** `SELECT account_id, currency_code, count(*) FROM recurring_transaction_templates_enc WHERE direction='INFLOW' AND frequency='MONTHLY' AND category_id IS NULL GROUP BY 1,2 HAVING count(*) > 1;`
-- **Found:** 2026-04-18 — fixed in PR #174; merge follow-up flagged by recurring-doctor review.
-
 ### Investigate why migration 20260416120000 stamped without running
 - **Priority:** Medium
 - **What:** The remote `supabase_migrations.schema_migrations` table has `20260416120000` marked applied, but the underlying DDL (ALTER TABLE, view rebuild) never executed. Likely causes: (a) a manual `supabase migration repair --status applied`, (b) a partial `db push` that errored mid-migration but still stamped optimistically, (c) a DB reset/restore that restored the history row but not the schema. Check CI deploy logs around 2026-04-16 and grep shell history for `migration repair`. If this recurs, any future migration that depends on `sub_payments` would compile locally but fail in prod.
@@ -70,12 +63,6 @@
 - **What:** `getBudgetProgress` in `mobile/lib/repositories/budgets.ts` filters `b.period = 'monthly'` (hardcoded). Webapp accepts `"monthly" | "yearly"` via `budgetSchema`. Any yearly budget created on webapp is invisible on mobile.
 - **Fix:** widen the SQL filter + surface a period chip in BudgetRow. Only needed once the webapp exposes yearly creation.
 - **Found:** mobile-webapp-parity on PR #223, 2026-04-22.
-
-### Webapp — expose "Reset all my data" in Settings
-- **Priority:** Medium
-- **What:** PR #227 shipped the `reset_user_data()` RPC + mobile Settings entry, but webapp Settings has no equivalent. Users who only use the web still can't wipe their own data. The RPC + confirmation copy already exist — webapp just needs a destructive-ghost button in `/settings` that calls the RPC, clears Route Cache (`updateTag` for all domain tags), and signs the user out to `/onboarding`.
-- **Touches:** `webapp/src/app/(dashboard)/settings/page.tsx` (or the nearest Settings surface), new server action `resetAllUserData` in `webapp/src/actions/profile.ts`.
-- **Found:** 2026-04-24, PR #227.
 
 ### `reset_user_data()` RPC — drift guard
 - **Priority:** Medium

--- a/webapp/src/actions/auth.ts
+++ b/webapp/src/actions/auth.ts
@@ -3,8 +3,10 @@
 import { createClient } from "@/lib/supabase/server";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { redirect } from "next/navigation";
+import { updateTag } from "next/cache";
 import { loginSchema, signupSchema, forgotPasswordSchema, resetPasswordSchema } from "@/lib/validators/auth";
 import { trackProductEvent, trackProductEventForUser } from "@/actions/product-events";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
 
 export type AuthActionResult = {
   error?: string;
@@ -180,6 +182,48 @@ export async function signOut(): Promise<void> {
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect("/login");
+}
+
+// Wipes ALL the calling user's app data but keeps the auth.users row and
+// active session. Mirrors the mobile flow in `mobile/lib/reset-data.ts`:
+// the SECURITY DEFINER `reset_user_data()` RPC scopes everything to
+// auth.uid(); the profile row is reset (`onboarding_completed = false`)
+// so the dashboard layout bounces the user to /onboarding on the next
+// navigation.
+export async function resetUserData(): Promise<AuthActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { error: "No autenticado" };
+
+  if (user.is_anonymous) {
+    return {
+      error:
+        "Estás en modo demo. Cierra sesión y crea una cuenta real para gestionar tus datos.",
+    };
+  }
+
+  const { error } = await supabase.rpc("reset_user_data");
+  if (error) {
+    console.error("[resetUserData] RPC failed:", error);
+    return { error: "No se pudo borrar los datos. Intenta de nuevo." };
+  }
+
+  revalidateFinancialViews();
+  // Domain extras not covered by revalidateFinancialViews.
+  updateTag("profile");
+  updateTag("destinatarios");
+  updateTag("dashboard-config");
+  updateTag("tags");
+  updateTag("wishlist");
+  updateTag("email-ingest");
+  updateTag("pdf-passwords");
+  updateTag("snapshots");
+  updateTag("capture-tokens");
+  updateTag("reminders");
+  updateTag("cashflow-planner");
+  updateTag("categories");
+  updateTag("impact");
+
+  redirect("/onboarding?reset=1");
 }
 
 // Permanently deletes the calling user's account and ALL associated data.

--- a/webapp/src/actions/auth.ts
+++ b/webapp/src/actions/auth.ts
@@ -3,10 +3,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { redirect } from "next/navigation";
-import { updateTag } from "next/cache";
 import { loginSchema, signupSchema, forgotPasswordSchema, resetPasswordSchema } from "@/lib/validators/auth";
 import { trackProductEvent, trackProductEventForUser } from "@/actions/product-events";
-import { revalidateFinancialViews } from "@/lib/cache/revalidation";
+import { revalidateAllUserData } from "@/lib/cache/revalidation";
 
 export type AuthActionResult = {
   error?: string;
@@ -207,21 +206,7 @@ export async function resetUserData(): Promise<AuthActionResult> {
     return { error: "No se pudo borrar los datos. Intenta de nuevo." };
   }
 
-  revalidateFinancialViews();
-  // Domain extras not covered by revalidateFinancialViews.
-  updateTag("profile");
-  updateTag("destinatarios");
-  updateTag("dashboard-config");
-  updateTag("tags");
-  updateTag("wishlist");
-  updateTag("email-ingest");
-  updateTag("pdf-passwords");
-  updateTag("snapshots");
-  updateTag("capture-tokens");
-  updateTag("reminders");
-  updateTag("cashflow-planner");
-  updateTag("categories");
-  updateTag("impact");
+  revalidateAllUserData();
 
   redirect("/onboarding?reset=1");
 }

--- a/webapp/src/app/(dashboard)/settings/perfil/page.tsx
+++ b/webapp/src/app/(dashboard)/settings/perfil/page.tsx
@@ -5,6 +5,7 @@ import { PageHeaderRow } from "@/components/ui/page-header-row";
 import { ProfileForm } from "@/components/settings/profile-form";
 import { SettingsBackLink } from "@/components/settings/settings-back-link";
 import { DeleteAccountSection } from "@/components/settings/delete-account-section";
+import { ResetDataSection } from "@/components/settings/reset-data-section";
 import { getProfile } from "@/actions/profile";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 
@@ -27,7 +28,12 @@ export default async function PerfilSettingsPage() {
         />
       </div>
       <ProfileForm profile={profile} />
-      {!isAnonymous && <DeleteAccountSection />}
+      {!isAnonymous && (
+        <>
+          <ResetDataSection />
+          <DeleteAccountSection />
+        </>
+      )}
     </div>
   );
 }

--- a/webapp/src/components/settings/reset-data-section.tsx
+++ b/webapp/src/components/settings/reset-data-section.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Eraser } from "lucide-react";
+import { toast } from "sonner";
+import { resetUserData } from "@/actions/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  DESTRUCTIVE_BUTTON_CLASS,
+  DESTRUCTIVE_GHOST_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+  PANEL_SURFACE_SUBTLE_CLASS,
+} from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
+
+const CONFIRMATION_PHRASE = "BORRAR";
+
+export function ResetDataSection() {
+  const [open, setOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const canConfirm = confirmation.trim().toUpperCase() === CONFIRMATION_PHRASE;
+
+  function handleReset() {
+    if (!canConfirm) return;
+    startTransition(async () => {
+      const result = await resetUserData();
+      // `resetUserData` redirects on success — only reach here on error.
+      if (result?.error) {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <section
+      // Intentionally omits the `surface-debt` tint DeleteAccountSection
+      // uses — reset is recoverable (account survives), delete is not.
+      className={cn(PANEL_SURFACE_SUBTLE_CLASS, "p-4 sm:p-5")}
+      aria-labelledby="reset-data-heading"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="space-y-1">
+          <h2
+            id="reset-data-heading"
+            className="text-sm font-semibold text-foreground"
+          >
+            Borrar todos mis datos
+          </h2>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Elimina cuentas, transacciones, presupuestos, deudas, recurrentes
+            y categorías personalizadas. Tu cuenta y tu sesión se mantienen:
+            volverás al onboarding. Esta acción no se puede deshacer.
+          </p>
+        </div>
+
+        <AlertDialog
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            if (!next) setConfirmation("");
+          }}
+        >
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS, "shrink-0")}
+            >
+              <Eraser className="size-4" aria-hidden />
+              Borrar mis datos
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>¿Borrar todos tus datos?</AlertDialogTitle>
+              <AlertDialogDescription className="space-y-2">
+                <span className="block">
+                  Se eliminarán cuentas, transacciones, presupuestos, deudas,
+                  recurrentes, destinatarios y configuración. Tu cuenta y
+                  correo se mantienen.
+                </span>
+                <span className="block">
+                  Para confirmar, escribe{" "}
+                  <span className="font-semibold text-foreground">
+                    {CONFIRMATION_PHRASE}
+                  </span>{" "}
+                  abajo.
+                </span>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+
+            <div className="space-y-2 pt-2">
+              <Label htmlFor="reset-confirmation" className="text-xs">
+                Confirmación
+              </Label>
+              <Input
+                id="reset-confirmation"
+                value={confirmation}
+                onChange={(e) => setConfirmation(e.target.value)}
+                placeholder={CONFIRMATION_PHRASE}
+                autoComplete="off"
+                autoCapitalize="characters"
+                disabled={isPending}
+              />
+            </div>
+
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                className={GHOST_BUTTON_CLASS}
+                disabled={isPending}
+              >
+                Cancelar
+              </AlertDialogCancel>
+              <AlertDialogAction
+                className={DESTRUCTIVE_BUTTON_CLASS}
+                onClick={handleReset}
+                disabled={!canConfirm || isPending}
+              >
+                {isPending ? "Borrando…" : "Borrar todo"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -27,3 +27,32 @@ export function revalidateFinancialViews() {
   updateTag("occurrences");
   updateTag("recurring");
 }
+
+/**
+ * Wider sweep for actions that wipe (or replace) the entire user dataset:
+ * reset_user_data, account import that touches every domain, etc.
+ *
+ * Includes everything in `revalidateFinancialViews()` plus the per-domain
+ * tags that aren't transaction-driven (profile, destinatarios, tags,
+ * wishlist, email-ingest, pdf-passwords, snapshots, capture-tokens,
+ * reminders, cashflow-planner, categories, impact, dashboard-config).
+ *
+ * Intentionally omits `exchange-rates` — it's a global, non-user-scoped
+ * cache populated from frankfurter.app and survives user data resets.
+ */
+export function revalidateAllUserData() {
+  revalidateFinancialViews();
+  updateTag("profile");
+  updateTag("destinatarios");
+  updateTag("dashboard-config");
+  updateTag("tags");
+  updateTag("wishlist");
+  updateTag("email-ingest");
+  updateTag("pdf-passwords");
+  updateTag("snapshots");
+  updateTag("capture-tokens");
+  updateTag("reminders");
+  updateTag("cashflow-planner");
+  updateTag("categories");
+  updateTag("impact");
+}


### PR DESCRIPTION
## Summary
- Webapp ahora puede borrar todos los datos del usuario (paridad con mobile, que ya lo expone vía `mobile/lib/reset-data.ts` desde PR #227).
- Nueva server action `resetUserData()` en `webapp/src/actions/auth.ts` llama el RPC existente `reset_user_data()` (SECURITY DEFINER, scoped a `auth.uid()`), invalida todos los cache tags de dominio (`revalidateFinancialViews()` + 13 extras), redirige a `/onboarding?reset=1`.
- Nuevo client component `ResetDataSection` (mirror de `DeleteAccountSection`) con `AlertDialog` + frase de confirmación `BORRAR` (distinta del `ELIMINAR` de delete) + icono `Eraser`. Mounted en `/settings/perfil` arriba de `DeleteAccountSection`, gated por `!isAnonymous`.
- La sesión se mantiene; el layout del dashboard rebota a `/onboarding` al ver `onboarding_completed=false`.

## Notes
- Surface intencionalmente neutral (sin tinte `surface-debt` que usa Delete) — reset es recuperable, delete no. Comentario inline para futuros contribuyentes.
- BACKLOG: también elimina la entrada de auditoría de templates recurrentes 20260416. Audit query (`SELECT account_id, currency_code, count(*) FROM recurring_transaction_templates_enc WHERE direction='INFLOW' AND frequency='MONTHLY' AND category_id IS NULL GROUP BY 1,2 HAVING count(*) > 1`) confirmó cero duplicados activos en producción — el step 5 omitido del recovery migration no tiene nada que mergear.

## Reviewers
- `server-action-reviewer`: PASS (auth, defense-in-depth, cache invalidation, return type).
- `zetas-front-guy`: PASS (tokens, reuse, hierarchy, copy).
- `perf-auditor`: PASS (redirect pattern, tag coverage, no nuevas DB queries en render path).

## Test plan
- [ ] Usuario real (no anónimo) → `/settings/perfil` → "Borrar mis datos" → escribir `BORRAR` → confirmar → redirige a `/onboarding`, datos del dashboard vacíos.
- [ ] Usuario anónimo (modo demo) → la sección **no** aparece (gated por `!isAnonymous`).
- [ ] Cancelar el dialog → no borra nada, input limpio al reabrir.
- [ ] Frase de confirmación incorrecta → botón disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)