### PR TITLE
fix: canonical Resumen del mes aggregates (@zeta/shared)

### DIFF
--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -1,6 +1,7 @@
 import * as Crypto from "expo-crypto";
 import {
   computeIdempotencyKey,
+  computeMonthlyAggregates,
   findReconciliationCandidates,
   mergeTransactionMetadata,
   type DataProvider,
@@ -299,64 +300,35 @@ export async function getMonthlyAggregates(options: {
     params.push(options.accountId);
   }
 
-  // Totals + count. INFLOW to debt accounts excluded from totalInflow.
-  const totalsRow = await db.getFirstAsync<{
-    count: number;
-    total_inflow: number;
-    total_outflow: number;
-    uncategorized_count: number;
-  }>(
-    `SELECT
-       COUNT(*) AS count,
-       COALESCE(SUM(CASE WHEN t.direction = 'INFLOW'
-                          AND a.account_type NOT IN ('CREDIT_CARD','LOAN')
-                          AND t.is_excluded = 0
-                         THEN t.amount ELSE 0 END), 0) AS total_inflow,
-       COALESCE(SUM(CASE WHEN t.direction = 'OUTFLOW' AND t.is_excluded = 0
-                         THEN t.amount ELSE 0 END), 0) AS total_outflow,
-       SUM(CASE WHEN t.direction = 'OUTFLOW' AND t.category_id IS NULL AND t.is_excluded = 0
-                THEN 1 ELSE 0 END) AS uncategorized_count
-     FROM transactions t
-     LEFT JOIN accounts a ON t.account_id = a.id
-     WHERE t.transaction_date LIKE ?
-       AND t.reconciled_into_transaction_id IS NULL${accountFilter}`,
-    params
-  );
-
-  // Per-day income/expense aggregation for the flow chart.
-  const dayRows = await db.getAllAsync<{
+  // Single slim SELECT for the month; the canonical aggregation lives in
+  // @zeta/shared/utils/monthly-aggregates so mobile and webapp produce the
+  // same numbers by construction. The previous SQL had a bug — COUNT(*)
+  // omitted the `t.is_excluded = 0` predicate that the sibling SUMs applied,
+  // inflating the row count whenever the user had excluded transactions.
+  const rows = await db.getAllAsync<{
+    amount: number;
+    direction: "INFLOW" | "OUTFLOW";
+    account_id: string;
+    category_id: string | null;
+    is_excluded: number;
+    reconciled_into_transaction_id: string | null;
     transaction_date: string;
-    income: number;
-    expense: number;
   }>(
-    `SELECT
-       t.transaction_date,
-       COALESCE(SUM(CASE WHEN t.direction = 'INFLOW'
-                          AND a.account_type NOT IN ('CREDIT_CARD','LOAN')
-                         THEN t.amount ELSE 0 END), 0) AS income,
-       COALESCE(SUM(CASE WHEN t.direction = 'OUTFLOW'
-                         THEN t.amount ELSE 0 END), 0) AS expense
-     FROM transactions t
-     LEFT JOIN accounts a ON t.account_id = a.id
-     WHERE t.transaction_date LIKE ?
-       AND t.is_excluded = 0
-       AND t.reconciled_into_transaction_id IS NULL${accountFilter}
-     GROUP BY t.transaction_date
-     ORDER BY t.transaction_date ASC`,
+    `SELECT t.amount, t.direction, t.account_id, t.category_id, t.is_excluded,
+            t.reconciled_into_transaction_id, t.transaction_date
+       FROM transactions t
+      WHERE t.transaction_date LIKE ?
+        AND t.reconciled_into_transaction_id IS NULL${accountFilter}`,
     params
   );
 
-  return {
-    count: totalsRow?.count ?? 0,
-    totalInflow: totalsRow?.total_inflow ?? 0,
-    totalOutflow: totalsRow?.total_outflow ?? 0,
-    uncategorizedCount: totalsRow?.uncategorized_count ?? 0,
-    daysByDate: dayRows.map((r) => ({
-      date: r.transaction_date,
-      income: r.income,
-      expense: r.expense,
-    })),
-  };
+  // Resolve debt accounts so INFLOWs into them are excluded from totalInflow.
+  const debtRows = await db.getAllAsync<{ id: string }>(
+    `SELECT id FROM accounts WHERE account_type IN ('CREDIT_CARD','LOAN')`
+  );
+  const debtAccountIds = new Set(debtRows.map((r) => r.id));
+
+  return computeMonthlyAggregates(rows, { debtAccountIds });
 }
 
 /** Narrow shape for the Categorizar panel — only the columns it renders. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,3 +23,4 @@ export * from "./utils/extra-payment";
 export * from "./utils/cc-projection";
 export * from "./utils/dashboard-layout";
 export * from "./utils/account-balance";
+export * from "./utils/monthly-aggregates";

--- a/packages/shared/src/utils/__tests__/monthly-aggregates.test.ts
+++ b/packages/shared/src/utils/__tests__/monthly-aggregates.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeMonthlyAggregates,
+  type AggregatableTransaction,
+} from "../monthly-aggregates";
+
+function tx(overrides: Partial<AggregatableTransaction>): AggregatableTransaction {
+  return {
+    amount: 0,
+    direction: "OUTFLOW",
+    account_id: "acct-checking",
+    category_id: "cat-food",
+    is_excluded: false,
+    reconciled_into_transaction_id: null,
+    transaction_date: "2026-05-15",
+    ...overrides,
+  };
+}
+
+const debtAccountIds = new Set(["acct-credit-card", "acct-loan"]);
+
+describe("computeMonthlyAggregates", () => {
+  it("counts only non-excluded, non-reconciled rows", () => {
+    const rows: AggregatableTransaction[] = [
+      tx({ amount: 100, direction: "OUTFLOW" }),
+      tx({ amount: 50, direction: "OUTFLOW", is_excluded: true }),
+      tx({ amount: 75, direction: "OUTFLOW", reconciled_into_transaction_id: "other" }),
+      // SQLite returns is_excluded as 0/1, not boolean — accept both.
+      tx({ amount: 25, direction: "OUTFLOW", is_excluded: 1 }),
+    ];
+
+    const result = computeMonthlyAggregates(rows, { debtAccountIds });
+    expect(result.count).toBe(1);
+    expect(result.totalOutflow).toBe(100);
+  });
+
+  it("excludes INFLOWs into debt accounts from totalInflow but still counts them", () => {
+    const rows: AggregatableTransaction[] = [
+      tx({ amount: 1000, direction: "INFLOW", account_id: "acct-checking" }),
+      tx({ amount: 500, direction: "INFLOW", account_id: "acct-credit-card" }),
+      tx({ amount: 300, direction: "INFLOW", account_id: "acct-loan" }),
+    ];
+
+    const result = computeMonthlyAggregates(rows, { debtAccountIds });
+    expect(result.totalInflow).toBe(1000);
+    expect(result.count).toBe(3);
+  });
+
+  it("counts uncategorized only on OUTFLOWs", () => {
+    const rows: AggregatableTransaction[] = [
+      tx({ direction: "OUTFLOW", category_id: null }),
+      tx({ direction: "OUTFLOW", category_id: "cat-food" }),
+      tx({ direction: "INFLOW", category_id: null }),
+    ];
+
+    const result = computeMonthlyAggregates(rows, { debtAccountIds });
+    expect(result.uncategorizedCount).toBe(1);
+  });
+
+  it("builds daysByDate sorted ascending with debt-INFLOW exclusion baked in", () => {
+    const rows: AggregatableTransaction[] = [
+      tx({ amount: 100, direction: "OUTFLOW", transaction_date: "2026-05-15" }),
+      tx({ amount: 500, direction: "INFLOW", transaction_date: "2026-05-15", account_id: "acct-checking" }),
+      tx({ amount: 200, direction: "INFLOW", transaction_date: "2026-05-15", account_id: "acct-credit-card" }),
+      tx({ amount: 50, direction: "OUTFLOW", transaction_date: "2026-05-01" }),
+    ];
+
+    const result = computeMonthlyAggregates(rows, { debtAccountIds });
+    expect(result.daysByDate).toEqual([
+      { date: "2026-05-01", income: 0, expense: 50 },
+      { date: "2026-05-15", income: 500, expense: 100 },
+    ]);
+  });
+
+  it("withDaysByDate: false skips the per-day buckets", () => {
+    const rows = [tx({ amount: 100, direction: "OUTFLOW" })];
+    const result = computeMonthlyAggregates(rows, {
+      debtAccountIds,
+      withDaysByDate: false,
+    });
+    expect(result.daysByDate).toEqual([]);
+    expect(result.count).toBe(1);
+    expect(result.totalOutflow).toBe(100);
+  });
+
+  it("empty input returns zeros", () => {
+    const result = computeMonthlyAggregates([], { debtAccountIds });
+    expect(result).toEqual({
+      count: 0,
+      totalInflow: 0,
+      totalOutflow: 0,
+      uncategorizedCount: 0,
+      daysByDate: [],
+    });
+  });
+});

--- a/packages/shared/src/utils/monthly-aggregates.ts
+++ b/packages/shared/src/utils/monthly-aggregates.ts
@@ -1,0 +1,114 @@
+/**
+ * Canonical aggregation for the "Resumen del mes" card on both mobile and
+ * webapp. Both surfaces had divergent ad-hoc implementations that produced
+ * 7-33× different numbers (live walkthrough 2026-05-21). This helper is the
+ * single source of truth for what counts as a movimiento / ingreso / gasto /
+ * uncategorizado for a given month.
+ *
+ * Rules (mirror CLAUDE.md "Income & Metrics Rules"):
+ *  - Exclude transactions with `is_excluded === true` from every total.
+ *  - Exclude reconciled-into-other-transaction rows (`reconciled_into_transaction_id !== null`).
+ *  - For totalInflow specifically, also exclude INFLOWs into debt accounts —
+ *    those are debt payments, not income (see `isDebtAccountType` in
+ *    @zeta/shared/utils/account-balance.ts).
+ *  - "Uncategorized" = OUTFLOW with no `category_id`. Not direction-agnostic.
+ *
+ * Pure function over plain row objects so it works identically against the
+ * decrypted Supabase view (webapp) and the local SQLite mirror (mobile).
+ */
+
+/** Minimum-information row shape — both platforms can project into this. */
+export interface AggregatableTransaction {
+  amount: number;
+  direction: "INFLOW" | "OUTFLOW";
+  account_id: string;
+  category_id: string | null;
+  /** Boolean on webapp; integer 0/1 from SQLite on mobile. */
+  is_excluded: boolean | number | null;
+  reconciled_into_transaction_id: string | null;
+  /** YYYY-MM-DD. Used only when caller wants the daily breakdown. */
+  transaction_date: string;
+}
+
+export interface MonthlyAggregatesResult {
+  /** All non-excluded, non-reconciled rows in scope. */
+  count: number;
+  /** Sum of INFLOW amounts, excluding INFLOWs into debt accounts. */
+  totalInflow: number;
+  /** Sum of OUTFLOW amounts. */
+  totalOutflow: number;
+  /** Count of OUTFLOWs with no category_id. */
+  uncategorizedCount: number;
+  /**
+   * Per-day breakdown (in transaction_date order ascending). Empty when the
+   * caller passes `{ withDaysByDate: false }`.
+   */
+  daysByDate: { date: string; income: number; expense: number }[];
+}
+
+export interface AggregateOptions {
+  /** Debt-account ids — INFLOWs into these accounts are NOT counted as income. */
+  debtAccountIds: ReadonlySet<string>;
+  /** Skip the per-day breakdown if the consumer doesn't need it. Default `true`. */
+  withDaysByDate?: boolean;
+}
+
+function isExcluded(value: boolean | number | null | undefined): boolean {
+  return value === true || value === 1;
+}
+
+/**
+ * Reduce an array of transactions to the canonical monthly aggregates.
+ *
+ * Caller is responsible for scoping the input to the desired month — either
+ * with a SQL `WHERE transaction_date BETWEEN ?` (mobile) or a Supabase
+ * `.gte/.lte("transaction_date", ...)` (webapp). This helper does NOT filter
+ * by date; it only applies the exclusion + direction + category rules.
+ */
+export function computeMonthlyAggregates(
+  rows: readonly AggregatableTransaction[],
+  options: AggregateOptions,
+): MonthlyAggregatesResult {
+  const withDays = options.withDaysByDate ?? true;
+  let count = 0;
+  let totalInflow = 0;
+  let totalOutflow = 0;
+  let uncategorizedCount = 0;
+  const dayBuckets = new Map<string, { income: number; expense: number }>();
+
+  for (const row of rows) {
+    if (row.reconciled_into_transaction_id !== null) continue;
+    if (isExcluded(row.is_excluded)) continue;
+
+    count += 1;
+
+    const isDebt = options.debtAccountIds.has(row.account_id);
+
+    if (row.direction === "INFLOW") {
+      if (!isDebt) {
+        totalInflow += row.amount;
+      }
+    } else {
+      // OUTFLOW
+      totalOutflow += row.amount;
+      if (row.category_id === null || row.category_id === undefined) {
+        uncategorizedCount += 1;
+      }
+    }
+
+    if (withDays) {
+      const bucket = dayBuckets.get(row.transaction_date) ?? { income: 0, expense: 0 };
+      if (row.direction === "INFLOW" && !isDebt) bucket.income += row.amount;
+      if (row.direction === "OUTFLOW") bucket.expense += row.amount;
+      dayBuckets.set(row.transaction_date, bucket);
+    }
+  }
+
+  const daysByDate = withDays
+    ? Array.from(dayBuckets.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, sums]) => ({ date, income: sums.income, expense: sums.expense }))
+    : [];
+
+  return { count, totalInflow, totalOutflow, uncategorizedCount, daysByDate };
+}

