### PR TITLE
Mobile parity foundations (Phase 0–2) + PaymentSheet fixes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -400,17 +400,24 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
 - **What:** `debt_scenarios`, `wishlist_reflections`, `dashboard_config` tables are used by the webapp but not synced to mobile. Add to SYNC_TABLES when mobile features need them.
 - **Found:** Mobile audit, 2026-04-15
 
-### Mobile /periodo PaymentSheet — pre-existing parity bugs (surfaced 2026-04-23)
-- **Priority:** High (data integrity)
-- **What:** `mobile/components/plan/PaymentSheet.tsx` `handleCreatePayment` + `handleLinkTransaction` write transactions + recurring_occurrences with several shape gaps vs webapp `webapp/src/actions/cashflow-planner.ts`:
-  1. **Wrong column names** (lines ~265, ~289): writes `description: "Pago: ..."` but `transactions_enc` view has `raw_description` + `clean_description`. PostgREST silently drops the unknown field, leaving both columns NULL. Breaks downstream queries (transaction list, search, reconciliation `findCandidateTransactions`).
-  2. **Raw idempotency key** (lines ~270, ~294): emits `MANUAL_FORM|${id}|${date}|${amount}|${label}` as the literal key. Webapp hashes the same inputs via `computeIdempotencyKey()` from `@zeta/shared` (SHA-256). The UNIQUE constraint compares raw vs hashed → mobile-created tx never dedups against webapp/PDF-imported counterpart.
-  3. **Missing `linked_manually: true`** in link-mode occurrence update (lines ~215-226). Webapp sets it. Breaks audit queries.
-  4. **Missing `recurrence_group_id` stamp + `categorization_source` backfill** on the linked transaction. Webapp `linkExistingTransactionToOccurrence` (occurrences.ts:915-932) handles both.
-  5. **Missing `applyAccountBalanceDelta`** on create-mode — webapp updates source + debt account `current_balance` inline; mobile waits for next pull. Balance shown on mobile/webapp diverges until next sync.
-- **Context:** Flagged by `mobile-webapp-parity` agent during the planning_* sync PR. All bugs pre-date that PR (present on main). Left intentionally out of scope to keep that PR reviewable.
-- **Scope of fix:** replace the two `transactions.insert` payloads with webapp-shaped ones + switch to `computeIdempotencyKey` + expand the occurrence UPDATE + extract/reuse a mobile `applyAccountBalanceDelta` helper (or add one in `lib/repositories/accounts.ts`).
-- **Found:** mobile-webapp-parity on planning_* sync PR, 2026-04-23.
+### Mobile PaymentSheet — recurring-template create-path divergence
+- **Priority:** Medium
+- **What:** When `entry.recurring_template_id` is set in `mobile/components/plan/PaymentSheet.tsx` `handleCreatePayment`, mobile inserts plain `"Pago: <label>"` transactions with `category_id: entry.category_id`. Webapp `cashflow-planner.ts:1243-1276` delegates to `recordRecurringOccurrencePayment` → `buildRecurringPaymentTransactions`, which produces transfer-style descriptions (`"Transferencia a <account> - <label>"` on OUTFLOW, `"Abono deuda desde <source> - <label>"` on INFLOW) and forces `category_id` to `TRANSFER_CATEGORY_ID` / `getDebtPaymentCategoryId(account_type)`.
+- **Impact:** Recurring debt payments created from mobile show different descriptions and category assignments than the same payment created from webapp. Visible in transaction lists, breaks debt category aggregation.
+- **Fix:** call the same shared logic from mobile (port `buildRecurringPaymentTransactions` to `@zeta/shared` if needed), or have mobile delegate via an RPC.
+- **Found:** mobile-webapp-parity on PaymentSheet parity PR, 2026-05-02.
+
+### Mobile PaymentSheet — link mode missing account/direction validation
+- **Priority:** Low
+- **What:** Webapp `linkExistingTransactionToOccurrence` (occurrences.ts:1172-1177) validates that the linked transaction's `account_id + direction` matches the template (or qualifies as a cross-account debt payment). Mobile accepts any candidate from the 50-tx search window. Risk: `revertOccurrence` on the webapp could delete a transaction the user didn't intend to link to this occurrence.
+- **Fix:** mirror the validation in mobile `handleLinkTransaction`. Needs the template's `account_id`, `direction`, `transfer_source_account_id` — fetch via repo before applying the link.
+- **Found:** mobile-webapp-parity on PaymentSheet parity PR, 2026-05-02.
+
+### Mobile transactions — `description` vs `clean_description` column drift (pre-existing)
+- **Priority:** Medium
+- **What:** SQLite `transactions` table has a column named `description` (since v1). Supabase `transactions` view exposes `clean_description`. `pull.ts` `getTableColumns()` filter drops the Supabase field every cycle because no local `clean_description` column exists. Mobile masks the gap by SELECTing `description as clean_description` and pushing `clean_description` on writes. Practical impact: every pull-back from Supabase loses the field; the local row keeps whatever was last written locally, never the Supabase truth.
+- **Fix:** rename local column with a v13 migration: `ALTER TABLE transactions RENAME COLUMN description TO clean_description`, then drop the SELECT alias + simplify `clean_description` push payload mapping.
+- **Found:** mobile-sync-doctor on PaymentSheet parity PR, 2026-05-02.
 
 ### Mobile Settings — v2 polish (layout + sizes)
 - **Priority:** Medium
@@ -890,3 +897,302 @@ Expo app sigue con estructura 4-tab. Ports pendientes del IA refactor:
 2. Webapp mobile/v2/plan parity (pendiente desde 2026-04-22).
 3. Phase 3 Préstamos design.
 4. Mobile native parity para Phase 1+2.
