### PR TITLE
feat(mobile): Phase 4 account heroes — flip/pulse/graph + QuickActionsBar shell

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -876,6 +876,15 @@ Expo app sigue con estructura 4-tab. Ports pendientes del IA refactor:
 - `/mas` o equivalente nativo (drawer? page?)
 - Onboarding nativo trim + skip path
 
+### Mobile SQLite — perf nits (P2)
+- **Partial index for visible-tx filter** — surfaced by `mobile-sync-doctor` during Phase 4 Stage A review. The composite `idx_transactions_reconciled_visible(reconciled_into_transaction_id, transaction_date)` with `IS NULL` on the leading column causes a full index scan on dense histories. Fix in a future migration:
+  ```sql
+  CREATE INDEX IF NOT EXISTS idx_transactions_not_reconciled
+    ON transactions(account_id, transaction_date)
+    WHERE reconciled_into_transaction_id IS NULL;
+  ```
+  Touches every visible-tx query (account detail, lists). Bundle with the next mobile schema migration; not a correctness bug.
+
 ### Triage candidates for next session — Phase 4+ continuation
 
 Phase 3 (planificador 4-step + Deseos/Puedo-pagar parity) shipped via PRs #248 and #249. Next slices:

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -876,6 +876,11 @@ Expo app sigue con estructura 4-tab. Ports pendientes del IA refactor:
 - `/mas` o equivalente nativo (drawer? page?)
 - Onboarding nativo trim + skip path
 
