### PR TITLE
fix(mobile): parity quick wins (5 cheap fixes from #257)

### DIFF
--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -346,6 +346,27 @@ export default function CaptureScreen() {
     setSaving(true);
     try {
       const trimmedDescription = description.trim();
+
+      // Resolve the destinatario *before* persisting the transaction so the
+      // new transaction row carries `destinatario_id` from the start. This
+      // mirrors webapp's persistTransaction (actions/transactions.ts:706),
+      // where destinatarioId is passed into the insert payload — not stamped
+      // afterwards. If destinatario creation fails the tx still saves.
+      let newDestinatarioId: string | null = null;
+      if (createDestinatario) {
+        try {
+          const { destinatarioId } = await createDestinatarioWithPattern({
+            user_id: session.user.id,
+            name: trimmedDescription,
+            default_category_id: categoryId,
+            pattern: trimmedDescription,
+          });
+          newDestinatarioId = destinatarioId;
+        } catch (err) {
+          console.error("Create destinatario from capture failed:", err);
+        }
+      }
+
       const newTxId = await createTransaction({
         user_id: session.user.id,
         account_id: accountId,
@@ -358,6 +379,7 @@ export default function CaptureScreen() {
         merchant_name: trimmedDescription,
         raw_description: trimmedDescription,
         category_id: categoryId,
+        destinatario_id: newDestinatarioId,
         notes: notes.trim() || null,
         provider: "MANUAL",
         capture_method: "MANUAL_FORM",
@@ -379,21 +401,6 @@ export default function CaptureScreen() {
         }
       } catch (err) {
         if (__DEV__) console.warn("[capture] location link failed", err);
-      }
-
-      let newDestinatarioId: string | null = null;
-      if (createDestinatario) {
-        try {
-          const { destinatarioId } = await createDestinatarioWithPattern({
-            user_id: session.user.id,
-            name: trimmedDescription,
-            default_category_id: categoryId,
-            pattern: trimmedDescription,
-          });
-          newDestinatarioId = destinatarioId;
-        } catch (err) {
-          console.error("Create destinatario from capture failed:", err);
-        }
       }
 
       if (createRecurring) {

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -144,6 +144,13 @@ export default function MobileOnboardingScreen() {
       // 3. Flip `onboarding_completed = true` only if both succeeded.
       // Not atomic without an RPC, but guarantees the flag never implies
       // "complete without an account".
+      // Match webapp finishOnboarding (actions/onboarding.ts): users whose
+      // primary purpose is debt-payoff get a DEBT-focused nav rail; everyone
+      // else gets PLAN. Without this, mobile-onboarded users land on the
+      // webapp with the database default (PLAN) regardless of intent.
+      const navFocus: "DEBT" | "PLAN" =
+        data.purpose === "manage_debt" ? "DEBT" : "PLAN";
+
       const { error: profileError } = await supabase
         .from("profiles")
         .update({
@@ -154,6 +161,7 @@ export default function MobileOnboardingScreen() {
           preferred_currency: data.currency,
           timezone,
           locale: "es-CO",
+          nav_focus: navFocus,
           mobile_dashboard_config: mobileDashboardConfig,
           updated_at: now,
         })

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -249,6 +249,11 @@ export default function TransactionDetailScreen() {
         notes: editNotes.trim() || null,
         is_excluded: editIsExcluded,
       });
+      // Persist tag changes — the TagSelector mutates `editTagIds` but the
+      // tx-update path doesn't carry tags. `saveTransactionTags` does a
+      // REPLACE on `transaction_tags` for this id and enqueues a sync row.
+      // Mirrors the webapp transaction-form `saveTags` call.
+      await saveTransactionTags(id, editTagIds);
       // Reload from DB to get fresh joined data (category_name_es, etc.)
       const updated = (await getTransactionById(id)) as TransactionDetail;
       setTransaction(updated);

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -68,6 +68,7 @@ export type CreateTransactionParams = {
   merchant_name?: string | null;
   raw_description?: string | null;
   category_id?: string | null;
+  destinatario_id?: string | null;
   notes?: string | null;
   provider?: DataProvider;
   capture_method?: TransactionCaptureMethod;
@@ -88,6 +89,7 @@ export type UpdateTransactionParams = {
   transaction_date?: string;
   transaction_time?: string | null;
   category_id?: string | null;
+  destinatario_id?: string | null;
   notes?: string | null;
   is_excluded?: boolean;
   reconciled_into_transaction_id?: string | null;
@@ -108,6 +110,12 @@ function buildInsertPayload(id: string, now: string, params: CreateTransactionPa
     user_id: params.user_id,
     account_id: params.account_id,
     category_id: params.category_id ?? null,
+    // Mirror webapp persistTransaction (webapp/src/actions/transactions.ts):
+    // mark as USER_CREATED only when the caller passes a category; otherwise
+    // fall back to SYSTEM_DEFAULT so dashboards that filter on this column
+    // count mobile-created rows the same as webapp-created rows.
+    categorization_source: params.category_id ? "USER_CREATED" : "SYSTEM_DEFAULT",
+    destinatario_id: params.destinatario_id ?? null,
     amount: params.amount,
     currency_code: params.currency_code,
     direction: params.direction,
@@ -160,15 +168,18 @@ export async function createTransaction(params: CreateTransactionParams): Promis
   await db.withTransactionAsync(async () => {
     await db.runAsync(
       `INSERT INTO transactions
-        (id, user_id, account_id, category_id, amount, currency_code, direction, description, merchant_name, raw_description,
-         transaction_date, transaction_time, location_id, status, idempotency_key, is_excluded, is_subscription, notes, provider,
-         capture_method, capture_input_text, reconciled_into_transaction_id, reconciliation_score, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, user_id, account_id, category_id, categorization_source, destinatario_id, amount, currency_code, direction,
+         description, merchant_name, raw_description, transaction_date, transaction_time, location_id, status, idempotency_key,
+         is_excluded, is_subscription, notes, provider, capture_method, capture_input_text, reconciled_into_transaction_id,
+         reconciliation_score, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         payload.id,
         payload.user_id,
         payload.account_id,
         payload.category_id,
+        payload.categorization_source,
+        payload.destinatario_id,
         payload.amount,
         payload.currency_code,
         payload.direction,
@@ -618,6 +629,10 @@ export async function updateTransaction(
     setClauses.push("categorization_source = ?");
     values.push("USER_OVERRIDE");
   }
+  if (params.destinatario_id !== undefined) {
+    setClauses.push("destinatario_id = ?");
+    values.push(params.destinatario_id ?? null);
+  }
   if (params.notes !== undefined) {
     setClauses.push("notes = ?");
     values.push(params.notes ?? null);
@@ -656,6 +671,7 @@ export async function updateTransaction(
     syncPayload.category_id = params.category_id ?? null;
     syncPayload.categorization_source = "USER_OVERRIDE";
   }
+  if (params.destinatario_id !== undefined) syncPayload.destinatario_id = params.destinatario_id ?? null;
   if (params.notes !== undefined) syncPayload.notes = params.notes ?? null;
   if (params.is_excluded !== undefined) syncPayload.is_excluded = params.is_excluded;
   if (params.reconciled_into_transaction_id !== undefined) {


### PR DESCRIPTION
## Summary

Cheap fixes from the [2026-05-21 parity audit](https://github.com/Cristian1911/personal_finance_manager_claude/pull/257). Each one was a small, isolated diff with no schema migration needed.

The larger ❌ critical items (balance adjustment, occurrence linking, full import parity) are tracked separately for dedicated follow-up PRs.

## What's fixed

| # | Audit ref | Fix |
|---|---|---|
| 1 | **C5** | `categorization_source` is now set on mobile-created transactions (`USER_CREATED` if category provided, else `SYSTEM_DEFAULT`). Was landing NULL — dashboards filtering on this column undercounted mobile-created rows. |
| 2 | **C4** | Mobile capture's "Crear destinatario" toggle now actually links the new destinatario to the new transaction. Flow reordered so the destinatario is created *before* `createTransaction` and its id is passed via the new `destinatario_id` param. |
| 3 | (refactor) | `destinatario_id` plumbed through `CreateTransactionParams` + `UpdateTransactionParams` + `buildInsertPayload` + INSERT/UPDATE SQL + sync payload. Mirrors webapp `persistTransaction`. |
| 4 | **C14** | Mobile onboarding now computes `nav_focus` from `app_purpose` the same way `finishOnboarding` does (`manage_debt` → DEBT, else PLAN). Mobile-onboarded users opening the webapp will land on the correct nav rail instead of the DB default. |
| 5 | **M7** | Mobile tx-detail `handleSave` now calls `saveTransactionTags` so TagSelector mutations actually persist. Was loading tags into `editTagIds` but never writing them back. |

## Out of scope (tracked in #257 + BACKLOG)

- C1/C2/C6/M18 balance adjustment on mobile create/update/import
- C3/C8/M17 occurrence linking on mobile create/import
- C6/C7/C8/C9 mobile import parity (snapshots, occurrence linking, destinatarios step)
- C13 `subscriptions.tsx` repository routing
- C11/C12 mobile category surface (direction picker + slug column)
- M9-M13 accounts list parity
- C15 onboarding `dashboard_config` seeding
- TagSelector mount on tx-detail edit form (separate UX gap surfaced while fixing M7)

## Test plan

- [x] `pnpm tsc --noEmit` from `mobile/` clean
- [ ] On mobile dev client: capture a transaction with category set → confirm Supabase row has `categorization_source = 'USER_CREATED'`
- [ ] Toggle "Crear destinatario" on capture → confirm both `destinatarios` row and `transactions.destinatario_id` are set
- [ ] Run mobile onboarding with `manage_debt` purpose → confirm `profiles.nav_focus = 'DEBT'`
- [ ] Edit a transaction on mobile and change tag selection → confirm `transaction_tags` reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)