### PR TITLE
fix(warnings): drop stray 'menu' route + gate dashboard zones by viewport

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -289,10 +289,6 @@ function RootLayoutNav() {
               options={{ presentation: "card", headerShown: false }}
             />
             <Stack.Screen
-              name="menu"
-              options={{ presentation: "card", headerShown: false }}
-            />
-            <Stack.Screen
               name="categorizar"
               options={{ presentation: "card", headerShown: false }}
             />

--- a/webapp/src/app/(dashboard)/dashboard/page.tsx
+++ b/webapp/src/app/(dashboard)/dashboard/page.tsx
@@ -53,6 +53,7 @@ import { HeroZone } from "@/components/dashboard/zones/hero-zone";
 import { WidgetsZone } from "@/components/dashboard/zones/widgets-zone";
 import { HealthZone } from "@/components/dashboard/zones/health-zone";
 import { MobileZone } from "@/components/dashboard/zones/mobile-zone";
+import { ViewportGate } from "@/components/ui/viewport-gate";
 import type { HealthMetersData } from "@/actions/health-meters";
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -237,15 +238,17 @@ export default async function DashboardPage({
 
   return (
     <>
-      {/* Mobile dashboard — CSS handles visibility, both zones always render */}
-      <div className="lg:hidden">
+      {/* Mobile dashboard — gated so recharts in the desktop branch never
+          mounts inside a display:none container (suppresses spurious
+          ResponsiveContainer width=0 warnings). */}
+      <ViewportGate query="(max-width: 1023px)">
         <Suspense fallback={<MobileZoneSkeleton />}>
           <MobileZone month={month} currency={currency as CurrencyCode} recentTx={recentTx} />
         </Suspense>
-      </div>
+      </ViewportGate>
 
       {/* Desktop dashboard — section-based layout */}
-      <div className="hidden lg:block">
+      <ViewportGate query="(min-width: 1024px)">
         <DashboardConfigProvider
           serverConfig={dashboardConfigData.config}
           appPurpose={dashboardConfigData.appPurpose}
@@ -371,7 +374,7 @@ export default async function DashboardPage({
             </DashboardSection>
           </div>
         </DashboardConfigProvider>
-      </div>
+      </ViewportGate>
     </>
   );
 }

--- a/webapp/src/app/(dashboard)/dashboard/page.tsx
+++ b/webapp/src/app/(dashboard)/dashboard/page.tsx
@@ -241,14 +241,14 @@ export default async function DashboardPage({
       {/* Mobile dashboard — gated so recharts in the desktop branch never
           mounts inside a display:none container (suppresses spurious
           ResponsiveContainer width=0 warnings). */}
-      <ViewportGate query="(max-width: 1023px)">
+      <ViewportGate query="(max-width: 1023px)" className="lg:hidden">
         <Suspense fallback={<MobileZoneSkeleton />}>
           <MobileZone month={month} currency={currency as CurrencyCode} recentTx={recentTx} />
         </Suspense>
       </ViewportGate>
 
       {/* Desktop dashboard — section-based layout */}
-      <ViewportGate query="(min-width: 1024px)">
+      <ViewportGate query="(min-width: 1024px)" className="hidden lg:block">
         <DashboardConfigProvider
           serverConfig={dashboardConfigData.config}
           appPurpose={dashboardConfigData.appPurpose}

--- a/webapp/src/components/ui/viewport-gate.tsx
+++ b/webapp/src/components/ui/viewport-gate.tsx
@@ -9,13 +9,20 @@ import { useEffect, useState } from "react";
  * doesn't match. Used to keep recharts/heavy trees out of the off-viewport
  * branch instead of relying on `display:none` (which triggers spurious
  * "width(0) height(0)" warnings from ResponsiveContainer).
+ *
+ * Pass a `className` (e.g. `"lg:hidden"` or `"hidden lg:block"`) so the
+ * off-viewport branch is hidden via CSS during the initial paint and
+ * hydration window — avoids a flash where both branches are visible
+ * before the post-hydration effect runs.
  */
 export function ViewportGate({
   query,
   children,
+  className,
 }: {
   query: string;
   children: React.ReactNode;
+  className?: string;
 }) {
   const [show, setShow] = useState(true);
 
@@ -27,5 +34,7 @@ export function ViewportGate({
     return () => mql.removeEventListener("change", handler);
   }, [query]);
 
-  return show ? <>{children}</> : null;
+  if (!show) return null;
+  if (className) return <div className={className}>{children}</div>;
+  return <>{children}</>;
 }

--- a/webapp/src/components/ui/viewport-gate.tsx
+++ b/webapp/src/components/ui/viewport-gate.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Renders children only when the media query matches. SSR + first client
+ * render always pass through (so server output and hydration match), then
+ * after mount the gate evaluates the real viewport and unmounts when it
+ * doesn't match. Used to keep recharts/heavy trees out of the off-viewport
+ * branch instead of relying on `display:none` (which triggers spurious
+ * "width(0) height(0)" warnings from ResponsiveContainer).
+ */
+export function ViewportGate({
+  query,
+  children,
+}: {
+  query: string;
+  children: React.ReactNode;
+}) {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setShow(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setShow(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return show ? <>{children}</> : null;
+}


### PR DESCRIPTION
## Summary
- **Mobile**: removed `<Stack.Screen name="menu" />` from root \`mobile/app/_layout.tsx\`. The tabs layout already owns it (`mobile/app/(tabs)/menu.tsx`); the duplicate root entry made expo-router warn on every navigation.
- **Webapp**: dashboard page used \`lg:hidden\` / \`hidden lg:block\` to toggle mobile vs desktop, so both trees mounted at every viewport. Charts inside the off-viewport branch sat in \`display:none\` containers and recharts logged \"width(0) height(0)\" on every render. New \`<ViewportGate query=\"...\">\` client wrapper unmounts the off-viewport branch after hydration so recharts only mounts inside a measurable container.

## Verified
- Zero recharts warnings at 700px viewport on the dashboard (was 8+ per render).
- Mobile dev server no longer logs `No route named "menu" exists`.
- `pnpm build` clean.

## Out of scope (still noisy)
- `SafeAreaView has been deprecated` — emitted by a transitive lib (likely `react-native-css-interop` or `expo-router/native-tabs`); no app code imports `SafeAreaView` from `react-native`. Will go away with future Expo / css-interop upgrades.
- 4 transient recharts warnings remain on the desktop dashboard (1280px) during initial mount before ResizeObserver settles. These existed before this PR and are inherent to recharts' first-paint behavior — eliminating them requires a per-chart \"wait until measured\" wrapper, which is a bigger refactor.

## Test plan
- [ ] Open dashboard at mobile viewport (<1024px) — Console clean, no recharts warnings.
- [ ] Resize between mobile and desktop — content swaps, no transient render glitches.
- [ ] Mobile app: navigate to / from \"Más\" tab — no \"No route named menu\" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)