--- a/webapp/src/actions/transactions.ts
+++ b/webapp/src/actions/transactions.ts
@@ -2,7 +2,12 @@
 
 import { cacheTag, cacheLife, updateTag } from "next/cache";
 import { createCachedClient } from "@/lib/supabase/cached";
-import { autoCategorize, computeIdempotencyKey } from "@zeta/shared";
+import {
+  autoCategorize,
+  computeIdempotencyKey,
+  computeMonthlyAggregates,
+  type MonthlyAggregatesResult,
+} from "@zeta/shared";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createDestinatario, matchTransactionToDestinatario } from "@/actions/destinatarios";
 import { createRecurringTemplate } from "@/actions/recurring-templates";
@@ -535,6 +540,101 @@ export async function getTransactions(
     );
   } catch {
     return { data: [], count: 0, page: params.page, pageSize: params.pageSize, totalPages: 0 };
+  }
+}
+
+// ─── Monthly aggregates (Resumen del mes / LECTURA card) ────────────────────
+//
+// Canonical aggregation for the Movimientos summary card. The list endpoint
+// (`getTransactionsCached`) returns a paginated `data[]` and an unfiltered
+// `count`, so reducing inflows/outflows/uncategorized from that response gives
+// page-1-only totals (the bug behind the 2026-05-21 live walkthrough's 7-33×
+// divergence). This action does a slim SELECT for the entire month and
+// reduces via the shared `computeMonthlyAggregates` helper that mobile uses
+// too — same numbers by construction.
+
+async function getMonthlyAggregatesCached(
+  userId: string,
+  accessToken: string,
+  dateFrom: string,
+  dateTo: string,
+  accountId: string | undefined,
+): Promise<MonthlyAggregatesResult> {
+  "use cache";
+  cacheTag("transactions");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const isDemo = await getIsDemoFilter(userId);
+  const demoAccountIds = await getDemoAccountIds(supabase, userId, isDemo);
+  if (!demoAccountIds) {
+    return {
+      count: 0,
+      totalInflow: 0,
+      totalOutflow: 0,
+      uncategorizedCount: 0,
+      daysByDate: [],
+    };
+  }
+
+  let query = supabase
+    .from("transactions")
+    .select(
+      "amount, direction, account_id, category_id, is_excluded, reconciled_into_transaction_id, transaction_date",
+    )
+    .eq("user_id", userId)
+    .in("account_id", demoAccountIds)
+    .gte("transaction_date", dateFrom)
+    .lte("transaction_date", dateTo)
+    .is("reconciled_into_transaction_id", null);
+
+  if (accountId) query = query.eq("account_id", accountId);
+
+  const { data, error } = await query;
+  if (error) throw error;
+
+  // Resolve debt accounts once so the helper can skip debt-INFLOWs from totalInflow.
+  const { data: accounts } = await supabase
+    .from("accounts")
+    .select("id, account_type")
+    .eq("user_id", userId);
+  const debtAccountIds = new Set(
+    (accounts ?? [])
+      .filter((a) => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN")
+      .map((a) => a.id),
+  );
+
+  return computeMonthlyAggregates(data ?? [], { debtAccountIds });
+}
+
+/**
+ * Public entry for the Movimientos card. Always month-scoped (defaults to the
+ * current month if `month` is missing) — the calling page may render a label
+ * like "Mayo 2026" without passing a URL param, and the count must agree
+ * with the label.
+ */
+export async function getMonthlyAggregates(
+  month?: string,
+  accountId?: string,
+): Promise<ActionResult<MonthlyAggregatesResult>> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const target = parseMonth(month);
+    const dateFrom = monthStartStr(target);
+    const dateTo = monthEndStr(target);
+    const data = await getMonthlyAggregatesCached(
+      user.id,
+      accessToken,
+      dateFrom,
+      dateTo,
+      accountId,
+    );
+    return { success: true, data };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Error al cargar el resumen mensual";
+    return { success: false, error: message };
   }
 }
 