+### Balance history chart: SOD vs EOD (cross-platform, P2)
+- Surfaced by Gemini review on PR #252 (`mobile/lib/repositories/accounts-detail.ts:62`). The current `dailyMap.set(p.date, p.balance)` after the descending walk + `reverse()` stores the **last** balance written per date, which for non-today dates ends up being a pre-tx (start-of-day) value rather than the end-of-day balance financial charts conventionally show.
+- **Webapp has the same algorithm** (`webapp/src/actions/accounts.ts:751-755`) — mobile intentionally mirrors. Mobile must NOT diverge unilaterally per the webapp-source-of-truth rule (would silently desync the two platforms' chart shapes).
+- Fix has to land in webapp first, then mobile mirrors. Sketch: emit one synthetic EOD point per day equal to `running` value at the day-N → day-N+1 transition (i.e. SOD day N+1 = EOD day N), and `current_balance` for today. Test against an account with multi-tx days.
+
 ### Mobile SQLite — perf nits (P2)
 - **Partial index for visible-tx filter** — surfaced by `mobile-sync-doctor` during Phase 4 Stage A review. The composite `idx_transactions_reconciled_visible(reconciled_into_transaction_id, transaction_date)` with `IS NULL` on the leading column causes a full index scan on dense histories. Fix in a future migration:
   ```sql

--- a/mobile/app/account/[id].tsx
+++ b/mobile/app/account/[id].tsx
@@ -103,10 +103,6 @@ export default function AccountDetailScreen() {
         setAccount(acc);
         setRecentTx(txs as TransactionRow[]);
         setSpendingSummary(summary);
-        // Release the full-screen spinner once shell data lands so the user
-        // sees the hero shell + QuickActionsBar + recent-tx immediately. The
-        // chart/pulse data continues to stream in behind heroLoading.
-        setLoading(false);
 
         if (acc) {
           const [history, pulse] = await Promise.all([
@@ -127,6 +123,7 @@ export default function AccountDetailScreen() {
         }
       } catch (error) {
         console.error("Failed to load account:", error);
+      } finally {
         if (!cancelled) setLoading(false);
       }
     })();

--- a/mobile/app/account/[id].tsx
+++ b/mobile/app/account/[id].tsx
@@ -8,7 +8,9 @@ import {
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { X, Pencil, Trash2 } from "lucide-react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { X } from "lucide-react-native";
+import { COLORS } from "../../lib/constants/colors";
 import {
   getAccountById,
   deleteAccount,
@@ -16,10 +18,20 @@ import {
 } from "../../lib/repositories/accounts";
 import { getTransactions } from "../../lib/repositories/transactions";
 import { getDatabase } from "../../lib/db/database";
-import { ACCOUNT_TYPES } from "../../lib/constants/accounts";
+import {
+  getBalanceHistory,
+  getSpendingPulse,
+  type SnapshotPoint,
+  type DailyPoint,
+} from "../../lib/repositories/accounts-detail";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { isDebtInflow } from "../../lib/transaction-semantics";
-import { AccountBalanceCard } from "../../components/accounts/AccountBalanceCard";
+import { AccountHero } from "../../components/accounts/AccountHero";
+import { QuickActionsBar } from "../../components/accounts/QuickActionsBar";
+import {
+  MOBILE_TAB_BAR_CLEARANCE,
+  SECTION_EYEBROW_CLASS,
+} from "../../lib/constants/styles";
 
 type TransactionRow = {
   id: string;
@@ -52,6 +64,7 @@ function DetailRow({ label, value }: { label: string; value: string }) {
 export default function AccountDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const [account, setAccount] = useState<AccountRow | null>(null);
   const [recentTx, setRecentTx] = useState<TransactionRow[]>([]);
   const [spendingSummary, setSpendingSummary] = useState<{
@@ -59,10 +72,15 @@ export default function AccountDetailScreen() {
     total_in: number;
     tx_count: number;
   } | null>(null);
+  const [snapshotData, setSnapshotData] = useState<SnapshotPoint[]>([]);
+  const [trendPercent, setTrendPercent] = useState<number | undefined>(undefined);
+  const [monthlySpent, setMonthlySpent] = useState(0);
+  const [dailyActivity, setDailyActivity] = useState<DailyPoint[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!id) return;
+    let cancelled = false;
     (async () => {
       try {
         const now = new Date();
@@ -81,22 +99,47 @@ export default function AccountDetailScreen() {
             [id, `${month}%`]
           ),
         ]);
+        if (cancelled) return;
         setAccount(acc);
         setRecentTx(txs as TransactionRow[]);
         setSpendingSummary(summary);
+        // Release the full-screen spinner once shell data lands so the user
+        // sees the hero shell + QuickActionsBar + recent-tx immediately. The
+        // chart/pulse data continues to stream in behind heroLoading.
+        setLoading(false);
+
+        if (acc) {
+          const [history, pulse] = await Promise.all([
+            getBalanceHistory(id, acc.current_balance ?? 0),
+            getSpendingPulse(id),
+          ]);
+          if (cancelled) return;
+          setSnapshotData(history);
+          if (history.length >= 2) {
+            const first = history[0].balance;
+            const last = history[history.length - 1].balance;
+            if (first !== 0) {
+              setTrendPercent(((last - first) / Math.abs(first)) * 100);
+            }
+          }
+          setMonthlySpent(pulse.monthlySpent);
+          setDailyActivity(pulse.dailyActivity);
+        }
       } catch (error) {
         console.error("Failed to load account:", error);
-      } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   const handleDelete = () => {
     if (!id) return;
     Alert.alert(
       "Eliminar cuenta",
-      "Esta accion no se puede deshacer. Se eliminaran tambien todas las transacciones de esta cuenta.",
+      "Esta acción no se puede deshacer. Se eliminarán también todas las transacciones de esta cuenta.",
       [
         { text: "Cancelar", style: "cancel" },
         {
@@ -118,21 +161,24 @@ export default function AccountDetailScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-z-surface-2">
-        <ActivityIndicator size="large" color="#10B981" />
+      <View
+        className="flex-1 items-center justify-center bg-z-surface-2"
+        style={{ paddingTop: insets.top }}
+      >
+        <ActivityIndicator size="large" color={COLORS.brass} />
       </View>
     );
   }
 
   if (!account) {
     return (
-      <View className="flex-1 bg-z-surface-2">
+      <View className="flex-1 bg-z-surface-2" style={{ paddingTop: insets.top }}>
         <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
           <Pressable
             onPress={() => router.back()}
             className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
           >
-            <X size={18} color="#6B7280" />
+            <X size={18} color={COLORS.sageDark} />
           </Pressable>
           <Text className="text-foreground font-inter-bold text-base">Cuenta</Text>
           <View className="w-8" />
@@ -146,71 +192,50 @@ export default function AccountDetailScreen() {
     );
   }
 
-  const typeDef = ACCOUNT_TYPES.find((t) => t.value === account.account_type);
-  const Icon = typeDef?.icon;
-  const color = account.color ?? "#6B7280";
   const currency = (account.currency_code as CurrencyCode) ?? "COP";
 
   return (
-    <View className="flex-1 bg-z-surface-2">
+    <View className="flex-1 bg-z-surface-2" style={{ paddingTop: insets.top }}>
       {/* Header */}
       <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
         <Pressable
           onPress={() => router.back()}
           className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
         >
-          <X size={18} color="#6B7280" />
+          <X size={18} color={COLORS.sageDark} />
         </Pressable>
         <Text className="text-foreground font-inter-bold text-base">Detalle</Text>
-        <View className="flex-row gap-2">
-          <Pressable
-            onPress={() => router.push(`/account/edit/${id}`)}
-            className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
-          >
-            <Pencil size={16} color="#6B7280" />
-          </Pressable>
-          <Pressable
-            onPress={handleDelete}
-            className="w-8 h-8 items-center justify-center rounded-full bg-red-50 active:bg-red-100"
-          >
-            <Trash2 size={16} color="#EF4444" />
-          </Pressable>
-        </View>
+        <View className="w-8" />
       </View>
 
-      <ScrollView className="flex-1">
-        {/* Hero */}
-        <View className="items-center pt-6 pb-5 border-b border-white-6 mx-4">
-          <View
-            className="w-16 h-16 rounded-full items-center justify-center mb-3"
-            style={{ backgroundColor: color + "20" }}
-          >
-            {Icon && <Icon size={30} color={color} />}
-          </View>
-          <Text className="text-foreground font-inter-bold text-xl">
-            {account.name}
-          </Text>
-          {account.institution_name && (
-            <Text className="text-muted-foreground font-inter text-sm mt-1">
-              {account.institution_name}
-            </Text>
-          )}
-          <View className="bg-z-surface-2 rounded-full px-3 py-1 mt-2">
-            <Text className="text-muted-foreground font-inter-medium text-xs">
-              {typeDef?.label ?? account.account_type}
-            </Text>
-          </View>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
+      >
+        {/* Hero — variant by account type */}
+        <View className="mx-4 mt-4">
+          <AccountHero
+            account={account}
+            snapshotData={snapshotData}
+            trendPercent={trendPercent}
+            monthlySpent={monthlySpent}
+            dailyActivity={dailyActivity}
+          />
         </View>
 
-        {/* Balance card with utilization */}
+        {/* Quick actions */}
         <View className="mx-4 mt-4">
-          <AccountBalanceCard account={account} />
+          <QuickActionsBar
+            account={account}
+            onEdit={() => router.push(`/account/edit/${id}`)}
+            onDelete={handleDelete}
+          />
         </View>
 
         {/* Monthly spending summary */}
         {spendingSummary && spendingSummary.tx_count > 0 && (
           <View className="mx-4 mt-4">
-            <Text className="text-muted-foreground font-inter-semibold text-xs uppercase mb-2">
+            <Text className={`${SECTION_EYEBROW_CLASS} mb-2`}>
               Resumen del mes
             </Text>
             <View className="flex-row gap-3">
@@ -241,7 +266,7 @@ export default function AccountDetailScreen() {
         {(account.account_type === "CREDIT_CARD" ||
           account.account_type === "LOAN") && (
           <View className="mx-4 mt-4">
-            <Text className="text-muted-foreground font-inter-semibold text-xs uppercase mb-2">
+            <Text className={`${SECTION_EYEBROW_CLASS} mb-2`}>
               Detalles
             </Text>
             <View className="bg-z-surface-2 rounded-xl px-4 border border-white-6">
@@ -274,8 +299,8 @@ export default function AccountDetailScreen() {
         )}
 
         {/* Recent transactions */}
-        <View className="mx-4 mt-4 mb-8">
-          <Text className="text-muted-foreground font-inter-semibold text-xs uppercase mb-2">
+        <View className="mx-4 mt-4">
+          <Text className={`${SECTION_EYEBROW_CLASS} mb-2`}>
             Ultimas transacciones
           </Text>
           {recentTx.length === 0 ? (
@@ -299,7 +324,7 @@ export default function AccountDetailScreen() {
                     onPress={() => router.push(`/transaction/${tx.id}`)}
                   >
                     {index > 0 && (
-                      <View className="absolute top-0 left-4 right-4 h-px bg-z-surface-2" />
+                      <View className="absolute top-0 left-4 right-4 h-px bg-white-6" />
                     )}
                     <View className="flex-1 min-w-0">
                       <Text

--- a/mobile/app/accounts-list.tsx
+++ b/mobile/app/accounts-list.tsx
@@ -29,9 +29,8 @@ const DEBT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
 
 function computeNetWorth(accounts: AccountRow[]) {
   return accounts.reduce((sum, acc) => {
-    return DEBT_TYPES.has(acc.account_type)
-      ? sum - acc.current_balance
-      : sum + acc.current_balance;
+    const balance = acc.current_balance ?? 0;
+    return DEBT_TYPES.has(acc.account_type) ? sum - balance : sum + balance;
   }, 0);
 }
 

--- a/mobile/app/accounts-list.tsx
+++ b/mobile/app/accounts-list.tsx
@@ -1,13 +1,155 @@
-import { View } from "react-native";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  ActivityIndicator,
+} from "react-native";
+import { useRouter, useFocusEffect } from "expo-router";
+import { useCallback, useMemo, useState } from "react";
+import { Plus } from "lucide-react-native";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import {
+  getAllAccounts,
+  type AccountRow,
+} from "../lib/repositories/accounts";
+import { AccountCard } from "../components/accounts/AccountCard";
 import { MobileHeader } from "../components/ui/MobileHeader";
+import { useSync } from "../lib/sync/hooks";
+import { COLORS } from "../lib/constants/colors";
+import {
+  BRASS_BUTTON_CLASS,
+  MOBILE_TAB_BAR_CLEARANCE,
+  PANEL_SURFACE_SUBTLE_CLASS,
+  SECTION_EYEBROW_CLASS,
+} from "../lib/constants/styles";
 
-// The accounts list content will be extracted from (tabs)/accounts.tsx
-// and reskinned in Phase 7. For now, this is the stack screen shell.
+const DEBT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
+
+function computeNetWorth(accounts: AccountRow[]) {
+  return accounts.reduce((sum, acc) => {
+    return DEBT_TYPES.has(acc.account_type)
+      ? sum - acc.current_balance
+      : sum + acc.current_balance;
+  }, 0);
+}
 
 export default function AccountsListScreen() {
+  const router = useRouter();
+  const { sync } = useSync();
+  const [accounts, setAccounts] = useState<AccountRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      const result = await getAllAccounts();
+      setAccounts(result);
+    } catch (error) {
+      console.error("Failed to load accounts:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadAccounts();
+    }, [loadAccounts])
+  );
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await sync();
+      await loadAccounts();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [sync, loadAccounts]);
+
+  const netWorth = useMemo(() => computeNetWorth(accounts), [accounts]);
+  const isNegative = netWorth < 0;
+
+  const listHeader = useMemo(
+    () => (
+      <View className="pt-4 pb-2 gap-4">
+        <View className={`${PANEL_SURFACE_SUBTLE_CLASS} p-5`}>
+          <Text className={SECTION_EYEBROW_CLASS}>Patrimonio neto</Text>
+          <Text
+            className={`font-inter-bold text-3xl mt-2 ${
+              isNegative ? "text-z-debt" : "text-foreground"
+            }`}
+          >
+            {formatCurrency(Math.abs(netWorth), "COP" as CurrencyCode)}
+          </Text>
+        </View>
+
+        <Pressable
+          className={`${BRASS_BUTTON_CLASS} rounded-xl py-3.5 items-center flex-row justify-center gap-2 active:bg-z-brass-80`}
+          onPress={() => router.push("/account/create")}
+          accessibilityRole="button"
+          accessibilityLabel="Nueva cuenta"
+        >
+          <Plus size={18} color={COLORS.ink} />
+          <Text className="text-z-ink font-inter-bold text-sm">
+            Nueva cuenta
+          </Text>
+        </Pressable>
+
+        {accounts.length > 0 && (
+          <Text className={`${SECTION_EYEBROW_CLASS} px-1`}>Mis cuentas</Text>
+        )}
+      </View>
+    ),
+    [netWorth, isNegative, accounts.length, router],
+  );
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-background">
+        <MobileHeader variant="sub" title="Mis cuentas" />
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color={COLORS.brass} />
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View className="flex-1 bg-background">
       <MobileHeader variant="sub" title="Mis cuentas" />
+      <FlatList
+        data={accounts}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{
+          paddingHorizontal: 16,
+          paddingBottom: MOBILE_TAB_BAR_CLEARANCE,
+        }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={COLORS.brass}
+          />
+        }
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={
+          <View className="flex-1 items-center justify-center px-4 pt-8">
+            <Text className="text-muted-foreground font-inter text-base text-center">
+              No tienes cuentas registradas.{"\n"}Crea una para empezar.
+            </Text>
+          </View>
+        }
+        ItemSeparatorComponent={() => <View className="h-2" />}
+        renderItem={({ item }) => (
+          <AccountCard
+            account={item}
+            onPress={() => router.push(`/account/${item.id}`)}
+          />
+        )}
+      />
     </View>
   );
 }

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -6,6 +6,7 @@ import {
   Alert,
   Switch,
 } from "react-native";
+import { MobileHeader } from "../components/ui/MobileHeader";
 import { MobileSheet } from "../components/ui/MobileSheet";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFocusEffect, useRouter } from "expo-router";
@@ -67,7 +68,7 @@ function SectionHeading({ label }: { label: string }) {
   return (
     <View className="flex-row items-center gap-3 mb-2 px-1">
       <Text className={SECTION_EYEBROW_CLASS}>{label}</Text>
-      <View className="h-px flex-1 bg-z-surface-2-6" />
+      <View className="h-px flex-1 bg-white-6" />
     </View>
   );
 }
@@ -648,13 +649,14 @@ export default function SettingsScreen() {
   const insets = useSafeAreaInsets();
 
   return (
-    <ScrollView
-      className={`flex-1 ${inkCls}`}
-      contentContainerStyle={{
-        paddingTop: insets.top,
-        paddingBottom: insets.bottom + 24,
-      }}
-    >
+    <View className={`flex-1 ${inkCls}`}>
+      <MobileHeader variant="sub" title="Ajustes" />
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{
+          paddingBottom: insets.bottom + 24,
+        }}
+      >
       <IdentityHero
         name={name}
         email={email}
@@ -849,6 +851,7 @@ export default function SettingsScreen() {
         selectedId={defaultAccountId}
         onSelect={handleSelectDefaultAccount}
       />
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }

--- a/mobile/components/accounts/AccountCard.tsx
+++ b/mobile/components/accounts/AccountCard.tsx
@@ -39,14 +39,14 @@ export function AccountCard({ account, onPress }: Props) {
           {account.name}
         </Text>
         <View className="flex-row items-center mt-0.5 gap-2">
-          {account.institution_name && (
+          {account.institution_name ? (
             <Text
               className="text-muted-foreground font-inter text-xs"
               numberOfLines={1}
             >
               {account.institution_name}
             </Text>
-          )}
+          ) : null}
           <View className="bg-black-10 rounded px-1.5 py-0.5">
             <Text className="text-muted-foreground font-inter text-xs">{shortLabel}</Text>
           </View>

--- a/mobile/components/accounts/AccountHero.tsx
+++ b/mobile/components/accounts/AccountHero.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from "react";
+import { View, Text } from "react-native";
+import { FlipZone } from "./FlipZone";
+import { SpendingPulseHero } from "./SpendingPulseHero";
+import { BalanceGraphHero } from "./BalanceGraphHero";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import type {
+  SnapshotPoint,
+  DailyPoint,
+} from "../../lib/repositories/accounts-detail";
+
+type Variant = "flip" | "pulse" | "graph";
+
+const DEBT_TYPES = new Set(["CREDIT_CARD", "LOAN"]);
+
+function getHeroVariant(account: AccountRow): Variant {
+  const t = account.account_type;
+  if (t === "CREDIT_CARD" || t === "SAVINGS") return "flip";
+  if (t === "CHECKING" && account.debit_card_mask) return "flip";
+  if (t === "LOAN" || t === "INVESTMENT") return "graph";
+  return "pulse";
+}
+
+type Props = {
+  account: AccountRow;
+  snapshotData: SnapshotPoint[];
+  trendPercent?: number;
+  monthlySpent?: number;
+  dailyActivity?: DailyPoint[];
+};
+
+export function AccountHero({
+  account,
+  snapshotData,
+  trendPercent,
+  monthlySpent,
+  dailyActivity,
+}: Props) {
+  const variant = getHeroVariant(account);
+  const isDebt = DEBT_TYPES.has(account.account_type);
+
+  // For debt accounts, present balance + history as positive magnitudes so
+  // the chart "decays" when payments reduce the debt. Memoize to keep stable
+  // references for downstream useMemo dep arrays (GraphFace SVG path math).
+  const displayAccount = useMemo<AccountRow>(
+    () =>
+      isDebt
+        ? { ...account, current_balance: Math.abs(account.current_balance ?? 0) }
+        : account,
+    [account, isDebt],
+  );
+  const displaySnapshotData = useMemo(
+    () =>
+      isDebt
+        ? snapshotData.map((p) => ({ ...p, balance: Math.abs(p.balance) }))
+        : snapshotData,
+    [snapshotData, isDebt],
+  );
+  const displayTrendPercent =
+    isDebt && trendPercent !== undefined ? -trendPercent : trendPercent;
+  const goodDirection: "up" | "down" = isDebt ? "down" : "up";
+
+  return (
+    <View className="rounded-2xl border border-white-6 bg-z-surface-2 p-5">
+      <View className="mb-4">
+        <Text
+          className="text-z-white font-inter-semibold text-lg"
+          numberOfLines={1}
+        >
+          {account.name}
+        </Text>
+        {account.institution_name ? (
+          <Text className="text-z-sage-dark font-inter text-xs mt-0.5">
+            {account.institution_name}
+          </Text>
+        ) : null}
+      </View>
+      {variant === "flip" && (
+        <FlipZone
+          account={displayAccount}
+          snapshotData={displaySnapshotData}
+          trendPercent={displayTrendPercent}
+          goodDirection={goodDirection}
+        />
+      )}
+      {variant === "pulse" && (
+        <SpendingPulseHero
+          account={displayAccount}
+          monthlySpent={monthlySpent ?? 0}
+          dailyActivity={dailyActivity ?? []}
+        />
+      )}
+      {variant === "graph" && (
+        <BalanceGraphHero
+          account={displayAccount}
+          snapshotData={displaySnapshotData}
+          trendPercent={displayTrendPercent}
+          goodDirection={goodDirection}
+        />
+      )}
+    </View>
+  );
+}

--- a/mobile/components/accounts/BalanceGraphHero.tsx
+++ b/mobile/components/accounts/BalanceGraphHero.tsx
@@ -1,0 +1,68 @@
+import { useMemo, useState } from "react";
+import { View, Text } from "react-native";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
+import { GraphFace, filterByRange } from "./GraphFace";
+import { RangePills, type RangeValue } from "./RangePills";
+import { TrendChip } from "../ui/TrendChip";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import type { SnapshotPoint } from "../../lib/repositories/accounts-detail";
+
+type Props = {
+  account: AccountRow;
+  snapshotData: SnapshotPoint[];
+  trendPercent?: number;
+  goodDirection?: "up" | "down";
+};
+
+export function BalanceGraphHero({
+  account,
+  snapshotData,
+  trendPercent,
+  goodDirection = "up",
+}: Props) {
+  const [range, setRange] = useState<RangeValue>(90);
+  const filtered = useMemo(
+    () => filterByRange(snapshotData, range),
+    [snapshotData, range],
+  );
+  const cc = (account.currency_code as CurrencyCode) ?? "COP";
+  const isDebt = account.account_type === "LOAN";
+  const strokeColor = isDebt ? COLORS.brass : COLORS.sageLight;
+
+  return (
+    <View className="gap-3">
+      <View className="flex-row items-start justify-between">
+        <View className="flex-row items-baseline gap-2 flex-1 min-w-0">
+          <Text
+            className="text-z-white font-inter-bold text-2xl tabular-nums"
+            numberOfLines={1}
+          >
+            {formatCurrency(account.current_balance ?? 0, cc)}
+          </Text>
+          <TrendChip percent={trendPercent} goodDirection={goodDirection} />
+        </View>
+        <View className="ml-2 max-w-[160px]">
+          <RangePills value={range} onChange={setRange} />
+        </View>
+      </View>
+      {filtered.length >= 2 ? (
+        <GraphFace
+          data={snapshotData}
+          filteredData={filtered}
+          currencyCode={cc}
+          range={range}
+          height={120}
+          strokeColor={strokeColor}
+          showHeader={false}
+        />
+      ) : (
+        <View className="h-[120px] items-center justify-center rounded-xl border border-white-6 bg-z-surface-2-55">
+          <Text className="text-z-sage-dark font-inter text-sm">
+            Sin datos suficientes
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/mobile/components/accounts/CardFace.tsx
+++ b/mobile/components/accounts/CardFace.tsx
@@ -1,0 +1,95 @@
+import { View, Text, StyleSheet } from "react-native";
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import type { AccountRow } from "../../lib/repositories/accounts";
+
+const INSTITUTION_GRADIENTS: Record<string, [string, string, string]> = {
+  bancolombia: ["#2d3a2a", "#3f4632", "#8b7a3a"],
+  nequi: ["#2a1040", "#45186e", "#c0408a"],
+  davivienda: ["#3a1010", "#6e1818", "#c42020"],
+  nu: ["#3a1a60", "#6b30a0", "#a060d0"],
+  "banco de bogota": ["#0a1a3a", "#183060", "#2850a0"],
+  falabella: ["#1a2a1a", "#2a4a2a", "#4a8a3a"],
+  lulo: ["#1a0a2a", "#3a1a5a", "#6a30a0"],
+};
+
+const FALLBACK_GRADIENT: [string, string, string] = ["#1a1a1a", "#252525", "#333333"];
+
+const TYPE_LABELS: Record<string, string> = {
+  CREDIT_CARD: "CRÉDITO",
+  SAVINGS: "AHORROS",
+  CHECKING: "DÉBITO",
+  CASH: "EFECTIVO",
+  INVESTMENT: "INVERSIÓN",
+  LOAN: "PRÉSTAMO",
+  OTHER: "CUENTA",
+};
+
+type Props = {
+  account: AccountRow;
+};
+
+export function CardFace({ account }: Props) {
+  const key = (account.institution_name ?? "").toLowerCase().trim();
+  const [c1, c2, c3] = INSTITUTION_GRADIENTS[key] ?? FALLBACK_GRADIENT;
+  const mask = account.debit_card_mask;
+  const typeLabel = TYPE_LABELS[account.account_type ?? ""] ?? "CUENTA";
+  const cc = (account.currency_code as CurrencyCode) ?? "COP";
+
+  return (
+    <View
+      style={{ aspectRatio: 85.6 / 53.98, width: "100%" }}
+      className="rounded-xl overflow-hidden"
+    >
+      <Svg style={StyleSheet.absoluteFill}>
+        <Defs>
+          <LinearGradient id="cardGrad" x1="0" y1="0" x2="1" y2="1">
+            <Stop offset="0" stopColor={c1} />
+            <Stop offset="0.5" stopColor={c2} />
+            <Stop offset="1" stopColor={c3} />
+          </LinearGradient>
+        </Defs>
+        <Rect x="0" y="0" width="100%" height="100%" fill="url(#cardGrad)" />
+      </Svg>
+      <View className="flex-1 p-4 justify-between">
+        <View className="flex-row items-start justify-between">
+          <Text
+            style={{ color: "rgba(255,255,255,0.7)" }}
+            className="font-inter-medium text-xs uppercase"
+            numberOfLines={1}
+          >
+            {account.institution_name ?? ""}
+          </Text>
+          <Text
+            style={{ color: "rgba(255,255,255,0.5)", letterSpacing: 1.5 }}
+            className="font-inter-semibold text-[10px] uppercase"
+          >
+            {typeLabel}
+          </Text>
+        </View>
+        <View className="flex-1 justify-center">
+          <Text
+            style={{ color: "#FFFFFF" }}
+            className="font-inter-bold text-xl tabular-nums"
+          >
+            {formatCurrency(account.current_balance ?? 0, cc)}
+          </Text>
+        </View>
+        <View className="flex-row items-end justify-between">
+          <Text
+            style={{ color: "rgba(255,255,255,0.6)", letterSpacing: 2 }}
+            className="font-inter-medium text-sm"
+          >
+            {mask ? `•••• ${mask}` : "••••"}
+          </Text>
+          <Text
+            style={{ color: "rgba(255,255,255,0.4)" }}
+            className="font-inter-medium text-xs"
+          >
+            {account.currency_code}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/mobile/components/accounts/FlipZone.tsx
+++ b/mobile/components/accounts/FlipZone.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from "react";
+import { View, Pressable, StyleSheet } from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  interpolate,
+  Extrapolation,
+} from "react-native-reanimated";
+import { CardFace } from "./CardFace";
+import { GraphFace } from "./GraphFace";
+import { RangePills, type RangeValue } from "./RangePills";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import type { SnapshotPoint } from "../../lib/repositories/accounts-detail";
+
+type Props = {
+  account: AccountRow;
+  snapshotData: SnapshotPoint[];
+  trendPercent?: number;
+  goodDirection?: "up" | "down";
+};
+
+export function FlipZone({
+  account,
+  snapshotData,
+  trendPercent,
+  goodDirection = "up",
+}: Props) {
+  const [flipped, setFlipped] = useState(false);
+  const [range, setRange] = useState<RangeValue>(90);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withTiming(flipped ? 1 : 0, { duration: 400 });
+  }, [flipped, progress]);
+
+  const handleFlip = useCallback(() => setFlipped((f) => !f), []);
+
+  const frontStyle = useAnimatedStyle(() => {
+    const rotate = interpolate(progress.value, [0, 1], [0, 180]);
+    const opacity = interpolate(
+      progress.value,
+      [0, 0.5, 0.5001],
+      [1, 1, 0],
+      Extrapolation.CLAMP,
+    );
+    return {
+      transform: [{ perspective: 1000 }, { rotateY: `${rotate}deg` }],
+      opacity,
+    };
+  });
+
+  const backStyle = useAnimatedStyle(() => {
+    const rotate = interpolate(progress.value, [0, 1], [180, 360]);
+    const opacity = interpolate(
+      progress.value,
+      [0, 0.4999, 0.5, 1],
+      [0, 0, 1, 1],
+      Extrapolation.CLAMP,
+    );
+    return {
+      transform: [{ perspective: 1000 }, { rotateY: `${rotate}deg` }],
+      opacity,
+    };
+  });
+
+  return (
+    <View className="gap-3">
+      <Pressable onPress={handleFlip}>
+        <View style={{ aspectRatio: 85.6 / 53.98, width: "100%" }}>
+          <Animated.View style={[StyleSheet.absoluteFill, frontStyle]}>
+            <CardFace account={account} />
+          </Animated.View>
+          <Animated.View style={[StyleSheet.absoluteFill, backStyle]}>
+            <GraphFace
+              data={snapshotData}
+              currencyCode={account.currency_code ?? "COP"}
+              range={range}
+              trendPercent={trendPercent}
+              goodDirection={goodDirection}
+              fillCard
+            />
+          </Animated.View>
+        </View>
+      </Pressable>
+      <View className="items-center gap-2">
+        <View className="flex-row gap-1.5">
+          <View
+            className={`w-1.5 h-1.5 rounded-full ${
+              !flipped ? "bg-z-brass" : "bg-white-15"
+            }`}
+          />
+          <View
+            className={`w-1.5 h-1.5 rounded-full ${
+              flipped ? "bg-z-brass" : "bg-white-15"
+            }`}
+          />
+        </View>
+        {flipped && <RangePills value={range} onChange={setRange} />}
+      </View>
+    </View>
+  );
+}

--- a/mobile/components/accounts/GraphFace.tsx
+++ b/mobile/components/accounts/GraphFace.tsx
@@ -1,0 +1,153 @@
+import { useMemo } from "react";
+import { View, Text } from "react-native";
+import Svg, { Defs, LinearGradient, Path, Stop } from "react-native-svg";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
+import { TrendChip } from "../ui/TrendChip";
+import type { SnapshotPoint } from "../../lib/repositories/accounts-detail";
+import type { RangeValue } from "./RangePills";
+
+type Props = {
+  data: SnapshotPoint[];
+  currencyCode: string;
+  range: RangeValue;
+  trendPercent?: number;
+  height?: number;
+  strokeColor?: string;
+  showHeader?: boolean;
+  /** When true, container takes card aspect ratio (85.6/53.98) and chart fills it. */
+  fillCard?: boolean;
+  /** Optional pre-filtered data; skips internal filterByRange. */
+  filteredData?: SnapshotPoint[];
+  /** Trend semantics: "up" = improvement (assets), "down" = improvement (debt). */
+  goodDirection?: "up" | "down";
+};
+
+export function filterByRange(
+  data: SnapshotPoint[],
+  range: RangeValue,
+): SnapshotPoint[] {
+  if (range === 0 || data.length === 0) return data;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - range);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  return data.filter((p) => p.date >= cutoffStr);
+}
+
+const CHART_W = 320;
+
+export function GraphFace({
+  data,
+  currencyCode,
+  range,
+  trendPercent,
+  height = 100,
+  strokeColor = COLORS.brass,
+  showHeader = true,
+  fillCard = false,
+  filteredData,
+  goodDirection = "up",
+}: Props) {
+  const filtered = useMemo(
+    () => filteredData ?? filterByRange(data, range),
+    [filteredData, data, range],
+  );
+
+  const h = height;
+
+  const paths = useMemo(() => {
+    if (filtered.length < 2) return null;
+    const min = Math.min(...filtered.map((p) => p.balance));
+    const max = Math.max(...filtered.map((p) => p.balance));
+    const span = max - min || 1;
+    const stepX = filtered.length > 1 ? CHART_W / (filtered.length - 1) : 0;
+    const linePath = filtered
+      .map((p, i) => {
+        const x = i * stepX;
+        const y = h - ((p.balance - min) / span) * h;
+        return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(" ");
+    const areaPath = `${linePath} L${CHART_W.toFixed(1)},${h} L0,${h} Z`;
+    return {
+      linePath,
+      areaPath,
+      latest: filtered[filtered.length - 1].balance,
+    };
+  }, [filtered, h]);
+
+  const emptyContainerStyle = fillCard
+    ? { aspectRatio: 85.6 / 53.98, width: "100%" as const }
+    : { height: h + (showHeader ? 28 : 0) };
+
+  if (!paths) {
+    return (
+      <View
+        style={emptyContainerStyle}
+        className="items-center justify-center rounded-xl border border-white-6 bg-z-surface-2-55"
+      >
+        <Text className="text-z-sage-dark font-inter text-sm">
+          Sin datos suficientes
+        </Text>
+      </View>
+    );
+  }
+
+  const headerNode = showHeader ? (
+    <View className="flex-row items-baseline gap-2">
+      <Text className="text-z-white font-inter-bold text-lg tabular-nums">
+        {formatCurrency(paths.latest, currencyCode as CurrencyCode)}
+      </Text>
+      <TrendChip percent={trendPercent} goodDirection={goodDirection} />
+    </View>
+  ) : null;
+
+  const chartNode = (
+    <Svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${CHART_W} ${h}`}
+      preserveAspectRatio="none"
+    >
+      <Defs>
+        <LinearGradient id="graphFill" x1="0" y1="0" x2="0" y2="1">
+          <Stop offset="0" stopColor={strokeColor} stopOpacity={0.3} />
+          <Stop offset="1" stopColor={strokeColor} stopOpacity={0} />
+        </LinearGradient>
+      </Defs>
+      <Path d={paths.areaPath} fill="url(#graphFill)" />
+      <Path
+        d={paths.linePath}
+        stroke={strokeColor}
+        strokeWidth={1.5}
+        fill="none"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </Svg>
+  );
+
+  if (fillCard) {
+    return (
+      <View
+        style={{ aspectRatio: 85.6 / 53.98, width: "100%" }}
+        className="rounded-xl bg-z-surface-2-55 border border-white-6 overflow-hidden p-3"
+      >
+        {headerNode}
+        <View className="flex-1">{chartNode}</View>
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-1">
+      {headerNode}
+      <View
+        style={{ height: h }}
+        className="rounded-xl bg-z-surface-2-55 border border-white-6 overflow-hidden"
+      >
+        {chartNode}
+      </View>
+    </View>
+  );
+}

