### PR TITLE
fix(import): 1/1 cuota parsing + cross-source AUTO_MERGE for terse PDF descriptions

### DIFF
--- a/packages/shared/src/utils/reconciliation.ts
+++ b/packages/shared/src/utils/reconciliation.ts
@@ -68,7 +68,11 @@ function tokenSimilarity(a: string, b: string): number {
   for (const token of aTokens) {
     if (bTokens.has(token)) overlap++;
   }
-  return overlap / Math.max(aTokens.size, bTokens.size);
+  // Containment-based: if the shorter side is fully present in the longer
+  // side, similarity = 1. Cross-source pairs (e.g. terse PDF "AMAZON.COM"
+  // vs verbose email "Compraste COP180.865 en AMAZON.COM con tu T.Cred…")
+  // would otherwise be diluted by the longer side's noise tokens.
+  return overlap / Math.min(aTokens.size, bTokens.size);
 }
 
 export function scoreReconciliationCandidate(

--- a/services/pdf_parser/parsers/bancolombia_credit_card.py
+++ b/services/pdf_parser/parsers/bancolombia_credit_card.py
@@ -219,9 +219,15 @@ def _parse_transaction_line(
         if cuota_match:
             try:
                 cuota_amount = _parse_colombian_number(cuota_match.group(1))
-                # Use cuota as amount, full price as original_amount
-                amount = cuota_amount
-                original_amount = valor_movimiento
+                # 1/1 single-pay charges have no separate cuota column — the
+                # second `$` is saldo pendiente (typically 0). Fall back to
+                # valor_movimiento per the pdf-parser convention.
+                if cuota_amount == 0 and valor_movimiento != 0:
+                    amount = valor_movimiento
+                    original_amount = None
+                else:
+                    amount = cuota_amount
+                    original_amount = valor_movimiento
             except ValueError:
                 pass
 

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -125,7 +125,14 @@ function sanitizeEaRate(
 function parsePayload(formData: FormData) {
   const rawPayload = formData.get("payload") as string;
   try {
-    return importPayloadSchema.safeParse(JSON.parse(rawPayload));
+    const result = importPayloadSchema.safeParse(JSON.parse(rawPayload));
+    if (!result.success) {
+      console.error(
+        "[importTransactions] payload validation failed:",
+        JSON.stringify(result.error.issues, null, 2),
+      );
+    }
+    return result;
   } catch (error) {
     console.error("Error parsing import payload:", error);
     return null;
@@ -854,6 +861,7 @@ export async function importTransactions(
 
   const parsed = parsePayload(formData);
   if (!parsed || !parsed.success) {
+    const firstIssue = parsed && !parsed.success ? parsed.error.issues[0] : null;
     await trackProductEvent({
       event_name: "import_completed",
       flow: "import",
@@ -862,7 +870,12 @@ export async function importTransactions(
       success: false,
       error_code: "invalid_payload",
     });
-    return { success: false, error: "Datos inválidos" };
+    return {
+      success: false,
+      error: firstIssue
+        ? `No pudimos validar la importación: ${firstIssue.message}`
+        : "No pudimos validar la importación. Intenta de nuevo.",
+    };
   }
 
   const { transactions, statementMeta, reconciliationDecisions = [], captureMethod = "PDF_IMPORT" } = parsed.data;


### PR DESCRIPTION
## Summary
- **Bancolombia credit-card 1/1 cuota bug** — single-pay charges (Amazon, Netflix, RECAUDO ASIST IGS) had no separate cuota column; parser was reading saldo pendiente (`$ 0,00`) as cuota → `amount=0` → entire import blocked by Zod validation. Fix: when parsed cuota is 0 but `valor_movimiento` ≠ 0, fall back to full price per pdf-parser convention.
- **Cross-source dedup miss** — terse PDF descriptions ("AMAZON.COM", 2 tokens) got diluted against verbose email descriptions (17 tokens) by `overlap / max(setSize)`. Switched `tokenSimilarity` to containment-based `overlap / min(setSize)` so a fully-contained shorter side scores 1.0 → AUTO_MERGE instead of REVIEW.
- **Diagnostic logging** — `importTransactions` now logs Zod `issues` server-side and surfaces a friendlier Spanish error to the toast (was silent `"Datos inválidos"`).

## Why it's safe
- Idempotency key uses `original_amount ?? amount` → old buggy runs hashed on `original_amount=fullPrice`, new runs hash on `amount=fullPrice` → same key. Re-imports won't duplicate.
- Buggy runs never persisted anyway (Zod blocked them upstream).
- AUTO_MERGE still requires amount within 5%, date within 3 days, and the 0.08 score-gap tiebreaker still protects multi-candidate ambiguity. `min` only loosens true matches.
- Stopwords (`compra/pago/debito/credito/transferencia/…`) stripped pre-tokenization, so "PAGO" → empty → 0 similarity. No spurious single-token matches.

## Reviewers consulted
- `import-flow-doctor` — verified other CC parsers (bogota, falabella, popular, confiar, nu) — none have the same footgun (popular already has `if monthly_pay > 0` guard).
- `server-action-reviewer` — softened toast wording to drop developer-flavored field paths from production error.

## Test plan
- [ ] Restart PDF parser; re-upload the failing Bancolombia statement (3 charges with 1/1 cuota) — should reach step 4 with `amount=fullPrice` for AMAZON.COM, NETFLIX, RECAUDO ASIST IGS.
- [ ] Confirm reconciliation step shows AMAZON.COM under **Duplicados** (auto-merged), not **Ambiguos**.
- [ ] Force a Zod failure (e.g. a manually crafted bad payload) — toast shows the Spanish validation message, server log shows full issues array.
- [ ] Multi-cuota installment (e.g. 3/24) still parses cuota separately and keeps `original_amount` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)