--- a/webapp/src/app/(dashboard)/transactions/page.tsx
+++ b/webapp/src/app/(dashboard)/transactions/page.tsx
@@ -2,7 +2,7 @@ import { connection } from "next/server";
 import { Suspense } from "react";
 import Link from "next/link";
 import { ArrowRight, Brain } from "lucide-react";
-import { getTransactions } from "@/actions/transactions";
+import { getTransactions, getMonthlyAggregates } from "@/actions/transactions";
 import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { getAllTags } from "@/actions/tags";
@@ -37,14 +37,21 @@ export default async function TransactionsPage({
   await connection();
   const params = await searchParams;
 
-  const [transactionsResult, accountsResult, categoriesResult, allTags, pendingEmailResult] =
-    await Promise.all([
-      getTransactions(params),
-      getAccounts(),
-      getCategories(),
-      getAllTags(),
-      getPendingEmailTransactions(),
-    ]);
+  const [
+    transactionsResult,
+    accountsResult,
+    categoriesResult,
+    allTags,
+    pendingEmailResult,
+    monthlyAggregatesResult,
+  ] = await Promise.all([
+    getTransactions(params),
+    getAccounts(),
+    getCategories(),
+    getAllTags(),
+    getPendingEmailTransactions(),
+    getMonthlyAggregates(params.month, params.accountId),
+  ]);
 
   const pendingTransactions = pendingEmailResult.success ? pendingEmailResult.data : [];
 
@@ -72,6 +79,8 @@ export default async function TransactionsPage({
       .filter((a) => a.account_type === "CREDIT_CARD" || a.account_type === "LOAN")
       .map((a) => a.id)
   );
+  // Desktop "Vista" cards show what's currently filtered+visible (the original
+  // semantic). Mobile LECTURA card needs full-month scope — see below.
   const inflowVisible = visibleTransactions
     .filter((tx) => tx.direction === "INFLOW" && !debtAccountIds.has(tx.account_id))
     .reduce((sum, tx) => sum + tx.amount, 0);
@@ -81,12 +90,15 @@ export default async function TransactionsPage({
   const uncategorizedVisible = visibleTransactions.filter(
     (tx) => tx.direction === "OUTFLOW" && !tx.category_id
   ).length;
-  const scopeLabel =
-    transactionsResult.totalPages > 1
-      ? "en esta página"
-      : hasActiveFilters
-        ? "en esta vista"
-        : "visibles";
+
+  // Mobile LECTURA card ("Resumen del mes") is scoped to the full selected
+  // month via `computeMonthlyAggregates`, not derived from the paginated
+  // `transactionsResult.data`. This ensures the card agrees with the displayed
+  // month label and matches mobile native by construction (same shared helper).
+  const monthlyAggregates = monthlyAggregatesResult.success
+    ? monthlyAggregatesResult.data
+    : { count: 0, totalInflow: 0, totalOutflow: 0, uncategorizedCount: 0, daysByDate: [] };
+  const scopeLabel = hasActiveFilters ? "en esta vista" : monthLabel.toLowerCase();
   const description = hasActiveFilters
     ? `Estás viendo ${transactionsResult.count} movimientos filtrados ${scopeLabel}. Úsalos para limpiar ruido y corregir criterio antes de que afecten presupuesto y plan.`
     : `${monthLabel} en una sola vista: ingresos, gastos y excepciones para leer rápido qué pasó antes de bajar al detalle.`;
@@ -99,10 +111,10 @@ export default async function TransactionsPage({
           categories={categories}
           accounts={accounts}
           tags={allTags}
-          count={transactionsResult.count}
-          totalInflow={inflowVisible}
-          totalOutflow={outflowVisible}
-          uncategorizedCount={uncategorizedVisible}
+          count={monthlyAggregates.count}
+          totalInflow={monthlyAggregates.totalInflow}
+          totalOutflow={monthlyAggregates.totalOutflow}
+          uncategorizedCount={monthlyAggregates.uncategorizedCount}
           pendingEmails={pendingTransactions}
           currency={summaryCurrency}
         />


### PR DESCRIPTION
## Summary

Finding 1 from the [2026-05-21 parity walkthrough](https://github.com/Cristian1911/personal_finance_manager_claude/pull/261). Mobile and webapp's "Resumen del mes" LECTURA card disagreed by 7-33× on every aggregate:

|  | Mobile | Webapp |
|---|---|---|
| MOVIMIENTOS | 112 | 1.371 |
| INGRESOS | \$3.787.610 | \$200.000 |
| GASTOS | \$9.946.089 | \$1.423.639 |
| Categorizar | 33 | 0 |

Two unrelated bugs, not a definition mismatch:

1. **Mobile** (`mobile/lib/repositories/transactions.ts`) — the SQL `COUNT(*)` for the month omitted `is_excluded = 0` while sibling `SUM(CASE WHEN ...)` clauses correctly applied it. The count inflated by every excluded txn.
2. **Webapp** (`(dashboard)/transactions/page.tsx`) — count was wired to `transactionsResult.count` (full filtered count from the list endpoint), while INGRESOS / GASTOS / Categorizar were reduced from `visibleTransactions` (paginated data array, page-1 only). The mobile MovimientosRoot displayed a card labeled "Resumen del **mes**" that actually showed paginated subset numbers.

## Fix

- New `packages/shared/src/utils/monthly-aggregates.ts` — `computeMonthlyAggregates(rows, { debtAccountIds })`. Pure JS function over a minimum-information row shape. Filters baked in (CLAUDE.md "Income & Metrics Rules"): exclude `is_excluded`, exclude reconciled rows, exclude INFLOWs into debt accounts from `totalInflow`, count uncategorized as OUTFLOW with no `category_id`.
- Webapp `getMonthlyAggregates(month, accountId?)` action — slim SELECT for the month (no pagination) → shared helper. Cached under `"transactions"` tag.
- Webapp page wiring — `MovimientosRoot` (mobile viewport) reads the month aggregate; desktop "Vista" cards keep the filtered-view semantics (their label says "en la vista").
- Mobile repository — drops the broken SQL CASE-WHEN, reduces via the shared helper. Same numbers as webapp by construction.

## Adjacent wins
- /accounts vs /transactions Categorizar internal mismatch (same root cause)
- Mobile uncategorized count now agrees with webapp's

## Test plan

- [x] `vitest run` on the new shared helper: 6/6 pass
- [x] `pnpm build` webapp: green
- [x] `pnpm tsc --noEmit` mobile: green
- [ ] Live walk-through on iOS sim + mobile-viewport webapp after merge — verify both surfaces show identical MOVIMIENTOS / INGRESOS / GASTOS / Categorizar for Mayo 2026

## Out of scope (separate follow-ups)
- POR RESOLVER count mismatch (mobile `pendingEmails = 0` hardcode — one-liner)
- Finding 2 (Hero ritmo divergence) — Option A picked, dedicated PR in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)