--- a/mobile/components/accounts/GraphFace.tsx
+++ b/mobile/components/accounts/GraphFace.tsx
@@ -28,9 +28,14 @@ export function filterByRange(
   range: RangeValue,
 ): SnapshotPoint[] {
   if (range === 0 || data.length === 0) return data;
+  // Snapshot dates come from accounts-detail.ts as Colombia-local YYYY-MM-DD
+  // (en-CA + America/Bogota). Use the same format for the cutoff to avoid a
+  // UTC-shifted off-by-one at night in UTC-5.
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - range);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const cutoffStr = cutoff.toLocaleDateString("en-CA", {
+    timeZone: "America/Bogota",
+  });
   return data.filter((p) => p.date >= cutoffStr);
 }
 

--- a/mobile/components/accounts/QuickActionsBar.tsx
+++ b/mobile/components/accounts/QuickActionsBar.tsx
@@ -1,0 +1,144 @@
+import { View, Text, Pressable, Alert } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  HandCoins,
+  ArrowLeftRight,
+  Plus,
+  RefreshCw,
+  Ellipsis,
+  type LucideIcon,
+} from "lucide-react-native";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import { COLORS } from "../../lib/constants/colors";
+
+type ActionType = "payment" | "transfer" | "add" | "reconcile" | "more";
+
+type ActionDef = {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  type: ActionType;
+};
+
+function getActionsForType(accountType: string): ActionDef[] {
+  switch (accountType) {
+    case "CREDIT_CARD":
+      return [
+        { key: "pay", label: "Pagar", icon: HandCoins, type: "payment" },
+        { key: "add", label: "Agregar", icon: Plus, type: "add" },
+        { key: "reconcile", label: "Ajustar", icon: RefreshCw, type: "reconcile" },
+        { key: "more", label: "Más", icon: Ellipsis, type: "more" },
+      ];
+    case "SAVINGS":
+    case "CHECKING":
+    case "CASH":
+      return [
+        { key: "transfer", label: "Transferir", icon: ArrowLeftRight, type: "transfer" },
+        { key: "add", label: "Agregar", icon: Plus, type: "add" },
+        { key: "reconcile", label: "Ajustar", icon: RefreshCw, type: "reconcile" },
+        { key: "more", label: "Más", icon: Ellipsis, type: "more" },
+      ];
+    case "LOAN":
+      return [
+        { key: "pay", label: "Pagar", icon: HandCoins, type: "payment" },
+        { key: "reconcile", label: "Ajustar", icon: RefreshCw, type: "reconcile" },
+        { key: "more", label: "Más", icon: Ellipsis, type: "more" },
+      ];
+    case "INVESTMENT":
+      return [
+        { key: "reconcile", label: "Ajustar", icon: RefreshCw, type: "reconcile" },
+        { key: "more", label: "Más", icon: Ellipsis, type: "more" },
+      ];
+    default:
+      return [
+        { key: "add", label: "Agregar", icon: Plus, type: "add" },
+        { key: "reconcile", label: "Ajustar", icon: RefreshCw, type: "reconcile" },
+        { key: "more", label: "Más", icon: Ellipsis, type: "more" },
+      ];
+  }
+}
+
+function ActionButton({
+  icon: Icon,
+  label,
+  onPress,
+}: {
+  icon: LucideIcon;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="items-center gap-1"
+      accessibilityRole="button"
+      accessibilityLabel={label}
+    >
+      <View className="h-10 w-10 items-center justify-center rounded-full bg-white-6 active:bg-white-12">
+        <Icon size={16} color={COLORS.sageLight} />
+      </View>
+      <Text className="text-z-sage-dark font-inter text-[10px]">{label}</Text>
+    </Pressable>
+  );
+}
+
+type Props = {
+  account: AccountRow;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+const STUB_MESSAGES: Record<string, string> = {
+  payment: "Pagos desde la cuenta llegarán pronto. Por ahora usa 'Agregar' para registrar una transacción.",
+  transfer: "Transferencias entre cuentas llegarán pronto. Por ahora usa 'Agregar' en cada cuenta.",
+  reconcile: "Ajuste de saldo llegará pronto. Por ahora edita la cuenta para corregir el balance manualmente.",
+};
+
+export function QuickActionsBar({ account, onEdit, onDelete }: Props) {
+  const router = useRouter();
+  const accountType = account.account_type ?? "OTHER";
+  const accountId = account.id;
+  const actions = getActionsForType(accountType);
+
+  function handleStub(type: ActionType) {
+    const msg = STUB_MESSAGES[type];
+    if (msg) Alert.alert("Próximamente", msg);
+  }
+
+  function handleMore() {
+    Alert.alert("Más opciones", undefined, [
+      { text: "Editar", onPress: onEdit },
+      { text: "Eliminar", style: "destructive", onPress: onDelete },
+      { text: "Cancelar", style: "cancel" },
+    ]);
+  }
+
+  function handlePress(action: ActionDef) {
+    switch (action.type) {
+      case "add":
+        router.push(`/transactions/new?account=${accountId}`);
+        return;
+      case "more":
+        handleMore();
+        return;
+      case "payment":
+      case "transfer":
+      case "reconcile":
+        handleStub(action.type);
+        return;
+    }
+  }
+
+  return (
+    <View className="flex-row items-start justify-center gap-6">
+      {actions.map((action) => (
+        <ActionButton
+          key={action.key}
+          icon={action.icon}
+          label={action.label}
+          onPress={() => handlePress(action)}
+        />
+      ))}
+    </View>
+  );
+}

--- a/mobile/components/accounts/RangePills.tsx
+++ b/mobile/components/accounts/RangePills.tsx
@@ -1,0 +1,49 @@
+import { ScrollView, Pressable, Text } from "react-native";
+
+export type RangeValue = 0 | 7 | 14 | 30 | 90 | 180 | 365;
+
+const RANGES: { label: string; value: RangeValue }[] = [
+  { label: "1S", value: 7 },
+  { label: "2S", value: 14 },
+  { label: "1M", value: 30 },
+  { label: "3M", value: 90 },
+  { label: "6M", value: 180 },
+  { label: "1A", value: 365 },
+  { label: "Todo", value: 0 },
+];
+
+type Props = {
+  value: RangeValue;
+  onChange: (v: RangeValue) => void;
+};
+
+export function RangePills({ value, onChange }: Props) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{ gap: 4, paddingHorizontal: 2 }}
+    >
+      {RANGES.map((r) => {
+        const active = r.value === value;
+        return (
+          <Pressable
+            key={r.value}
+            onPress={() => onChange(r.value)}
+            className={`rounded-full px-2.5 py-0.5 ${
+              active ? "bg-z-brass" : "bg-white-6"
+            }`}
+          >
+            <Text
+              className={`font-inter-medium text-xs ${
+                active ? "text-z-ink" : "text-z-sage-dark"
+              }`}
+            >
+              {r.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/mobile/components/accounts/SpendingPulseHero.tsx
+++ b/mobile/components/accounts/SpendingPulseHero.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from "react";
+import { View, Text } from "react-native";
+import Svg, { Defs, LinearGradient, Path, Stop } from "react-native-svg";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import type { DailyPoint } from "../../lib/repositories/accounts-detail";
+
+type Props = {
+  account: AccountRow;
+  monthlySpent: number;
+  dailyActivity: DailyPoint[];
+};
+
+export function SpendingPulseHero({
+  account,
+  monthlySpent,
+  dailyActivity,
+}: Props) {
+  const cc = (account.currency_code as CurrencyCode) ?? "COP";
+
+  // Use last 30 data points for the sparkline
+  const sparkData = useMemo(
+    () => dailyActivity.slice(-30),
+    [dailyActivity],
+  );
+
+  const w = 320;
+  const h = 40;
+  const sparkPath = useMemo(() => {
+    if (sparkData.length < 2) return "";
+    const max = Math.max(...sparkData.map((p) => p.amount), 0);
+    const span = max || 1;
+    const stepX = w / (sparkData.length - 1);
+    return sparkData
+      .map((p, i) => {
+        const x = i * stepX;
+        const y = h - (p.amount / span) * h;
+        return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(" ");
+  }, [sparkData]);
+
+  const areaPath = sparkPath
+    ? `${sparkPath} L${w.toFixed(1)},${h} L0,${h} Z`
+    : "";
+
+  return (
+    <View className="gap-3">
+      <View className="flex-row items-start justify-between">
+        <View className="flex-1 min-w-0">
+          <Text className="text-z-white font-inter-bold text-2xl tabular-nums">
+            {formatCurrency(account.current_balance ?? 0, cc)}
+          </Text>
+          <Text
+            className="text-z-sage-dark font-inter text-xs mt-0.5"
+            numberOfLines={1}
+          >
+            {account.institution_name ?? ""}
+            {account.debit_card_mask ? ` • ${account.debit_card_mask}` : ""}
+          </Text>
+        </View>
+        <View className="rounded-xl border border-z-brass-20 bg-z-brass-8 px-3 py-1.5 items-end">
+          <Text
+            className="text-z-brass-70 font-inter-semibold text-[10px] uppercase"
+            style={{ letterSpacing: 1.8 }}
+          >
+            Este mes
+          </Text>
+          <Text className="text-z-brass font-inter-bold text-sm tabular-nums">
+            -{formatCurrency(monthlySpent, cc)}
+          </Text>
+        </View>
+      </View>
+      {sparkData.length >= 2 && (
+        <View style={{ height: h }}>
+          <Svg
+            width="100%"
+            height={h}
+            viewBox={`0 0 ${w} ${h}`}
+            preserveAspectRatio="none"
+          >
+            <Defs>
+              <LinearGradient id="pulseFill" x1="0" y1="0" x2="0" y2="1">
+                <Stop offset="0" stopColor={COLORS.brass} stopOpacity={0.2} />
+                <Stop offset="1" stopColor={COLORS.brass} stopOpacity={0} />
+              </LinearGradient>
+            </Defs>
+            <Path d={areaPath} fill="url(#pulseFill)" />
+            <Path
+              d={sparkPath}
+              stroke={COLORS.brass}
+              strokeWidth={1.5}
+              fill="none"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          </Svg>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/mobile/components/inicio/InicioRoot.tsx
+++ b/mobile/components/inicio/InicioRoot.tsx
@@ -148,11 +148,11 @@ export function InicioRoot() {
   const today = toLocalDateString(new Date());
   const dateLabel = formatHeaderDate(new Date());
 
+  const pulseDays = layout.pulseRange === "weekly" ? 7 : summary.daysRemaining;
   const pulseValue =
     layout.pulseRange === "weekly"
-      ? Math.round(summary.spentLast7 / Math.max(1, 7))
+      ? Math.round(summary.availableTotal / Math.max(1, pulseDays))
       : summary.availablePerDay;
-  const pulseDays = layout.pulseRange === "weekly" ? 7 : summary.daysRemaining;
   const pulseTrend =
     layout.pulseRange === "weekly" ? summary.spentTrend7 : summary.spentTrend30;
 

--- a/mobile/components/inicio/widgets/PulseWidget.tsx
+++ b/mobile/components/inicio/widgets/PulseWidget.tsx
@@ -141,7 +141,7 @@ export function PulseWidget({
         </View>
         {canExpand && (
           <View className="flex-row items-center gap-1">
-            <Text className="text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
+            <Text className={SECTION_EYEBROW_CLASS}>
               {expanded ? "Ocultar" : "Ver cálculo"}
             </Text>
             <ChevronDown
@@ -166,12 +166,7 @@ export function PulseWidget({
                 value={`−${formatCurrency(breakdown.pendingObligations, currency)}`}
                 tone="debt"
               />
-              <Row
-                label="– Ya gastado"
-                value={`−${formatCurrency(breakdown.alreadySpent, currency)}`}
-                tone="debt"
-              />
-              <View className="mt-1 h-px bg-z-surface-2-6" />
+              <View className="mt-1 h-px bg-white-6" />
               <Row
                 label="= Disponible"
                 value={formatCurrency(breakdown.availableTotal, currency)}
@@ -181,10 +176,18 @@ export function PulseWidget({
                 ÷ {daysRemaining} días ({breakdown.windowEndLabel}) ={" "}
                 {formatCurrency(availablePerDay, currency)}/día
               </Text>
+              <View className="mt-1 h-px bg-white-6" />
+              <Row
+                label="Ya gastado este mes"
+                value={formatCurrency(breakdown.alreadySpent, currency)}
+              />
+              <Text className="text-[10px] font-inter text-muted-foreground">
+                Ya descontado del saldo líquido — informativo
+              </Text>
 
               {nextIncome && (
                 <>
-                  <View className="mt-1 h-px bg-z-surface-2-6" />
+                  <View className="mt-1 h-px bg-white-6" />
                   <View className="flex-row items-start justify-between gap-2">
                     <Text className="flex-1 text-[11px] font-inter-semibold text-z-income">
                       Próximo ingreso: {nextIncome.name}

--- a/mobile/components/ui/TrendChip.tsx
+++ b/mobile/components/ui/TrendChip.tsx
@@ -1,0 +1,34 @@
+import { View, Text } from "react-native";
+
+type Props = {
+  /** Percent change. 0 (or undefined) hides the chip. */
+  percent?: number;
+  /** Which direction means improvement. "up" = balance growth (assets); "down" = debt reduction. */
+  goodDirection?: "up" | "down";
+};
+
+/**
+ * Small tinted pill showing trend direction (▲/▼) and absolute percent.
+ * The arrow always reflects the actual numeric direction; color reflects
+ * whether that direction is "good" for this account type.
+ */
+export function TrendChip({ percent, goodDirection = "up" }: Props) {
+  if (percent === undefined || percent === 0) return null;
+  const arrowUp = percent > 0;
+  const isGood = goodDirection === "up" ? arrowUp : !arrowUp;
+  return (
+    <View
+      className={`rounded-full px-1.5 py-0.5 ${
+        isGood ? "bg-z-income-12" : "bg-z-debt-12"
+      }`}
+    >
+      <Text
+        className={`font-inter-semibold text-xs ${
+          isGood ? "text-z-income" : "text-z-debt"
+        }`}
+      >
+        {arrowUp ? "▲" : "▼"} {Math.abs(percent).toFixed(1)}%
+      </Text>
+    </View>
+  );
+}

--- a/mobile/lib/repositories/accounts-detail.ts
+++ b/mobile/lib/repositories/accounts-detail.ts
@@ -1,0 +1,111 @@
+import { getDatabase } from "../db/database";
+
+export interface SnapshotPoint {
+  date: string;
+  balance: number;
+}
+
+export interface DailyPoint {
+  date: string;
+  amount: number;
+}
+
+function toColombiaDateString(d: Date): string {
+  return d.toLocaleDateString("en-CA", { timeZone: "America/Bogota" });
+}
+
+/**
+ * Running balance per day for the last year, walking transactions backwards
+ * from currentBalance. Mirrors webapp getAccountBalanceHistoryCached.
+ */
+export async function getBalanceHistory(
+  accountId: string,
+  currentBalance: number,
+): Promise<SnapshotPoint[]> {
+  const db = await getDatabase();
+  const today = new Date();
+  const oneYearAgo = new Date(today);
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+  const cutoff = toColombiaDateString(oneYearAgo);
+
+  const rows = await db.getAllAsync<{
+    transaction_date: string;
+    amount: number;
+    direction: "INFLOW" | "OUTFLOW";
+  }>(
+    `SELECT transaction_date, amount, direction
+       FROM transactions
+      WHERE account_id = ?
+        AND is_excluded = 0
+        AND reconciled_into_transaction_id IS NULL
+        AND transaction_date >= ?
+      ORDER BY transaction_date DESC, created_at DESC
+      LIMIT 5000`,
+    [accountId, cutoff],
+  );
+
+  if (rows.length === 0) {
+    return [{ date: toColombiaDateString(today), balance: currentBalance }];
+  }
+
+  const points: SnapshotPoint[] = [
+    { date: toColombiaDateString(today), balance: currentBalance },
+  ];
+  let running = currentBalance;
+  for (const tx of rows) {
+    if (tx.direction === "OUTFLOW") running += tx.amount;
+    else running -= tx.amount;
+    points.push({ date: tx.transaction_date, balance: running });
+  }
+  points.reverse();
+
+  const dailyMap = new Map<string, number>();
+  for (const p of points) dailyMap.set(p.date, p.balance);
+  return Array.from(dailyMap, ([date, balance]) => ({ date, balance })).sort(
+    (a, b) => a.date.localeCompare(b.date),
+  );
+}
+
+/**
+ * Last-30-day daily outflow series + month-to-date total.
+ * Mirrors webapp getAccountSpendingPulseCached.
+ */
+export async function getSpendingPulse(
+  accountId: string,
+): Promise<{ monthlySpent: number; dailyActivity: DailyPoint[] }> {
+  const db = await getDatabase();
+  const now = new Date();
+  const todayStr = toColombiaDateString(now);
+  const firstOfMonth = `${todayStr.slice(0, 7)}-01`;
+  const thirtyDaysAgo = new Date(now);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  const cutoff = toColombiaDateString(thirtyDaysAgo);
+
+  const rows = await db.getAllAsync<{
+    transaction_date: string;
+    amount: number;
+  }>(
+    `SELECT transaction_date, amount
+       FROM transactions
+      WHERE account_id = ?
+        AND direction = 'OUTFLOW'
+        AND is_excluded = 0
+        AND reconciled_into_transaction_id IS NULL
+        AND transaction_date >= ?
+      ORDER BY transaction_date ASC`,
+    [accountId, cutoff],
+  );
+
+  let monthlySpent = 0;
+  const dailyMap = new Map<string, number>();
+  for (const row of rows) {
+    const amt = row.amount ?? 0;
+    dailyMap.set(row.transaction_date, (dailyMap.get(row.transaction_date) ?? 0) + amt);
+    if (row.transaction_date >= firstOfMonth) monthlySpent += amt;
+  }
+
+  return {
+    monthlySpent,
+    dailyActivity: Array.from(dailyMap, ([date, amount]) => ({ date, amount })),
+  };
+}


### PR DESCRIPTION
## Summary
- Three account-detail hero variants by type: flip card (CREDIT_CARD/SAVINGS/debit), spending pulse (CASH/OTHER), balance graph (LOAN/INVESTMENT). Flip variant tap-flips a card face to a chart with range pills.
- QuickActionsBar below hero with type-aware actions. Header Pencil/Trash2 folded into "Más" sheet to avoid duplicate edit/delete affordances. Pagar / Transferir / Ajustar are intentional stubs (`Alert.alert("Próximamente", …)`) — full dialogs deferred until each can ride through mobile-webapp-parity + mobile-sync-doctor.
- Perf + design review-gate sweep on the same diff (see below).

## Review gates run
- **mobile-perf-doctor** — fixed 2 HIGH + 2 MEDIUM:
  - `AccountHero` `displayAccount` / `displaySnapshotData` wrapped in `useMemo` → stops `GraphFace` SVG path math running 7× on initial load (one for each stage-load setState).
  - `account/[id].tsx` releases the full-screen spinner after stage-1 `Promise.all` so the shell + QuickActionsBar + recent-tx paint immediately while history/pulse stream in.
  - `FlipZone.handleFlip` extracted to `useCallback` (defensive for any future list-row usage).
  - `accounts-list.tsx` `ListHeaderComponent` + `netWorth` wrapped in `useMemo`.
- **zetas-front-guy** — fixed 3 P0 + 2 P1 + 1 bonus:
  - `useSafeAreaInsets().top` applied to all three header surfaces in `account/[id].tsx` (loading, not-found, main) — was clipping under the iOS notch.
  - Hex icon colors (`#10B981`, `#6B7280`, `#E5E5E5`) → `COLORS.brass` / `COLORS.sageDark` / `COLORS.sageLight`.
  - Undefined `bg-z-surface-2-6` (silent NativeWind no-op → invisible dividers) → `bg-white-6` in PulseWidget + settings.
  - Eyebrow tracking normalized to `SECTION_EYEBROW_CLASS` in PulseWidget + `account/[id].tsx` (was `tracking-[2px]` vs canonical `tracking-[4px]`).
  - Invisible recent-tx divider (`bg-z-surface-2` painted on a same-color parent) → `bg-white-6`.
- **Deliberate defers**: `CardFace` SVG gradient hex (institution-mapped, SVG-context inline required), `AccountCard` `#6B7280` fallback (flagged low-risk), `AccountHero` full-opacity `bg-z-surface-2` (intentional — hero focal surface stronger than `PANEL_SURFACE_SUBTLE`).

## Build
- `pnpm build` (webapp) — clean
- `pnpm exec tsc --noEmit` (mobile) — clean

## Test plan
- [ ] iOS sim — open an account of each type (CREDIT_CARD, SAVINGS, CHECKING with debit mask, CASH, LOAN, INVESTMENT) and confirm the right hero variant renders.
- [ ] Tap a flip-variant hero, confirm the card flips smoothly (~400ms) and the dot indicator + RangePills appear on the back face.
- [ ] Change range pills on a flipped card / on `BalanceGraphHero` — chart redraws, no jank.
- [ ] On `account/[id].tsx`, confirm the header sits below the iOS notch (was clipping pre-fix).
- [ ] QuickActionsBar: tap "Agregar" — routes to `/transactions/new?account=<id>`. Tap "Pagar"/"Transferir"/"Ajustar" — confirm "Próximamente" alert. Tap "Más" → Editar / Eliminar work the same as before.
- [ ] Verify recent-tx divider lines are visible between rows.
- [ ] `accounts-list.tsx` — pull-to-refresh, confirm net-worth header doesn't flash/rebuild content.
- [ ] `Inicio` PulseWidget — confirm divider lines between "Cómo se calcula" rows are visible (was silently invisible pre-fix).

## Deferred (BACKLOG)
- Full `QuickPaymentDialog` / `TransferDialog` / `ReconcileBalanceDialog` ports (each needs mobile-webapp-parity + mobile-sync-doctor review).
- Partial index `transactions(account_id, transaction_date) WHERE reconciled_into_transaction_id IS NULL` — bundle with next mobile schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)