+
+---
+
+## Mobile RN ↔ Webapp mobile-view parity audit (2026-05-02)
+
+> Source: 6 parallel audit agents comparing webapp's mobile view (design source of truth) against the Expo RN app, page-by-page, component-by-component. Webapp mobile view is more polished; below is the work to bring RN to parity.
+>
+> Severity tags: **[P0]** missing feature / broken behavior · **[P1]** visible polish gap · **[P2]** minor cosmetic/copy · **[ORPHAN]** RN-only feature (decide: port to webapp or remove).
+
+### 1. Home / Dashboard / Accounts
+
+#### `/dashboard` — `mobile/components/inicio/InicioRoot.tsx`
+- [P0] Missing **HealthZone / HealthScore** section (`webapp/.../zones/health-zone.tsx`) — no health meters, score, runway equivalent.
+- [P0] Missing **FlujoSection** — burn rate card, waterfall, cashflow charts (`flujo-section.tsx`, `flujo-waterfall.tsx`, `flujo-charts.tsx`).
+- [P0] Missing **ActividadHeatmap** (calendar-style activity heatmap).
+- [P0] Missing **AccountsOverview** section in dashboard (sparklined account cards under "Cuentas"). `mobile/components/dashboard/` only has unused stubs (`BalanceCard`, `MonthSummary`, `CategoryBreakdown`, `PurchaseDecisionCard`).
+- [P0] Missing **DashboardAlerts** banner (`dashboard-alerts.tsx`).
+- [P0] Missing **PaymentReminders / UpcomingPayments** card — RN exposes only an `attention` chip widget.
+- [P0] Missing widgets: **DebtProgress, EmergencyFund, Deseos, SavingsRate, InterestPaid, BurnRate, RunwayMiniChart**. RN `WIDGET_CATALOG` (`mobile/lib/dashboard/widgets.ts`) only has: `ritmo`, `attention`, `where_today`, `recent`, `puedo_comprarlo` + pulse hero.
+- [P0] Missing **MonthSelector / DashboardAccountPicker** — no scope selector.
+- [P0] Missing **DashboardHero / StatusHeadline** ("Tu estado financiero de hoy" + KPIs + 50/30/20 allocation strip).
+- [P0] Missing **InicioDiscoveryRail** (entry chips into Plan/Deseos/Decisión).
+- [P1] Missing **DemoBanner / GuestBanner / DebtFreeBanner** conditional banners.
+- [P1] Missing **dashboard customization persistence beyond widget list** — webapp persists `profiles.dashboard_config` via `getDashboardConfigWithPurpose` + `DashboardConfigProvider`; RN persists widget array via AsyncStorage only (not synced to Supabase — spawn `mobile-sync-doctor` if parity required).
+- [P1] Missing **content-shaped skeletons** — RN has no per-widget skeleton.
+- [P1] No **live metrics hook** — webapp `useLiveDashboard` silently corrects stale values; RN `useDashboardData` reloads only on `useFocusEffect`.
+- [P2] Header subtitle differs: RN shows date pill; webapp shows month + tagline.
+
+#### `/accounts` (lista) — `mobile/app/(tabs)/accounts.tsx`
+- [P0] Missing **SummaryCard "Base financiera"** (patrimonio neto + cuentas activas + presión de deuda).
+- [P0] Missing **AttentionCard** from `getAttentionSnapshot`.
+- [P0] Missing **multi-currency footer** (secondary currency totals).
+- [P0] Missing **liquidity vs debt grouping** ("Liquidez y ahorro" / "Deuda" sections).
+- [P1] `AccountCard` has no sparkline / trend / brass accents — webapp uses `getAccountsWithSparklineData`.
+- [P1] Empty state is one centered line; webapp has empty Card with "Crear cuenta" + "Importar extracto" CTAs.
+- [P2] Dead/orphan file `mobile/app/accounts-list.tsx` — remove or wire.
+
+#### `/accounts/[id]` (detalle) — `mobile/app/account/[id].tsx`
+- [P0] Missing **AccountHero variants** (`flip` for CC/SAVINGS, `pulse` for CHECKING/CASH/OTHER, `graph` for LOAN/INVESTMENT). RN renders centered icon only.
+- [P0] Missing **FlipZone / CardFace / GraphFace** (CC flip animation + back-side balance graph).
+- [P0] Missing **BalanceGraphHero** + **RangePills** (30/90/180/365) snapshot-based area chart.
+- [P0] Missing **SpendingPulseHero** (30-day sparkline + monthly spend badge).
+- [P0] Missing **QuickActionsBar**: Pagar / Transferir / Agregar / Ajustar / Más. RN only has Pencil/Trash icons.
+- [P0] Missing **QuickPaymentDialog** (CC payments).
+- [P0] Missing **TransferDialog** (between accounts).
+- [P0] Missing **ReconcileBalanceDialog** (manual balance adjust).
+- [P0] Missing **StatementSnapshotsCard / StatementHistoryTimeline** (CC/loan/savings statement history with metrics + due dates).
+- [P1] `RecentTransactions` thin row vs webapp's full `recent-transactions.tsx` with category chip, destinatario, brass tokens.
+- [P1] Hardcoded colors throughout (`text-gray-900`, `bg-white`, `text-sky-600`, `text-green-600`) — port to `text-z-*`, `bg-z-surface-2`, `border-white/6` design tokens.
+- [P1] Header is bespoke instead of `MobileHeader variant="sub"`.
+- [P1] No skeleton; uses `ActivityIndicator`.
+- [P2] Stat tiles use raw `bg-white` / `border-gray-100` instead of `PANEL_INSET_CLASS`.
+- [P1] Delete confirm uses `Alert.alert` instead of styled AlertDialog.
+- [P1] No FAB on `/accounts` list — inconsistent with other tabs.
+
+### 2. Transactions / Capture
+
+#### `/(tabs)/transactions` — `MovimientosRoot`
+- [P0] `MovimientosUtilidades` missing filter pills: `tagId`, `dateFrom`, `dateTo`, `amountMin`, `amountMax`, `capture_method` (only `accountId`, `direction`, `showExcluded` exist vs 9 in webapp).
+- [P0] `MovimientosHerramientas` missing `pendingEmails` tile/prop (Bancolombia email-ingest approval flow).
+- [P0] No "Compra consciente / ¿Debería comprar esto?" entry tile.
+- [P1] `MovimientosTransactionRow` lacks inline `CategoryZonePicker` / `DestinatarioZonePicker` / `TagZonePicker` / `LinkPickerSheet` chips — RN navigates to detail.
+- [P1] No `Link2` (link-to-occurrence) or `Repeat` (recurring) badge on rows.
+- [P1] No "Cargar más" / count indicator on infinite scroll.
+- [P2] Verify `MovimientosLectura` parity (chart needs `transactions` + `debtAccountIds`).
+
+#### `/transactions/[id]` (detail) — `mobile/app/transaction/[id].tsx`
+- [P0] No **PromoteToRecurringButton** ("Hacer recurrente").
+- [P0] No **LinkPickerSheet** ("Vincular a recurrente") — `getCandidateOccurrencesForTransaction` + `linkExistingTransactionToOccurrence` absent.
+- [P0] No destinatario assign/change UI on detail.
+- [P0] No tag add/picker — `editTagIds` stored but no `TagZonePicker` UI; only read-only display.
+- [P0] No "linked recurring" surface when `isLinkedToOccurrence === true` (with unlink action).
+- [P1] No installment surface (`installment_number` / `installment_count`) for CC cuotas.
+- [P1] No `capture_method` tier badge (PDF_IMPORT / EMAIL_IMPORT / OCR / MANUAL_FORM / TEXT_QUICK_CAPTURE).
+- [P1] RN status mapping (`CLEARED/PENDING/POSTED`) is placeholder — webapp has no such field; remove or align.
+- [P2] Verify `is_excluded` 1/0 boolean round-trip via sync (`mobile-sync-doctor`).
+
+#### `/transactions/new` — **does not exist on RN**
+- [P0] No equivalent of webapp's `MobileTransactionForm` (full form: date, amount, account, category, destinatario, currency, notes, tags, "create destinatario" + "create recurring template" toggles). RN only offers capture/screenshot/voice — no deliberate "manual full form" path.
+- [P0] No `?type=expense|income|transfer` preset routing.
+- [P0] No transfer-between-accounts flow.
+- [P1] No installment fields on RN capture.
+
+#### Capture flows
+- [P0] RN `capture.tsx` (726 LOC) calls local repo `createTransaction`, NOT the `createQuickCaptureTransaction` server action — verify same `parseQuickCaptureText` + `autoCategorize` + idempotency parity.
+- [ORPHAN] `capture-screenshot`, `capture-voice`, `annotate-screenshot` — RN-only. Verify screenshot uses `OCR_BATCH` capture_method correctly. Voice already shares `parseQuickCaptureText`.
+- [P1] No discoverability — list/detail tabs don't expose all 3 capture entry points.
+
+### 3. Plan / Periodo / Presupuesto / Recurrentes / Pendientes
+
+#### `/plan` — `PlanRoot`
+- [P0] No month navigation (`MonthSelector` + `?month=`); RN locked to current month.
+- [P0] No tab nav (Resumen / Presupuesto / Periodo / Recurrentes / Deseos) — RN exposes only via `PlanToolsChips` separate stack routes.
+- [P0] No `PlanMainAccountsSection` (current balance per main account, totalInBase, unconvertible warning) — webapp `plan-mobile-accounts-card`.
+- [P1] No `plan-distribution` / `plan-flow-chart` (planned-vs-confirmed cashflow).
+- [P1] No `plan-drill-cards` / `plan-expandable-chips` (inline drill into pending vs paid).
+- [P1] No deseos/wishlist link in plan surface.
+
+#### `/periodo` — `mobile/app/periodo.tsx`
+- [P0] No entry create/edit (`EntryFormDialog` for INCOME/EXPENSE) — RN periodo is read-only.
+- [P0] No `AutoAssignButton` for unassigned expenses.
+- [P0] No delete entry, no toggle income status (`onToggleStatus`, `handleDeleteEntry`).
+- [P0] No "balance envelope" support (PR #243/244 main-accounts-as-planning-income).
+- [P1] Period summary chip minimal — webapp shows `percentAssigned` + unassigned count + dates.
+- [P1] Status enum mismatch: RN `PLANNED/COMPLETED/SKIPPED` vs webapp lowercase `pending/paid/skipped` from occurrences. Confirm sync layer maps both.
+- [P2] Bespoke `pt-14`/`ArrowLeft` header instead of `MobileHeader variant="sub"`.
+
+#### `/presupuesto` — `BudgetsRoot`
+- [P0] No month navigation.
+- [P0] No 50/30/20 allocation chip + `Plan5030_20Sheet` (essential vs wants %).
+- [P0] No category grouping by pressure (over → near → safe) — RN renders flat list.
+- [P0] No treemap visualization.
+- [P1] No essential vs wants split breakdown.
+- [P1] Verify `PressureChip` ("En control / Atención / Sobre límite") on RN BudgetsHero.
+- [P1] No category drill-down on tap.
+
+#### `/recurrentes` — `RecurrentesRoot`
+- [P0] **No template editor.** No `recurring-form-dialog` equivalent. Users cannot create/edit recurring templates from app — only mark occurrences paid/skipped.
+- [P0] No `mobile-recurrentes-templates-strip` (horizontal strip of all templates with edit affordance).
+- [P0] No link-picker / merge-picker sheets — user can't manually link existing transaction to occurrence.
+- [P0] No `recurring-impact-dialog` for amount/frequency mid-cycle changes.
+- [P1] No `recurring-mini-calendar` or `recurring-payment-timeline`.
+- [P1] No "Próximas" 30/60/90-day cashflow projection tile.
+- [P2] `RecurringSummaryCard` shows 4 counters; webapp shows total expected + breakdown chips with status colors.
+
+#### `/pendientes`
+- [P0] **No mobile route at all.** Pending occurrences only visible inside `/recurrentes`. Add dedicated screen or surface in PlanRoot.
+
+#### Cross-cutting (plan cluster)
+- [P1] Hand-rolled `pt-14` headers + `paddingBottom: 100` magic numbers — should use `MobileHeader` + `MOBILE_TAB_BAR_CLEARANCE_CLASS` + safe-area inset.
+- [P1] Status badge palette (`bg-z-alert/10`, `bg-z-income/10`) diverges from webapp pending/paid (`pendiente` brass, `pagado` sage).
+- [P2] Tab order in `(tabs)/_layout.tsx` exposes `plan` + `budgets` + `deudas` as siblings; webapp consolidates Plan as single hub.
+
+#### New RN files needed
+- `mobile/components/recurrentes/RecurringFormSheet.tsx`
+- `mobile/app/pendientes.tsx`
+- `mobile/components/budgets/AllocationSheet.tsx`
+- `mobile/components/plan/PlanMainAccountsCard.tsx`
+
+### 4. Deudas / Deseos / Puedo-pagar
+
+#### `/deudas`
+- [P0] No "Pago extra" action (`ExtraPaymentTrigger` / sheet).
+- [P0] No multi-currency rollup (`secondaryCurrencies`) on `DeudasHero`.
+- [P0] No `ExchangeRateNudge` (USD/COP vs 30d avg).
+- [P0] No month selector for past-month reads.
+- [P1] No "closest debt-free" tile (`closestExitName` + months + progress per loan).
+- [P1] `DeudasSalaryBar` uses raw `monthlyIncome`; webapp uses `getCurrentSalaryBreakdown()` from `@zeta/shared` — port for parity.
+- [P1] No "Simular pagos" chip-row pattern above salary bar.
+- [P2] Verify `monthlyInterestEstimate` math parity (webapp `getDebtOverview` vs RN local `monthlyInterest`).
+
+#### `/deudas/planificador`
+- [P0] **Strategy gap**: only `avalanche` + `snowball`. Webapp adds manual allocations (`manualOverrides`, `cascadeRedirects`) + saved scenarios.
+- [P0] **Scenario persistence**: webapp loads/saves via `getScenarios()` + `ScenarioManager` (3-cap, A/B/C). RN simulation is ephemeral.
+- [P0] **Compare step missing**: webapp 4-step (Cash → Allocate → Compare → Detail) with side-by-side comparison + baseline. RN has 3 tabs, no comparison.
+- [P0] **Cash entries are richer on web**: webapp accepts multiple `cashEntry` (one-off, recurring, time-bounded) via `expandCashEntries`. RN accepts single flat number.
+- [P0] **Detail step missing**: webapp `DetailStep` shows month-by-month payoff schedule + interest curve + income context. RN shows aggregate totals only.
+- [P0] Uses local SQLite `calculatePayoff` (`PayoffResultCard.tsx`) instead of shared `runScenario()` from `@zeta/shared` — engines drift; port to shared.
+- [P1] No empty-state "No hay deudas activas" — RN crashes silently if `data` null.
+- [P1] No `PageHero` stat row (Deudas activas / Saldo / Escenarios / Ingreso).
+- [P1] No income context in results ("X% of income to debt").
+- [P2] Strategy descriptions missing Spanish accents ("interes", "rapidas").
+
+#### Deseos (`/deseos` → `/plan?tab=deseos`)
+- [P0] **Score & verdict missing on RN list** — webapp `DeseosItem` shows traffic-light + verdict label + numeric score from `getWishlistItemsWithFreshScores()`. RN shows cached `last_score` only, no verdict text, no live re-score.
+- [P0] **No `DeseosNudgeBanner`** (`getActiveNudges()`: debt_milestone, score_transition, budget_surplus, desire_maturity).
+- [P0] **No `DeseosReflectionCard`** (14-day/60-day post-purchase reflection + rating + worth-it).
+- [P0] **No `DeseosInsights`** aggregated patterns.
+- [P0] **No `DeseosEnrichDrawer`** — RN form captures only `name + amount`, items can never be scored without urgency/desire-type/category.
+- [P0] **No bought-items section** (`status=bought/reflected/archived`).
+- [P1] No per-row CTAs (Comprado, retry score, complete enrichment, delete).
+- [P1] No urgency / desire-type chips.
+- [P2] Sort drift: RN by status; webapp by enriched-score-desc then unenriched.
+
+#### `/puedo-pagar`
+- [P0] **Decision engine drift**: webapp uses `analyzePurchaseDecisionAction` (server action). RN uses local `analyzeLocally` from `lib/services/purchase-decision`. Confirm both delegate to `@zeta/shared`; port if RN reimplements.
+- [P1] No category picker on RN — `categoryId` omitted from analyze payload, blocking budget-impact reasons.
+- [P1] No "name" field input.
+- [P1] No reset action / no "scroll verdict into view" focus behavior.
+- [P2] RN saves to wishlist via local `createWishlistItem`; webapp uses `saveAffordToWishlist` which stores `last_verdict` / `last_score` / `category_id` / `funding_type`. RN drops these → wishlist appears unscored.
+
+#### `/subscriptions`
+- [ORPHAN] **RN-only screen.** Webapp has no `/suscripciones` UI; manages via `is_subscription` flag + `recurring_transaction_templates`. RN screen CRUDs templates filtered to `SUBSCRIPTIONS_CATEGORY_ID` with suggested-name chips. **Recommendation: port to webapp** as `/suscripciones` (single-category recurring view) — real user feature. Until then, ensure RN shares validators/side-effects with webapp recurring flows (parity gate).
+
+#### Cross-cutting (decision tools)
+- [P1] Confirm `useSafeAreaInsets` honored on all RN debt/deseos screens.
+- [P1] Planificador tab labels drift: RN "Extra/Estrategia/Resultados" vs webapp "1. Efectivo / 2. Estrategia / 3. Comparar / 4. Detalle".
+- [P2] RN Deseos summary uses `text-z-alert` for total; webapp uses neutral. Pick one tone token.
+
+### 5. Import / Categorizar / Destinatarios / Categories / Etiquetas
+
+#### `/import`
+- [P0] No separate "Confirmar" step — webapp 6 steps, RN collapses to 4.
+- [P0] No "Destinatarios sugeridos" sub-flow — RN deep-links away to `/destinatarios` instead of returning to wizard.
+- [P0] No `previewImportReconciliation` parity — RN builds ad-hoc preview shape (lines 677–711) instead of canonical `ReconciliationPreviewResult`.
+- [P0] No multi-statement / multi-account mapping table (`parsed-transaction-table.tsx` 320 LOC) — RN assumes single `selectedAccount`.
+- [P0] No "Create account from statement" inline flow (`create-account-dialog.tsx`).
+- [P0] No PDF password vault suggestions UI (`initialVaultSuggestions`).
+- [P0] No pending-email-statement entry (`pending-email-statements.tsx`) — can't pick up `EMAIL_PDF_IMPORT` queued by email ingest.
+- [P0] No screenshot/OCR entry (`?mode=screenshot` + `getPendingScreenshotFile()`).
+- [P1] No `WizardActionBar` parity (sticky-bar overshoot/safe-area pattern).
+- [P1] No `Narrator`/`STEP_DESCRIPTIONS` per step.
+- [P1] No `step-results.tsx` parity (counts breakdown + post-import actions).
+
+#### `/categorizar`
+- [P0] No "Auto-review" tab + `bulkConfirmAutoCategory`.
+- [P0] No bulk-select / bulk-categorize (`BulkActionBar` + `bulkCategorize`).
+- [P0] No category suggestion chips inline on rows.
+- [P1] No undo / toast confirmation after assigning.
+
+#### `/destinatarios`
+- [P0] No create destinatario flow (`create-destinatario-dialog.tsx`).
+- [P0] No edit (rename, change category, toggle active, edit notes) — detail read-only.
+- [P0] No rule add/edit/delete on detail (`addDestinatarioRule` / `removeDestinatarioRule`).
+- [P0] No merge destinatarios (`merge-dialog.tsx`).
+- [P0] No "Suggestions" tab (`destinatario-suggestions-tab.tsx`) — clusters of unassigned merchants.
+- [P0] No `bulkLinkToDestinatario` retroactive matcher.
+- [P0] No delete destinatario.
+- [P0] No zone picker (`destinatario-zone-picker.tsx`).
+- [P1] No spend stats / monthly chart / direction split / cashflow / top categories on detail (webapp 838 LOC).
+- [P1] No sort/filter on list (zone, active, count).
+
+#### `/categories`
+- [P0] No icon picker — `CategoryFormSheet` has color presets only (webapp has `IconPicker` Lucide+emoji).
+- [P0] No zone assignment (essentials/wants/savings).
+- [P0] No category kit selection / onboarding kit picker.
+- [P1] No `displayOrder` reordering (drag).
+- [P1] Verify `name` (English) field parity.
+
+#### `/etiquetas` (tags)
+- [P0] **Entire route missing on mobile.** SQLite tables + sync push wired, but zero UI to view/create/edit/delete/assign tags.
+
+#### `/gestionar` (Más hub)
+- [P1] `menu.tsx` does not surface `AttentionHub` (signals + action/suggestion counts) — static link grid only.
+
+#### Cross-cutting (data hygiene)
+- [P1] Raw `paddingBottom: 100` instead of `MOBILE_TAB_BAR_CLEARANCE_CLASS` across `DestinatariosRoot`, `DestinatarioDetail`, `CategorizarRoot`, `CategoriesRoot`.
+- [P1] Empty states minimal vs richer webapp empty states with primary CTAs.
+- [P2] Unaccented strings: `categorizar.tsx` ("categoria", "transaccion") and `CategoriesRoot.tsx` ("Categorias", "personalizadas", "sincronizaran").
+
+### 6. Settings / Auth / Nav shell
+
+#### Tab bar — `MobileTabBar.tsx`
+- [P0] Hardcoded entries — webapp swaps 3rd tab via `profile.nav_focus` (`Plan` vs `Deudas`). Add `getMobileTabs(focus)` parity.
+- [P0] No 5th `Más` tab (`/gestionar`, `LayoutGrid`) — `menu.tsx` unreachable from bar.
+- [P0] No focus-mode hide (`FOCUS_MODE_PATHS` + runtime `useHideTabBar()`). RN only hides on keyboard.
+- [P1] No `FocusModeAccent` (2px brass top accent when bar hidden).
+- [P1] FAB context-actions hardcoded — webapp `FabMenu` accepts per-route `contextActions` (`new-recurring`, `new-account`).
+- [P1] Quick-capture is TODO Alert ("Próximamente"); webapp ships it.
+- [P2] Active label `text-muted-fg-70` non-default token — verify NativeWind resolution.
+
+#### Header — `MobileHeader.tsx`
+- [P1] No `backStyle="exit"` (X icon, "Salir") for committed wizards.
+- [P1] No attention badge + avatar menu via `MobileShellProvider`.
+- [P2] Solid `bg-background-92` instead of `expo-blur` — confirm sticky+blur parity.
+
+#### `/settings`
+- [P0] Flat single screen vs sectioned `SettingsNavigationList`. Missing sub-routes: `/settings/perfil`, `/integraciones`, `/email`, `/pdf-passwords`, `/etiquetas`, `/analytics`, `/bug`.
+- [P0] Missing surfaces: Integraciones (Telegram/MCP/IA tokens), Email ingest, PDF passwords manager, Tags editor, Analytics activity, Bug report form, Demo-mode card UX, Review-mode toggle (dev), Build info.
+- [P0] No `SettingsIdentityHero` (avatar + name + member-since).
+- [P1] RN-only biometrics + sync controls — keep but reorganize under sectioned list for layout parity.
+- [P1] Missing disclaimer copy ("Zeta no es un asesor financiero…").
+- [P2] `menu.tsx` duplicates settings entry-points instead of pointing to `/gestionar` parity.
+
+#### `/onboarding`
+- [P1] Step counts differ: webapp 4 (`FUNCTIONAL_STEPS=3` + celebration) vs RN 5 (welcome/profile/pulse/account/complete) — eyebrows say "Paso 1 de 3" vs "Paso 1 de 5".
+- [P0] RN persists via `bootstrapOnboardingLocally` (SQLite) — verify also calls `finishOnboarding` server action with same payload (`app_purpose`, `estimated_monthly_income/expenses`, `preferred_currency`, `timezone`, `locale`, default account, `dashboard_config`, `mobile_layout`). Parity gate.
+- [P1] No `skipOnboardingWithDefaults` path on RN.
+- [P1] No `trackClientEvent` analytics (`onboarding_started/step_completed/skipped/completed`).
+- [P2] Step copy diverges ("Sobre ti" vs "Tu perfil").
+
+#### `/auth`
+- [P0] No magic-link / passwordless path (webapp `AuthSessionShortcuts`).
+- [P0] No `/reset-password` deep-link callback handling — file exists, verify `supabase://reset` routes correctly.
+- [P1] RN-only biometrics — keep, but ensure no duplication.
+- [P1] No callback error states (`auth_callback_failed`, `auth_callback_missing_params`).
+- [P2] Webapp wraps login in `PANEL_SURFACE_CLASS` card with hero copy; RN renders form on background. Align hero copy.
+
+#### Modals / sheets / safe area
+- [P1] Verify `MobileSheet` + `FabMenuSheet` overlay above tab bar (z-order discipline).
+- [P1] Confirm every focus-mode screen honors `useSafeAreaInsets()` — `menu.tsx` to verify.
+
+#### Visual polish (shell)
+- [P1] Port `mobile-settings.tsx` sectioned card pattern (`rounded-xl border divide-y` + `ChevronRight`).
+- [P2] Lucide icon mismatch: `menu.tsx` uses `Wallet/Upload/Settings/PiggyBank/Repeat`; webapp `mobile-nav.ts` uses `LayoutDashboard/ArrowLeftRight/PiggyBank/Landmark/LayoutGrid`. Align `Más` hub icon with `LayoutGrid`.
+
+### Triage (parity)
+
+**P0 count is high (~80 items).** Suggested attack order:
+1. **Fill missing routes** — `/transactions/new` form, `/pendientes`, `/etiquetas`, `/settings/*` sub-routes.
+2. **Decision engines parity** — port RN deudas planificador + puedo-pagar to `@zeta/shared` shared engines (avoid drift).
+3. **Dashboard widget catalog** — import the 8 missing widgets (HealthZone, Flujo, Heatmap, AccountsOverview, DashboardAlerts, UpcomingPayments, BurnRate, RunwayMiniChart).
+4. **Account detail heroes** — flip/pulse/graph variants + QuickActionsBar (Pagar/Transferir/Ajustar dialogs).
+5. **CRUD gaps** — destinatarios edit/create/merge, recurring template editor, deseos enrich drawer.
+6. **Import wizard step parity** — restore Confirmar, multi-statement table, password vault, email-statement entry.
+7. **Tab bar / shell** — `nav_focus`, 5-slot `Más` tab, focus-mode hide.
+8. **Polish sweep** — design tokens (no hardcoded colors), `MobileHeader`, `MOBILE_TAB_BAR_CLEARANCE_CLASS`, accents in copy.
+
+**ORPHANS to decide:** `/subscriptions` (port to webapp recommended), `capture-screenshot` + `capture-voice` + `annotate-screenshot` (RN-only by design — verify they share shared utils).

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,115 +1,127 @@
-# HANDOVER — 2026-04-22 (late afternoon) — Play Store login fix + PR triage + Budgets tab polish
+# HANDOVER — 2026-05-03 — Mobile RN ↔ Webapp parity (Phase 0 foundations)
 
 > Supersedes prior handovers. For earlier handovers see git history (`HANDOVER.md@HEAD~N`).
 
-## 1. Session Summary
+Branch: `feat/mobile-shared-engines` (despite the name, it's the home for all Phase 0–2 parity work; rename on PR if desired).
 
-Three concurrent threads:
+## What landed (7 commits on this branch)
 
-1. **Fixed the Play Store AAB login failure** — user downloaded the Play Console bundle and got `"Network request failed"` at login. Root cause: EAS `production` environment had **no variables**, so the shipped build fell through to `mobile/lib/supabase.ts:9`'s `https://invalid.localhost` fallback. Populated EAS remote env + fixed a `.env` prefix typo + bumped app version for re-upload.
-2. **Merged/closed the 3 open PRs** — addressed Gemini comments on each before acting. #222 merged with the real parity fix (Gemini caught my initial misread). #219 merged with Gemini's nit applied. #203 closed (fully obsolete — every BACKLOG change had been superseded by newer commits).
-3. **Shipped the Budgets tab polish slice** (PR #223, open) — first of the remaining mobile design slices. Structural extraction + `MobileHeader` + canonical tokens + `FlatList` + memoized rows + Reanimated chevron + Alert-surfaced errors. 5 review agents (mobile-perf-doctor, zetas-front-guy, superpowers:code-reviewer, mobile-sync-doctor, mobile-webapp-parity) + Gemini — all findings triaged, real fixes applied, pre-existing issues filed to BACKLOG.
+| Commit | Phase | Summary |
+|---|---|---|
+| `398f4bd` | 0a | PayoffResultCard ported to `@zeta/shared` `runScenario` (engine drift fix). 175 LOC of local sim removed. |
+| `754119f` | 0b | Tab bar parity: `getMobileTabs(focus)`, `Más` tab, `useHideTabBar`, `FocusModeAccent`, `(tabs)/menu.tsx` relocation |
+| `9b65fa8` | 0c | Tab-bar clearance sweep — 13 files, `paddingBottom: 100/120` → `MOBILE_TAB_BAR_CLEARANCE` constant; `useTabBarClearance` hook added |
+| `15e234f` | 0d | Hardcoded color codemod — 38 files, 148 token replacements (`bg-white`, `text-gray-*`, `text-sky-*`, etc.) |
+| `903a2f5` | 1 | Scaffolded `/transactions/new` (focus-mode), `/pendientes`, `/etiquetas` |
+| `3d30b6e` | 2 | Enabled 3 dashboard widgets that already had implementations (next_bill, next_income, accounts) |
 
-## 2. Changes Made
+Mobile `tsc --noEmit` clean throughout. Shared `scenario-engine` tests green (19/19). Pre-existing failures in `auto-categorize` + `debt-stats` tests are unrelated to this branch.
 
-### EAS / mobile-release fix (shipped via PR #222)
+## Why we stopped here
 
-- **`mobile/.env`** (modified, gitignored) — renamed `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` → `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`. Wrong prefix meant Expo silently ignored it; locally the `ANON_KEY` fallback masked the bug.
-- **`mobile/app.json`** (modified, rode on PR #222) — bumped `expo.version` 1.1.0 → 1.1.1 so Play Console accepts the re-upload. `versionCode` auto-increments via EAS remote.
-- **EAS remote env** (not in git) — pushed three production-env vars via `eas env:create --environment production`:
-  - `EXPO_PUBLIC_SUPABASE_URL=https://tgkhaxipfgskxydotdtu.supabase.co`
-  - `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable__1o6wPIiW_9cVOwEx6izxg_QCnniqyu`
-  - `EXPO_PUBLIC_API_URL=https://pfm.sanson1911.cloud`
-  - ANON_KEY was denied by the permission system (agent-inferred); not needed — code reads PUBLISHABLE first.
+The audit's full P0 list (`BACKLOG.md` line 903–1199) is ~80 items spread across 12 phases. Phases 0–2 above are the mechanical/foundational subset. Phases 3–8 each represent multi-hour to multi-day feature work (planificador 4-step, account hero variants, destinatario CRUD, import wizard restoration). Pushing through all of them in one session would produce shallow, half-built work — better to ship foundations now and tackle each remaining phase as its own follow-up PR.
 
-### PR #222 — `fix(mobile): align categorization_source clear with webapp` (MERGED `123fe2b`)
+## Suggested next session
 
-- **`mobile/lib/repositories/transactions.ts`** (modified) — `updateTransaction`: when `params.category_id !== undefined` (assign OR clear), always sets `categorization_source = "USER_OVERRIDE"`. Matches webapp `actions/transactions.ts:841` which uses `categoryChanged` (true in both directions). Applied to SQLite UPDATE + `syncPayload`.
-  - **Correction story:** initial PR #222 attempt guarded the set with `if (params.category_id)` — only flagged on assign, not clear. I told the user Gemini was wrong. Gemini was right; I re-read `webapp/src/actions/transactions.ts:824` (`categoryChanged = existing.category_id !== parsed.data.category_id`) and confirmed it flips `USER_OVERRIDE` on clears too. Applied the correct fix before merge.
-- **`HANDOVER.md`** + **`BACKLOG.md`** (modified) — updated stale claims that said "webapp doesn't flag USER_OVERRIDE on clear".
-- **`mobile/app.json`** — v1.1.1 bump bundled here.
+Pick one of:
 
-### PR #219 — `docs(backlog): expo-system-ui for Android theme` (MERGED `04f1798`)
+- **Phase 3 planificador 4-step** — biggest UX impact, depends only on Phase 0a engines (already merged). Webapp source: `webapp/src/components/deudas/planificador/*`. Spawn `mobile-perf-doctor` after.
+- **Phase 5 destinatarios CRUD** — biggest functional gap, low blast radius. Webapp source: `webapp/src/components/destinatarios/*` + `actions/destinatarios.ts`. Spawn `mobile-webapp-parity` + `mobile-sync-doctor`.
+- **Phase 6 import wizard** — restores feature completeness on a cluster the user runs every month. Spawn `import-flow-doctor`.
 
-- **`BACKLOG.md`** — moved the `expo-system-ui` entry from `## Features` to `## Bugs` per Gemini's nit. Amended the single commit + force-push-with-lease.
+## Deferred (still P0 in BACKLOG.md §3 onwards)
 
-### PR #203 — CLOSED (not merged)
+Each item below is a focused session of its own. Listed with the most natural agent gate.
 
-- Stale. Gemini had approved with no feedback, but the 2-day-old BACKLOG changes had all been superseded (Flow 01 PR #205, Flow 02 shipped as Variant B in PR #204, Flow 06 already marked shipped, Import reconciliation truncate entry added to main via PR #216, etc). Closed with rationale comment.
+### Phase 2 remainder — heavy widgets (mobile-perf-doctor)
+- HealthZone (multiple meters + score + runway)
+- FlujoSection (burn rate card + waterfall + cashflow charts)
+- ActividadHeatmap (calendar SVG grid)
+- DashboardAlerts banner
+- UpcomingPayments standalone widget
+- BurnRate, RunwayMiniChart sparkline
+- DashboardHero / StatusHeadline + 50/30/20 strip
+- MonthSelector / DashboardAccountPicker
+- InicioDiscoveryRail + DemoBanner / GuestBanner / DebtFreeBanner
+- `useLiveDashboard` parity (silent stale-value correction)
+- `dashboard_config` Supabase persistence (mobile currently AsyncStorage only) — `mobile-sync-doctor` gate
 
-### PR #223 — `feat(mobile): Budgets tab polish` (OPEN, CI green, branch `feat/mobile-budgets-polish`)
+### Phase 3 — Decision tools (mobile-webapp-parity, mobile-perf-doctor)
+- Planificador: 4-step flow (Cash → Allocate → Compare → Detail), multi-cashEntry input, scenario persistence (`getScenarios`/save A/B/C cap)
+- Puedo-pagar: category picker, name field, scroll-to-verdict focus, `funding_type` + `last_verdict` + `last_score` + `category_id` on save-to-wishlist
+- Deseos: live re-score on list, `DeseosEnrichDrawer`, `DeseosNudgeBanner`, `DeseosReflectionCard`, bought-items section, urgency/desire-type chips, per-row CTAs
 
-Three commits:
-- `9de6195` — initial slice (structural extraction + tokens + FlatList + memo).
-- `a68b1e2` — post-review fixes (stale amountInput, error surface via `Alert`, slash-opacity token).
-- `132ef7d` — Gemini fixes (Reanimated chevron, className gap).
+### Phase 4 — Account detail heroes
+- AccountHero variants (`flip` for CC/SAVINGS, `pulse` for CHECKING/CASH/OTHER, `graph` for LOAN/INVESTMENT)
+- FlipZone / CardFace / GraphFace
+- BalanceGraphHero + RangePills (30/90/180/365)
+- SpendingPulseHero (30-day sparkline)
+- QuickActionsBar: Pagar, Transferir, Agregar, Ajustar, Más
+- QuickPaymentDialog, TransferDialog, ReconcileBalanceDialog
+- StatementSnapshotsCard / StatementHistoryTimeline
+- Move `RecentTransactions` to use webapp's full row pattern
+- Replace `Alert.alert` delete confirm with styled AlertDialog
 
-Files:
-- **`mobile/app/(tabs)/budgets.tsx`** (modified) — 276 lines → 5-line thunk delegating to `BudgetsRoot`.
-- **`mobile/components/budgets/BudgetsRoot.tsx`** (created) — `MobileHeader variant="main" title="Presupuestos"` + `AvatarMenuTrigger` + `MonthSelector`, race-guarded `loadData` via `requestIdRef`, `FlatList` for rows (`initialNumToRender=10`, `windowSize=5`, Android `removeClippedSubviews`), `KeyboardAvoidingView` for the inline edit inputs, memoized `listHeader` + `listEmpty`.
-- **`mobile/components/budgets/BudgetsHero.tsx`** (created) — memoized summary card: spent / target / % usado / "Quedan $X" line. Falls back to "Aún no has fijado un presupuesto" when none configured.
-- **`mobile/components/budgets/BudgetRow.tsx`** (created) — memoized row with `AnimatedAccordion` inline edit. Chevron rotation via `useSharedValue` + `withTiming(220ms)` + `Animated.View` wrapper. `useEffect` resyncs `amountInput` to `item.amount` on collapse so external data refresh isn't stale on next open. `handleSave` / `handleDelete` wrap mutations in `try/catch` + `Alert.alert` for user-visible errors. Invalid amount (≤ 0) surfaces `Alert.alert("Monto inválido", …)` — parity with webapp's Zod `.min(0)`.
-- **`mobile/lib/constants/styles.ts`** (modified) — added `DESTRUCTIVE_GHOST_BUTTON_CLASS = "border border-z-debt-25 bg-black-10 text-z-expense"`. Note: `border-z-debt-25` pre-computed token (NativeWind v3 can't consume `/25` slash-opacity).
+### Phase 5 — CRUD parity (mobile-webapp-parity, mobile-sync-doctor)
+- `/destinatarios`: create, edit (rename / category / active / notes), rule add/edit/delete, merge, suggestions tab, `bulkLinkToDestinatario`, delete, zone picker, spend stats / monthly chart on detail
+- `/recurrentes`: template editor (RecurringFormSheet), templates strip, link-picker / merge-picker sheets, `recurring-impact-dialog`, `recurring-mini-calendar`, payment timeline, "Próximas" 30/60/90-day tile
+- `/categorizar`: Auto-review tab + `bulkConfirmAutoCategory`, bulk-select + `bulkCategorize`, suggestion chips inline, undo toast
+- `/categories`: `IconPicker` (Lucide+emoji), zone assignment (essentials/wants/savings), kit picker, `displayOrder` drag reorder
+- `/etiquetas`: full CRUD UI (file scaffolded; needs list, create, edit, delete, assign-to-tx)
+- `/movimientos`: filter pills (`tagId`, `dateFrom`, `dateTo`, `amountMin`, `amountMax`, `capture_method`), `pendingEmails` tile, "Compra consciente" entry, inline zone pickers on rows, `Link2`/`Repeat` badges
+- `/transactions/[id]`: PromoteToRecurringButton, LinkPickerSheet, destinatario picker, tag picker, linked-recurring surface, installment surface, capture_method tier badge
+- `/pendientes`: real list + actions (file scaffolded)
 
-### BACKLOG additions (carried in PR #223 commit `a68b1e2`)
+### Phase 6 — Import wizard parity (import-flow-doctor)
+- Restore "Confirmar" step (current RN collapses 6 → 4)
+- "Destinatarios sugeridos" sub-flow (return to wizard, not deep-link away)
+- `previewImportReconciliation` parity (use canonical `ReconciliationPreviewResult`)
+- Multi-statement / multi-account mapping table
+- "Create account from statement" inline flow
+- PDF password vault suggestions UI (`initialVaultSuggestions`)
+- Pending-email-statement entry (`EMAIL_PDF_IMPORT`)
+- Screenshot/OCR entry (`?mode=screenshot` + `getPendingScreenshotFile()`)
+- WizardActionBar parity, `STEP_DESCRIPTIONS` Narrator, `step-results.tsx` parity
 
-Three entries added to `## Bugs` section:
-- **Mobile — `budgets` SQLite missing `is_demo` column (sync drift).** Supabase view has `is_demo: boolean`; SQLite schema doesn't. Pull drops it silently. Pre-existing; not blocking. Fix: v11 migration + `BOOLEAN_FIELDS["budgets"]` entry.
-- **Mobile — yearly budgets not displayed.** `getBudgetProgress` hardcodes `period = 'monthly'`. Webapp supports `"monthly" | "yearly"`. Read-side gap.
-- **Webapp — `DESTRUCTIVE_GHOST_BUTTON_CLASS` parity.** PR #223 added to mobile; webapp only has solid destructive. Components re-invent ad hoc.
+### Phase 7 — Onboarding / auth / settings (mobile-webapp-parity)
+- Onboarding step count: 5 → 4 (match webapp `FUNCTIONAL_STEPS=3` + celebration)
+- `finishOnboarding` server action wiring with same payload (`app_purpose`, `estimated_monthly_income/expenses`, `preferred_currency`, `timezone`, `locale`, default account, `dashboard_config`, `mobile_layout`)
+- `skipOnboardingWithDefaults` path
+- `trackClientEvent` analytics
+- Magic-link / passwordless auth path
+- `/reset-password` deep-link callback
+- Auth callback error states
+- `SettingsIdentityHero` (avatar + name + member-since)
+- `/settings/perfil`, `/integraciones`, `/email`, `/pdf-passwords`, `/etiquetas`, `/analytics`, `/bug` sub-routes
+- Tab bar: read `profile.nav_focus` from SQLite (requires column add — `mobile-sync-doctor`)
 
-## 3. Key Decisions
+### Phase 8 — Webapp `/suscripciones` (recurring-doctor, server-action-reviewer, perf-auditor, zetas-front-guy)
+- New webapp route `/suscripciones` filtering recurring templates to `SUBSCRIPTIONS_CATEGORY_ID`
+- Suggested-name chips
+- After ship, re-verify RN `/subscriptions` shape parity
 
-- **EAS env via `eas env:create` (remote secrets) rather than hardcoding in `eas.json`.** Cleaner; keeps creds out of git even when they're public-safe. `EXPO_PUBLIC_API_URL` is now set in both places (eas.json build-profile + remote env) — EAS emits a harmless duplication warning; build-profile value wins. User OK'd leaving as-is.
-- **Did NOT push `EXPO_PUBLIC_SUPABASE_ANON_KEY` to EAS remote.** Permission system denied it as "agent-inferred value". Not needed — `mobile/lib/supabase.ts:12-15` reads PUBLISHABLE first and that's present. User has the exact command to run manually if they want the fallback.
-- **Closed PR #203 rather than rebasing.** 2 days of main drift made every one of its BACKLOG edits obsolete. Rebasing would produce a near-empty PR. Closed with a detailed rationale comment listing each superseded change.
-- **Applied Gemini's PR #222 fix even though I had told the user Gemini was wrong.** Verified against `webapp/src/actions/transactions.ts:824,841` and confirmed Gemini was right on the parity rule. Corrected HANDOVER + BACKLOG claims; wrote the commit message to call out the correction arc.
-- **Started with Budgets tab over Movimientos slice 2 / Plan / Deudas.** User picked; rationale was "smallest scope, fast feedback loop, validates mobile-perf-doctor on a fresh tab".
-- **Budget row holds its own `expanded` + `amountInput` state, Root holds `savingId`.** Mirrors `MovimientosTransactionRow` (each row owns its local UI state). Only the saving row re-renders on save-state flip.
-- **Used `useSharedValue` + `useEffect` + `useAnimatedStyle` for chevron rotation, not the Gemini-suggested inline `useAnimatedStyle(() => ({ transform: [{ rotate: withTiming(...) }] }))`.** Reanimated 3 worklets can't cleanly capture React state inside useAnimatedStyle; shared-value-driven-by-effect is the canonical pattern.
-- **Summary totals from in-memory reduce, not SQL aggregate.** Unlike Movimientos (feed paginated — summing the feed inflates as you scroll), the budgets list is already bounded (~one row per category), so `useMemo` reduce over full `items` is correct and simpler.
-- **Empty-list message (`listEmpty`)** still says "Crea presupuestos desde categorías en la web" — kept the original copy verbatim; no mobile-side budget creation flow exists yet.
+## How to ship this branch
 
-## 4. Current State
+```sh
+git push -u origin feat/mobile-shared-engines
+gh pr create --title "Mobile parity foundations (Phase 0–2)" --body "$(cat <<'EOF'
+## Summary
+Foundations subset of the mobile RN ↔ webapp parity audit (BACKLOG.md §903+).
+- Engine drift fix: PayoffResultCard now uses @zeta/shared runScenario
+- Tab bar parity: getMobileTabs(focus), Más tab, focus-mode hide, brass accent
+- Tab-bar clearance sweep (13 files), color token codemod (38 files)
+- Scaffolds: /transactions/new, /pendientes, /etiquetas
+- 3 dashboard widgets enabled (next_bill, next_income, accounts)
 
-- **Build:** `npx tsc --noEmit` in `mobile/` is clean on the current branch. CI (`Mobile PR Verify` typecheck job) SUCCESS on PR #223 commit `132ef7d` at `2026-04-22T18:17:31Z`.
-- **Branch:** `feat/mobile-budgets-polish`, 0 uncommitted changes, up to date with origin. Main has new commits since session start (PR #222, PR #219).
-- **PRs state:**
-  - #222 MERGED (123fe2b)
-  - #219 MERGED (04f1798)
-  - #203 CLOSED (not merged)
-  - #223 OPEN — CI green, Gemini's 2 comments addressed + replied, ready to merge
-- **EAS production env:** populated with `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `EXPO_PUBLIC_API_URL`. `EXPO_PUBLIC_SUPABASE_ANON_KEY` NOT set (user can run manually if desired).
-- **Play Store AAB:** v1.1.0 currently live, broken login. **User still needs to run `eas build --platform android --profile production-android`** and re-upload v1.1.1 to Play Console after #223 merges (or before — the build isn't blocked on the Budgets slice).
+Phases 3–8 are deferred — see HANDOVER.md.
 
-## 5. Open Issues & Gotchas
-
-- **User must trigger the EAS build themselves.** I did not kick it off (billed). Command: `cd mobile && eas build --platform android --profile production-android`.
-- **PR #223 merge sequence with EAS build:** the v1.1.1 bump rides on PR #223. If the user wants to build the AAB sooner, they can either (a) wait for #223 merge or (b) cherry-pick the `app.json` bump onto main directly. Not urgent.
-- **Pre-existing mobile-sync drift on `budgets.is_demo`** — filed in BACKLOG. Fix path documented (v11 migration + `BOOLEAN_FIELDS`). User-created budgets work today because Supabase defaults `is_demo=false` on insert. Demo budgets seeded via `mobile/lib/demo-data.ts` would need the flag to filter correctly.
-- **Mobile DELETE push lacks defense-in-depth `user_id` filter.** Surfaced by `mobile-webapp-parity` review but deemed non-blocking (RLS covers). Not filed in BACKLOG — consider if encountering during a future mobile-sync slice.
-- **Gemini on PR #223 also mentioned AnimatedAccordion `estimatedHeight` caveat.** Kept the default `500`; the edit form fits comfortably. If the form ever grows (e.g., period picker for yearly budgets), bump the estimate.
-- **Lockfile not touched this session.** `pnpm install` not needed.
-
-## 6. Suggested Next Steps
-
-1. **Merge PR #223** after any final visual verification on device/simulator (`gh pr merge 223 --squash --delete-branch`).
-2. **Trigger EAS build + re-upload AAB** — `cd mobile && eas build --platform android --profile production-android`, wait for build, upload to Play Console closed track.
-3. **Next mobile slice.** User-stated plan is sequential through the remaining slices:
-   - **Movimientos slice 2** — destinatario / tag / vincular-a-recurrente chips on rows + email-pending detail panel. Reopens recently-shipped files from PR #221.
-   - **Plan tab parity** vs webapp `/plan` — high-traffic, lots of moving parts (`PlanResumenZone`, `PlanMobileZone`, tabs).
-   - **Deudas tab parity** vs webapp `/deudas` — high-visibility, split-bar hero + rings.
-4. **Optional BACKLOG cleanup during next slice:** the three items filed from PR #223 reviews (budgets `is_demo`, yearly budgets display, webapp `DESTRUCTIVE_GHOST_BUTTON_CLASS` parity) are all small and opportunistic.
-
-## 7. Context for Claude
-
-- **EAS env visibility** — `eas env:list --environment production` shows only what's pushed via `eas env:create`. `.env` in the repo is gitignored and NOT used by EAS cloud builds; local dev reads it via Expo's dotenv loader.
-- **Supabase publishable vs anon key** — both work for anon role. Publishable (`sb_publishable__…`) is the newer Supabase naming; ANON (`eyJ…` JWT) is the legacy form. Either satisfies `mobile/lib/supabase.ts:85-96`; code tries publishable first.
-- **Gemini bot quirk:** when Gemini's comment claim contradicts my stated understanding, re-read the primary source before dismissing. I got this wrong on PR #222 first pass — corrected before merge. Primary sources beat confidence.
-- **`MOBILE_CARD_CLASS` already includes `p-3`.** Applying `p-4` on top is a smell (last one wins at style-merge time but both compile). Prefer `PANEL_SURFACE_SUBTLE_CLASS + p-4` when the card needs different padding.
-- **`DESTRUCTIVE_GHOST_BUTTON_CLASS` uses pre-computed `border-z-debt-25`**, not `border-z-debt/25`. NativeWind v3 (mobile) cannot consume slash-opacity syntax. The token is defined in `mobile/tailwind.config.js`: `"z-debt-25": "rgba(224,85,69,0.25)"`.
-- **Reanimated 3 chevron pattern** — shared value + `useEffect(…, [expanded, sharedValue])` + `useAnimatedStyle` reading `${sharedValue.value}deg`. Works because worklets re-run when shared values change; effect bridges React state → shared value. Applied in `BudgetRow.tsx:53-61`.
-- **`useFocusEffect` + `loadData`** re-fires on `loadData` reference change (its callback is captured via `useCallback(…, [loadData])`). When `currentMonth` flips, `loadData` identity changes → effect re-runs. Confirmed working on Movimientos + Budgets.
-- **`requestIdRef` race-guard pattern** — both `setItems` and the `finally { setLoading(false) }` check `requestId === requestIdRef.current`. Dropping the guard on `setLoading` is a subtle bug (last-completing fetch clears loading even if its data was dropped).
-- **Review gate order for mobile slices:** mobile-perf-doctor → zetas-front-guy → superpowers:code-reviewer → mobile-sync-doctor (if repository writes) → mobile-webapp-parity (if Supabase mutation or cross-platform feature). All 5 ran on #223; future mobile tab polishes should hit the same gates.
-- **User explicitly wants sequential mobile slices, not parallel.** Established when picking Budgets first: "Budgets, then Movimientos slice 2, then Plan, then Deudas". Don't bundle.
+## Test plan
+- [ ] Mobile typecheck (`pnpm --filter mobile exec tsc --noEmit`)
+- [ ] Open /menu from Más tab, verify navigation
+- [ ] Open /transactions/new, confirm tab bar hides + brass accent shows
+- [ ] Confirm /pendientes and /etiquetas reachable
+- [ ] Open AddWidgetSheet, confirm Próximo pago/Próximo ingreso/Cuentas selectable
+- [ ] Run planificador, confirm payoff numbers match webapp scenario tool
+EOF
+)"
+```

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -17,6 +17,10 @@ Branch: `feat/mobile-shared-engines` (despite the name, it's the home for all Ph
 
 Mobile `tsc --noEmit` clean throughout. Shared `scenario-engine` tests green (19/19). Pre-existing failures in `auto-categorize` + `debt-stats` tests are unrelated to this branch.
 
+## Tracked follow-ups
+
+- **PaymentSheet atomic balance update** (Gemini review on PR #247, line 91) — `updateAccountBalanceRemote` reads `current_balance` then writes a computed new value, which is racey under concurrent payment creation. Fix is a Supabase RPC (`update_account_balance_atomic`) that does the read+compute+update in one DB round-trip with row-level locking. Out of scope for Phase 0–2; needs `supabase-migrator` agent for the RPC + RLS check.
+
 ## Why we stopped here
 
 The audit's full P0 list (`BACKLOG.md` line 903–1199) is ~80 items spread across 12 phases. Phases 0–2 above are the mechanical/foundational subset. Phases 3–8 each represent multi-hour to multi-day feature work (planificador 4-step, account hero variants, destinatario CRUD, import wizard restoration). Pushing through all of them in one session would produce shallow, half-built work — better to ship foundations now and tackle each remaining phase as its own follow-up PR.

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -238,7 +238,7 @@ export default function LoginScreen() {
 
         <TouchableOpacity
           className={`mt-3 rounded-lg py-3.5 items-center border ${
-            demoLoading ? "border-white-6 bg-white-5" : "border-white-6 bg-z-surface-2-55"
+            demoLoading ? "border-white-6 bg-z-surface-2-5" : "border-white-6 bg-z-surface-2-55"
           }`}
           onPress={handleTryDemo}
           disabled={demoLoading || loading}

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,22 +1,31 @@
+import { View } from "react-native";
 import { Tabs } from "expo-router";
 import { MobileTabBar } from "../../components/ui/MobileTabBar";
+import { TabBarVisibilityProvider } from "../../components/nav/TabBarVisibilityProvider";
+import { FocusModeAccent } from "../../components/nav/FocusModeAccent";
 
 export default function TabLayout() {
   return (
-    <Tabs
-      tabBar={(props) => <MobileTabBar {...props} />}
-      screenOptions={{
-        headerShown: false,
-      }}
-    >
-      <Tabs.Screen name="index" />
-      <Tabs.Screen name="transactions" />
-      <Tabs.Screen name="plan" />
-      <Tabs.Screen name="deudas" />
-      {/* Hidden tabs — kept as files but not in tab bar */}
-      <Tabs.Screen name="import" options={{ href: null }} />
-      <Tabs.Screen name="accounts" options={{ href: null }} />
-      <Tabs.Screen name="budgets" options={{ href: null }} />
-    </Tabs>
+    <TabBarVisibilityProvider>
+      <View style={{ flex: 1 }}>
+        <FocusModeAccent />
+        <Tabs
+          tabBar={(props) => <MobileTabBar {...props} />}
+          screenOptions={{
+            headerShown: false,
+          }}
+        >
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="transactions" />
+          <Tabs.Screen name="plan" />
+          <Tabs.Screen name="deudas" />
+          <Tabs.Screen name="menu" />
+          {/* Hidden tabs — kept as files but not in tab bar */}
+          <Tabs.Screen name="import" options={{ href: null }} />
+          <Tabs.Screen name="accounts" options={{ href: null }} />
+          <Tabs.Screen name="budgets" options={{ href: null }} />
+        </Tabs>
+      </View>
+    </TabBarVisibilityProvider>
   );
 }

--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -191,7 +191,7 @@ type ReconciliationPreview = {
 };
 
 function ItemSeparator() {
-  return <View className="ml-12 h-px bg-white-6" />;
+  return <View className="ml-12 h-px bg-z-surface-2-6" />;
 }
 
 function AccountSelector({

--- a/mobile/app/(tabs)/menu.tsx
+++ b/mobile/app/(tabs)/menu.tsx
@@ -7,8 +7,8 @@ import {
   PiggyBank,
   Repeat,
 } from "lucide-react-native";
-import { MobileHeader } from "../components/ui/MobileHeader";
-import { HubEntry } from "../components/ui/HubEntry";
+import { MobileHeader } from "../../components/ui/MobileHeader";
+import { HubEntry } from "../../components/ui/HubEntry";
 
 export default function MenuScreen() {
   const router = useRouter();

--- a/mobile/app/account/[id].tsx
+++ b/mobile/app/account/[id].tsx
@@ -33,16 +33,16 @@ type TransactionRow = {
 };
 
 function getAmountColorClass(isDebtPayment: boolean, isInflow: boolean): string {
-  if (isDebtPayment) return "text-sky-600";
-  if (isInflow) return "text-green-600";
-  return "text-gray-900";
+  if (isDebtPayment) return "text-z-brass";
+  if (isInflow) return "text-z-income";
+  return "text-foreground";
 }
 
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
-    <View className="flex-row items-start py-3 border-b border-gray-100">
-      <Text className="text-gray-500 font-inter text-sm w-24 mt-0.5">{label}</Text>
-      <Text className="text-gray-900 font-inter-medium text-sm text-right flex-1 ml-4 leading-5">
+    <View className="flex-row items-start py-3 border-b border-white-6">
+      <Text className="text-muted-foreground font-inter text-sm w-24 mt-0.5">{label}</Text>
+      <Text className="text-foreground font-inter-medium text-sm text-right flex-1 ml-4 leading-5">
         {value}
       </Text>
     </View>
@@ -118,7 +118,7 @@ export default function AccountDetailScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-white">
+      <View className="flex-1 items-center justify-center bg-z-surface-2">
         <ActivityIndicator size="large" color="#10B981" />
       </View>
     );
@@ -126,19 +126,19 @@ export default function AccountDetailScreen() {
 
   if (!account) {
     return (
-      <View className="flex-1 bg-white">
+      <View className="flex-1 bg-z-surface-2">
         <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
           <Pressable
             onPress={() => router.back()}
-            className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+            className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
           >
             <X size={18} color="#6B7280" />
           </Pressable>
-          <Text className="text-gray-900 font-inter-bold text-base">Cuenta</Text>
+          <Text className="text-foreground font-inter-bold text-base">Cuenta</Text>
           <View className="w-8" />
         </View>
         <View className="flex-1 items-center justify-center px-8">
-          <Text className="text-gray-400 font-inter text-base">
+          <Text className="text-muted-fg-70 font-inter text-base">
             Cuenta no encontrada
           </Text>
         </View>
@@ -152,20 +152,20 @@ export default function AccountDetailScreen() {
   const currency = (account.currency_code as CurrencyCode) ?? "COP";
 
   return (
-    <View className="flex-1 bg-white">
+    <View className="flex-1 bg-z-surface-2">
       {/* Header */}
       <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
         <Pressable
           onPress={() => router.back()}
-          className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+          className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
         >
           <X size={18} color="#6B7280" />
         </Pressable>
-        <Text className="text-gray-900 font-inter-bold text-base">Detalle</Text>
+        <Text className="text-foreground font-inter-bold text-base">Detalle</Text>
         <View className="flex-row gap-2">
           <Pressable
             onPress={() => router.push(`/account/edit/${id}`)}
-            className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+            className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
           >
             <Pencil size={16} color="#6B7280" />
           </Pressable>
@@ -180,23 +180,23 @@ export default function AccountDetailScreen() {
 
       <ScrollView className="flex-1">
         {/* Hero */}
-        <View className="items-center pt-6 pb-5 border-b border-gray-100 mx-4">
+        <View className="items-center pt-6 pb-5 border-b border-white-6 mx-4">
           <View
             className="w-16 h-16 rounded-full items-center justify-center mb-3"
             style={{ backgroundColor: color + "20" }}
           >
             {Icon && <Icon size={30} color={color} />}
           </View>
-          <Text className="text-gray-900 font-inter-bold text-xl">
+          <Text className="text-foreground font-inter-bold text-xl">
             {account.name}
           </Text>
           {account.institution_name && (
-            <Text className="text-gray-500 font-inter text-sm mt-1">
+            <Text className="text-muted-foreground font-inter text-sm mt-1">
               {account.institution_name}
             </Text>
           )}
-          <View className="bg-gray-100 rounded-full px-3 py-1 mt-2">
-            <Text className="text-gray-600 font-inter-medium text-xs">
+          <View className="bg-z-surface-2 rounded-full px-3 py-1 mt-2">
+            <Text className="text-muted-foreground font-inter-medium text-xs">
               {typeDef?.label ?? account.account_type}
             </Text>
           </View>
@@ -210,28 +210,28 @@ export default function AccountDetailScreen() {
         {/* Monthly spending summary */}
         {spendingSummary && spendingSummary.tx_count > 0 && (
           <View className="mx-4 mt-4">
-            <Text className="text-gray-500 font-inter-semibold text-xs uppercase mb-2">
+            <Text className="text-muted-foreground font-inter-semibold text-xs uppercase mb-2">
               Resumen del mes
             </Text>
             <View className="flex-row gap-3">
-              <View className="flex-1 bg-white rounded-xl p-4 border border-gray-100 items-center">
-                <Text className="text-gray-400 font-inter text-xs mb-1">
+              <View className="flex-1 bg-z-surface-2 rounded-xl p-4 border border-white-6 items-center">
+                <Text className="text-muted-fg-70 font-inter text-xs mb-1">
                   Gastos del mes
                 </Text>
-                <Text className="text-gray-900 font-inter-semibold text-sm">
+                <Text className="text-foreground font-inter-semibold text-sm">
                   {formatCurrency(spendingSummary.total_out, currency)}
                 </Text>
               </View>
-              <View className="flex-1 bg-white rounded-xl p-4 border border-gray-100 items-center">
-                <Text className="text-gray-400 font-inter text-xs mb-1">
+              <View className="flex-1 bg-z-surface-2 rounded-xl p-4 border border-white-6 items-center">
+                <Text className="text-muted-fg-70 font-inter text-xs mb-1">
                   Ingresos del mes
                 </Text>
-                <Text className="text-green-600 font-inter-semibold text-sm">
+                <Text className="text-z-income font-inter-semibold text-sm">
                   {formatCurrency(spendingSummary.total_in, currency)}
                 </Text>
               </View>
             </View>
-            <Text className="text-gray-400 font-inter text-xs mt-1.5 text-center">
+            <Text className="text-muted-fg-70 font-inter text-xs mt-1.5 text-center">
               {spendingSummary.tx_count} transacciones este mes
             </Text>
           </View>
@@ -241,10 +241,10 @@ export default function AccountDetailScreen() {
         {(account.account_type === "CREDIT_CARD" ||
           account.account_type === "LOAN") && (
           <View className="mx-4 mt-4">
-            <Text className="text-gray-500 font-inter-semibold text-xs uppercase mb-2">
+            <Text className="text-muted-foreground font-inter-semibold text-xs uppercase mb-2">
               Detalles
             </Text>
-            <View className="bg-white rounded-xl px-4 border border-gray-100">
+            <View className="bg-z-surface-2 rounded-xl px-4 border border-white-6">
               {account.credit_limit != null && (
                 <DetailRow
                   label="Limite de credito"
@@ -275,17 +275,17 @@ export default function AccountDetailScreen() {
 
         {/* Recent transactions */}
         <View className="mx-4 mt-4 mb-8">
-          <Text className="text-gray-500 font-inter-semibold text-xs uppercase mb-2">
+          <Text className="text-muted-foreground font-inter-semibold text-xs uppercase mb-2">
             Ultimas transacciones
           </Text>
           {recentTx.length === 0 ? (
-            <View className="bg-white rounded-xl px-4 py-6 border border-gray-100 items-center">
-              <Text className="text-gray-400 font-inter text-sm">
+            <View className="bg-z-surface-2 rounded-xl px-4 py-6 border border-white-6 items-center">
+              <Text className="text-muted-fg-70 font-inter text-sm">
                 Sin transacciones
               </Text>
             </View>
           ) : (
-            <View className="bg-white rounded-xl border border-gray-100 overflow-hidden">
+            <View className="bg-z-surface-2 rounded-xl border border-white-6 overflow-hidden">
               {recentTx.map((tx, index) => {
                 const isInflow = tx.direction === "INFLOW";
                 const isDebtPayment = isDebtInflow({
@@ -295,21 +295,21 @@ export default function AccountDetailScreen() {
                 return (
                   <Pressable
                     key={tx.id}
-                    className="flex-row items-center px-4 py-3 active:bg-gray-50"
+                    className="flex-row items-center px-4 py-3 active:bg-z-surface-2-55"
                     onPress={() => router.push(`/transaction/${tx.id}`)}
                   >
                     {index > 0 && (
-                      <View className="absolute top-0 left-4 right-4 h-px bg-gray-100" />
+                      <View className="absolute top-0 left-4 right-4 h-px bg-z-surface-2" />
                     )}
                     <View className="flex-1 min-w-0">
                       <Text
-                        className="text-gray-900 font-inter-medium text-sm"
+                        className="text-foreground font-inter-medium text-sm"
                         numberOfLines={1}
                       >
                         {tx.merchant_name ?? tx.description ?? "Sin descripcion"}
                       </Text>
                       {(tx.category_name_es || isDebtPayment) && (
-                        <Text className="text-gray-400 font-inter text-xs mt-0.5">
+                        <Text className="text-muted-fg-70 font-inter text-xs mt-0.5">
                           {isDebtPayment ? "Abono a deuda" : tx.category_name_es}
                         </Text>
                       )}

--- a/mobile/app/bug-report.tsx
+++ b/mobile/app/bug-report.tsx
@@ -252,17 +252,17 @@ export default function BugReportScreen() {
 
   return (
     <KeyboardAvoidingView
-      className="flex-1 bg-gray-100"
+      className="flex-1 bg-z-surface-2"
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
-      <View className="flex-row items-center justify-between px-4 pt-4 pb-2 bg-white border-b border-gray-100">
+      <View className="flex-row items-center justify-between px-4 pt-4 pb-2 bg-z-surface-2 border-b border-white-6">
         <Pressable
           onPress={() => router.back()}
-          className="w-8 h-8 items-center justify-center rounded-full bg-gray-100 active:bg-gray-200"
+          className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
         >
           <ArrowLeft size={18} color="#6B7280" />
         </Pressable>
-        <Text className="text-gray-900 font-inter-bold text-base">
+        <Text className="text-foreground font-inter-bold text-base">
           Quick Capture de Bug
         </Text>
         <View className="w-8" />
@@ -274,25 +274,25 @@ export default function BugReportScreen() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode={Platform.OS === "ios" ? "interactive" : "on-drag"}
       >
-        <View className="rounded-xl border border-gray-200 bg-white p-4">
-          <Text className="text-gray-900 font-inter-semibold text-base">
+        <View className="rounded-xl border border-white-8 bg-z-surface-2 p-4">
+          <Text className="text-foreground font-inter-semibold text-base">
             Describe lo que fallo
           </Text>
-          <Text className="text-gray-500 font-inter text-xs mt-1">
+          <Text className="text-muted-foreground font-inter text-xs mt-1">
             Esto crea un ticket en Supabase y adjunta evidencia para revisarlo desde local.
           </Text>
 
-          <Text className="mt-4 mb-1 text-sm font-inter-medium text-gray-700">
+          <Text className="mt-4 mb-1 text-sm font-inter-medium text-foreground">
             Titulo del bug
           </Text>
           <TextInput
             value={title}
             onChangeText={setTitle}
             placeholder="Ej: En editar transaccion se solapan fecha y cuenta"
-            className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+            className="rounded-xl border border-white-10 bg-z-surface-2-55 px-3 py-2.5 text-foreground"
           />
 
-          <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">
+          <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">
             Descripcion
           </Text>
           <TextInput
@@ -300,28 +300,28 @@ export default function BugReportScreen() {
             onChangeText={setDescription}
             placeholder="Que hiciste, que esperabas y que ocurrio"
             multiline
-            className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+            className="rounded-xl border border-white-10 bg-z-surface-2-55 px-3 py-2.5 text-foreground"
             style={{ minHeight: 88, textAlignVertical: "top" }}
           />
 
-          <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">
+          <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">
             Pantalla/ruta (opcional)
           </Text>
           <TextInput
             value={routeHint}
             onChangeText={setRouteHint}
             placeholder="Ej: /transaction/123"
-            className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+            className="rounded-xl border border-white-10 bg-z-surface-2-55 px-3 py-2.5 text-foreground"
           />
 
-          <Text className="mt-3 mb-1 text-sm font-inter-medium text-gray-700">
+          <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">
             Zona afectada (opcional)
           </Text>
           <TextInput
             value={areaHint}
             onChangeText={setAreaHint}
             placeholder="Ej: parte superior derecha, bloque fecha/cuenta"
-            className="rounded-xl border border-gray-300 bg-gray-50 px-3 py-2.5 text-gray-900"
+            className="rounded-xl border border-white-10 bg-z-surface-2-55 px-3 py-2.5 text-foreground"
           />
 
           {pendingScreenshotUri ? (
@@ -331,7 +331,7 @@ export default function BugReportScreen() {
             />
           ) : (
             <Pressable
-              className="mt-4 rounded-xl border border-gray-300 bg-white px-3 py-3 flex-row items-center justify-center active:bg-gray-50"
+              className="mt-4 rounded-xl border border-white-10 bg-z-surface-2 px-3 py-3 flex-row items-center justify-center active:bg-z-surface-2-55"
               onPress={handlePickAttachment}
               disabled={picking || submitting}
             >
@@ -340,7 +340,7 @@ export default function BugReportScreen() {
               ) : (
                 <>
                   <Paperclip size={16} color="#6B7280" />
-                  <Text className="ml-2 text-gray-700 font-inter-medium text-sm">
+                  <Text className="ml-2 text-foreground font-inter-medium text-sm">
                     Adjuntar captura o PDF
                   </Text>
                 </>
@@ -350,11 +350,11 @@ export default function BugReportScreen() {
 
           {!pendingScreenshotUri && attachment && (
             <View className="mt-2 rounded-lg bg-sky-50 border border-sky-200 px-3 py-2">
-              <Text className="text-sky-700 font-inter text-xs" numberOfLines={2}>
+              <Text className="text-z-brass font-inter text-xs" numberOfLines={2}>
                 Archivo: {attachment.name}
               </Text>
               {typeof attachment.size === "number" && (
-                <Text className="text-sky-700 font-inter text-xs mt-1">
+                <Text className="text-z-brass font-inter text-xs mt-1">
                   Tamaño: {formatBytes(attachment.size)}
                 </Text>
               )}
@@ -363,7 +363,7 @@ export default function BugReportScreen() {
                 className="mt-2 self-start rounded-md border border-sky-300 px-2 py-1 active:bg-sky-100"
                 disabled={submitting}
               >
-                <Text className="text-sky-700 font-inter-medium text-xs">
+                <Text className="text-z-brass font-inter-medium text-xs">
                   Quitar adjunto
                 </Text>
               </Pressable>
@@ -372,7 +372,7 @@ export default function BugReportScreen() {
         </View>
         <Pressable
           className={`mt-5 rounded-xl py-3.5 items-center flex-row justify-center ${
-            canSubmit && !submitting ? "bg-primary" : "bg-gray-300"
+            canSubmit && !submitting ? "bg-primary" : "bg-z-surface-3"
           }`}
           onPress={handleSubmit}
           disabled={!canSubmit || submitting}

--- a/mobile/app/bug-report.tsx
+++ b/mobile/app/bug-report.tsx
@@ -13,6 +13,7 @@ import {
 import { useRouter } from "expo-router";
 import Constants from "expo-constants";
 import * as DocumentPicker from "expo-document-picker";
+import { MOBILE_TAB_BAR_CLEARANCE } from "../lib/constants/styles";
 import { ArrowLeft, Paperclip, Send } from "lucide-react-native";
 import { supabase } from "../lib/supabase";
 import { useAuth } from "../lib/auth";
@@ -269,7 +270,7 @@ export default function BugReportScreen() {
 
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode={Platform.OS === "ios" ? "interactive" : "on-drag"}
       >

--- a/mobile/app/capture-screenshot.tsx
+++ b/mobile/app/capture-screenshot.tsx
@@ -247,7 +247,7 @@ export default function CaptureScreenshotScreen() {
           onPress={() => (step === "pick" ? router.back() : resetFlow())}
           accessibilityRole="button"
           accessibilityLabel={step === "pick" ? "Volver" : "Reiniciar"}
-          className="h-10 w-10 items-center justify-center rounded-full bg-white-6"
+          className="h-10 w-10 items-center justify-center rounded-full bg-z-surface-2-6"
         >
           <ArrowLeft size={18} color={COLORS.foreground} />
         </Pressable>

--- a/mobile/app/capture-voice.tsx
+++ b/mobile/app/capture-voice.tsx
@@ -284,7 +284,7 @@ export default function CaptureVoiceScreen() {
           onPress={() => (step === "idle" ? router.back() : reset())}
           accessibilityRole="button"
           accessibilityLabel={step === "idle" ? "Volver" : "Reiniciar"}
-          className="h-10 w-10 items-center justify-center rounded-full bg-white-6"
+          className="h-10 w-10 items-center justify-center rounded-full bg-z-surface-2-6"
         >
           <ArrowLeft size={18} color={COLORS.foreground} />
         </Pressable>

--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -455,7 +455,7 @@ export default function CaptureScreen() {
       >
         <Pressable
           onPress={() => router.back()}
-          className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+          className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
           accessibilityLabel="Volver"
         >
           <ArrowLeft size={16} color={COLORS.sageDark} />
@@ -655,7 +655,7 @@ export default function CaptureScreen() {
                 />
               </View>
 
-              <View className="h-px bg-white-6" />
+              <View className="h-px bg-z-surface-2-6" />
 
               <View className="flex-row items-start gap-3">
                 <View className="flex-1">

--- a/mobile/app/etiquetas.tsx
+++ b/mobile/app/etiquetas.tsx
@@ -1,0 +1,30 @@
+import { ScrollView, Text, View } from "react-native";
+import { Stack } from "expo-router";
+import { MobileHeader } from "../components/ui/MobileHeader";
+import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS } from "../lib/constants/styles";
+
+/**
+ * Tags (`/etiquetas`) — webapp has full CRUD UI for tags + tag groups, mobile
+ * has the SQLite tables and sync but zero UI. Scaffold only — list, create,
+ * edit, delete, and assign-to-transaction land in Phase 5.
+ */
+export default function EtiquetasScreen() {
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen options={{ headerShown: false }} />
+      <MobileHeader variant="sub" title="Etiquetas" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}>
+        <View className={`${PANEL_INSET_CLASS} p-4 gap-2`}>
+          <Text className="text-sm font-inter-semibold text-foreground">
+            Próximamente
+          </Text>
+          <Text className="text-[12px] font-inter text-muted-foreground leading-5">
+            Las etiquetas se podrán crear, editar y asignar a movimientos desde aquí.
+            Por ahora la sincronización ya está activa, pero la interfaz llega en la
+            siguiente entrega.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/mobile/app/pendientes.tsx
+++ b/mobile/app/pendientes.tsx
@@ -1,0 +1,31 @@
+import { ScrollView, Text, View } from "react-native";
+import { Stack } from "expo-router";
+import { MobileHeader } from "../components/ui/MobileHeader";
+import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS } from "../lib/constants/styles";
+
+/**
+ * Pending recurring occurrences for the active month — webapp parity entry
+ * point. Currently RN exposes pending occurrences only inside `/recurrentes`;
+ * this dedicated screen will list pending → paid actions in chronological
+ * order. Scaffold only — list + actions land in Phase 5 alongside the
+ * recurring template editor.
+ */
+export default function PendientesScreen() {
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen options={{ headerShown: false }} />
+      <MobileHeader variant="sub" title="Pendientes" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}>
+        <View className={`${PANEL_INSET_CLASS} p-4 gap-2`}>
+          <Text className="text-sm font-inter-semibold text-foreground">
+            Próximamente
+          </Text>
+          <Text className="text-[12px] font-inter text-muted-foreground leading-5">
+            Aquí verás las ocurrencias recurrentes pendientes del mes para marcarlas como
+            pagadas o saltarlas sin entrar al detalle de cada plantilla.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/mobile/app/periodo.tsx
+++ b/mobile/app/periodo.tsx
@@ -13,7 +13,7 @@ import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
 import { useAuth } from "../lib/auth";
 import { COLORS } from "../lib/constants/colors";
 import { isDebtAccountType } from "../lib/constants/accounts";
-import { PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "../lib/constants/styles";
 import { getActivePeriodWithEntries } from "../lib/repositories/planning";
 import { getAllAccounts } from "../lib/repositories/accounts";
 import { getTemplatesByIds } from "../lib/repositories/recurring";
@@ -265,7 +265,7 @@ export default function PeriodoScreen() {
       <Header onBack={() => router.back()} />
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
       >
         {/* Period summary */}
         <View className={`${PANEL_INSET_CLASS} flex-row items-center justify-between px-4 py-2.5`}>

--- a/mobile/app/periodo.tsx
+++ b/mobile/app/periodo.tsx
@@ -442,7 +442,7 @@ function StatusBadge({ status }: { status: string }) {
   const config: Record<string, { label: string; bg: string; text: string }> = {
     PLANNED: { label: "Pendiente", bg: "bg-z-alert/10", text: "text-z-alert" },
     COMPLETED: { label: "Pagado", bg: "bg-z-income/10", text: "text-z-income" },
-    SKIPPED: { label: "Omitido", bg: "bg-white/5", text: "text-muted-foreground" },
+    SKIPPED: { label: "Omitido", bg: "bg-z-surface-2/5", text: "text-muted-foreground" },
   };
   const c = config[status] ?? config.PLANNED;
   return (
@@ -495,13 +495,13 @@ function IncomeCard({
                   <Check size={12} color={color} />
                 </View>
               ) : (
-                <View className="h-5 w-5 rounded-md border border-white/10 bg-white/5" />
+                <View className="h-5 w-5 rounded-md border border-white/10 bg-z-surface-2/5" />
               )}
             </View>
           </View>
 
           {/* Progress bar */}
-          <View className="h-1.5 w-full rounded-full bg-white-6 overflow-hidden">
+          <View className="h-1.5 w-full rounded-full bg-z-surface-2-6 overflow-hidden">
             <View className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
           </View>
 

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -67,7 +67,7 @@ function SectionHeading({ label }: { label: string }) {
   return (
     <View className="flex-row items-center gap-3 mb-2 px-1">
       <Text className={SECTION_EYEBROW_CLASS}>{label}</Text>
-      <View className="h-px flex-1 bg-white-6" />
+      <View className="h-px flex-1 bg-z-surface-2-6" />
     </View>
   );
 }
@@ -268,7 +268,7 @@ function AccountPickerModal({
             </Text>
             <Pressable
               onPress={onClose}
-              className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+              className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
               accessibilityLabel="Cerrar"
             >
               <X size={16} color={COLORS.sageDark} />
@@ -280,8 +280,8 @@ function AccountPickerModal({
                 onSelect(null);
                 onClose();
               }}
-              className={`flex-row items-center gap-2.5 rounded-lg px-3 py-3 active:bg-white/5 ${
-                selectedId === null ? "bg-white/8" : ""
+              className={`flex-row items-center gap-2.5 rounded-lg px-3 py-3 active:bg-z-surface-2/5 ${
+                selectedId === null ? "bg-z-surface-2/8" : ""
               }`}
             >
               <X size={14} color={COLORS.sageDark} />
@@ -299,8 +299,8 @@ function AccountPickerModal({
                     onSelect(acct.id);
                     onClose();
                   }}
-                  className={`mt-1 flex-row items-center gap-2.5 rounded-lg px-3 py-3 active:bg-white/5 ${
-                    isSel ? "bg-white/8" : ""
+                  className={`mt-1 flex-row items-center gap-2.5 rounded-lg px-3 py-3 active:bg-z-surface-2/5 ${
+                    isSel ? "bg-z-surface-2/8" : ""
                   }`}
                 >
                   <Wallet size={14} color={COLORS.sageDark} />

--- a/mobile/app/subscriptions.tsx
+++ b/mobile/app/subscriptions.tsx
@@ -414,7 +414,7 @@ export default function SubscriptionsScreen() {
             </Text>
             {accounts.length === 0 ? (
               <View className="rounded-xl border border-amber-700/30 bg-amber-900/20 px-3 py-2.5">
-                <Text className="text-amber-400 font-inter text-xs">
+                <Text className="text-z-alert font-inter text-xs">
                   Crea una cuenta primero para registrar suscripciones.
                 </Text>
               </View>
@@ -571,7 +571,7 @@ export default function SubscriptionsScreen() {
                         {togglingId === item.id ? (
                           <ActivityIndicator size="small" color="#0284C7" />
                         ) : (
-                          <Text className="text-sky-400 font-inter-medium text-xs">
+                          <Text className="text-z-brass font-inter-medium text-xs">
                             {item.is_active ? "Pausar" : "Activar"}
                           </Text>
                         )}

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -312,7 +312,7 @@ export default function TransactionDetailScreen() {
         <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
           <Pressable
             onPress={() => router.back()}
-            className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+            className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
           >
             <X size={18} color="#938C7E" />
           </Pressable>
@@ -379,7 +379,7 @@ export default function TransactionDetailScreen() {
           <>
             <Pressable
               onPress={() => router.back()}
-              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
             >
               <X size={18} color="#938C7E" />
             </Pressable>
@@ -389,7 +389,7 @@ export default function TransactionDetailScreen() {
             <View className="flex-row gap-2">
               <Pressable
                 onPress={enterEditMode}
-                className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+                className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
               >
                 <Pencil size={16} color="#938C7E" />
               </Pressable>
@@ -464,7 +464,7 @@ export default function TransactionDetailScreen() {
             <FormField label="Fecha" required>
               <Pressable
                 onPress={() => setShowDatePicker(true)}
-                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-white/10"
+                className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-z-surface-2/10"
               >
                 <Text className="text-foreground font-inter text-sm">
                   {editDate.toLocaleDateString("es-CO", {
@@ -481,17 +481,17 @@ export default function TransactionDetailScreen() {
             <FormField label="Categoría">
               {isDebtPayment ? (
                 <View className="bg-sky-900/20 border border-sky-700/30 rounded-xl px-4 py-3 flex-row items-center justify-between">
-                  <Text className="font-inter-medium text-sm text-sky-400">
+                  <Text className="font-inter-medium text-sm text-z-brass">
                     Abono a deuda
                   </Text>
-                  <Text className="font-inter text-xs text-sky-500">
+                  <Text className="font-inter text-xs text-z-brass">
                     Categoria fija
                   </Text>
                 </View>
               ) : (
                 <Pressable
                   onPress={() => setShowCategoryPicker(true)}
-                  className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-white/10"
+                  className="bg-black-10 border border-white-6 rounded-xl px-4 py-3 flex-row items-center justify-between active:bg-z-surface-2/10"
                 >
                   <Text
                     className={`font-inter text-sm ${

--- a/mobile/app/transactions/new.tsx
+++ b/mobile/app/transactions/new.tsx
@@ -1,8 +1,9 @@
 import { ScrollView, Text, View } from "react-native";
 import { Stack } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { MobileHeader } from "../../components/ui/MobileHeader";
 import { useHideTabBar } from "../../components/nav/TabBarVisibilityProvider";
-import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
 
 /**
  * Manual full transaction form. Mirrors webapp `MobileTransactionForm`.
@@ -10,11 +11,12 @@ import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS } from "../../lib/constants
  */
 export default function NewTransactionScreen() {
   useHideTabBar();
+  const insets = useSafeAreaInsets();
   return (
     <View className="flex-1 bg-background">
       <Stack.Screen options={{ headerShown: false }} />
       <MobileHeader variant="sub" title="Nuevo movimiento" />
-      <ScrollView contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}>
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: insets.bottom }}>
         <View className={`${PANEL_INSET_CLASS} p-4 gap-2`}>
           <Text className="text-sm font-inter-semibold text-foreground">
             Formulario en construcción

--- a/mobile/app/transactions/new.tsx
+++ b/mobile/app/transactions/new.tsx
@@ -1,0 +1,31 @@
+import { ScrollView, Text, View } from "react-native";
+import { Stack } from "expo-router";
+import { MobileHeader } from "../../components/ui/MobileHeader";
+import { useHideTabBar } from "../../components/nav/TabBarVisibilityProvider";
+import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS } from "../../lib/constants/styles";
+
+/**
+ * Manual full transaction form. Mirrors webapp `MobileTransactionForm`.
+ * Scaffold only — fields, validation, and submission land in Phase 3.
+ */
+export default function NewTransactionScreen() {
+  useHideTabBar();
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen options={{ headerShown: false }} />
+      <MobileHeader variant="sub" title="Nuevo movimiento" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}>
+        <View className={`${PANEL_INSET_CLASS} p-4 gap-2`}>
+          <Text className="text-sm font-inter-semibold text-foreground">
+            Formulario en construcción
+          </Text>
+          <Text className="text-[12px] font-inter text-muted-foreground leading-5">
+            Esta pantalla reemplazará la captura rápida con un formulario completo: monto,
+            cuenta, categoría, destinatario, etiquetas, notas, y opción de crear plantilla
+            recurrente. Llega en la siguiente entrega de paridad con la webapp.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/mobile/components/accounts/AccountBalanceCard.tsx
+++ b/mobile/components/accounts/AccountBalanceCard.tsx
@@ -44,7 +44,7 @@ export function AccountBalanceCard({ account }: Props) {
   };
 
   return (
-    <View className="bg-white rounded-2xl p-5 border border-gray-100">
+    <View className="bg-z-surface-2 rounded-2xl p-5 border border-white-6">
       {/* Top: Icon + type badge + currency */}
       <View className="flex-row items-center justify-between mb-4">
         <View className="flex-row items-center gap-2">
@@ -54,26 +54,26 @@ export function AccountBalanceCard({ account }: Props) {
           >
             {Icon && <Icon size={20} color={color} />}
           </View>
-          <View className="bg-gray-100 rounded-full px-2.5 py-1">
-            <Text className="text-gray-600 font-inter-medium text-xs">
+          <View className="bg-z-surface-2 rounded-full px-2.5 py-1">
+            <Text className="text-muted-foreground font-inter-medium text-xs">
               {ACCOUNT_TYPE_LABELS[account.account_type] ?? account.account_type}
             </Text>
           </View>
         </View>
-        <View className="bg-gray-100 rounded-full px-2.5 py-1">
-          <Text className="text-gray-500 font-inter-semibold text-xs">
+        <View className="bg-z-surface-2 rounded-full px-2.5 py-1">
+          <Text className="text-muted-foreground font-inter-semibold text-xs">
             {account.currency_code}
           </Text>
         </View>
       </View>
 
       {/* Balance */}
-      <Text className="text-gray-500 font-inter text-xs mb-1">
+      <Text className="text-muted-foreground font-inter text-xs mb-1">
         Balance actual
       </Text>
       <Text
         className={`font-inter-bold text-3xl ${
-          isDebt ? "text-red-600" : "text-gray-900"
+          isDebt ? "text-z-expense" : "text-foreground"
         }`}
       >
         {formatCurrency(account.current_balance, currency)}
@@ -83,7 +83,7 @@ export function AccountBalanceCard({ account }: Props) {
       {showUtilization && (
         <View className="mt-4">
           <View className="flex-row items-center justify-between mb-1.5">
-            <Text className="text-gray-500 font-inter text-xs">
+            <Text className="text-muted-foreground font-inter text-xs">
               Utilizacion de credito
             </Text>
             <Text
@@ -94,7 +94,7 @@ export function AccountBalanceCard({ account }: Props) {
             </Text>
           </View>
           {/* Track */}
-          <View className="h-2.5 bg-gray-100 rounded-full overflow-hidden">
+          <View className="h-2.5 bg-z-surface-2 rounded-full overflow-hidden">
             {/* Fill */}
             <View
               className="h-full rounded-full"
@@ -105,10 +105,10 @@ export function AccountBalanceCard({ account }: Props) {
             />
           </View>
           <View className="flex-row items-center justify-between mt-1">
-            <Text className="text-gray-400 font-inter text-[10px]">
+            <Text className="text-muted-fg-70 font-inter text-[10px]">
               {formatCurrency(Math.abs(account.current_balance), currency)} usado
             </Text>
-            <Text className="text-gray-400 font-inter text-[10px]">
+            <Text className="text-muted-fg-70 font-inter text-[10px]">
               {formatCurrency(account.credit_limit!, currency)} limite
             </Text>
           </View>

--- a/mobile/components/categories/CategoriesRoot.tsx
+++ b/mobile/components/categories/CategoriesRoot.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../lib/repositories/categories";
 import { getDatabase } from "../../lib/db/database";
 import { COLORS } from "../../lib/constants/colors";
-import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
 import { MobileHeader } from "../ui/MobileHeader";
 import { MCard } from "../ui/MCard";
 import { CategoryRow } from "./CategoryRow";
@@ -311,7 +311,7 @@ export function CategoriesRoot() {
 
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/categories/CategoryFormSheet.tsx
+++ b/mobile/components/categories/CategoryFormSheet.tsx
@@ -184,7 +184,7 @@ export function CategoryFormSheet({
                       setParentId(null);
                       setParentPickerOpen(false);
                     }}
-                    className={`px-3.5 py-2.5 active:bg-white/5 border-b border-white-6 ${
+                    className={`px-3.5 py-2.5 active:bg-z-surface-2/5 border-b border-white-6 ${
                       !parentId ? "bg-z-brass-8" : ""
                     }`}
                   >
@@ -203,7 +203,7 @@ export function CategoryFormSheet({
                         setParentId(parent.id);
                         setParentPickerOpen(false);
                       }}
-                      className={`flex-row items-center gap-2.5 px-3.5 py-2.5 active:bg-white/5 ${
+                      className={`flex-row items-center gap-2.5 px-3.5 py-2.5 active:bg-z-surface-2/5 ${
                         idx < parentCategories.length - 1
                           ? "border-b border-white-6"
                           : ""
@@ -278,7 +278,7 @@ export function CategoryFormSheet({
                   className="flex-row items-center justify-center gap-2 rounded-xl border border-red-500/20 bg-red-500/8 py-3 active:opacity-80"
                 >
                   <Trash2 size={14} color="#E05545" />
-                  <Text className="text-[13px] font-inter-semibold text-red-400">
+                  <Text className="text-[13px] font-inter-semibold text-z-expense">
                     Eliminar categoria
                   </Text>
                 </Pressable>

--- a/mobile/components/categories/CategoryRow.tsx
+++ b/mobile/components/categories/CategoryRow.tsx
@@ -16,7 +16,7 @@ export function CategoryRow({ category, isSystem, onEdit }: CategoryRowProps) {
     <Pressable
       onPress={!isSystem && onEdit ? () => onEdit(category.id) : undefined}
       className={`flex-row items-center gap-3 px-3.5 py-2.5 ${
-        !isSystem ? "active:bg-white/5" : ""
+        !isSystem ? "active:bg-z-surface-2/5" : ""
       }`}
       disabled={isSystem}
       accessibilityLabel={displayName}

--- a/mobile/components/categorizar/CategorizarRoot.tsx
+++ b/mobile/components/categorizar/CategorizarRoot.tsx
@@ -15,7 +15,7 @@ import {
 import { COLORS } from "../../lib/constants/colors";
 import { MobileHeader } from "../ui/MobileHeader";
 import { MCard } from "../ui/MCard";
-import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
 import { UncategorizedRow } from "./UncategorizedRow";
 import { CategoryPickerSheet } from "./CategoryPickerSheet";
 
@@ -97,7 +97,7 @@ export function CategorizarRoot() {
 
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/categorizar/CategoryPickerSheet.tsx
+++ b/mobile/components/categorizar/CategoryPickerSheet.tsx
@@ -107,7 +107,7 @@ export function CategoryPickerSheet({
                     <Pressable
                       key={child.id}
                       onPress={() => handleSelect(child.id)}
-                      className={`flex-row items-center gap-3 px-3.5 py-2.5 active:bg-white/5 ${
+                      className={`flex-row items-center gap-3 px-3.5 py-2.5 active:bg-z-surface-2/5 ${
                         idx < children.length - 1
                           ? "border-b border-white-6"
                           : ""
@@ -142,7 +142,7 @@ export function CategoryPickerSheet({
                     <Pressable
                       key={cat.id}
                       onPress={() => handleSelect(cat.id)}
-                      className={`flex-row items-center gap-3 px-3.5 py-2.5 active:bg-white/5 ${
+                      className={`flex-row items-center gap-3 px-3.5 py-2.5 active:bg-z-surface-2/5 ${
                         idx < grouped.standalone.length - 1
                           ? "border-b border-white-6"
                           : ""

--- a/mobile/components/common/KeyboardScreen.tsx
+++ b/mobile/components/common/KeyboardScreen.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, View } from "react-native";
 import { ArrowLeft } from "lucide-react-native";
 import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { AppKeyboardAwareScrollView } from "./AppKeyboardAwareScrollView";
+import { MOBILE_TAB_BAR_CLEARANCE } from "../../lib/constants/styles";
 
 export function KeyboardScreen({
   title,
@@ -34,7 +35,7 @@ export function KeyboardScreen({
       <AppKeyboardAwareScrollView
         avoidKeyboard={false}
         style={{ flex: 1 }}
-        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         bottomOffset={20}
       >
         {children}

--- a/mobile/components/common/KeyboardScreen.tsx
+++ b/mobile/components/common/KeyboardScreen.tsx
@@ -24,7 +24,7 @@ export function KeyboardScreen({
       <View className="flex-row items-center justify-between border-b border-white-6 bg-z-surface-2-55 px-4 pb-2 pt-4">
         <Pressable
           onPress={onBack}
-          className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+          className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
         >
           <ArrowLeft size={18} color="#938C7E" />
         </Pressable>

--- a/mobile/components/deseos/DeseosRoot.tsx
+++ b/mobile/components/deseos/DeseosRoot.tsx
@@ -20,6 +20,7 @@ import {
   SECTION_EYEBROW_CLASS,
   BRASS_BUTTON_CLASS,
   GHOST_BUTTON_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE,
 } from "../../lib/constants/styles";
 
 interface DeseosState {
@@ -110,7 +111,7 @@ export function DeseosRoot() {
       />
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={COLORS.brass} />
         }

--- a/mobile/components/destinatarios/DestinatarioDetail.tsx
+++ b/mobile/components/destinatarios/DestinatarioDetail.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../lib/repositories/destinatarios";
 import { getDatabase } from "../../lib/db/database";
 import { COLORS } from "../../lib/constants/colors";
-import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
 import { MobileHeader } from "../ui/MobileHeader";
 import { MCard, MListRow } from "../ui/MCard";
 import { StateChip } from "../ui/StateChip";
@@ -93,7 +93,7 @@ export function DestinatarioDetail({ id }: DestinatarioDetailProps) {
 
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/destinatarios/DestinatarioDetail.tsx
+++ b/mobile/components/destinatarios/DestinatarioDetail.tsx
@@ -175,7 +175,7 @@ export function DestinatarioDetail({ id }: DestinatarioDetailProps) {
                       {rule.match_type}
                     </Text>
                     {rule.match_count > 0 && (
-                      <View className="rounded-full bg-white-8 px-2 py-0.5">
+                      <View className="rounded-full bg-z-surface-2-8 px-2 py-0.5">
                         <Text className="text-[10px] font-inter-medium text-muted-foreground">
                           {rule.match_count}
                         </Text>

--- a/mobile/components/destinatarios/DestinatarioRow.tsx
+++ b/mobile/components/destinatarios/DestinatarioRow.tsx
@@ -20,7 +20,7 @@ export function DestinatarioRow({
   return (
     <Pressable
       onPress={() => onPress(id)}
-      className="flex-row items-center px-3.5 py-2.5 active:bg-white-4"
+      className="flex-row items-center px-3.5 py-2.5 active:bg-z-surface-2-4"
       accessibilityLabel={`Ver detalles de ${name}`}
     >
       {/* Left: icon + name + category */}
@@ -48,7 +48,7 @@ export function DestinatarioRow({
       {/* Right: count badge + chevron */}
       <View className="flex-row items-center gap-2">
         {transactionCount > 0 && (
-          <View className="rounded-full bg-white-8 px-2 py-0.5">
+          <View className="rounded-full bg-z-surface-2-8 px-2 py-0.5">
             <Text className="text-[10px] font-inter-medium text-muted-foreground">
               {transactionCount}
             </Text>

--- a/mobile/components/destinatarios/DestinatariosRoot.tsx
+++ b/mobile/components/destinatarios/DestinatariosRoot.tsx
@@ -8,7 +8,7 @@ import {
   type DestinatarioWithCount,
 } from "../../lib/repositories/destinatarios";
 import { COLORS } from "../../lib/constants/colors";
-import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
 import { MobileHeader } from "../ui/MobileHeader";
 import { MCard } from "../ui/MCard";
 import { DestinatarioRow } from "./DestinatarioRow";
@@ -67,7 +67,7 @@ export function DestinatariosRoot() {
 
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/deudas/DeudasAccountsAccordion.tsx
+++ b/mobile/components/deudas/DeudasAccountsAccordion.tsx
@@ -58,7 +58,7 @@ export function DeudasAccountsAccordion({
 
               {/* Progress bar */}
               {account.creditLimit > 0 && (
-                <View className="h-2 rounded-full bg-white-6 overflow-hidden">
+                <View className="h-2 rounded-full bg-z-surface-2-6 overflow-hidden">
                   <View
                     className={`h-full rounded-full ${barColor}`}
                     style={{ width: `${Math.min(utilization, 100)}%` }}

--- a/mobile/components/deudas/DeudasRoot.tsx
+++ b/mobile/components/deudas/DeudasRoot.tsx
@@ -7,6 +7,7 @@ import { getDebtOverview, type DebtOverviewData } from "../../lib/repositories/d
 import { getDatabase } from "../../lib/db/database";
 import { getPreferredCurrency } from "../../lib/profile";
 import { COLORS } from "../../lib/constants/colors";
+import { MOBILE_TAB_BAR_CLEARANCE } from "../../lib/constants/styles";
 import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
 import { useExpandableZone } from "../ui/useExpandableZone";
@@ -74,7 +75,7 @@ export function DeudasRoot() {
       />
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/deudas/DeudasSalaryBar.tsx
+++ b/mobile/components/deudas/DeudasSalaryBar.tsx
@@ -30,7 +30,7 @@ export function DeudasSalaryBar({
       </Text>
 
       {/* Stacked bar */}
-      <View className="h-3 rounded-full bg-white-6 overflow-hidden flex-row">
+      <View className="h-3 rounded-full bg-z-surface-2-6 overflow-hidden flex-row">
         <View
           className="h-full rounded-l-full"
           style={{

--- a/mobile/components/deudas/PayoffResultCard.tsx
+++ b/mobile/components/deudas/PayoffResultCard.tsx
@@ -1,5 +1,14 @@
 import { View, Text } from "react-native";
-import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import {
+  formatCurrency,
+  expandCashEntries,
+  runScenario,
+  type CashEntry,
+  type CurrencyCode,
+  type DebtAccount,
+  type ScenarioInput,
+  type ScenarioResult,
+} from "@zeta/shared";
 import { Calendar, TrendingDown, DollarSign } from "lucide-react-native";
 import { MCard } from "../ui/MCard";
 import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
@@ -7,6 +16,8 @@ import { COLORS } from "../../lib/constants/colors";
 import type { DebtAccountInfo } from "../../lib/repositories/debt";
 
 type Strategy = "avalanche" | "snowball";
+
+const SIMULATION_HORIZON_MONTHS = 360; // 30-year cap, matches shared engine behavior
 
 interface PayoffResult {
   accountId: string;
@@ -33,16 +44,77 @@ interface PayoffResultCardProps {
   currency: CurrencyCode;
 }
 
-/**
- * Simulate monthly debt payoff using the chosen strategy.
- * Extra cash is applied to the top-priority account on top of minimum payments.
- */
+function toSharedDebtAccount(info: DebtAccountInfo): DebtAccount {
+  return {
+    id: info.id,
+    name: info.name,
+    type: info.type,
+    balance: info.balance,
+    creditLimit: info.creditLimit > 0 ? info.creditLimit : null,
+    interestRate: info.interestRate,
+    monthlyPayment: info.monthlyPayment,
+    paymentDay: info.paymentDay,
+    cutoffDay: null,
+    currency: info.currency as CurrencyCode,
+    color: null,
+    institutionName: null,
+    currencyBreakdown: null,
+    loanAmount: null,
+  };
+}
+
+function buildCashEntries(
+  extraCash: number,
+  currency: CurrencyCode,
+  startMonth: string
+): CashEntry[] {
+  if (extraCash <= 0) return [];
+  return expandCashEntries([
+    {
+      id: "extra",
+      amount: extraCash,
+      month: startMonth,
+      currency,
+      recurring: { months: SIMULATION_HORIZON_MONTHS },
+    },
+  ]);
+}
+
+function summarizePerAccount(
+  accounts: DebtAccountInfo[],
+  result: ScenarioResult
+): PayoffResult[] {
+  const interestByAccount = new Map<string, number>();
+  for (const m of result.timeline) {
+    for (const a of m.accounts) {
+      interestByAccount.set(
+        a.accountId,
+        (interestByAccount.get(a.accountId) ?? 0) + a.interestAccrued
+      );
+    }
+  }
+  const payoffMonthByAccount = new Map<string, number>();
+  for (const entry of result.payoffOrder) {
+    payoffMonthByAccount.set(entry.accountId, entry.month);
+  }
+
+  return accounts.map((a) => ({
+    accountId: a.id,
+    name: a.name,
+    balance: a.balance,
+    interestRate: a.interestRate,
+    monthlyPayment: a.monthlyPayment,
+    payoffMonth: payoffMonthByAccount.get(a.id) ?? SIMULATION_HORIZON_MONTHS,
+    totalInterest: Math.round(interestByAccount.get(a.id) ?? 0),
+  }));
+}
+
 function calculatePayoff(
   accounts: DebtAccountInfo[],
   extraCash: number,
-  strategy: Strategy
+  strategy: Strategy,
+  currency: CurrencyCode
 ): PayoffSummary {
-  // Filter to accounts with a balance
   const active = accounts.filter((a) => a.balance > 0);
   if (active.length === 0) {
     return {
@@ -54,125 +126,27 @@ function calculatePayoff(
     };
   }
 
-  // Sort by strategy
-  const sorted = [...active].sort((a, b) =>
-    strategy === "avalanche"
-      ? (b.interestRate ?? 0) - (a.interestRate ?? 0)
-      : a.balance - b.balance
-  );
+  const startMonth = new Date().toISOString().slice(0, 7);
+  const sharedAccounts = active.map(toSharedDebtAccount);
+  const baseInput: Omit<ScenarioInput, "cashEntries"> = {
+    accounts: sharedAccounts,
+    strategy,
+    allocations: { manualOverrides: [], cascadeRedirects: [] },
+    startMonth,
+  };
 
-  // ── With extra cash ─────────────────────────────────────────────
-  const withExtra = simulate(sorted, extraCash);
-
-  // ── Baseline (minimum payments only) ────────────────────────────
-  const baseline = simulate(sorted, 0);
+  const withExtra = runScenario({
+    ...baseInput,
+    cashEntries: buildCashEntries(extraCash, currency, startMonth),
+  });
+  const baseline = runScenario({ ...baseInput, cashEntries: [] });
 
   return {
     totalMonths: withExtra.totalMonths,
-    totalInterestPaid: Math.round(withExtra.totalInterest),
+    totalInterestPaid: Math.round(withExtra.totalInterestPaid),
     baselineMonths: baseline.totalMonths,
-    baselineInterest: Math.round(baseline.totalInterest),
-    results: withExtra.perAccount.map((r) => ({
-      accountId: r.id,
-      name: r.name,
-      balance: r.originalBalance,
-      interestRate: r.interestRate,
-      monthlyPayment: r.monthlyPayment,
-      payoffMonth: r.payoffMonth,
-      totalInterest: Math.round(r.interestPaid),
-    })),
-  };
-}
-
-function simulate(
-  accounts: DebtAccountInfo[],
-  extraCash: number
-): {
-  totalMonths: number;
-  totalInterest: number;
-  perAccount: {
-    id: string;
-    name: string;
-    originalBalance: number;
-    interestRate: number;
-    monthlyPayment: number;
-    payoffMonth: number;
-    interestPaid: number;
-  }[];
-} {
-  const MAX_MONTHS = 360; // 30-year cap
-
-  // Working balances
-  const balances = accounts.map((a) => a.balance);
-  const paidOff = accounts.map(() => false);
-  const payoffMonths = accounts.map(() => 0);
-  const interestPaid = accounts.map(() => 0);
-  let month = 0;
-
-  // Track freed minimums from paid-off debts (snowball/avalanche cascade)
-  let freedMinimums = 0;
-
-  while (balances.some((b, i) => !paidOff[i] && b > 0) && month < MAX_MONTHS) {
-    month++;
-
-    // 1. Apply monthly interest
-    for (let i = 0; i < accounts.length; i++) {
-      if (paidOff[i]) continue;
-      const monthlyRate = (accounts[i].interestRate ?? 0) / 100 / 12;
-      const interest = balances[i] * monthlyRate;
-      interestPaid[i] += interest;
-      balances[i] += interest;
-    }
-
-    // 2. Apply minimum payments
-    for (let i = 0; i < accounts.length; i++) {
-      if (paidOff[i]) continue;
-      const minPay = Math.min(accounts[i].monthlyPayment, balances[i]);
-      balances[i] -= minPay;
-      if (balances[i] <= 0.01) {
-        balances[i] = 0;
-        paidOff[i] = true;
-        payoffMonths[i] = month;
-        // Freed minimum rolls into the extra pool for remaining debts
-        freedMinimums += accounts[i].monthlyPayment;
-      }
-    }
-
-    // 3. Apply extra cash + freed minimums to priority-order debts
-    let remaining = extraCash + freedMinimums;
-    for (let i = 0; i < accounts.length; i++) {
-      if (paidOff[i] || remaining <= 0) continue;
-      const payment = Math.min(remaining, balances[i]);
-      balances[i] -= payment;
-      remaining -= payment;
-      if (balances[i] <= 0.01) {
-        balances[i] = 0;
-        paidOff[i] = true;
-        payoffMonths[i] = month;
-        freedMinimums += accounts[i].monthlyPayment;
-      }
-    }
-  }
-
-  // Handle accounts that couldn't be paid off within the cap
-  for (let i = 0; i < accounts.length; i++) {
-    if (!paidOff[i]) {
-      payoffMonths[i] = MAX_MONTHS;
-    }
-  }
-
-  return {
-    totalMonths: Math.max(...payoffMonths),
-    totalInterest: interestPaid.reduce((a, b) => a + b, 0),
-    perAccount: accounts.map((a, i) => ({
-      id: a.id,
-      name: a.name,
-      originalBalance: a.balance,
-      interestRate: a.interestRate,
-      monthlyPayment: a.monthlyPayment,
-      payoffMonth: payoffMonths[i],
-      interestPaid: interestPaid[i],
-    })),
+    baselineInterest: Math.round(baseline.totalInterestPaid),
+    results: summarizePerAccount(active, withExtra),
   };
 }
 
@@ -191,7 +165,7 @@ export function PayoffResultCard({
   extraCash,
   currency,
 }: PayoffResultCardProps) {
-  const summary = calculatePayoff(accounts, extraCash, strategy);
+  const summary = calculatePayoff(accounts, extraCash, strategy, currency);
 
   if (summary.results.length === 0) {
     return (

--- a/mobile/components/deudas/PlanificadorRoot.tsx
+++ b/mobile/components/deudas/PlanificadorRoot.tsx
@@ -16,6 +16,7 @@ import { useSync } from "../../lib/sync/hooks";
 import { COLORS } from "../../lib/constants/colors";
 import {
   BRASS_BUTTON_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE,
   PANEL_SURFACE_SUBTLE_CLASS,
 } from "../../lib/constants/styles";
 import { MobileHeader } from "../ui/MobileHeader";
@@ -105,7 +106,7 @@ export function PlanificadorRoot() {
 
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/inicio/AddWidgetSheet.tsx
+++ b/mobile/components/inicio/AddWidgetSheet.tsx
@@ -53,7 +53,7 @@ export function AddWidgetSheet({
           </Pressable>
         </View>
 
-        <View className="h-px bg-white-6 mx-4" />
+        <View className="h-px bg-z-surface-2-6 mx-4" />
 
         <ScrollView contentContainerStyle={{ paddingVertical: 8 }}>
           {WIDGET_CATALOG.map((entry) => (

--- a/mobile/components/inicio/InicioRoot.tsx
+++ b/mobile/components/inicio/InicioRoot.tsx
@@ -287,7 +287,7 @@ export function InicioRoot() {
             <Pressable
               onPress={handleResetToDefault}
               accessibilityLabel="Restablecer predeterminado"
-              className="flex-row items-center justify-center gap-2 rounded-2xl border border-white-6 bg-white-3 py-2.5"
+              className="flex-row items-center justify-center gap-2 rounded-2xl border border-white-6 bg-z-surface-2-3 py-2.5"
             >
               <RotateCcw size={14} color={COLORS.sageDark} />
               <Text className="text-[11px] font-inter-semibold text-muted-foreground">
@@ -306,7 +306,7 @@ export function InicioRoot() {
             className={
               editing
                 ? "flex-row items-center gap-1.5 rounded-full border border-z-brass-30 bg-z-brass-10 px-3 py-1.5"
-                : "flex-row items-center gap-1.5 rounded-full border border-white-6 bg-white-3 px-3 py-1.5"
+                : "flex-row items-center gap-1.5 rounded-full border border-white-6 bg-z-surface-2-3 px-3 py-1.5"
             }
           >
             <Settings2

--- a/mobile/components/inicio/InicioRoot.tsx
+++ b/mobile/components/inicio/InicioRoot.tsx
@@ -40,6 +40,9 @@ import { renderAttentionWidget } from "./widgets/AttentionWidget";
 import { renderWhereTodayWidget } from "./widgets/WhereTodayWidget";
 import { renderRecentWidget } from "./widgets/RecentWidget";
 import { renderPuedoComprarloWidget } from "./widgets/PuedoComprarloWidget";
+import { renderNextBillWidget } from "./widgets/NextBillWidget";
+import { renderNextIncomeWidget } from "./widgets/NextIncomeWidget";
+import { renderAccountsWidget } from "./widgets/AccountsWidget";
 
 const WEEKDAY_ES = ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"];
 const MONTH_ES = [
@@ -193,6 +196,23 @@ export function InicioRoot() {
           });
         case "puedo_comprarlo":
           return renderPuedoComprarloWidget();
+        case "next_bill":
+          return renderNextBillWidget({
+            bill: summary.nextBill,
+            upcoming: summary.upcomingBills,
+            currency: summary.currency,
+          });
+        case "next_income":
+          return renderNextIncomeWidget({
+            income: summary.nextIncome,
+            upcoming: summary.upcomingIncomes,
+            currency: summary.currency,
+          });
+        case "accounts":
+          return renderAccountsWidget({
+            accounts: summary.accounts,
+            currency: summary.currency,
+          });
         default:
           return UNKNOWN_RENDER;
       }

--- a/mobile/components/inicio/widgets/PulseWidget.tsx
+++ b/mobile/components/inicio/widgets/PulseWidget.tsx
@@ -171,7 +171,7 @@ export function PulseWidget({
                 value={`−${formatCurrency(breakdown.alreadySpent, currency)}`}
                 tone="debt"
               />
-              <View className="mt-1 h-px bg-white-6" />
+              <View className="mt-1 h-px bg-z-surface-2-6" />
               <Row
                 label="= Disponible"
                 value={formatCurrency(breakdown.availableTotal, currency)}
@@ -184,7 +184,7 @@ export function PulseWidget({
 
               {nextIncome && (
                 <>
-                  <View className="mt-1 h-px bg-white-6" />
+                  <View className="mt-1 h-px bg-z-surface-2-6" />
                   <View className="flex-row items-start justify-between gap-2">
                     <Text className="flex-1 text-[11px] font-inter-semibold text-z-income">
                       Próximo ingreso: {nextIncome.name}

--- a/mobile/components/movimientos/MovimientosHerramientas.tsx
+++ b/mobile/components/movimientos/MovimientosHerramientas.tsx
@@ -179,7 +179,7 @@ function CategorizarDetail({
             <Pressable
               key={tx.id}
               onPress={() => onPick(tx.id)}
-              className="flex-row items-center gap-2 rounded-lg px-1.5 py-1.5 active:bg-white-5"
+              className="flex-row items-center gap-2 rounded-lg px-1.5 py-1.5 active:bg-z-surface-2-5"
             >
               <View
                 className={`h-5 w-5 items-center justify-center rounded-md ${isInflow ? "bg-z-income-10" : "bg-z-expense-12"}`}
@@ -238,7 +238,7 @@ function ImportarDetail({ onOpen }: { onOpen: () => void }) {
       </Text>
       <Pressable
         onPress={onOpen}
-        className="flex-row items-center gap-3 rounded-xl p-2 active:bg-white-5"
+        className="flex-row items-center gap-3 rounded-xl p-2 active:bg-z-surface-2-5"
       >
         <View className="h-8 w-8 items-center justify-center rounded-lg border border-z-sage-20 bg-z-sage-10">
           <FileUp size={16} color={COLORS.sageLight} />

--- a/mobile/components/movimientos/MovimientosRoot.tsx
+++ b/mobile/components/movimientos/MovimientosRoot.tsx
@@ -29,7 +29,7 @@ import {
 } from "./MovimientosUtilidades";
 import { MovimientosTransactionRow } from "./MovimientosTransactionRow";
 import { CategoryPickerSheet } from "../categorizar/CategoryPickerSheet";
-import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
 
 type ToolId = "categorizar" | "importar";
 const PAGE_SIZE = 25;
@@ -349,7 +349,7 @@ export function MovimientosRoot() {
         renderItem={renderItem}
         ListHeaderComponent={listHeader}
         ListFooterComponent={listFooter}
-        contentContainerStyle={{ padding: 16, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/movimientos/MovimientosTransactionRow.tsx
+++ b/mobile/components/movimientos/MovimientosTransactionRow.tsx
@@ -28,7 +28,7 @@ function MovimientosTransactionRowBase({
     <View className={expanded ? "border-l-2 border-l-z-brass pl-2" : ""}>
       <Pressable
         onPress={() => setExpanded((prev) => !prev)}
-        className={`flex-row items-center gap-2 rounded-xl px-1.5 py-2 active:bg-white-5 ${isExcluded ? "opacity-40" : ""}`}
+        className={`flex-row items-center gap-2 rounded-xl px-1.5 py-2 active:bg-z-surface-2-5 ${isExcluded ? "opacity-40" : ""}`}
       >
         <View
           className={`h-[22px] w-[22px] items-center justify-center rounded-md ${isInflow ? "bg-z-income-10" : "bg-z-expense-12"}`}
@@ -113,7 +113,7 @@ function MovimientosTransactionRowBase({
 
           <Pressable
             onPress={() => router.push(`/transaction/${tx.id}` as any)}
-            className="flex-row items-center gap-1 rounded-full border border-white-8 bg-black-10 px-2.5 py-1 active:bg-white-5"
+            className="flex-row items-center gap-1 rounded-full border border-white-8 bg-black-10 px-2.5 py-1 active:bg-z-surface-2-5"
           >
             <Pencil size={10} color={COLORS.sageDark} />
             <Text className="text-[10px] font-inter-semibold text-muted-foreground">

--- a/mobile/components/movimientos/MovimientosUtilidades.tsx
+++ b/mobile/components/movimientos/MovimientosUtilidades.tsx
@@ -264,7 +264,7 @@ function AccountOption({
   return (
     <Pressable
       onPress={onPress}
-      className={`flex-row items-center gap-3 px-3.5 py-2.5 border-b border-white-6 last:border-b-0 ${active ? "bg-z-brass-10" : ""} active:bg-white-5`}
+      className={`flex-row items-center gap-3 px-3.5 py-2.5 border-b border-white-6 last:border-b-0 ${active ? "bg-z-brass-10" : ""} active:bg-z-surface-2-5`}
     >
       {color ? (
         <View className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />

--- a/mobile/components/nav/FocusModeAccent.tsx
+++ b/mobile/components/nav/FocusModeAccent.tsx
@@ -1,0 +1,28 @@
+import { View } from "react-native";
+import { usePathname } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { isFocusModePath } from "../../lib/constants/mobile-nav";
+import { useTabBarVisibility } from "./TabBarVisibilityProvider";
+
+/**
+ * 2px brass strip pinned to the top safe-area edge whenever the tab bar is
+ * hidden via focus mode. Acts as the visual cue that the current screen is a
+ * single-task surface — without it, the disappearing tab bar reads like a
+ * glitch. Mounted once in `(tabs)/_layout.tsx`.
+ */
+export function FocusModeAccent() {
+  const pathname = usePathname();
+  const insets = useSafeAreaInsets();
+  const { isHidden: contextHidden } = useTabBarVisibility();
+  const focused = contextHidden || isFocusModePath(pathname);
+
+  if (!focused) return null;
+
+  return (
+    <View
+      pointerEvents="none"
+      className="absolute left-0 right-0 z-50 h-0.5 bg-z-brass"
+      style={{ top: insets.top }}
+    />
+  );
+}

--- a/mobile/components/nav/FocusModeAccent.tsx
+++ b/mobile/components/nav/FocusModeAccent.tsx
@@ -21,7 +21,7 @@ export function FocusModeAccent() {
   return (
     <View
       pointerEvents="none"
-      className="absolute left-0 right-0 z-50 h-0.5 bg-z-brass"
+      className="absolute left-0 right-0 z-10 h-0.5 bg-z-brass"
       style={{ top: insets.top }}
     />
   );

--- a/mobile/components/nav/TabBarVisibilityProvider.tsx
+++ b/mobile/components/nav/TabBarVisibilityProvider.tsx
@@ -1,0 +1,55 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface TabBarVisibilityValue {
+  isHidden: boolean;
+  setHidden: (hidden: boolean) => void;
+}
+
+const TabBarVisibilityContext = createContext<TabBarVisibilityValue>({
+  isHidden: false,
+  setHidden: () => {},
+});
+
+export function TabBarVisibilityProvider({ children }: { children: ReactNode }) {
+  const [hideCount, setHideCount] = useState(0);
+
+  const setHidden = useCallback((hidden: boolean) => {
+    setHideCount((prev) => Math.max(0, prev + (hidden ? 1 : -1)));
+  }, []);
+
+  const value = useMemo(
+    () => ({ isHidden: hideCount > 0, setHidden }),
+    [hideCount, setHidden]
+  );
+
+  return (
+    <TabBarVisibilityContext.Provider value={value}>
+      {children}
+    </TabBarVisibilityContext.Provider>
+  );
+}
+
+export function useTabBarVisibility() {
+  return useContext(TabBarVisibilityContext);
+}
+
+/**
+ * Hides the tab bar while the calling component is mounted and `active` is
+ * true. Reference-counted: multiple callers compose cleanly.
+ */
+export function useHideTabBar(active: boolean = true) {
+  const { setHidden } = useTabBarVisibility();
+  useEffect(() => {
+    if (!active) return;
+    setHidden(true);
+    return () => setHidden(false);
+  }, [active, setHidden]);
+}

--- a/mobile/components/onboarding/PurposeOption.tsx
+++ b/mobile/components/onboarding/PurposeOption.tsx
@@ -38,7 +38,7 @@ export function PurposeOption({
     >
       <View
         className={`h-10 w-10 items-center justify-center rounded-xl ${
-          selected ? "bg-z-brass-20" : "bg-white-6"
+          selected ? "bg-z-brass-20" : "bg-z-surface-2-6"
         }`}
       >
         <Icon

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -12,7 +12,14 @@ import {
 } from "react-native";
 import { Check, ChevronDown, X, Link2 } from "lucide-react-native";
 import * as Crypto from "expo-crypto";
-import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import {
+  applyAccountBalanceDelta,
+  computeIdempotencyKey,
+  formatCurrency,
+  formatDate,
+  type CurrencyCode,
+  type TransactionDirection,
+} from "@zeta/shared";
 import { supabase } from "../../lib/supabase";
 import { useAuth } from "../../lib/auth";
 import { COLORS } from "../../lib/constants/colors";
@@ -21,6 +28,62 @@ import { toLocalDateString, toLocalMonthString } from "../../lib/utils/date";
 import { parseLocalizedAmount } from "../../lib/amount";
 import { isDebtAccountType } from "../../lib/constants/accounts";
 import { markEntryCompleted } from "../../lib/repositories/planning";
+import { computeRecurringGroupUuid } from "../../lib/utils/recurring-group";
+
+const expoHashFn = (payload: string) =>
+  Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, payload);
+
+async function buildIdempotencyKey(params: {
+  txId: string;
+  date: string;
+  amount: number;
+  description: string;
+}): Promise<string> {
+  // Mirrors webapp `cashflow-planner.ts:1283-1292`: same provider name and
+  // providerTransactionId so SHA-256 hash matches across platforms and the
+  // UNIQUE constraint dedups consistently.
+  return computeIdempotencyKey(
+    {
+      provider: "MANUAL_FORM",
+      providerTransactionId: params.txId,
+      transactionDate: params.date,
+      amount: params.amount,
+      rawDescription: params.description,
+    },
+    expoHashFn,
+  );
+}
+
+// Updates accounts.current_balance on Supabase to keep the webapp + dashboard
+// in sync immediately. Local SQLite reconciles on the next pull.
+async function updateAccountBalanceRemote(params: {
+  accountId: string;
+  userId: string;
+  direction: TransactionDirection;
+  amount: number;
+}): Promise<void> {
+  const sb = supabase as any;
+  const { data: acct } = await sb
+    .from("accounts")
+    .select("current_balance, account_type")
+    .eq("id", params.accountId)
+    .eq("user_id", params.userId)
+    .single();
+  if (!acct) return;
+
+  const newBalance = applyAccountBalanceDelta({
+    currentBalance: acct.current_balance,
+    accountType: acct.account_type,
+    direction: params.direction,
+    amount: params.amount,
+  });
+
+  await sb
+    .from("accounts")
+    .update({ current_balance: newBalance })
+    .eq("id", params.accountId)
+    .eq("user_id", params.userId);
+}
 
 // ── Types ──
 
@@ -204,7 +267,7 @@ export function PaymentSheet({
         const monthPrefix = toLocalMonthString() + "%";
         const { data: occurrences } = await sb
           .from("recurring_occurrences")
-          .select("id")
+          .select("id, occurrence_date")
           .eq("template_id", entry.recurring_template_id)
           .eq("user_id", userId)
           .eq("status", "pending")
@@ -213,14 +276,47 @@ export function PaymentSheet({
           .limit(1);
 
         if (occurrences && occurrences.length > 0) {
+          const occ = occurrences[0];
+
+          // Stamp recurrence_group_id on the linked tx so visibility
+          // predicates and revert flows match webapp's
+          // linkExistingTransactionToOccurrence.
+          const recurrenceGroupId = await computeRecurringGroupUuid(
+            entry.recurring_template_id,
+            occ.occurrence_date,
+          );
+          const txEnrichment: Record<string, unknown> = {
+            recurrence_group_id: recurrenceGroupId,
+          };
+          // If the linked tx has no category but the entry does, backfill it.
+          const candidate = candidates.find((c) => c.id === selectedCandidateId);
+          if (candidate && entry.category_id) {
+            const { data: txRow } = await sb
+              .from("transactions")
+              .select("category_id")
+              .eq("id", selectedCandidateId)
+              .eq("user_id", userId)
+              .single();
+            if (txRow && !txRow.category_id) {
+              txEnrichment.category_id = entry.category_id;
+              txEnrichment.categorization_source = "RECURRING_TEMPLATE";
+            }
+          }
+          await sb
+            .from("transactions")
+            .update(txEnrichment)
+            .eq("id", selectedCandidateId)
+            .eq("user_id", userId);
+
           await sb
             .from("recurring_occurrences")
             .update({
               status: "paid",
               transaction_id: selectedCandidateId,
               paid_at: new Date().toISOString(),
+              linked_manually: true,
             })
-            .eq("id", occurrences[0].id)
+            .eq("id", occ.id)
             .eq("user_id", userId);
         }
       }
@@ -250,8 +346,44 @@ export function PaymentSheet({
       const outflowTxId = Crypto.randomUUID();
       const transferGroupId = debtAccount ? Crypto.randomUUID() : null;
       const sb = supabase as any;
+      // OUTFLOW shows the entry label in the source ledger ("Netflix"),
+      // INFLOW on the debt account shows "Pago: Netflix". Mirrors webapp
+      // `cashflow-planner.ts:1305-1306` (OUTFLOW) and `:1366-1367` (INFLOW).
+      const outflowDescription = entry.label;
+      const inflowDescription = `Pago: ${entry.label}`;
+
+      // Resolve the matching occurrence up-front so we can stamp
+      // recurrence_group_id on the inserted transactions (mirrors webapp).
+      let occurrenceRow: { id: string; occurrence_date: string } | null = null;
+      let recurrenceGroupId: string | null = null;
+      if (entry.recurring_template_id) {
+        const monthPrefix = toLocalMonthString() + "%";
+        const { data: occurrences } = await sb
+          .from("recurring_occurrences")
+          .select("id, occurrence_date")
+          .eq("template_id", entry.recurring_template_id)
+          .eq("user_id", userId)
+          .eq("status", "pending")
+          .like("occurrence_date", monthPrefix)
+          .order("occurrence_date", { ascending: true })
+          .limit(1);
+        if (occurrences && occurrences.length > 0) {
+          const occ = occurrences[0];
+          occurrenceRow = occ;
+          recurrenceGroupId = await computeRecurringGroupUuid(
+            entry.recurring_template_id,
+            occ.occurrence_date,
+          );
+        }
+      }
 
       // 1. OUTFLOW from source
+      const outflowKey = await buildIdempotencyKey({
+        txId: outflowTxId,
+        date: today,
+        amount: resolvedAmount,
+        description: outflowDescription,
+      });
       const { error: outflowErr } = await sb
         .from("transactions")
         .insert({
@@ -262,13 +394,15 @@ export function PaymentSheet({
           currency_code: entry.currency_code,
           direction: "OUTFLOW",
           transaction_date: today,
-          description: `Pago: ${entry.label}`,
+          raw_description: outflowDescription,
+          clean_description: outflowDescription,
           merchant_name: entry.label,
           capture_method: "MANUAL_FORM",
           category_id: entry.category_id,
           transfer_group_id: transferGroupId,
-          idempotency_key: `MANUAL_FORM|${outflowTxId}|${today}|${resolvedAmount}|${entry.label}`,
+          idempotency_key: outflowKey,
           is_recurring: !!entry.recurring_template_id,
+          recurrence_group_id: recurrenceGroupId,
         });
 
       if (outflowErr) throw new Error(outflowErr.message);
@@ -276,6 +410,12 @@ export function PaymentSheet({
       // 2. INFLOW on debt account
       if (debtAccount && transferGroupId) {
         const inflowTxId = Crypto.randomUUID();
+        const inflowKey = await buildIdempotencyKey({
+          txId: inflowTxId,
+          date: today,
+          amount: resolvedAmount,
+          description: inflowDescription,
+        });
         const { error: inflowErr } = await sb
           .from("transactions")
           .insert({
@@ -286,44 +426,52 @@ export function PaymentSheet({
             currency_code: entry.currency_code,
             direction: "INFLOW",
             transaction_date: today,
-            description: `Pago: ${entry.label}`,
+            raw_description: inflowDescription,
+            clean_description: inflowDescription,
             merchant_name: entry.label,
             capture_method: "MANUAL_FORM",
             category_id: entry.category_id,
             transfer_group_id: transferGroupId,
-            idempotency_key: `MANUAL_FORM|${inflowTxId}|${today}|${resolvedAmount}|${entry.label}`,
+            idempotency_key: inflowKey,
             is_recurring: !!entry.recurring_template_id,
+            recurrence_group_id: recurrenceGroupId,
           });
-        if (inflowErr) throw new Error(inflowErr.message);
-      }
-
-      // 3. Link to recurring occurrence
-      if (entry.recurring_template_id) {
-        const monthPrefix = toLocalMonthString() + "%";
-        const { data: occurrences } = await sb
-          .from("recurring_occurrences")
-          .select("id")
-          .eq("template_id", entry.recurring_template_id)
-          .eq("user_id", userId)
-          .eq("status", "pending")
-          .like("occurrence_date", monthPrefix)
-          .order("occurrence_date", { ascending: true })
-          .limit(1);
-
-        if (occurrences && occurrences.length > 0) {
-          await sb
-            .from("recurring_occurrences")
-            .update({
-              status: "paid",
-              transaction_id: outflowTxId,
-              paid_at: new Date().toISOString(),
-            })
-            .eq("id", occurrences[0].id)
-            .eq("user_id", userId);
+        if (inflowErr && !inflowErr.message?.includes("23505")) {
+          throw new Error(inflowErr.message);
         }
       }
 
-      // 4. Mark planning entry COMPLETED (local + enqueued)
+      // 3. Link to recurring occurrence
+      if (occurrenceRow) {
+        await sb
+          .from("recurring_occurrences")
+          .update({
+            status: "paid",
+            transaction_id: outflowTxId,
+            paid_at: new Date().toISOString(),
+          })
+          .eq("id", occurrenceRow.id)
+          .eq("user_id", userId);
+      }
+
+      // 4. Update account balances on Supabase so the webapp reflects the
+      // payment immediately. Local SQLite reconciles on the next pull.
+      await updateAccountBalanceRemote({
+        accountId: selectedSourceId,
+        userId,
+        direction: "OUTFLOW",
+        amount: resolvedAmount,
+      });
+      if (debtAccount) {
+        await updateAccountBalanceRemote({
+          accountId: debtAccount.id,
+          userId,
+          direction: "INFLOW",
+          amount: resolvedAmount,
+        });
+      }
+
+      // 5. Mark planning entry COMPLETED (local + enqueued)
       await markEntryCompleted(entry.id);
 
       handleClose();

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -56,6 +56,9 @@ async function buildIdempotencyKey(params: {
 
 // Updates accounts.current_balance on Supabase to keep the webapp + dashboard
 // in sync immediately. Local SQLite reconciles on the next pull.
+// Throws on fetch/update errors so the caller's try/catch can surface the
+// failure — silent failure would leave the transaction recorded with the
+// account balance still stale.
 async function updateAccountBalanceRemote(params: {
   accountId: string;
   userId: string;
@@ -63,13 +66,14 @@ async function updateAccountBalanceRemote(params: {
   amount: number;
 }): Promise<void> {
   const sb = supabase as any;
-  const { data: acct } = await sb
+  const { data: acct, error: fetchErr } = await sb
     .from("accounts")
     .select("current_balance, account_type")
     .eq("id", params.accountId)
     .eq("user_id", params.userId)
     .single();
-  if (!acct) return;
+  if (fetchErr) throw new Error(fetchErr.message);
+  if (!acct) throw new Error("Cuenta no encontrada");
 
   const newBalance = applyAccountBalanceDelta({
     currentBalance: acct.current_balance,
@@ -78,11 +82,12 @@ async function updateAccountBalanceRemote(params: {
     amount: params.amount,
   });
 
-  await sb
+  const { error: updateErr } = await sb
     .from("accounts")
     .update({ current_balance: newBalance })
     .eq("id", params.accountId)
     .eq("user_id", params.userId);
+  if (updateErr) throw new Error(updateErr.message);
 }
 
 // ── Types ──
@@ -302,13 +307,19 @@ export function PaymentSheet({
               txEnrichment.categorization_source = "RECURRING_TEMPLATE";
             }
           }
-          await sb
+          // Sequence: enrich tx first, only mark occurrence paid if that
+          // succeeded. Operations aren't atomic — failing the second after
+          // the first persisted is recoverable; failing the second after
+          // it persisted leaves the user with a paid occurrence pointing
+          // at an un-stamped tx, which breaks revertOccurrence.
+          const { error: txErr } = await sb
             .from("transactions")
             .update(txEnrichment)
             .eq("id", selectedCandidateId)
             .eq("user_id", userId);
+          if (txErr) throw new Error(txErr.message);
 
-          await sb
+          const { error: occErr } = await sb
             .from("recurring_occurrences")
             .update({
               status: "paid",
@@ -318,6 +329,7 @@ export function PaymentSheet({
             })
             .eq("id", occ.id)
             .eq("user_id", userId);
+          if (occErr) throw new Error(occErr.message);
         }
       }
 
@@ -441,9 +453,9 @@ export function PaymentSheet({
         }
       }
 
-      // 3. Link to recurring occurrence
+      // 3. Link to recurring occurrence (only after the OUTFLOW persisted).
       if (occurrenceRow) {
-        await sb
+        const { error: occErr } = await sb
           .from("recurring_occurrences")
           .update({
             status: "paid",
@@ -452,6 +464,7 @@ export function PaymentSheet({
           })
           .eq("id", occurrenceRow.id)
           .eq("user_id", userId);
+        if (occErr) throw new Error(occErr.message);
       }
 
       // 4. Update account balances on Supabase so the webapp reflects the

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -417,7 +417,9 @@ export function PaymentSheet({
           recurrence_group_id: recurrenceGroupId,
         });
 
-      if (outflowErr) throw new Error(outflowErr.message);
+      if (outflowErr && !outflowErr.message?.includes("23505")) {
+        throw new Error(outflowErr.message);
+      }
 
       // 2. INFLOW on debt account
       if (debtAccount && transferGroupId) {

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -692,7 +692,7 @@ export function PaymentSheet({
                             <Pressable
                               key={acc.id}
                               onPress={() => { setSelectedSourceId(acc.id); setShowSourcePicker(false); }}
-                              className={`flex-row items-center justify-between px-3 py-2.5 active:bg-white/5 ${i > 0 ? "border-t border-white-6" : ""}`}
+                              className={`flex-row items-center justify-between px-3 py-2.5 active:bg-z-surface-2/5 ${i > 0 ? "border-t border-white-6" : ""}`}
                             >
                               <Text className="text-[13px] font-inter-medium text-foreground">{acc.name}</Text>
                               {acc.id === selectedSourceId && <Check size={14} color={COLORS.income} />}

--- a/mobile/components/plan/PlanNetHero.tsx
+++ b/mobile/components/plan/PlanNetHero.tsx
@@ -134,7 +134,7 @@ function PlanNetHeroBase({
         )}
 
         {/* Burn bar — fijos paid / libre gastado */}
-        <View className="mt-3 h-2 flex-row overflow-hidden rounded-full bg-white-6">
+        <View className="mt-3 h-2 flex-row overflow-hidden rounded-full bg-z-surface-2-6">
           <View className="bg-z-alert" style={{ width: `${plannedExpenses > 0 ? Math.min((paidExpenses / (confirmedIncome || 1)) * 100, 100) : 0}%` }} />
           <View className="bg-z-debt" style={{ width: `${Math.min((discretionarySpent / (confirmedIncome || 1)) * 100, 100 - (paidExpenses / (confirmedIncome || 1)) * 100)}%` }} />
         </View>
@@ -190,7 +190,7 @@ function PlanNetHeroBase({
                   {Math.round(incomePct)}% recibido
                 </Text>
               </View>
-              <View className="h-1.5 flex-row overflow-hidden rounded-full bg-white-6">
+              <View className="h-1.5 flex-row overflow-hidden rounded-full bg-z-surface-2-6">
                 <View className="bg-z-income rounded-full" style={{ width: `${incomePct}%` }} />
               </View>
               {confirmedIncome > 0 && (
@@ -222,7 +222,7 @@ function PlanNetHeroBase({
                   {Math.round(expensePct)}% pagado
                 </Text>
               </View>
-              <View className="h-1.5 flex-row overflow-hidden rounded-full bg-white-6">
+              <View className="h-1.5 flex-row overflow-hidden rounded-full bg-z-surface-2-6">
                 <View className="bg-z-alert rounded-full" style={{ width: `${expensePct}%` }} />
               </View>
               {paidExpenses > 0 && (

--- a/mobile/components/plan/PlanRoot.tsx
+++ b/mobile/components/plan/PlanRoot.tsx
@@ -14,6 +14,7 @@ import { computeTimeline, type TimelineData } from "../../lib/utils/timeline";
 import { toLocalDateString, toLocalMonthString } from "../../lib/utils/date";
 import { DEBT_ACCOUNT_TYPES, LIQUID_ACCOUNT_TYPES } from "../../lib/constants/accounts";
 import { COLORS } from "../../lib/constants/colors";
+import { MOBILE_TAB_BAR_CLEARANCE } from "../../lib/constants/styles";
 import { getPreferredCurrency } from "../../lib/profile";
 import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
@@ -227,7 +228,7 @@ export function PlanRoot() {
       />
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 10, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 10, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={COLORS.brass} />
         }

--- a/mobile/components/recurrentes/RecurrentesRoot.tsx
+++ b/mobile/components/recurrentes/RecurrentesRoot.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../lib/repositories/recurring";
 import { getPreferredCurrency } from "../../lib/profile";
 import { COLORS } from "../../lib/constants/colors";
-import { SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
 import { MobileHeader } from "../ui/MobileHeader";
 import { MonthSelector } from "../common/MonthSelector";
 import { MCard } from "../ui/MCard";
@@ -120,7 +120,7 @@ export function RecurrentesRoot() {
       <MobileHeader variant="sub" title="Recurrentes" />
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: 100 }}
+        contentContainerStyle={{ padding: 16, gap: 8, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -117,7 +117,7 @@ export function CategoryPicker({
             </Text>
             <Pressable
               onPress={handleClose}
-              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
             >
               <X size={18} color="#938C7E" />
             </Pressable>
@@ -139,9 +139,9 @@ export function CategoryPicker({
           {/* "None" option */}
           <Pressable
             onPress={() => handleSelect(null, null)}
-            className="flex-row items-center px-4 py-3.5 border-b border-white-6 active:bg-white/5"
+            className="flex-row items-center px-4 py-3.5 border-b border-white-6 active:bg-z-surface-2/5"
           >
-            <View className="w-3 h-3 rounded-full bg-white/15 mr-3" />
+            <View className="w-3 h-3 rounded-full bg-z-surface-2/15 mr-3" />
             <Text className="text-muted-foreground font-inter text-sm flex-1">
               Sin categoría
             </Text>
@@ -171,7 +171,7 @@ export function CategoryPicker({
                   onPress={() =>
                     handleSelect(item.item.id, displayName(item.item))
                   }
-                  className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-white/5`}
+                  className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-z-surface-2/5`}
                 >
                   {item.item.color ? (
                     <View
@@ -179,7 +179,7 @@ export function CategoryPicker({
                       style={{ backgroundColor: item.item.color }}
                     />
                   ) : (
-                    <View className="w-3 h-3 rounded-full bg-white/15 mr-3" />
+                    <View className="w-3 h-3 rounded-full bg-z-surface-2/15 mr-3" />
                   )}
                   <Text
                     className={`font-inter text-sm flex-1 ${
@@ -193,7 +193,7 @@ export function CategoryPicker({
               );
             }}
             ItemSeparatorComponent={() => (
-              <View className="h-px bg-white-6 ml-4" />
+              <View className="h-px bg-z-surface-2-6 ml-4" />
             )}
           />
         </View>

--- a/mobile/components/transactions/CategoryZonePickerSheet.tsx
+++ b/mobile/components/transactions/CategoryZonePickerSheet.tsx
@@ -128,8 +128,8 @@ function SubRow({
       onPress={onPress}
       accessibilityRole="button"
       accessibilityState={{ selected: isSelected }}
-      className={`flex-row items-center gap-2.5 rounded-lg px-3 py-2.5 active:bg-white/5 ${
-        isSelected ? "bg-white/8" : ""
+      className={`flex-row items-center gap-2.5 rounded-lg px-3 py-2.5 active:bg-z-surface-2/5 ${
+        isSelected ? "bg-z-surface-2/8" : ""
       }`}
     >
       <View
@@ -224,7 +224,7 @@ export function CategoryZonePickerSheet({
             </View>
             <Pressable
               onPress={handleClose}
-              className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-white/10"
+              className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
               accessibilityLabel="Cerrar"
             >
               <X size={16} color={COLORS.sageDark} />
@@ -364,9 +364,9 @@ export function CategoryZonePickerSheet({
                                 accessibilityState={{
                                   selected: selectedId === expandedInRow.id,
                                 }}
-                                className={`flex-row items-center gap-2.5 rounded-lg px-3 py-2.5 active:bg-white/5 ${
+                                className={`flex-row items-center gap-2.5 rounded-lg px-3 py-2.5 active:bg-z-surface-2/5 ${
                                   selectedId === expandedInRow.id
-                                    ? "bg-white/8"
+                                    ? "bg-z-surface-2/8"
                                     : ""
                                 }`}
                               >
@@ -420,8 +420,8 @@ export function CategoryZonePickerSheet({
                   accessibilityRole="button"
                   accessibilityLabel="Sin categoría"
                   accessibilityState={{ selected: selectedId === null }}
-                  className={`mt-4 flex-row items-center gap-2.5 rounded-lg px-3 py-2.5 active:bg-white/5 ${
-                    selectedId === null ? "bg-white/8" : ""
+                  className={`mt-4 flex-row items-center gap-2.5 rounded-lg px-3 py-2.5 active:bg-z-surface-2/5 ${
+                    selectedId === null ? "bg-z-surface-2/8" : ""
                   }`}
                 >
                   <X size={14} color={COLORS.sageDark} />

--- a/mobile/components/transactions/TagSelector.tsx
+++ b/mobile/components/transactions/TagSelector.tsx
@@ -65,7 +65,7 @@ export function TagSelector({ selectedTagIds, onChange }: Props) {
   if (tags.length === 0) {
     return (
       <View className="py-2">
-        <Text className="text-gray-400 font-inter text-xs text-center">
+        <Text className="text-muted-fg-70 font-inter text-xs text-center">
           No hay tags disponibles
         </Text>
       </View>
@@ -79,7 +79,7 @@ export function TagSelector({ selectedTagIds, onChange }: Props) {
     <View>
       {grouped.map((group) => (
         <View key={group.groupName} className="mb-3">
-          <Text className="text-gray-500 font-inter-medium text-xs mb-1.5">
+          <Text className="text-muted-foreground font-inter-medium text-xs mb-1.5">
             {group.groupName}
           </Text>
           <View className="flex-row flex-wrap gap-1.5">
@@ -93,7 +93,7 @@ export function TagSelector({ selectedTagIds, onChange }: Props) {
                   className={`rounded-full px-2.5 py-1 border ${
                     isSelected
                       ? "border-amber-600 bg-amber-50"
-                      : "border-gray-200 bg-gray-50"
+                      : "border-white-8 bg-z-surface-2-55"
                   }`}
                   style={
                     isSelected
@@ -103,7 +103,7 @@ export function TagSelector({ selectedTagIds, onChange }: Props) {
                 >
                   <Text
                     className={`font-inter-medium text-xs ${
-                      isSelected ? "text-amber-700" : "text-gray-600"
+                      isSelected ? "text-z-alert" : "text-muted-foreground"
                     }`}
                     style={isSelected ? { color: "#937844" } : undefined}
                   >

--- a/mobile/components/transactions/TransactionRow.tsx
+++ b/mobile/components/transactions/TransactionRow.tsx
@@ -38,7 +38,7 @@ export function TransactionRow({
 
   return (
     <Pressable
-      className="flex-row items-center px-4 py-3 bg-z-surface-2-55 active:bg-white/5"
+      className="flex-row items-center px-4 py-3 bg-z-surface-2-55 active:bg-z-surface-2/5"
       onPress={() => router.push(`/transaction/${id}`)}
     >
       {/* Category icon circle */}
@@ -72,7 +72,7 @@ export function TransactionRow({
       {/* Amount */}
       <Text
         className={`font-inter-bold text-sm ${
-          isDebtPayment ? "text-sky-600" : isInflow ? "text-green-600" : "text-foreground"
+          isDebtPayment ? "text-z-brass" : isInflow ? "text-z-income" : "text-foreground"
         }`}
       >
         {isInflow ? "+" : "-"}

--- a/mobile/components/ui/AvatarMenu.tsx
+++ b/mobile/components/ui/AvatarMenu.tsx
@@ -127,7 +127,7 @@ function AvatarMenuPopover({
               )}
             </View>
 
-            <View className="h-px bg-white-6 mx-4" />
+            <View className="h-px bg-z-surface-2-6 mx-4" />
 
             {/* Featured IMPORTAR card */}
             <View className="px-4 pt-3 pb-2">
@@ -157,7 +157,7 @@ function AvatarMenuPopover({
               </Pressable>
             </View>
 
-            <View className="h-px bg-white-6 mx-4 mt-2" />
+            <View className="h-px bg-z-surface-2-6 mx-4 mt-2" />
 
             {/* Nav rows */}
             <View className="py-1">
@@ -201,7 +201,7 @@ function MenuRow({
   return (
     <Pressable
       onPress={onPress}
-      className="flex-row items-center gap-3 px-4 py-3 active:bg-white/5"
+      className="flex-row items-center gap-3 px-4 py-3 active:bg-z-surface-2/5"
     >
       {icon}
       <Text className="flex-1 text-sm font-inter-medium text-foreground">

--- a/mobile/components/ui/ExpandableChip.tsx
+++ b/mobile/components/ui/ExpandableChip.tsx
@@ -42,7 +42,7 @@ const TONE: Record<ChipTone, ToneStyles> = {
     value: "text-foreground",
     label: "text-z-sage-dark",
     activeBorder: "border-white-25",
-    activeFill: "bg-white-10",
+    activeFill: "bg-z-surface-2-10",
   },
 };
 

--- a/mobile/components/ui/MobileSheet.tsx
+++ b/mobile/components/ui/MobileSheet.tsx
@@ -48,7 +48,7 @@ export function MobileSheet({
           style={{ paddingBottom: insets.bottom + 16 }}
         >
           {!hideHandle && (
-            <View className="mx-auto mt-3 mb-3 h-1 w-10 rounded-full bg-white-10" />
+            <View className="mx-auto mt-3 mb-3 h-1 w-10 rounded-full bg-z-surface-2-10" />
           )}
           {children}
         </Pressable>

--- a/mobile/components/ui/MobileTabBar.tsx
+++ b/mobile/components/ui/MobileTabBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { Alert, View, Pressable, Text } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useKeyboardState } from "react-native-keyboard-controller";
@@ -20,7 +20,7 @@ interface TabBarProps {
   navigation: { navigate: (name: string) => void };
 }
 
-function TabButton({
+const TabButton = memo(function TabButton({
   tab,
   active,
   onPress,
@@ -48,7 +48,7 @@ function TabButton({
       </Text>
     </Pressable>
   );
-}
+});
 
 interface MobileTabBarProps extends TabBarProps {
   /** User preference for the dynamic 3rd tab. Defaults to "PLAN". */
@@ -62,6 +62,34 @@ export function MobileTabBar({ state, navigation, navFocus }: MobileTabBarProps)
   const keyboardVisible = useKeyboardState((s) => s.isVisible);
   const { isHidden: contextHidden } = useTabBarVisibility();
   const [menuOpen, setMenuOpen] = useState(false);
+
+  const navigate = useCallback(
+    (name: string) => navigation.navigate(name),
+    [navigation]
+  );
+
+  const tabs = useMemo(() => getMobileTabs(navFocus), [navFocus]);
+  const leftTabs = useMemo(() => tabs.slice(0, 2), [tabs]);
+  const rightTabs = useMemo(() => tabs.slice(2), [tabs]);
+
+  const renderTab = useCallback(
+    (tab: MobileTab) => {
+      const routeIndex = state.routes.findIndex((r) => r.name === tab.name);
+      const active =
+        routeIndex >= 0
+          ? state.index === routeIndex
+          : isMobileTabActive(pathname, tab);
+      return (
+        <TabButton
+          key={tab.name}
+          tab={tab}
+          active={active}
+          onPress={() => navigate(tab.name)}
+        />
+      );
+    },
+    [state, pathname, navigate]
+  );
 
   function handleFabAction(action: FabMenuAction) {
     switch (action) {
@@ -83,24 +111,6 @@ export function MobileTabBar({ state, navigation, navFocus }: MobileTabBarProps)
 
   if (keyboardVisible) return null;
   if (contextHidden || isFocusModePath(pathname)) return null;
-
-  const tabs = getMobileTabs(navFocus);
-  const leftTabs = tabs.slice(0, 2);
-  const rightTabs = tabs.slice(2);
-
-  function renderTab(tab: MobileTab) {
-    const routeIndex = state.routes.findIndex((r) => r.name === tab.name);
-    const active =
-      routeIndex >= 0 ? state.index === routeIndex : isMobileTabActive(pathname, tab);
-    return (
-      <TabButton
-        key={tab.name}
-        tab={tab}
-        active={active}
-        onPress={() => navigation.navigate(tab.name)}
-      />
-    );
-  }
 
   return (
     <>

--- a/mobile/components/ui/MobileTabBar.tsx
+++ b/mobile/components/ui/MobileTabBar.tsx
@@ -3,40 +3,29 @@ import { Alert, View, Pressable, Text } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useKeyboardState } from "react-native-keyboard-controller";
 import { Plus } from "lucide-react-native";
-import { useRouter } from "expo-router";
+import { useRouter, usePathname } from "expo-router";
 import { COLORS } from "../../lib/constants/colors";
 import { FabMenuSheet, type FabMenuAction } from "./FabMenuSheet";
 import {
-  LayoutDashboard,
-  ArrowLeftRight,
-  PiggyBank,
-  Landmark,
-} from "lucide-react-native";
-
-const TABS = [
-  { name: "index", title: "Inicio", icon: LayoutDashboard },
-  { name: "transactions", title: "Movim.", icon: ArrowLeftRight },
-  // FAB goes here (index 2)
-  { name: "plan", title: "Plan", icon: PiggyBank },
-  { name: "deudas", title: "Deudas", icon: Landmark },
-] as const;
-
-const LEFT_TABS = TABS.slice(0, 2);
-const RIGHT_TABS = TABS.slice(2);
+  getMobileTabs,
+  isFocusModePath,
+  isMobileTabActive,
+  type MobileTab,
+  type NavFocus,
+} from "../../lib/constants/mobile-nav";
+import { useTabBarVisibility } from "../nav/TabBarVisibilityProvider";
 
 interface TabBarProps {
   state: { routes: Array<{ name: string }>; index: number };
   navigation: { navigate: (name: string) => void };
 }
 
-type TabDef = (typeof TABS)[number];
-
 function TabButton({
   tab,
   active,
   onPress,
 }: {
-  tab: TabDef;
+  tab: MobileTab;
   active: boolean;
   onPress: () => void;
 }) {
@@ -61,10 +50,17 @@ function TabButton({
   );
 }
 
-export function MobileTabBar({ state, navigation }: TabBarProps) {
+interface MobileTabBarProps extends TabBarProps {
+  /** User preference for the dynamic 3rd tab. Defaults to "PLAN". */
+  navFocus?: NavFocus;
+}
+
+export function MobileTabBar({ state, navigation, navFocus }: MobileTabBarProps) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const pathname = usePathname();
   const keyboardVisible = useKeyboardState((s) => s.isVisible);
+  const { isHidden: contextHidden } = useTabBarVisibility();
   const [menuOpen, setMenuOpen] = useState(false);
 
   function handleFabAction(action: FabMenuAction) {
@@ -85,73 +81,67 @@ export function MobileTabBar({ state, navigation }: TabBarProps) {
     }
   }
 
-  // Hide tab bar when keyboard is open
   if (keyboardVisible) return null;
+  if (contextHidden || isFocusModePath(pathname)) return null;
+
+  const tabs = getMobileTabs(navFocus);
+  const leftTabs = tabs.slice(0, 2);
+  const rightTabs = tabs.slice(2);
+
+  function renderTab(tab: MobileTab) {
+    const routeIndex = state.routes.findIndex((r) => r.name === tab.name);
+    const active =
+      routeIndex >= 0 ? state.index === routeIndex : isMobileTabActive(pathname, tab);
+    return (
+      <TabButton
+        key={tab.name}
+        tab={tab}
+        active={active}
+        onPress={() => navigation.navigate(tab.name)}
+      />
+    );
+  }
 
   return (
     <>
-    <FabMenuSheet
-      visible={menuOpen}
-      onClose={() => setMenuOpen(false)}
-      onAction={handleFabAction}
-    />
-    <View
-      className="border-t border-white-6 bg-background-92"
-      style={{ paddingBottom: insets.bottom }}
-    >
-      <View className="flex-row items-center h-14">
-        <View className="flex-1 flex-row items-center justify-around">
-          {LEFT_TABS.map((tab) => {
-            const routeIndex = state.routes.findIndex(
-              (r) => r.name === tab.name
-            );
-            return (
-              <TabButton
-                key={tab.name}
-                tab={tab}
-                active={state.index === routeIndex}
-                onPress={() => navigation.navigate(tab.name)}
-              />
-            );
-          })}
-        </View>
+      <FabMenuSheet
+        visible={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onAction={handleFabAction}
+      />
+      <View
+        className="border-t border-white-6 bg-background-92"
+        style={{ paddingBottom: insets.bottom }}
+      >
+        <View className="flex-row items-center h-14">
+          <View className="flex-1 flex-row items-center justify-around">
+            {leftTabs.map(renderTab)}
+          </View>
 
-        {/* Center FAB */}
-        <View className="items-center justify-center px-4">
-          <Pressable
-            onPress={() => setMenuOpen(true)}
-            accessibilityRole="button"
-            accessibilityLabel="Registrar movimiento"
-            className="h-12 w-12 -mt-4 items-center justify-center rounded-full bg-z-brass"
-            style={{
-              shadowColor: COLORS.brass,
-              shadowOffset: { width: 0, height: 0 },
-              shadowOpacity: 0.4,
-              shadowRadius: 16,
-              elevation: 8,
-            }}
-          >
-            <Plus size={20} color={COLORS.ink} strokeWidth={2.5} />
-          </Pressable>
-        </View>
+          {/* Center FAB */}
+          <View className="items-center justify-center px-4">
+            <Pressable
+              onPress={() => setMenuOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="Registrar movimiento"
+              className="h-12 w-12 -mt-4 items-center justify-center rounded-full bg-z-brass"
+              style={{
+                shadowColor: COLORS.brass,
+                shadowOffset: { width: 0, height: 0 },
+                shadowOpacity: 0.4,
+                shadowRadius: 16,
+                elevation: 8,
+              }}
+            >
+              <Plus size={20} color={COLORS.ink} strokeWidth={2.5} />
+            </Pressable>
+          </View>
 
-        <View className="flex-1 flex-row items-center justify-around">
-          {RIGHT_TABS.map((tab) => {
-            const routeIndex = state.routes.findIndex(
-              (r) => r.name === tab.name
-            );
-            return (
-              <TabButton
-                key={tab.name}
-                tab={tab}
-                active={state.index === routeIndex}
-                onPress={() => navigation.navigate(tab.name)}
-              />
-            );
-          })}
+          <View className="flex-1 flex-row items-center justify-around">
+            {rightTabs.map(renderTab)}
+          </View>
         </View>
       </View>
-    </View>
     </>
   );
 }

--- a/mobile/components/ui/SectionDivider.tsx
+++ b/mobile/components/ui/SectionDivider.tsx
@@ -7,11 +7,11 @@ interface SectionDividerProps {
 export function SectionDivider({ label }: SectionDividerProps) {
   return (
     <View className="flex-row items-center gap-2 px-0.5 py-1">
-      <View className="h-px flex-1 bg-white-6" />
+      <View className="h-px flex-1 bg-z-surface-2-6" />
       <Text className="text-[9px] font-inter-semibold uppercase tracking-[4px] text-z-sage-dark">
         {label}
       </Text>
-      <View className="h-px flex-1 bg-white-6" />
+      <View className="h-px flex-1 bg-z-surface-2-6" />
     </View>
   );
 }

--- a/mobile/components/ui/ToneActionRow.tsx
+++ b/mobile/components/ui/ToneActionRow.tsx
@@ -8,7 +8,7 @@ const SURFACE: Record<ChipTone, string> = {
   income: "border-z-income-30 bg-z-income-10",
   debt: "border-z-debt-30 bg-z-debt-12",
   alert: "border-z-alert-25 bg-z-alert-12",
-  foreground: "border-white-10 bg-white-3",
+  foreground: "border-white-10 bg-z-surface-2-3",
 };
 
 const TITLE_COLOR: Record<ChipTone, string> = {

--- a/mobile/lib/constants/mobile-nav.ts
+++ b/mobile/lib/constants/mobile-nav.ts
@@ -1,0 +1,92 @@
+import {
+  LayoutDashboard,
+  ArrowLeftRight,
+  PiggyBank,
+  Landmark,
+  LayoutGrid,
+  type LucideIcon,
+} from "lucide-react-native";
+
+export type NavFocus = "PLAN" | "DEBT";
+
+export type MobileTab = {
+  /** Expo Router screen name (matches file name in `app/(tabs)/`) */
+  name: string;
+  title: string;
+  /** Pathname-style href for focus-mode + active checks */
+  href: string;
+  icon: LucideIcon;
+  matchHrefs?: string[];
+};
+
+const INICIO_TAB: MobileTab = {
+  name: "index",
+  title: "Inicio",
+  href: "/",
+  icon: LayoutDashboard,
+};
+
+const MOVIMIENTOS_TAB: MobileTab = {
+  name: "transactions",
+  title: "Movim.",
+  href: "/transactions",
+  icon: ArrowLeftRight,
+};
+
+const PLAN_TAB: MobileTab = {
+  name: "plan",
+  title: "Plan",
+  href: "/plan",
+  icon: PiggyBank,
+};
+
+const DEUDAS_TAB: MobileTab = {
+  name: "deudas",
+  title: "Deudas",
+  href: "/deudas",
+  matchHrefs: ["/deudas/planificador"],
+  icon: Landmark,
+};
+
+const MAS_TAB: MobileTab = {
+  name: "menu",
+  title: "Más",
+  href: "/menu",
+  icon: LayoutGrid,
+};
+
+/**
+ * Returns the four navigable tabs in display order. The third slot swaps
+ * between Plan and Deudas based on the user's `nav_focus` preference; the
+ * fifth slot ("Más") is always present. The FAB is rendered between slot 2
+ * and slot 3 by `MobileTabBar` itself — it is not part of this list.
+ */
+export function getMobileTabs(focus: NavFocus = "PLAN"): MobileTab[] {
+  const thirdTab = focus === "DEBT" ? DEUDAS_TAB : PLAN_TAB;
+  return [INICIO_TAB, MOVIMIENTOS_TAB, thirdTab, MAS_TAB];
+}
+
+export function isMobileTabActive(pathname: string, tab: MobileTab): boolean {
+  const hrefs = [tab.href, ...(tab.matchHrefs ?? [])];
+  return hrefs.some((h) => pathname === h || pathname.startsWith(`${h}/`));
+}
+
+/**
+ * Pathnames that render in "focus mode" — the bottom tab bar is hidden so the
+ * user can complete the task without parallel navigation. Keep in sync with
+ * the webapp list in `webapp/src/lib/constants/mobile-nav.ts`.
+ */
+const FOCUS_MODE_PATHS: ReadonlyArray<string> = [
+  "/transactions/new",
+  "/recurrentes/new",
+  "/deudas/planificador",
+] as const;
+
+const FOCUS_MODE_PATH_REGEXES: ReadonlyArray<RegExp> = [
+  /^\/recurrentes\/[^/]+\/edit$/,
+] as const;
+
+export function isFocusModePath(pathname: string): boolean {
+  if (FOCUS_MODE_PATHS.includes(pathname)) return true;
+  return FOCUS_MODE_PATH_REGEXES.some((re) => re.test(pathname));
+}

--- a/mobile/lib/dashboard/widgets.ts
+++ b/mobile/lib/dashboard/widgets.ts
@@ -34,9 +34,9 @@ export type CatalogEntry = {
 export const WIDGET_CATALOG: CatalogEntry[] = [
   { type: "recent", label: "Movimientos recientes", description: "Tus últimas transacciones", defaultSize: "S", available: true },
   { type: "puedo_comprarlo", label: "¿Puedo comprarlo?", description: "Evalúa una compra contra el plan", defaultSize: "S", available: true },
-  { type: "next_bill", label: "Próximo pago", description: "La siguiente obligación a pagar", defaultSize: "S", available: false },
-  { type: "next_income", label: "Próximo ingreso", description: "Tu siguiente entrada de dinero", defaultSize: "S", available: false },
-  { type: "accounts", label: "Cuentas", description: "Tus cuentas principales", defaultSize: "S", available: false },
+  { type: "next_bill", label: "Próximo pago", description: "La siguiente obligación a pagar", defaultSize: "S", available: true },
+  { type: "next_income", label: "Próximo ingreso", description: "Tu siguiente entrada de dinero", defaultSize: "S", available: true },
+  { type: "accounts", label: "Cuentas", description: "Tus cuentas principales", defaultSize: "S", available: true },
   { type: "goal", label: "Meta de ahorro", description: "Progreso de tu objetivo", defaultSize: "S", available: false },
   { type: "spending_by_category", label: "Gasto por categoría", description: "Top categorías del mes", defaultSize: "M", available: false },
   { type: "cashflow_calendar", label: "Calendario de flujo", description: "Ingresos y pagos por día", defaultSize: "L", available: false },

--- a/mobile/lib/db/schema.ts
+++ b/mobile/lib/db/schema.ts
@@ -422,6 +422,19 @@ export const DB_MIGRATIONS: DbMigration[] = [
       `CREATE INDEX IF NOT EXISTS idx_planning_assignments_expense ON planning_assignments(expense_entry_id)`,
     ],
   },
+  {
+    version: 12,
+    statements: [
+      // Close column drift surfaced by mobile-sync-doctor on the PaymentSheet
+      // parity PR. PaymentSheet now stamps `recurrence_group_id` on linked
+      // and system-created transactions (mirroring webapp); without the
+      // mirror, getTableColumns() in pull.ts silently drops it every cycle.
+      // (Note: `clean_description` is a separate pre-existing drift — the
+      //  local column is named `description`, pulls drop the Supabase
+      //  `clean_description` field. Out of scope for this PR.)
+      `ALTER TABLE transactions ADD COLUMN recurrence_group_id TEXT`,
+    ],
+  },
 ];
 
 export const LATEST_DB_VERSION =

--- a/mobile/lib/hooks/useTabBarClearance.ts
+++ b/mobile/lib/hooks/useTabBarClearance.ts
@@ -1,0 +1,18 @@
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { MOBILE_TAB_BAR_CLEARANCE } from "../constants/styles";
+
+/**
+ * Returns the bottom padding (in px) every page-level scroll container should
+ * apply so its content clears the floating tab bar + FAB overshoot + the
+ * device safe-area inset. Use as `paddingBottom` on `contentContainerStyle`
+ * (ScrollView/FlatList) or as `style.paddingBottom` on a fixed-height root.
+ *
+ * Mirrors webapp's `MOBILE_TAB_BAR_CLEARANCE_CLASS`.
+ *
+ * Sheet/Drawer content does NOT use this — sheets float above the tab bar,
+ * so they only need `insets.bottom`.
+ */
+export function useTabBarClearance(): number {
+  const insets = useSafeAreaInsets();
+  return MOBILE_TAB_BAR_CLEARANCE + insets.bottom;
+}

--- a/mobile/lib/utils/recurring-group.ts
+++ b/mobile/lib/utils/recurring-group.ts
@@ -1,0 +1,29 @@
+import * as Crypto from "expo-crypto";
+
+// Mirrors webapp `computeRecurringGroupUuid` in
+// `webapp/src/actions/recurring-templates.ts`. Both sides MUST produce the
+// same UUID for the same (templateId, occurrenceDate) pair so that
+// recurrence_group_id matches between system-created and manually-linked
+// transactions.
+export async function computeRecurringGroupUuid(
+  templateId: string,
+  occurrenceDate: string,
+): Promise<string> {
+  const payload = `${templateId}|${occurrenceDate}`;
+  const hex = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    payload,
+  );
+
+  const bytes: number[] = [];
+  for (let i = 0; i < 32; i += 2) {
+    bytes.push(parseInt(hex.slice(i, i + 2), 16));
+  }
+
+  // Force RFC-compatible version/variant bits so Postgres UUID parsing accepts it.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const out = bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${out.slice(0, 8)}-${out.slice(8, 12)}-${out.slice(12, 16)}-${out.slice(16, 20)}-${out.slice(20, 32)}`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,3 +22,4 @@ export * from "./utils/salary-breakdown";
 export * from "./utils/extra-payment";
 export * from "./utils/cc-projection";
 export * from "./utils/dashboard-layout";
+export * from "./utils/account-balance";

--- a/packages/shared/src/utils/account-balance.ts
+++ b/packages/shared/src/utils/account-balance.ts
@@ -1,0 +1,51 @@
+import type { AccountType, TransactionDirection } from "../types/domain";
+
+const DEBT_ACCOUNT_TYPES = new Set<AccountType>(["CREDIT_CARD", "LOAN"]);
+
+export function isDebtAccountType(accountType: string): accountType is AccountType {
+  return DEBT_ACCOUNT_TYPES.has(accountType as AccountType);
+}
+
+export function applyAccountBalanceDelta(params: {
+  currentBalance: number;
+  accountType: string;
+  direction: TransactionDirection;
+  amount: number;
+}): number {
+  // Supabase returns numeric columns as strings — coerce to avoid string concat.
+  const balance = Number(params.currentBalance);
+  const amount = Number(params.amount);
+
+  if (isDebtAccountType(params.accountType)) {
+    if (params.direction === "INFLOW") return balance - amount;
+    return balance + amount;
+  }
+
+  if (params.direction === "INFLOW") return balance + amount;
+  return balance - amount;
+}
+
+export function reverseAccountBalanceDelta(params: {
+  currentBalance: number;
+  accountType: string;
+  direction: TransactionDirection;
+  amount: number;
+}): number {
+  return applyAccountBalanceDelta({
+    ...params,
+    direction: params.direction === "INFLOW" ? "OUTFLOW" : "INFLOW",
+  });
+}
+
+export function getDirectionForBalanceDelta(params: {
+  accountType: string;
+  delta: number;
+}): TransactionDirection | null {
+  if (params.delta === 0) return null;
+
+  if (isDebtAccountType(params.accountType)) {
+    return params.delta > 0 ? "OUTFLOW" : "INFLOW";
+  }
+
+  return params.delta > 0 ? "INFLOW" : "OUTFLOW";
+}

--- a/webapp/src/lib/utils/account-balance.ts
+++ b/webapp/src/lib/utils/account-balance.ts
@@ -1,51 +1,9 @@
-import type { AccountType, TransactionDirection } from "@/types/domain";
-
-const DEBT_ACCOUNT_TYPES = new Set<AccountType>(["CREDIT_CARD", "LOAN"]);
-
-export function isDebtAccountType(accountType: string): accountType is AccountType {
-  return DEBT_ACCOUNT_TYPES.has(accountType as AccountType);
-}
-
-export function applyAccountBalanceDelta(params: {
-  currentBalance: number;
-  accountType: string;
-  direction: TransactionDirection;
-  amount: number;
-}): number {
-  // Supabase returns numeric columns as strings — coerce to avoid string concatenation on +
-  const balance = Number(params.currentBalance);
-  const amount = Number(params.amount);
-
-  if (isDebtAccountType(params.accountType)) {
-    if (params.direction === "INFLOW") return balance - amount;
-    return balance + amount;
-  }
-
-  if (params.direction === "INFLOW") return balance + amount;
-  return balance - amount;
-}
-
-export function reverseAccountBalanceDelta(params: {
-  currentBalance: number;
-  accountType: string;
-  direction: TransactionDirection;
-  amount: number;
-}): number {
-  return applyAccountBalanceDelta({
-    ...params,
-    direction: params.direction === "INFLOW" ? "OUTFLOW" : "INFLOW",
-  });
-}
-
-export function getDirectionForBalanceDelta(params: {
-  accountType: string;
-  delta: number;
-}): TransactionDirection | null {
-  if (params.delta === 0) return null;
-
-  if (isDebtAccountType(params.accountType)) {
-    return params.delta > 0 ? "OUTFLOW" : "INFLOW";
-  }
-
-  return params.delta > 0 ? "INFLOW" : "OUTFLOW";
-}
+// Re-exports from @zeta/shared so webapp and mobile share one implementation.
+// Avoids the "two divergent isDebtAccountType predicates" drift the parity
+// agent flagged on PaymentSheet.
+export {
+  applyAccountBalanceDelta,
+  reverseAccountBalanceDelta,
+  getDirectionForBalanceDelta,
+  isDebtAccountType,
+} from "@zeta/shared";


### PR DESCRIPTION
## Summary

Foundations subset of the mobile RN ↔ webapp parity audit (`BACKLOG.md` §903+).

### Mobile parity (this session, 7 commits)

- **Phase 0a · engine drift fix** — `PayoffResultCard` now uses `@zeta/shared` `runScenario` (175 LOC of local sim removed). `purchase-decision.ts` already delegated correctly.
- **Phase 0b · tab bar parity** — `getMobileTabs(focus)`, `Más` tab, `useHideTabBar`, `FocusModeAccent`, `(tabs)/menu.tsx` relocation.
- **Phase 0c · clearance sweep** — 13 files, `paddingBottom: 100/120` magic numbers → `MOBILE_TAB_BAR_CLEARANCE` constant. `useTabBarClearance()` hook added for callers that also want safe-area inset.
- **Phase 0d · token codemod** — 38 files, 148 hardcoded color replacements (`bg-white`, `text-gray-*`, `text-sky-*`, `text-green-*`, etc.) mapped to design tokens.
- **Phase 1 · scaffolds** — `/transactions/new` (focus-mode), `/pendientes`, `/etiquetas` placeholder screens with `MobileHeader variant="sub"`.
- **Phase 2 · widgets enabled** — `next_bill`, `next_income`, `accounts` (already implemented as files, just unwired and `available: false`).

### Bundled with branch (pre-existing, not authored this session)

- `912ec76` · `fix(mobile): PaymentSheet parity with webapp (5 bugs)`
- `d445a24` · `fix(mobile): propagate Supabase errors in PaymentSheet (Gemini)`

These were on `fix/mobile-paymentsheet-parity` (the branch this work spawned from). They have no separate open PR — surfacing them here so they ship.

## What's deferred

Heavy phases 3–8 are documented in `HANDOVER.md` with per-phase scope and the suggested agent gates. Each is a focused next-session PR:

- Phase 2 remainder — chart-heavy widgets (HealthZone, Flujo, Heatmap, BurnRate, Runway, DashboardAlerts, Hero/StatusHeadline)
- Phase 3 — Planificador 4-step + scenario persistence + deseos enrich drawer/nudges/reflection
- Phase 4 — Account hero variants (flip/pulse/graph) + QuickActionsBar dialogs
- Phase 5 — Destinatarios CRUD, recurring template editor, bulk categorizar, etiquetas UI
- Phase 6 — Import wizard restoration (Confirmar step, multi-statement, password vault, email entry, screenshot mode)
- Phase 7 — Onboarding step-count alignment, magic-link auth, settings sub-routes, `nav_focus` SQLite column
- Phase 8 — Webapp `/suscripciones` port

## Test plan

- [ ] `pnpm --filter mobile exec tsc --noEmit` passes (verified mid-branch, re-run on PR)
- [ ] `pnpm --filter @zeta/shared test --run` — `scenario-engine.test.ts` green (other suites have pre-existing unrelated failures)
- [ ] On simulator: open `/menu` from the new `Más` tab, navigate back via tab bar
- [ ] On simulator: open `/transactions/new` → confirm tab bar hides + 2px brass strip appears at top
- [ ] On simulator: confirm `/pendientes` and `/etiquetas` reachable from menu and back-nav works
- [ ] On simulator: open `AddWidgetSheet` → confirm `Próximo pago`, `Próximo ingreso`, `Cuentas` are now selectable; add one and verify it renders
- [ ] On simulator: open `/deudas/planificador` → numbers should match webapp `runScenario` output for the same inputs (engine port regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)