### PR TITLE
feat(hero): V7 hybrid runway hero — Option A, predictive runway canonical

### DIFF
--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -113,19 +113,19 @@ export function HybridHero({
     [today, endOfMonth, liquidBalance, nextIncomeDate, nextIncomeAmount, pendingObligations, dailyOutflows],
   );
 
-  // Period-aware status (not today-micro-spend). availableTotal < 0
-  // means actually overspent; "Hoy a tope" is the softer "today's
-  // allowance is gone but period is fine" copy.
+  // Status: red on overspend (today OR period), amber on period strain.
+  const overspentToday = ritmo.spentToday > ritmo.availablePerDay;
   const status: { label: string; color: string } =
-    ritmo.availableTotal < 0
+    ritmo.availableTotal < 0 || overspentToday
       ? { label: "Te pasaste", color: COLORS.debt }
       : ritmo.spentFraction >= 0.85
         ? { label: "Vas justo", color: COLORS.alert }
-        : ritmo.allowedToday <= 0
-          ? { label: "Hoy a tope", color: COLORS.alert }
-          : { label: "Vas bien", color: COLORS.income };
+        : { label: "Vas bien", color: COLORS.income };
 
-  const amountColor = status.color;
+  const amountColor =
+    status.color === COLORS.income && ritmo.spentToday === 0
+      ? COLORS.sageLight
+      : status.color;
 
   const sparkValues = ritmo.calendar.slice(-7).map((d) => d.expense);
   const sparkMax = sparkValues.reduce((m, v) => Math.max(m, v), 0);
@@ -156,7 +156,7 @@ export function HybridHero({
       {/* Top row: eyebrow + status pill */}
       <View className="flex-row items-center justify-between">
         <Text className="text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
-          Hoy puedes gastar
+          Gasto de hoy
         </Text>
         <View
           className="flex-row items-center gap-1.5 rounded-full border border-white-6 bg-white-4 px-2.5 py-1"
@@ -171,18 +171,31 @@ export function HybridHero({
         </View>
       </View>
 
-      {/* Bottom row: amount + sparkline */}
+      {/* Bottom row: today's spend (headline fact) + sparkline. */}
       <View className="mt-2 flex-row items-end justify-between">
         <Text
           className="text-[44px] font-inter-bold tracking-[-1.6px]"
           style={{ color: amountColor, fontVariant: ["tabular-nums"] }}
         >
-          {formatCurrency(ritmo.allowedToday, currency)}
+          {formatCurrency(ritmo.spentToday, currency)}
         </Text>
         {sparkValues.length > 0 && (
           <Sparkline values={sparkValues} max={sparkMax} color={status.color} />
         )}
       </View>
+
+      {/* Daily allowance context — always rendered. */}
+      <Text
+        className="mt-2 text-[12px]"
+        style={{
+          color: overspentToday ? COLORS.alert : COLORS.sageLight,
+          fontVariant: ["tabular-nums"],
+        }}
+      >
+        {overspentToday
+          ? `Por encima de ${formatCurrency(ritmo.availablePerDay, currency)} al día`
+          : `de ${formatCurrency(ritmo.availablePerDay, currency)} al día`}
+      </Text>
 
       {/* % del período above bar */}
       <View className="mt-5 flex-row items-end justify-end">

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { ChevronDown, ChevronRight } from "lucide-react-native";
 import Svg, { Polyline, Line, Defs, LinearGradient, Stop, Rect } from "react-native-svg";
@@ -45,9 +45,12 @@ interface HybridHeroProps {
 
 const BUCKET_TONE: Record<string, string> = {
   none: "bg-z-surface-2",
-  low: "bg-z-income/20",
-  med: "bg-z-alert/30",
-  high: "bg-z-debt/40",
+  // NativeWind v3 cannot parse Tailwind v4's `/N` opacity modifier — the
+  // class compiles to nothing and renders fully transparent. Use the
+  // pre-computed tokens from mobile/tailwind.config.js instead.
+  low: "bg-z-income-20",
+  med: "bg-z-alert-30",
+  high: "bg-z-debt-40",
 };
 
 const BUCKET_LABEL: Record<string, string> = {
@@ -82,7 +85,11 @@ function formatShortDate(iso: string): string {
   });
 }
 
-export function HybridHero({
+// Wrapped in memo so InicioRoot state changes (editing toggle, catalog
+// open, refresh, layout edits, widget activation) don't cascade into a
+// hero re-render. All props from InicioRoot are stable primitives or
+// useMemo-gated objects.
+export const HybridHero = memo(function HybridHero({
   today,
   endOfMonth,
   liquidBalance,
@@ -271,7 +278,7 @@ export function HybridHero({
           <View className="mb-3 flex-row gap-1 rounded-lg border border-white-6 bg-z-surface-2 p-0.5">
             <Pressable
               onPress={() => setView("calc")}
-              className={`flex-1 rounded-md px-2 py-1.5 ${view === "calc" ? "bg-z-brass/20" : ""}`}
+              className={`flex-1 rounded-md px-2 py-1.5 ${view === "calc" ? "bg-z-brass-20" : ""}`}
             >
               <Text
                 className="text-center text-[10px] font-inter-semibold uppercase tracking-[1.2px]"
@@ -282,7 +289,7 @@ export function HybridHero({
             </Pressable>
             <Pressable
               onPress={() => setView("pattern")}
-              className={`flex-1 rounded-md px-2 py-1.5 ${view === "pattern" ? "bg-z-brass/20" : ""}`}
+              className={`flex-1 rounded-md px-2 py-1.5 ${view === "pattern" ? "bg-z-brass-20" : ""}`}
             >
               <Text
                 className="text-center text-[10px] font-inter-semibold uppercase tracking-[1.2px]"
@@ -326,7 +333,7 @@ export function HybridHero({
       )}
     </View>
   );
-}
+});
 
 function Sparkline({
   values,

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -6,22 +6,16 @@ import { useRouter } from "expo-router";
 import {
   formatCurrency,
   computeRitmo,
+  BUCKET_LABEL,
+  WEEKDAYS_MONDAY_START,
+  deriveRitmoStatus,
+  weekdayMondayStart,
   type CurrencyCode,
+  type DailyBucket,
   type RitmoResult,
+  type RitmoStatusTone,
 } from "@zeta/shared";
 import { COLORS } from "../../lib/constants/colors";
-
-/**
- * V7 hybrid hero (React Native) — Option A canonical, predictive-runway
- * model. Mirrors webapp/src/components/dashboard/hybrid-hero.tsx exactly
- * via the shared `computeRitmo` helper.
- *
- *   ┌─ Eyebrow + status pill           (top row, both small)
- *   ├─ Big "Hoy puedes gastar" + sparkline (heavy visuals paired)
- *   ├─ Period progress bar with gradient
- *   ├─ Gastados / Restantes legend (each on its own row)
- *   └─ Expand → tabs (Cómo se calcula / Patrón del mes with clickable days)
- */
 
 export interface PrimaryAccountSummary {
   id: string;
@@ -43,32 +37,24 @@ interface HybridHeroProps {
   primaryAccount?: PrimaryAccountSummary;
 }
 
-const BUCKET_TONE: Record<string, string> = {
+// NativeWind v3 can't parse Tailwind v4's `/N` opacity modifier — those
+// classes compile to nothing. Use the pre-computed tokens from
+// mobile/tailwind.config.js instead.
+const BUCKET_TONE: Record<DailyBucket, string> = {
   none: "bg-z-surface-2",
-  // NativeWind v3 cannot parse Tailwind v4's `/N` opacity modifier — the
-  // class compiles to nothing and renders fully transparent. Use the
-  // pre-computed tokens from mobile/tailwind.config.js instead.
   low: "bg-z-income-20",
   med: "bg-z-alert-30",
   high: "bg-z-debt-40",
 };
 
-const BUCKET_LABEL: Record<string, string> = {
-  none: "Sin gasto",
-  low: "Día tranquilo",
-  med: "Día normal",
-  high: "Día caro",
+const TONE_COLOR: Record<RitmoStatusTone, string> = {
+  income: COLORS.income,
+  alert: COLORS.alert,
+  debt: COLORS.debt,
 };
-
-const WEEKDAYS = ["L", "M", "X", "J", "V", "S", "D"];
 
 function dayOfMonth(iso: string): number {
   return parseInt(iso.slice(8, 10), 10);
-}
-
-function weekdayMondayStart(iso: string): number {
-  const d = new Date(`${iso}T12:00:00`).getDay();
-  return (d + 6) % 7;
 }
 
 function formatDayLabel(iso: string): string {
@@ -85,10 +71,6 @@ function formatShortDate(iso: string): string {
   });
 }
 
-// Wrapped in memo so InicioRoot state changes (editing toggle, catalog
-// open, refresh, layout edits, widget activation) don't cascade into a
-// hero re-render. All props from InicioRoot are stable primitives or
-// useMemo-gated objects.
 export const HybridHero = memo(function HybridHero({
   today,
   endOfMonth,
@@ -120,22 +102,17 @@ export const HybridHero = memo(function HybridHero({
     [today, endOfMonth, liquidBalance, nextIncomeDate, nextIncomeAmount, pendingObligations, dailyOutflows],
   );
 
-  // Status: red on overspend (today OR period), amber on period strain.
   const overspentToday = ritmo.spentToday > ritmo.availablePerDay;
-  const status: { label: string; color: string } =
-    ritmo.availableTotal < 0 || overspentToday
-      ? { label: "Te pasaste", color: COLORS.debt }
-      : ritmo.spentFraction >= 0.85
-        ? { label: "Vas justo", color: COLORS.alert }
-        : { label: "Vas bien", color: COLORS.income };
-
+  const status = deriveRitmoStatus(ritmo);
+  const statusColor = TONE_COLOR[status.tone];
   const amountColor =
-    status.color === COLORS.income && ritmo.spentToday === 0
-      ? COLORS.sageLight
-      : status.color;
+    status.tone === "income" && ritmo.spentToday === 0 ? COLORS.sageLight : statusColor;
 
-  const sparkValues = ritmo.calendar.slice(-7).map((d) => d.expense);
-  const sparkMax = sparkValues.reduce((m, v) => Math.max(m, v), 0);
+  const spark = useMemo(() => {
+    const values = ritmo.calendar.slice(-7).map((d) => d.expense);
+    const max = values.reduce((m, v) => Math.max(m, v), 0);
+    return { values, max };
+  }, [ritmo.calendar]);
 
   const cumulativeByDate = useMemo(() => {
     const map = new Map<string, number>();
@@ -147,19 +124,24 @@ export const HybridHero = memo(function HybridHero({
     return map;
   }, [ritmo.calendar]);
 
-  const selectedEntry = selectedDay
-    ? ritmo.calendar.find((d) => d.date === selectedDay)
-    : null;
-  const selectedBalance = selectedEntry
-    ? ritmo.periodBudget - (cumulativeByDate.get(selectedEntry.date) ?? 0)
-    : null;
+  const selectedEntry = useMemo(
+    () => (selectedDay ? ritmo.calendar.find((d) => d.date === selectedDay) ?? null : null),
+    [selectedDay, ritmo.calendar],
+  );
+  const selectedBalance = useMemo(
+    () =>
+      selectedEntry
+        ? ritmo.periodBudget - (cumulativeByDate.get(selectedEntry.date) ?? 0)
+        : null,
+    [selectedEntry, cumulativeByDate, ritmo.periodBudget],
+  );
 
   const windowEndLabel = formatShortDate(ritmo.windowEndDate);
   const nextIncomeDateLabel = nextIncomeDate ? formatShortDate(nextIncomeDate) : null;
   const dailyValue = `${formatCurrency(ritmo.availablePerDay, currency)}/día`;
 
   return (
-    <View className="mx-4 mb-3 rounded-2xl border border-white-6 bg-z-surface p-5">
+    <View className="rounded-2xl border border-white-6 bg-z-surface p-5">
       {/* Top row: eyebrow + status pill */}
       <View className="flex-row items-center justify-between">
         <Text className="text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
@@ -168,10 +150,10 @@ export const HybridHero = memo(function HybridHero({
         <View
           className="flex-row items-center gap-1.5 rounded-full border border-white-6 bg-white-4 px-2.5 py-1"
         >
-          <View className="size-1.5 rounded-full" style={{ backgroundColor: status.color }} />
+          <View className="size-1.5 rounded-full" style={{ backgroundColor: statusColor }} />
           <Text
             className="text-[10px] font-inter-semibold uppercase tracking-[1.2px]"
-            style={{ color: status.color }}
+            style={{ color: statusColor }}
           >
             {status.label}
           </Text>
@@ -181,13 +163,13 @@ export const HybridHero = memo(function HybridHero({
       {/* Bottom row: today's spend (headline fact) + sparkline. */}
       <View className="mt-2 flex-row items-end justify-between">
         <Text
-          className="text-[44px] font-inter-bold tracking-[-1.6px]"
+          className="text-[34px] font-inter-bold tracking-[-1.2px]"
           style={{ color: amountColor, fontVariant: ["tabular-nums"] }}
         >
           {formatCurrency(ritmo.spentToday, currency)}
         </Text>
-        {sparkValues.length > 0 && (
-          <Sparkline values={sparkValues} max={sparkMax} color={status.color} />
+        {spark.values.length > 0 && (
+          <Sparkline values={spark.values} max={spark.max} color={statusColor} />
         )}
       </View>
 
@@ -335,7 +317,7 @@ export const HybridHero = memo(function HybridHero({
   );
 });
 
-function Sparkline({
+const Sparkline = memo(function Sparkline({
   values,
   max,
   color,
@@ -385,9 +367,9 @@ function Sparkline({
       />
     </Svg>
   );
-}
+});
 
-function CalcView(props: {
+const CalcView = memo(function CalcView(props: {
   ritmo: RitmoResult;
   liquidBalance: number;
   pendingObligations: number;
@@ -484,7 +466,7 @@ function CalcView(props: {
       )}
     </View>
   );
-}
+});
 
 function Row({
   label,
@@ -517,7 +499,7 @@ function Row({
   );
 }
 
-function PatternView(props: {
+const PatternView = memo(function PatternView(props: {
   ritmo: RitmoResult;
   currency: CurrencyCode;
   selectedDay: string | null;
@@ -558,7 +540,7 @@ function PatternView(props: {
           flex-1 + gap combo that was collapsing empty cells in partial
           rows and misaligning columns. */}
       <View className="flex-row">
-        {WEEKDAYS.map((label) => (
+        {WEEKDAYS_MONDAY_START.map((label) => (
           <View key={label} style={{ width: `${100 / 7}%`, alignItems: "center" }}>
             <Text className="text-[9px] font-inter-semibold uppercase tracking-wider text-z-sage-dark">
               {label}
@@ -614,9 +596,9 @@ function PatternView(props: {
 
       {/* Legend */}
       <View className="mt-3 flex-row flex-wrap gap-3">
-        <LegendDot color="rgba(92,184,138,0.30)" label="Día tranquilo" />
-        <LegendDot color="rgba(212,168,67,0.40)" label="Día normal" />
-        <LegendDot color="rgba(224,85,69,0.50)" label="Día caro" />
+        <LegendDot color="rgba(92,184,138,0.30)" label={BUCKET_LABEL.low} />
+        <LegendDot color="rgba(212,168,67,0.40)" label={BUCKET_LABEL.med} />
+        <LegendDot color="rgba(224,85,69,0.50)" label={BUCKET_LABEL.high} />
       </View>
 
       {selectedEntry && (
@@ -655,7 +637,7 @@ function PatternView(props: {
       )}
     </View>
   );
-}
+});
 
 function LegendDot({ color, label }: { color: string; label: string }) {
   return (

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -582,18 +582,17 @@ function PatternView(props: {
                   className={`items-end justify-start rounded-md px-1 py-0.5 ${BUCKET_TONE[day.bucket]}`}
                   style={{
                     aspectRatio: 1,
+                    // Future days dim naturally — no separate "today"
+                    // ring needed (today is the last fully-bright cell).
                     opacity: day.isFuture ? 0.3 : 1,
-                    borderWidth: day.isToday || isSelected ? 2 : 0,
-                    // Brass for both today AND selected so the indicator
-                    // stays on-brand. Selected wins when both apply.
-                    borderColor:
-                      isSelected || day.isToday ? COLORS.brass : "transparent",
+                    borderWidth: isSelected ? 2 : 0,
+                    borderColor: isSelected ? COLORS.brass : "transparent",
                   }}
                 >
                   <Text
                     className="text-[10px]"
                     style={{
-                      color: day.bucket === "high" ? COLORS.foreground : COLORS.sageDark,
+                      color: COLORS.foreground,
                       fontVariant: ["tabular-nums"],
                     }}
                   >

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -520,53 +520,87 @@ function PatternView(props: {
 }) {
   const { ritmo, currency, selectedDay, onSelect, selectedEntry, selectedBalance } = props;
   if (ritmo.calendar.length === 0) return null;
+
+  // Build week rows. RN doesn't have CSS Grid, so we emit 7-cell rows
+  // explicitly — each cell flex-1 + aspectRatio 1 to stay square.
   const firstIso = ritmo.calendar[0].date;
   const leadingEmpty = weekdayMondayStart(firstIso);
+  type Cell = RitmoResult["calendar"][number] | null;
+  const weeks: Cell[][] = [];
+  let row: Cell[] = new Array<Cell>(leadingEmpty).fill(null);
+  for (const day of ritmo.calendar) {
+    row.push(day);
+    if (row.length === 7) {
+      weeks.push(row);
+      row = [];
+    }
+  }
+  if (row.length > 0) {
+    while (row.length < 7) row.push(null);
+    weeks.push(row);
+  }
 
   return (
     <View>
       <Text className="mb-2 text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
         Toca un día para ver su detalle
       </Text>
-      <View className="flex-row flex-wrap gap-1.5">
+
+      {/* Weekday header — one flex-row of 7 equal columns. */}
+      <View className="flex-row">
         {WEEKDAYS.map((label) => (
-          <View key={label} style={{ width: "13.5%", alignItems: "center" }}>
+          <View key={label} className="flex-1 items-center">
             <Text className="text-[9px] font-inter-semibold uppercase tracking-wider text-z-sage-dark">
               {label}
             </Text>
           </View>
         ))}
-        {Array.from({ length: leadingEmpty }).map((_, i) => (
-          <View key={`empty-${i}`} style={{ width: "13.5%", aspectRatio: 1 }} />
-        ))}
-        {ritmo.calendar.map((day) => {
-          const isSelected = day.date === selectedDay;
-          return (
-            <Pressable
-              key={day.date}
-              onPress={() => onSelect(day.date)}
-              className={`items-end justify-start rounded-md px-1 py-0.5 ${BUCKET_TONE[day.bucket]}`}
-              style={{
-                width: "13.5%",
-                aspectRatio: 1,
-                opacity: day.isFuture ? 0.3 : 1,
-                borderWidth: day.isToday || isSelected ? 2 : 0,
-                borderColor: isSelected ? COLORS.brass : day.isToday ? COLORS.foreground : "transparent",
-              }}
-            >
-              <Text
-                className="text-[9px]"
+      </View>
+
+      {/* Week rows */}
+      {weeks.map((week, wi) => (
+        <View key={`w-${wi}`} className="mt-1.5 flex-row" style={{ gap: 6 }}>
+          {week.map((day, di) => {
+            if (!day) {
+              return (
+                <View
+                  key={`empty-${wi}-${di}`}
+                  className="flex-1"
+                  style={{ aspectRatio: 1 }}
+                />
+              );
+            }
+            const isSelected = day.date === selectedDay;
+            return (
+              <Pressable
+                key={day.date}
+                onPress={() => onSelect(day.date)}
+                className={`flex-1 items-end justify-start rounded-md px-1 py-0.5 ${BUCKET_TONE[day.bucket]}`}
                 style={{
-                  color: day.bucket === "high" ? COLORS.foreground : COLORS.sageDark,
-                  fontVariant: ["tabular-nums"],
+                  aspectRatio: 1,
+                  opacity: day.isFuture ? 0.3 : 1,
+                  borderWidth: day.isToday || isSelected ? 2 : 0,
+                  borderColor: isSelected
+                    ? COLORS.brass
+                    : day.isToday
+                      ? COLORS.foreground
+                      : "transparent",
                 }}
               >
-                {dayOfMonth(day.date)}
-              </Text>
-            </Pressable>
-          );
-        })}
-      </View>
+                <Text
+                  className="text-[10px]"
+                  style={{
+                    color: day.bucket === "high" ? COLORS.foreground : COLORS.sageDark,
+                    fontVariant: ["tabular-nums"],
+                  }}
+                >
+                  {dayOfMonth(day.date)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ))}
 
       {/* Legend */}
       <View className="mt-3 flex-row flex-wrap gap-3">

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -1,0 +1,612 @@
+import { useMemo, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { ChevronDown, ChevronRight } from "lucide-react-native";
+import Svg, { Polyline, Line, Defs, LinearGradient, Stop, Rect } from "react-native-svg";
+import { useRouter } from "expo-router";
+import {
+  formatCurrency,
+  computeRitmo,
+  type CurrencyCode,
+  type RitmoResult,
+} from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
+
+/**
+ * V7 hybrid hero (React Native) — Option A canonical, predictive-runway
+ * model. Mirrors webapp/src/components/dashboard/hybrid-hero.tsx exactly
+ * via the shared `computeRitmo` helper.
+ *
+ *   ┌─ Eyebrow + status pill           (top row, both small)
+ *   ├─ Big "Hoy puedes gastar" + sparkline (heavy visuals paired)
+ *   ├─ Period progress bar with gradient
+ *   ├─ Gastados / Restantes legend (each on its own row)
+ *   └─ Expand → tabs (Cómo se calcula / Patrón del mes with clickable days)
+ */
+
+export interface PrimaryAccountSummary {
+  id: string;
+  name: string;
+  currentBalance: number;
+  currencyCode: CurrencyCode;
+}
+
+interface HybridHeroProps {
+  today: string;
+  endOfMonth: string;
+  liquidBalance: number;
+  pendingObligations: number;
+  nextIncomeDate: string | null;
+  nextIncomeAmount: number;
+  nextIncomeName: string | null;
+  dailyOutflows: { date: string; expense: number }[];
+  currency: CurrencyCode;
+  primaryAccount?: PrimaryAccountSummary;
+}
+
+const BUCKET_TONE: Record<string, string> = {
+  none: "bg-z-surface-2",
+  low: "bg-z-income/20",
+  med: "bg-z-alert/30",
+  high: "bg-z-debt/40",
+};
+
+const BUCKET_LABEL: Record<string, string> = {
+  none: "Sin gasto",
+  low: "Día tranquilo",
+  med: "Día normal",
+  high: "Día caro",
+};
+
+const WEEKDAYS = ["L", "M", "X", "J", "V", "S", "D"];
+
+function dayOfMonth(iso: string): number {
+  return parseInt(iso.slice(8, 10), 10);
+}
+
+function weekdayMondayStart(iso: string): number {
+  const d = new Date(`${iso}T12:00:00`).getDay();
+  return (d + 6) % 7;
+}
+
+function formatDayLabel(iso: string): string {
+  return new Date(`${iso}T12:00:00`)
+    .toLocaleDateString("es-CO", { weekday: "short", day: "numeric", month: "short" })
+    .replace(/\./g, "")
+    .toLowerCase();
+}
+
+function formatShortDate(iso: string): string {
+  return new Date(`${iso}T12:00:00`).toLocaleDateString("es-CO", {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+export function HybridHero({
+  today,
+  endOfMonth,
+  liquidBalance,
+  pendingObligations,
+  nextIncomeDate,
+  nextIncomeAmount,
+  nextIncomeName,
+  dailyOutflows,
+  currency,
+  primaryAccount,
+}: HybridHeroProps) {
+  const router = useRouter();
+  const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<"calc" | "pattern">("calc");
+  const [selectedDay, setSelectedDay] = useState<string | null>(null);
+
+  const ritmo: RitmoResult = useMemo(
+    () =>
+      computeRitmo({
+        today,
+        endOfMonth,
+        liquidBalance,
+        nextIncomeDate,
+        nextIncomeAmount,
+        pendingObligations,
+        dailyOutflows,
+      }),
+    [today, endOfMonth, liquidBalance, nextIncomeDate, nextIncomeAmount, pendingObligations, dailyOutflows],
+  );
+
+  // Period-aware status (not today-micro-spend). availableTotal < 0
+  // means actually overspent; "Hoy a tope" is the softer "today's
+  // allowance is gone but period is fine" copy.
+  const status: { label: string; color: string } =
+    ritmo.availableTotal < 0
+      ? { label: "Te pasaste", color: COLORS.debt }
+      : ritmo.spentFraction >= 0.85
+        ? { label: "Vas justo", color: COLORS.alert }
+        : ritmo.allowedToday <= 0
+          ? { label: "Hoy a tope", color: COLORS.alert }
+          : { label: "Vas bien", color: COLORS.income };
+
+  const amountColor = status.color;
+
+  const sparkValues = ritmo.calendar.slice(-7).map((d) => d.expense);
+  const sparkMax = sparkValues.reduce((m, v) => Math.max(m, v), 0);
+
+  const cumulativeByDate = useMemo(() => {
+    const map = new Map<string, number>();
+    let running = 0;
+    for (const day of ritmo.calendar) {
+      running += day.expense;
+      map.set(day.date, running);
+    }
+    return map;
+  }, [ritmo.calendar]);
+
+  const selectedEntry = selectedDay
+    ? ritmo.calendar.find((d) => d.date === selectedDay)
+    : null;
+  const selectedBalance = selectedEntry
+    ? ritmo.periodBudget - (cumulativeByDate.get(selectedEntry.date) ?? 0)
+    : null;
+
+  const windowEndLabel = formatShortDate(ritmo.windowEndDate);
+  const nextIncomeDateLabel = nextIncomeDate ? formatShortDate(nextIncomeDate) : null;
+  const dailyValue = `${formatCurrency(ritmo.availablePerDay, currency)}/día`;
+
+  return (
+    <View className="mx-4 mb-3 rounded-2xl border border-white-6 bg-z-surface p-5">
+      {/* Top row: eyebrow + status pill */}
+      <View className="flex-row items-center justify-between">
+        <Text className="text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
+          Hoy puedes gastar
+        </Text>
+        <View
+          className="flex-row items-center gap-1.5 rounded-full border border-white-6 bg-white-4 px-2.5 py-1"
+        >
+          <View className="size-1.5 rounded-full" style={{ backgroundColor: status.color }} />
+          <Text
+            className="text-[10px] font-inter-semibold uppercase tracking-[1.2px]"
+            style={{ color: status.color }}
+          >
+            {status.label}
+          </Text>
+        </View>
+      </View>
+
+      {/* Bottom row: amount + sparkline */}
+      <View className="mt-2 flex-row items-end justify-between">
+        <Text
+          className="text-[44px] font-inter-bold tracking-[-1.6px]"
+          style={{ color: amountColor, fontVariant: ["tabular-nums"] }}
+        >
+          {formatCurrency(ritmo.allowedToday, currency)}
+        </Text>
+        {sparkValues.length > 0 && (
+          <Sparkline values={sparkValues} max={sparkMax} color={status.color} />
+        )}
+      </View>
+
+      {/* % del período above bar */}
+      <View className="mt-5 flex-row items-end justify-end">
+        <Text className="text-[10px] font-inter-medium text-z-sage-light" style={{ fontVariant: ["tabular-nums"] }}>
+          {Math.round(ritmo.spentFraction * 100)}% del período
+        </Text>
+      </View>
+
+      {/* Period progress bar with gradient */}
+      <View className="mt-1 h-2.5 w-full overflow-hidden rounded-full bg-z-surface-2">
+        <Svg height="10" width="100%">
+          <Defs>
+            <LinearGradient id="periodGrad" x1="0" y1="0" x2="1" y2="0">
+              {/* Mobile color palette lacks an "excellent" + "sage" stop, so we
+               *  approximate the webapp gradient with income → income → alert → debt. */}
+              <Stop offset="0" stopColor={COLORS.income} />
+              <Stop offset="0.4" stopColor={COLORS.income} />
+              <Stop offset="0.7" stopColor={COLORS.alert} />
+              <Stop offset="1" stopColor={COLORS.debt} />
+            </LinearGradient>
+          </Defs>
+          <Rect
+            x="0"
+            y="0"
+            width={`${Math.min(100, Math.round(ritmo.spentFraction * 100))}%`}
+            height="10"
+            rx="5"
+            fill="url(#periodGrad)"
+          />
+        </Svg>
+      </View>
+
+      {/* Legend rows */}
+      <View className="mt-3 gap-1">
+        <View className="flex-row items-baseline justify-between">
+          <Text className="text-[11px] font-inter text-z-sage-dark">Gastados</Text>
+          <Text className="text-[11px] font-inter text-z-sage-light" style={{ fontVariant: ["tabular-nums"] }}>
+            {formatCurrency(ritmo.spentMonth, currency)}
+          </Text>
+        </View>
+        <View className="flex-row items-baseline justify-between">
+          <Text className="text-[11px] font-inter text-z-sage-dark">Restantes</Text>
+          <Text
+            className="text-[11px] font-inter"
+            style={{
+              fontVariant: ["tabular-nums"],
+              color: ritmo.availableTotal < 0 ? COLORS.debt : COLORS.sageLight,
+            }}
+          >
+            {formatCurrency(ritmo.availableTotal, currency)}
+          </Text>
+        </View>
+      </View>
+
+      {/* Expand toggle */}
+      <Pressable
+        onPress={() => setExpanded((v) => !v)}
+        className="mt-4 flex-row items-center justify-center gap-1.5 rounded-lg border border-white-6 px-3 py-2 active:bg-white-4"
+      >
+        <Text className="text-[11px] font-inter-semibold tracking-wide text-z-sage-light">
+          {expanded ? "Ocultar detalle" : "Ver detalle"}
+        </Text>
+        <ChevronDown
+          size={14}
+          color={COLORS.brass}
+          style={{ transform: [{ rotate: expanded ? "180deg" : "0deg" }] }}
+        />
+      </Pressable>
+
+      {expanded && (
+        <View className="mt-4 border-t border-dashed border-white-6 pt-4">
+          {/* Tabs */}
+          <View className="mb-3 flex-row gap-1 rounded-lg border border-white-6 bg-z-surface-2 p-0.5">
+            <Pressable
+              onPress={() => setView("calc")}
+              className={`flex-1 rounded-md px-2 py-1.5 ${view === "calc" ? "bg-z-brass/20" : ""}`}
+            >
+              <Text
+                className="text-center text-[10px] font-inter-semibold uppercase tracking-[1.2px]"
+                style={{ color: view === "calc" ? COLORS.brass : COLORS.sageDark }}
+              >
+                Cómo se calcula
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() => setView("pattern")}
+              className={`flex-1 rounded-md px-2 py-1.5 ${view === "pattern" ? "bg-z-brass/20" : ""}`}
+            >
+              <Text
+                className="text-center text-[10px] font-inter-semibold uppercase tracking-[1.2px]"
+                style={{ color: view === "pattern" ? COLORS.brass : COLORS.sageDark }}
+              >
+                Patrón del mes
+              </Text>
+            </Pressable>
+          </View>
+
+          {view === "calc" ? (
+            <CalcView
+              ritmo={ritmo}
+              liquidBalance={liquidBalance}
+              pendingObligations={pendingObligations}
+              nextIncomeName={nextIncomeName}
+              nextIncomeAmount={nextIncomeAmount}
+              nextIncomeDateLabel={nextIncomeDateLabel}
+              windowEndLabel={windowEndLabel}
+              dailyValue={dailyValue}
+              currency={currency}
+              primaryAccount={primaryAccount}
+              onAccountPress={() =>
+                primaryAccount &&
+                router.push(`/account/${primaryAccount.id}` as never)
+              }
+            />
+          ) : (
+            <PatternView
+              ritmo={ritmo}
+              currency={currency}
+              selectedDay={selectedDay}
+              onSelect={(date) =>
+                setSelectedDay((prev) => (prev === date ? null : date))
+              }
+              selectedEntry={selectedEntry ?? null}
+              selectedBalance={selectedBalance}
+            />
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function Sparkline({
+  values,
+  max,
+  color,
+}: {
+  values: number[];
+  max: number;
+  color: string;
+}) {
+  const w = 96;
+  const h = 32;
+  const pad = 3;
+  if (values.length === 0) return null;
+  if (values.length === 1) {
+    return (
+      <Svg width={w} height={h}>
+        <Line
+          x1={pad}
+          x2={w - pad}
+          y1={h / 2}
+          y2={h / 2}
+          stroke={color}
+          strokeWidth={2}
+          strokeLinecap="round"
+          opacity={0.6}
+        />
+      </Svg>
+    );
+  }
+  const safeMax = max > 0 ? max : 1;
+  const step = (w - pad * 2) / (values.length - 1);
+  const points = values
+    .map((v, i) => {
+      const x = pad + step * i;
+      const y = h - pad - (v / safeMax) * (h - pad * 2);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <Svg width={w} height={h}>
+      <Polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.75}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}
+
+function CalcView(props: {
+  ritmo: RitmoResult;
+  liquidBalance: number;
+  pendingObligations: number;
+  nextIncomeName: string | null;
+  nextIncomeAmount: number;
+  nextIncomeDateLabel: string | null;
+  windowEndLabel: string;
+  dailyValue: string;
+  currency: CurrencyCode;
+  primaryAccount?: PrimaryAccountSummary;
+  onAccountPress: () => void;
+}) {
+  const {
+    ritmo,
+    liquidBalance,
+    pendingObligations,
+    nextIncomeName,
+    nextIncomeAmount,
+    nextIncomeDateLabel,
+    windowEndLabel,
+    dailyValue,
+    currency,
+    primaryAccount,
+    onAccountPress,
+  } = props;
+  return (
+    <View className="gap-3">
+      <View className="gap-1.5 rounded-lg border border-white-6 bg-z-surface-2 p-3">
+        <Text className="text-[10px] font-inter-bold uppercase tracking-[2px] text-z-brass">
+          Cómo se calcula
+        </Text>
+        <Row label="Saldo líquido" value={formatCurrency(liquidBalance, currency)} />
+        <Row
+          label="− Obligaciones pendientes"
+          value={`−${formatCurrency(pendingObligations, currency)}`}
+          valueColor={COLORS.expense}
+        />
+        <Row
+          label="− Ya gastado"
+          value={`−${formatCurrency(ritmo.spentMonth, currency)}`}
+          valueColor={COLORS.expense}
+        />
+        <View className="my-1 border-t border-white-6" />
+        <Row
+          label="= Disponible"
+          value={formatCurrency(ritmo.availableTotal, currency)}
+          bold
+          valueColor={ritmo.availableTotal < 0 ? COLORS.debt : undefined}
+        />
+        <Text className="text-[10px] text-muted-foreground">
+          ÷ {ritmo.daysRemaining} días (hasta {windowEndLabel}) = {dailyValue}
+        </Text>
+        {nextIncomeDateLabel && nextIncomeAmount > 0 && (
+          <>
+            <View className="my-1 border-t border-white-6" />
+            <View className="flex-row items-center justify-between">
+              <Text className="text-[11px] font-inter text-z-income" numberOfLines={1}>
+                Próximo ingreso: {nextIncomeName ?? "ingreso"}
+              </Text>
+              <Text
+                className="text-[11px] font-inter text-z-income"
+                style={{ fontVariant: ["tabular-nums"] }}
+              >
+                +{formatCurrency(nextIncomeAmount, currency)} el {nextIncomeDateLabel}
+              </Text>
+            </View>
+          </>
+        )}
+      </View>
+
+      {primaryAccount && (
+        <Pressable
+          onPress={onAccountPress}
+          className="flex-row items-center justify-between rounded-lg border border-white-6 bg-black-20 p-3 active:bg-white-4"
+        >
+          <View className="flex-1">
+            <Text className="text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
+              Cuenta principal
+            </Text>
+            <Text className="mt-0.5 text-[12px] text-z-sage-light" numberOfLines={1}>
+              {primaryAccount.name}
+            </Text>
+          </View>
+          <View className="flex-row items-center gap-1.5">
+            <Text
+              className="text-[15px] font-inter-bold text-foreground"
+              style={{ fontVariant: ["tabular-nums"] }}
+            >
+              {formatCurrency(primaryAccount.currentBalance, primaryAccount.currencyCode)}
+            </Text>
+            <ChevronRight size={14} color={COLORS.sageDark} />
+          </View>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+function Row({
+  label,
+  value,
+  valueColor,
+  bold,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+  bold?: boolean;
+}) {
+  return (
+    <View className="flex-row items-baseline justify-between">
+      <Text
+        className={`text-[11px] ${bold ? "font-inter-semibold text-foreground" : "font-inter text-z-sage-light"}`}
+      >
+        {label}
+      </Text>
+      <Text
+        className={`text-[11px] ${bold ? "font-inter-semibold" : "font-inter"}`}
+        style={{
+          color: valueColor ?? (bold ? COLORS.foreground : COLORS.sageLight),
+          fontVariant: ["tabular-nums"],
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function PatternView(props: {
+  ritmo: RitmoResult;
+  currency: CurrencyCode;
+  selectedDay: string | null;
+  onSelect: (date: string) => void;
+  selectedEntry: RitmoResult["calendar"][number] | null;
+  selectedBalance: number | null;
+}) {
+  const { ritmo, currency, selectedDay, onSelect, selectedEntry, selectedBalance } = props;
+  if (ritmo.calendar.length === 0) return null;
+  const firstIso = ritmo.calendar[0].date;
+  const leadingEmpty = weekdayMondayStart(firstIso);
+
+  return (
+    <View>
+      <Text className="mb-2 text-[10px] font-inter-semibold uppercase tracking-[2px] text-z-sage-dark">
+        Toca un día para ver su detalle
+      </Text>
+      <View className="flex-row flex-wrap gap-1.5">
+        {WEEKDAYS.map((label) => (
+          <View key={label} style={{ width: "13.5%", alignItems: "center" }}>
+            <Text className="text-[9px] font-inter-semibold uppercase tracking-wider text-z-sage-dark">
+              {label}
+            </Text>
+          </View>
+        ))}
+        {Array.from({ length: leadingEmpty }).map((_, i) => (
+          <View key={`empty-${i}`} style={{ width: "13.5%", aspectRatio: 1 }} />
+        ))}
+        {ritmo.calendar.map((day) => {
+          const isSelected = day.date === selectedDay;
+          return (
+            <Pressable
+              key={day.date}
+              onPress={() => onSelect(day.date)}
+              className={`items-end justify-start rounded-md px-1 py-0.5 ${BUCKET_TONE[day.bucket]}`}
+              style={{
+                width: "13.5%",
+                aspectRatio: 1,
+                opacity: day.isFuture ? 0.3 : 1,
+                borderWidth: day.isToday || isSelected ? 2 : 0,
+                borderColor: isSelected ? COLORS.brass : day.isToday ? COLORS.foreground : "transparent",
+              }}
+            >
+              <Text
+                className="text-[9px]"
+                style={{
+                  color: day.bucket === "high" ? COLORS.foreground : COLORS.sageDark,
+                  fontVariant: ["tabular-nums"],
+                }}
+              >
+                {dayOfMonth(day.date)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* Legend */}
+      <View className="mt-3 flex-row flex-wrap gap-3">
+        <LegendDot color="rgba(92,184,138,0.30)" label="Día tranquilo" />
+        <LegendDot color="rgba(212,168,67,0.40)" label="Día normal" />
+        <LegendDot color="rgba(224,85,69,0.50)" label="Día caro" />
+      </View>
+
+      {selectedEntry && (
+        <View className="mt-3 rounded-lg border border-white-6 bg-z-surface-2 p-3">
+          <View className="flex-row items-baseline justify-between">
+            <Text className="text-[12px] font-inter-semibold text-z-sage-light">
+              {formatDayLabel(selectedEntry.date)}
+            </Text>
+            <Text className="text-[10px] font-inter-medium uppercase tracking-[1.2px] text-z-sage-dark">
+              {BUCKET_LABEL[selectedEntry.bucket] ?? ""}
+            </Text>
+          </View>
+          <Text
+            className="mt-1 text-[18px] font-inter-semibold text-foreground"
+            style={{ fontVariant: ["tabular-nums"] }}
+          >
+            {selectedEntry.expense > 0
+              ? `−${formatCurrency(selectedEntry.expense, currency)}`
+              : "Sin gasto"}
+          </Text>
+          {selectedBalance !== null && (
+            <Text
+              className="mt-1 text-[11px]"
+              style={{
+                color: selectedBalance < 0 ? COLORS.debt : COLORS.sageDark,
+                fontVariant: ["tabular-nums"],
+              }}
+            >
+              Restante después de este día:{" "}
+              <Text className="font-inter-semibold">
+                {formatCurrency(selectedBalance, currency)}
+              </Text>
+            </Text>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <View className="flex-row items-center gap-1.5">
+      <View
+        style={{ width: 10, height: 10, borderRadius: 2, backgroundColor: color }}
+      />
+      <Text className="text-[10px] text-z-sage-dark">{label}</Text>
+    </View>
+  );
+}

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -546,10 +546,13 @@ function PatternView(props: {
         Toca un día para ver su detalle
       </Text>
 
-      {/* Weekday header — one flex-row of 7 equal columns. */}
+      {/* Each cell slot occupies exactly 1/7 of the row width with
+          internal padding creating the visual gap. This avoids the
+          flex-1 + gap combo that was collapsing empty cells in partial
+          rows and misaligning columns. */}
       <View className="flex-row">
         {WEEKDAYS.map((label) => (
-          <View key={label} className="flex-1 items-center">
+          <View key={label} style={{ width: `${100 / 7}%`, alignItems: "center" }}>
             <Text className="text-[9px] font-inter-semibold uppercase tracking-wider text-z-sage-dark">
               {label}
             </Text>
@@ -557,46 +560,47 @@ function PatternView(props: {
         ))}
       </View>
 
-      {/* Week rows */}
       {weeks.map((week, wi) => (
-        <View key={`w-${wi}`} className="mt-1.5 flex-row" style={{ gap: 6 }}>
+        <View key={`w-${wi}`} className="mt-1.5 flex-row">
           {week.map((day, di) => {
             if (!day) {
               return (
                 <View
                   key={`empty-${wi}-${di}`}
-                  className="flex-1"
-                  style={{ aspectRatio: 1 }}
+                  style={{ width: `${100 / 7}%`, aspectRatio: 1 }}
                 />
               );
             }
             const isSelected = day.date === selectedDay;
             return (
-              <Pressable
+              <View
                 key={day.date}
-                onPress={() => onSelect(day.date)}
-                className={`flex-1 items-end justify-start rounded-md px-1 py-0.5 ${BUCKET_TONE[day.bucket]}`}
-                style={{
-                  aspectRatio: 1,
-                  opacity: day.isFuture ? 0.3 : 1,
-                  borderWidth: day.isToday || isSelected ? 2 : 0,
-                  borderColor: isSelected
-                    ? COLORS.brass
-                    : day.isToday
-                      ? COLORS.foreground
-                      : "transparent",
-                }}
+                style={{ width: `${100 / 7}%`, padding: 3 }}
               >
-                <Text
-                  className="text-[10px]"
+                <Pressable
+                  onPress={() => onSelect(day.date)}
+                  className={`items-end justify-start rounded-md px-1 py-0.5 ${BUCKET_TONE[day.bucket]}`}
                   style={{
-                    color: day.bucket === "high" ? COLORS.foreground : COLORS.sageDark,
-                    fontVariant: ["tabular-nums"],
+                    aspectRatio: 1,
+                    opacity: day.isFuture ? 0.3 : 1,
+                    borderWidth: day.isToday || isSelected ? 2 : 0,
+                    // Brass for both today AND selected so the indicator
+                    // stays on-brand. Selected wins when both apply.
+                    borderColor:
+                      isSelected || day.isToday ? COLORS.brass : "transparent",
                   }}
                 >
-                  {dayOfMonth(day.date)}
-                </Text>
-              </Pressable>
+                  <Text
+                    className="text-[10px]"
+                    style={{
+                      color: day.bucket === "high" ? COLORS.foreground : COLORS.sageDark,
+                      fontVariant: ["tabular-nums"],
+                    }}
+                  >
+                    {dayOfMonth(day.date)}
+                  </Text>
+                </Pressable>
+              </View>
             );
           })}
         </View>

--- a/mobile/components/inicio/InicioRoot.tsx
+++ b/mobile/components/inicio/InicioRoot.tsx
@@ -17,7 +17,6 @@ import {
   SYSTEM_INSIGHTS,
   WIDGET_CATALOG,
   type DashboardLayout,
-  type PulseRange,
   type WidgetInstance,
   type WidgetType,
 } from "../../lib/dashboard/widgets";
@@ -31,7 +30,7 @@ import { MobileHeader } from "../ui/MobileHeader";
 import { AvatarMenuTrigger } from "../ui/AvatarMenu";
 import { SectionDivider } from "../ui/SectionDivider";
 import { MOBILE_TAB_BAR_CLEARANCE } from "../../lib/constants/styles";
-import { PulseWidget } from "./widgets/PulseWidget";
+import { HybridHero } from "./HybridHero";
 import { WidgetGrid, type WidgetRender } from "./WidgetGrid";
 import { ChipEyebrow } from "../ui/ExpandableChip";
 import { AddWidgetSheet } from "./AddWidgetSheet";
@@ -98,11 +97,6 @@ export function InicioRoot() {
     [userId]
   );
 
-  const handlePulseRangeChange = useCallback(
-    (next: PulseRange) => persist({ ...layout, pulseRange: next }),
-    [layout, persist]
-  );
-
   const handleRemove = useCallback(
     (id: string) =>
       persist({ ...layout, widgets: layout.widgets.filter((w) => w.id !== id) }),
@@ -148,18 +142,11 @@ export function InicioRoot() {
   const today = toLocalDateString(new Date());
   const dateLabel = formatHeaderDate(new Date());
 
-  const pulseDays = layout.pulseRange === "weekly" ? 7 : summary.daysRemaining;
-  const pulseValue =
-    layout.pulseRange === "weekly"
-      ? Math.round(summary.availableTotal / Math.max(1, pulseDays))
-      : summary.availablePerDay;
-  const pulseTrend =
-    layout.pulseRange === "weekly" ? summary.spentTrend7 : summary.spentTrend30;
-
   const primaryAccount = useMemo(() => {
     const a = summary.accounts.find((x) => x.current_balance > 0);
     if (!a) return null;
     return {
+      id: a.id,
       name: a.name,
       currentBalance: a.current_balance,
       currencyCode: a.currency_code as typeof summary.currency,
@@ -245,34 +232,30 @@ export function InicioRoot() {
           />
         }
       >
-        <PulseWidget
-          availablePerDay={pulseValue}
-          daysRemaining={pulseDays}
-          currency={summary.currency}
-          onTrack={summary.onTrack}
-          range={layout.pulseRange}
-          onRangeChange={handlePulseRangeChange}
-          trend={pulseTrend}
-          breakdown={{
-            liquidBalance: summary.liquidBalance,
-            pendingObligations: summary.pendingObligations,
-            alreadySpent: summary.totalSpentThisMonth,
-            availableTotal: summary.availableTotal,
-            windowEndLabel: summary.daysLabel,
-          }}
-          primaryAccount={primaryAccount}
-          nextIncome={
-            summary.nextIncome
-              ? {
-                  name: summary.nextIncome.name,
-                  amount: summary.nextIncome.amount,
-                  date: summary.nextIncome.date,
-                }
-              : null
-          }
-          expanded={activeZone === "hero"}
-          onToggle={() => toggle("hero")}
-        />
+        {(() => {
+          // V7 HybridHero — Option A, predictive runway canonical.
+          // PulseWidget removed 2026-05-21; the component file is kept
+          // in place as a 1-line rollback target if needed.
+          const now = new Date();
+          const m = String(now.getMonth() + 1).padStart(2, "0");
+          const today = `${now.getFullYear()}-${m}-${String(now.getDate()).padStart(2, "0")}`;
+          const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+          const endOfMonth = `${now.getFullYear()}-${m}-${String(lastDay).padStart(2, "0")}`;
+          return (
+            <HybridHero
+              today={today}
+              endOfMonth={endOfMonth}
+              liquidBalance={summary.liquidBalance}
+              pendingObligations={summary.pendingObligations}
+              nextIncomeDate={summary.nextIncome?.date ?? null}
+              nextIncomeAmount={summary.nextIncome?.amount ?? 0}
+              nextIncomeName={summary.nextIncome?.name ?? null}
+              dailyOutflows={summary.dailyOutflowsThisMonth}
+              currency={summary.currency}
+              primaryAccount={primaryAccount ?? undefined}
+            />
+          );
+        })()}
 
         <SectionDivider label="Herramientas" />
         <WidgetGrid

--- a/mobile/components/inicio/InicioRoot.tsx
+++ b/mobile/components/inicio/InicioRoot.tsx
@@ -141,6 +141,14 @@ export function InicioRoot() {
 
   const today = toLocalDateString(new Date());
   const dateLabel = formatHeaderDate(new Date());
+  const endOfMonth = useMemo(() => {
+    // Last day of `today`'s month, YYYY-MM-DD. Recomputed only when the
+    // local date string rolls over, so HybridHero's memoized props stay
+    // reference-stable across InicioRoot state changes.
+    const [y, m] = today.split("-").map(Number);
+    const last = new Date(y, m, 0).getDate();
+    return `${y}-${String(m).padStart(2, "0")}-${String(last).padStart(2, "0")}`;
+  }, [today]);
 
   const primaryAccount = useMemo(() => {
     const a = summary.accounts.find((x) => x.current_balance > 0);
@@ -232,30 +240,18 @@ export function InicioRoot() {
           />
         }
       >
-        {(() => {
-          // V7 HybridHero — Option A, predictive runway canonical.
-          // PulseWidget removed 2026-05-21; the component file is kept
-          // in place as a 1-line rollback target if needed.
-          const now = new Date();
-          const m = String(now.getMonth() + 1).padStart(2, "0");
-          const today = `${now.getFullYear()}-${m}-${String(now.getDate()).padStart(2, "0")}`;
-          const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-          const endOfMonth = `${now.getFullYear()}-${m}-${String(lastDay).padStart(2, "0")}`;
-          return (
-            <HybridHero
-              today={today}
-              endOfMonth={endOfMonth}
-              liquidBalance={summary.liquidBalance}
-              pendingObligations={summary.pendingObligations}
-              nextIncomeDate={summary.nextIncome?.date ?? null}
-              nextIncomeAmount={summary.nextIncome?.amount ?? 0}
-              nextIncomeName={summary.nextIncome?.name ?? null}
-              dailyOutflows={summary.dailyOutflowsThisMonth}
-              currency={summary.currency}
-              primaryAccount={primaryAccount ?? undefined}
-            />
-          );
-        })()}
+        <HybridHero
+          today={today}
+          endOfMonth={endOfMonth}
+          liquidBalance={summary.liquidBalance}
+          pendingObligations={summary.pendingObligations}
+          nextIncomeDate={summary.nextIncome?.date ?? null}
+          nextIncomeAmount={summary.nextIncome?.amount ?? 0}
+          nextIncomeName={summary.nextIncome?.name ?? null}
+          dailyOutflows={summary.dailyOutflowsThisMonth}
+          currency={summary.currency}
+          primaryAccount={primaryAccount ?? undefined}
+        />
 
         <SectionDivider label="Herramientas" />
         <WidgetGrid

--- a/mobile/lib/dashboard/useDashboardData.ts
+++ b/mobile/lib/dashboard/useDashboardData.ts
@@ -76,6 +76,11 @@ export type DashboardSummary = {
   liquidBalance: number;
   pendingObligations: number;
   totalSpentThisMonth: number;
+  /** Per-day OUTFLOW totals for the current calendar month — drives the
+   *  V7 HybridHero calendar heatmap and the period progress bar. Ordered
+   *  by date ascending. Excluded + reconciled + transfer rows already
+   *  removed by the same filter the totals use. */
+  dailyOutflowsThisMonth: { date: string; expense: number }[];
 
   /** "Por resolver" tile — counts for the HERRAMIENTAS system widget. */
   attention: {
@@ -111,6 +116,7 @@ const EMPTY: DashboardSummary = {
   liquidBalance: 0,
   pendingObligations: 0,
   totalSpentThisMonth: 0,
+  dailyOutflowsThisMonth: [],
   attention: { overdue: 0, upcoming: 0, pendingEmails: 0 },
 };
 
@@ -190,6 +196,8 @@ export function useDashboardData() {
       let last7Total = 0;
       let last30Total = 0;
       let totalOutflow = 0;
+      // Per-day OUTFLOW bucket keyed by ISO date for the V7 hero calendar.
+      const outflowByDate = new Map<string, number>();
 
       const yesterdayDate = new Date(now);
       yesterdayDate.setDate(yesterdayDate.getDate() - 1);
@@ -202,6 +210,10 @@ export function useDashboardData() {
         totalOutflow += amount;
         if (tx.transaction_date === today) spentToday += amount;
         if (tx.transaction_date === yesterdayStr) spentYesterday += amount;
+        outflowByDate.set(
+          tx.transaction_date,
+          (outflowByDate.get(tx.transaction_date) ?? 0) + amount,
+        );
         const txDate = new Date(tx.transaction_date + "T12:00:00");
         const diffDays = Math.floor(
           (now.getTime() - txDate.getTime()) / (1000 * 60 * 60 * 24)
@@ -215,6 +227,10 @@ export function useDashboardData() {
           spentTrend30[29 - diffDays] += amount;
         }
       }
+
+      const dailyOutflowsThisMonth = Array.from(outflowByDate.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, expense]) => ({ date, expense }));
 
       const avgLast7 = last7Total / 7;
       const projectedMonthly = avgLast7 * daysInMonth;
@@ -342,6 +358,7 @@ export function useDashboardData() {
         liquidBalance,
         pendingObligations,
         totalSpentThisMonth: totalOutflow,
+        dailyOutflowsThisMonth,
         attention: {
           overdue: overdueCount,
           upcoming: upcomingCount,

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -80,11 +80,13 @@ module.exports = {
         "z-debt-20": "rgba(224,85,69,0.20)",
         "z-debt-25": "rgba(224,85,69,0.25)",
         "z-debt-30": "rgba(224,85,69,0.30)",
+        "z-debt-40": "rgba(224,85,69,0.40)",
         "z-debt-70": "rgba(224,85,69,0.70)",
 
         // z-alert (base #D4A843 = rgb(212,168,67))
         "z-alert-12": "rgba(212,168,67,0.12)",
         "z-alert-25": "rgba(212,168,67,0.25)",
+        "z-alert-30": "rgba(212,168,67,0.30)",
 
         // z-sage (base #D9CCB9 = rgb(217,204,185) for light)
         "z-sage-10": "rgba(217,204,185,0.10)",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,3 +23,4 @@ export * from "./utils/extra-payment";
 export * from "./utils/cc-projection";
 export * from "./utils/dashboard-layout";
 export * from "./utils/account-balance";
+export * from "./utils/ritmo";

--- a/packages/shared/src/utils/__tests__/ritmo.test.ts
+++ b/packages/shared/src/utils/__tests__/ritmo.test.ts
@@ -95,6 +95,24 @@ describe("computeRitmo", () => {
     expect(r.spentFraction).toBeCloseTo(0.3, 5);
   });
 
+  it("surfaces a negative availableTotal when pending obligations exceed liquid balance", () => {
+    const input: RitmoInput = {
+      today: "2026-05-21",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 58_000,
+      pendingObligations: 217_516,
+      dailyOutflows: days("2026-05-01", 21, 0),
+    };
+    const r = computeRitmo(input);
+
+    // availableTotal is signed so the UI can render "Disponible: −$159.516".
+    expect(r.availableTotal).toBe(-159_516);
+    // Daily allowance is clamped at zero so we never say "spend -$N per day".
+    expect(r.availablePerDay).toBe(0);
+    // Progress bar pegs at 100% — caller is fully overspent for the period.
+    expect(r.spentFraction).toBe(1);
+  });
+
   it("can exceed 1.0 on spentFraction when the user has overspent", () => {
     const input: RitmoInput = {
       today: "2026-05-25",

--- a/packages/shared/src/utils/__tests__/ritmo.test.ts
+++ b/packages/shared/src/utils/__tests__/ritmo.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { computeRitmo, type RitmoInput } from "../ritmo";
+
+function days(from: string, count: number, perDay = 0): { date: string; expense: number }[] {
+  const out: { date: string; expense: number }[] = [];
+  const start = new Date(`${from}T12:00:00`);
+  for (let i = 0; i < count; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    out.push({
+      date: d.toISOString().slice(0, 10),
+      expense: perDay,
+    });
+  }
+  return out;
+}
+
+describe("computeRitmo", () => {
+  it("returns the basic month-end window when no next-income is provided", () => {
+    const input: RitmoInput = {
+      today: "2026-05-21",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 2_000_000,
+      pendingObligations: 200_000,
+      dailyOutflows: days("2026-05-01", 21, 50_000),
+    };
+    const r = computeRitmo(input);
+
+    expect(r.windowEndDate).toBe("2026-05-31");
+    expect(r.daysRemaining).toBe(11);
+    expect(r.daysElapsed).toBe(21);
+    expect(r.daysInMonth).toBe(31);
+    expect(r.availableTotal).toBe(1_800_000);
+    expect(r.availablePerDay).toBe(Math.round(1_800_000 / 11));
+    expect(r.spentMonth).toBe(50_000 * 21);
+  });
+
+  it("respects an in-window next-income date by shortening the runway window", () => {
+    const input: RitmoInput = {
+      today: "2026-05-21",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 500_000,
+      nextIncomeDate: "2026-05-26",
+      nextIncomeAmount: 2_000_000,
+      pendingObligations: 0,
+      dailyOutflows: days("2026-05-01", 21, 30_000),
+    };
+    const r = computeRitmo(input);
+
+    expect(r.windowEndDate).toBe("2026-05-26");
+    expect(r.daysRemaining).toBe(6);
+    expect(r.availableTotal).toBe(500_000);
+    expect(r.availablePerDay).toBe(Math.round(500_000 / 6));
+  });
+
+  it("falls back to end-of-month when nextIncomeDate is in the past", () => {
+    const input: RitmoInput = {
+      today: "2026-05-21",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 500_000,
+      nextIncomeDate: "2026-05-15", // already past
+      pendingObligations: 0,
+      dailyOutflows: days("2026-05-01", 21, 0),
+    };
+    const r = computeRitmo(input);
+    expect(r.windowEndDate).toBe("2026-05-31");
+  });
+
+  it("clamps allowedToday at zero when today's spending already exceeded the daily budget", () => {
+    const outflows = days("2026-05-01", 21, 0);
+    outflows[20] = { date: "2026-05-21", expense: 999_999 }; // big spend today
+    const input: RitmoInput = {
+      today: "2026-05-21",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 1_000_000,
+      pendingObligations: 0,
+      dailyOutflows: outflows,
+    };
+    const r = computeRitmo(input);
+    expect(r.allowedToday).toBe(0);
+    expect(r.spentToday).toBe(999_999);
+  });
+
+  it("computes spentFraction as spent / (spent + available)", () => {
+    const input: RitmoInput = {
+      today: "2026-05-15",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 700_000,
+      pendingObligations: 0,
+      dailyOutflows: days("2026-05-01", 15, 20_000), // 300k spent
+    };
+    const r = computeRitmo(input);
+    expect(r.spentMonth).toBe(300_000);
+    expect(r.periodBudget).toBe(1_000_000); // 300k spent + 700k available
+    expect(r.spentFraction).toBeCloseTo(0.3, 5);
+  });
+
+  it("can exceed 1.0 on spentFraction when the user has overspent", () => {
+    const input: RitmoInput = {
+      today: "2026-05-25",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 0,
+      pendingObligations: 0,
+      dailyOutflows: days("2026-05-01", 25, 50_000), // 1.25M spent, 0 available
+    };
+    const r = computeRitmo(input);
+    expect(r.availableTotal).toBe(0);
+    expect(r.periodBudget).toBe(1_250_000);
+    expect(r.spentFraction).toBe(1);
+  });
+
+  it("classifies daily buckets relative to month-to-date average", () => {
+    const outflows = [
+      { date: "2026-05-01", expense: 10_000 },  // low: 25% of avg
+      { date: "2026-05-02", expense: 40_000 },  // med
+      { date: "2026-05-03", expense: 100_000 }, // high: 250% of avg
+      { date: "2026-05-04", expense: 0 },       // none
+    ];
+    const input: RitmoInput = {
+      today: "2026-05-04",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 1_000_000,
+      pendingObligations: 0,
+      dailyOutflows: outflows,
+    };
+    const r = computeRitmo(input);
+
+    // avg = 37,500 over 4 days
+    expect(r.calendar[0].bucket).toBe("low");
+    expect(r.calendar[1].bucket).toBe("med");
+    expect(r.calendar[2].bucket).toBe("high");
+    expect(r.calendar[3].bucket).toBe("none");
+  });
+
+  it("marks today + future flags on the calendar entries", () => {
+    const input: RitmoInput = {
+      today: "2026-05-21",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 1_000_000,
+      pendingObligations: 0,
+      dailyOutflows: [
+        { date: "2026-05-20", expense: 30_000 },
+        { date: "2026-05-21", expense: 50_000 },
+        { date: "2026-05-22", expense: 0 },
+      ],
+    };
+    const r = computeRitmo(input);
+    expect(r.calendar[0]).toMatchObject({ date: "2026-05-20", isToday: false, isFuture: false });
+    expect(r.calendar[1]).toMatchObject({ date: "2026-05-21", isToday: true, isFuture: false });
+    expect(r.calendar[2]).toMatchObject({ date: "2026-05-22", isToday: false, isFuture: true });
+  });
+
+  it("never divides by zero on empty months", () => {
+    const input: RitmoInput = {
+      today: "2026-05-01",
+      endOfMonth: "2026-05-31",
+      liquidBalance: 1_000_000,
+      pendingObligations: 0,
+      dailyOutflows: [],
+    };
+    const r = computeRitmo(input);
+    expect(Number.isFinite(r.availablePerDay)).toBe(true);
+    expect(Number.isFinite(r.spentFraction)).toBe(true);
+  });
+});

--- a/packages/shared/src/utils/ritmo.ts
+++ b/packages/shared/src/utils/ritmo.ts
@@ -153,14 +153,15 @@ export function computeRitmo(input: RitmoInput): RitmoResult {
   const spentFraction =
     periodBudget > 0 ? Math.min(1, spentMonth / periodBudget) : availableTotal < 0 ? 1 : 0;
 
-  // On-track = projected month-end spend (using last-7-day avg as
-  // best-guess pace) doesn't exceed what we have. Tolerant of inputs
-  // where dailyOutflows is short (early in month).
+  // On-track = projected spend for the REMAINING window (using last-7-day
+  // avg as best-guess pace) fits within `availableTotal` — which already
+  // nets out pendingObligations. Comparing remaining-vs-remaining is more
+  // precise than projecting the whole month against total cash, and it
+  // correctly fails when a big bill is pending.
   const last7Days = input.dailyOutflows.slice(-7);
   const last7Total = last7Days.reduce((s, r) => s + r.expense, 0);
   const avgLast7 = last7Days.length > 0 ? last7Total / last7Days.length : 0;
-  const projectedMonthly = avgLast7 * daysInMonth;
-  const onTrack = projectedMonthly <= input.liquidBalance + spentMonth;
+  const onTrack = avgLast7 * daysRemaining <= availableTotal;
 
   // Calendar buckets — relative to month-to-date daily average.
   const dailyAvg = daysElapsed > 0 ? spentMonth / daysElapsed : 0;

--- a/packages/shared/src/utils/ritmo.ts
+++ b/packages/shared/src/utils/ritmo.ts
@@ -129,8 +129,13 @@ export function computeRitmo(input: RitmoInput): RitmoResult {
   const daysElapsed = daysBetween(startOfMonth, input.today);
   const daysInMonth = daysBetween(startOfMonth, input.endOfMonth);
 
-  const availableTotal = clampPositive(input.liquidBalance - input.pendingObligations);
-  const availablePerDay = Math.round(availableTotal / daysRemaining);
+  // availableTotal is signed — the UI uses it to surface "you're overspent"
+  // (negative Disponible). The daily allowance and progress bar consume
+  // the clamped non-negative version so we never tell the user "you can
+  // spend -$5,000 per day".
+  const availableTotal = input.liquidBalance - input.pendingObligations;
+  const availableTotalClamped = clampPositive(availableTotal);
+  const availablePerDay = Math.round(availableTotalClamped / daysRemaining);
 
   let spentMonth = 0;
   let spentToday = 0;
@@ -141,8 +146,12 @@ export function computeRitmo(input: RitmoInput): RitmoResult {
 
   const allowedToday = clampPositive(availablePerDay - spentToday);
 
-  const periodBudget = spentMonth + availableTotal;
-  const spentFraction = periodBudget > 0 ? spentMonth / periodBudget : 0;
+  // periodBudget uses the clamped headroom — when availableTotal is
+  // negative, the budget IS what's been spent (no headroom left). The
+  // progress bar pegs at 100% via Math.min below.
+  const periodBudget = spentMonth + availableTotalClamped;
+  const spentFraction =
+    periodBudget > 0 ? Math.min(1, spentMonth / periodBudget) : availableTotal < 0 ? 1 : 0;
 
   // On-track = projected month-end spend (using last-7-day avg as
   // best-guess pace) doesn't exceed what we have. Tolerant of inputs

--- a/packages/shared/src/utils/ritmo.ts
+++ b/packages/shared/src/utils/ritmo.ts
@@ -1,0 +1,181 @@
+/**
+ * Canonical "ritmo" computation for the dashboard hero on both mobile and
+ * webapp. Predictive runway model (audit Option A, picked 2026-05-21):
+ *
+ *   ┌─ Today's permission = available balance for the period ÷ days remaining
+ *   ├─ Period progress    = fraction of the period's available balance already spent
+ *   └─ Daily buckets      = per-day spend classified relative to month-avg
+ *
+ * Pure function over plain inputs so both platforms produce identical
+ * numbers. Mobile feeds it from SQLite + local profile; webapp feeds it
+ * from cached Supabase actions.
+ *
+ * Replaces:
+ *  - mobile/lib/dashboard/useDashboardData.ts (lines ~140-220) — the
+ *    avgLast7 × daysInMonth projection
+ *  - webapp/src/actions/allocation.ts (50/30/20 allocation that was
+ *    surfaced in the dashboard hero) — deprecated for the hero; the
+ *    allocation lens still belongs in /presupuesto.
+ */
+
+/** Calendar-bucket label for the V7 calendar heatmap. */
+export type DailyBucket = "none" | "low" | "med" | "high";
+
+export interface RitmoDailyOutflow {
+  /** YYYY-MM-DD. */
+  date: string;
+  /** Sum of OUTFLOW amounts on this day (excluded + reconciled + transfer rows already removed). */
+  expense: number;
+}
+
+export interface RitmoInput {
+  /** Today's date in YYYY-MM-DD format. Caller resolves locale/timezone. */
+  today: string;
+  /** Last day of the current calendar month, YYYY-MM-DD. */
+  endOfMonth: string;
+  /** Sum of liquid (CHECKING / SAVINGS / CASH / OTHER) account balances. */
+  liquidBalance: number;
+  /**
+   * Optional next-paycheck-or-income date inside the current month. When
+   * present and on/after today, the predictive window ends here (the user
+   * gets fresh income then, runway calculations reset). When absent, the
+   * window ends at end-of-month.
+   */
+  nextIncomeDate?: string | null;
+  /** Expected amount of the next income event (used by callers to label the period; not directly required for math). */
+  nextIncomeAmount?: number | null;
+  /**
+   * Sum of OUTFLOW obligations (and debt-INFLOW payments) due between
+   * today and windowEndDate. Reduces the period's available balance.
+   */
+  pendingObligations: number;
+  /** Per-day OUTFLOW totals across the current calendar month, in order. */
+  dailyOutflows: RitmoDailyOutflow[];
+}
+
+export interface RitmoResult {
+  /** Where the predictive window ends. */
+  windowEndDate: string;
+  /** Days from today through windowEndDate, inclusive of today. Min 1. */
+  daysRemaining: number;
+  /** Days from start-of-month through today, inclusive. */
+  daysElapsed: number;
+  /** Days in the full current month. */
+  daysInMonth: number;
+  /** Total liquid balance minus pending obligations through the window. */
+  availableTotal: number;
+  /** availableTotal ÷ daysRemaining, rounded. */
+  availablePerDay: number;
+  /** spentToday subtracted from availablePerDay; clamped at 0. */
+  allowedToday: number;
+  /** Sum of OUTFLOWs so far this month. */
+  spentMonth: number;
+  /** OUTFLOWs on the `today` date. */
+  spentToday: number;
+  /**
+   * Period budget = spentMonth + availableTotal. The denominator for the
+   * V7 progress bar. Reflects the user's commitment for the month — what
+   * they've already laid out plus what's left to spend before windowEnd.
+   */
+  periodBudget: number;
+  /** spentMonth ÷ periodBudget. Clamped at 0; can exceed 1 when overspent. */
+  spentFraction: number;
+  /** Predictive verdict: are we on track to not overshoot the period? */
+  onTrack: boolean;
+  /**
+   * Per-day calendar buckets for the V7 secondary view. One entry per
+   * date in `dailyOutflows`. "Today's date" gets `isToday: true`.
+   * Buckets are relative to the month's running daily average so the
+   * heatmap stays useful for both light and heavy spenders.
+   */
+  calendar: Array<{
+    date: string;
+    expense: number;
+    bucket: DailyBucket;
+    isToday: boolean;
+    isFuture: boolean;
+  }>;
+}
+
+function clampPositive(n: number): number {
+  return Number.isFinite(n) ? Math.max(0, n) : 0;
+}
+
+function daysBetween(fromIso: string, toIso: string): number {
+  const from = new Date(`${fromIso}T12:00:00`).getTime();
+  const to = new Date(`${toIso}T12:00:00`).getTime();
+  return Math.max(1, Math.ceil((to - from) / 86_400_000) + 1);
+}
+
+function bucketFor(expense: number, avg: number): DailyBucket {
+  if (expense <= 0) return "none";
+  if (avg <= 0) return "med";
+  if (expense < 0.5 * avg) return "low";
+  if (expense > 1.5 * avg) return "high";
+  return "med";
+}
+
+export function computeRitmo(input: RitmoInput): RitmoResult {
+  const windowEndDate =
+    input.nextIncomeDate && input.nextIncomeDate >= input.today
+      ? input.nextIncomeDate
+      : input.endOfMonth;
+
+  const daysRemaining = daysBetween(input.today, windowEndDate);
+
+  // Days elapsed = today − start of the calendar month + 1. Derive start
+  // by replacing the day component with "01".
+  const startOfMonth = `${input.today.slice(0, 7)}-01`;
+  const daysElapsed = daysBetween(startOfMonth, input.today);
+  const daysInMonth = daysBetween(startOfMonth, input.endOfMonth);
+
+  const availableTotal = clampPositive(input.liquidBalance - input.pendingObligations);
+  const availablePerDay = Math.round(availableTotal / daysRemaining);
+
+  let spentMonth = 0;
+  let spentToday = 0;
+  for (const row of input.dailyOutflows) {
+    spentMonth += row.expense;
+    if (row.date === input.today) spentToday += row.expense;
+  }
+
+  const allowedToday = clampPositive(availablePerDay - spentToday);
+
+  const periodBudget = spentMonth + availableTotal;
+  const spentFraction = periodBudget > 0 ? spentMonth / periodBudget : 0;
+
+  // On-track = projected month-end spend (using last-7-day avg as
+  // best-guess pace) doesn't exceed what we have. Tolerant of inputs
+  // where dailyOutflows is short (early in month).
+  const last7Days = input.dailyOutflows.slice(-7);
+  const last7Total = last7Days.reduce((s, r) => s + r.expense, 0);
+  const avgLast7 = last7Days.length > 0 ? last7Total / last7Days.length : 0;
+  const projectedMonthly = avgLast7 * daysInMonth;
+  const onTrack = projectedMonthly <= input.liquidBalance + spentMonth;
+
+  // Calendar buckets — relative to month-to-date daily average.
+  const dailyAvg = daysElapsed > 0 ? spentMonth / daysElapsed : 0;
+  const calendar = input.dailyOutflows.map((row) => ({
+    date: row.date,
+    expense: row.expense,
+    bucket: bucketFor(row.expense, dailyAvg),
+    isToday: row.date === input.today,
+    isFuture: row.date > input.today,
+  }));
+
+  return {
+    windowEndDate,
+    daysRemaining,
+    daysElapsed,
+    daysInMonth,
+    availableTotal,
+    availablePerDay,
+    allowedToday,
+    spentMonth,
+    spentToday,
+    periodBudget,
+    spentFraction,
+    onTrack,
+    calendar,
+  };
+}

--- a/packages/shared/src/utils/ritmo.ts
+++ b/packages/shared/src/utils/ritmo.ts
@@ -1,25 +1,54 @@
 /**
- * Canonical "ritmo" computation for the dashboard hero on both mobile and
- * webapp. Predictive runway model (audit Option A, picked 2026-05-21):
+ * Canonical "ritmo" (runway) computation for the dashboard hero, shared
+ * by webapp + mobile. Pure function over plain inputs:
  *
  *   ┌─ Today's permission = available balance for the period ÷ days remaining
  *   ├─ Period progress    = fraction of the period's available balance already spent
  *   └─ Daily buckets      = per-day spend classified relative to month-avg
- *
- * Pure function over plain inputs so both platforms produce identical
- * numbers. Mobile feeds it from SQLite + local profile; webapp feeds it
- * from cached Supabase actions.
- *
- * Replaces:
- *  - mobile/lib/dashboard/useDashboardData.ts (lines ~140-220) — the
- *    avgLast7 × daysInMonth projection
- *  - webapp/src/actions/allocation.ts (50/30/20 allocation that was
- *    surfaced in the dashboard hero) — deprecated for the hero; the
- *    allocation lens still belongs in /presupuesto.
  */
 
 /** Calendar-bucket label for the V7 calendar heatmap. */
 export type DailyBucket = "none" | "low" | "med" | "high";
+
+/** Spanish UI labels for each bucket (legend + a11y). Both platforms read from this. */
+export const BUCKET_LABEL: Record<DailyBucket, string> = {
+  none: "Sin gasto",
+  low: "Día tranquilo",
+  med: "Día normal",
+  high: "Día caro",
+};
+
+/** Single-letter Spanish weekday header for Monday-start calendars: L M X J V S D. */
+export const WEEKDAYS_MONDAY_START = ["L", "M", "X", "J", "V", "S", "D"] as const;
+
+/**
+ * Weekday index for a Monday-start grid. `2026-05-04` (Mon) → 0,
+ * `2026-05-10` (Sun) → 6. Pure ISO-string math, no locale branch.
+ */
+export function weekdayMondayStart(iso: string): number {
+  const d = new Date(`${iso}T12:00:00`).getDay();
+  return d === 0 ? 6 : d - 1;
+}
+
+/** Status tone for the runway hero. */
+export type RitmoStatusTone = "income" | "alert" | "debt";
+
+/**
+ * Derives the status pill content. Both platforms read the same logic so
+ * the verdict (red/amber/green) stays consistent across web + mobile.
+ *
+ * Why: overspent today OR negative period balance is always "debt" (red).
+ * Past 85% of the period budget is "alert" (amber). Otherwise "income".
+ */
+export function deriveRitmoStatus(ritmo: Pick<RitmoResult, "availableTotal" | "spentToday" | "availablePerDay" | "spentFraction">): {
+  tone: RitmoStatusTone;
+  label: string;
+} {
+  const overspentToday = ritmo.spentToday > ritmo.availablePerDay;
+  if (ritmo.availableTotal < 0 || overspentToday) return { tone: "debt", label: "Te pasaste" };
+  if (ritmo.spentFraction >= 0.85) return { tone: "alert", label: "Vas justo" };
+  return { tone: "income", label: "Vas bien" };
+}
 
 export interface RitmoDailyOutflow {
   /** YYYY-MM-DD. */

--- a/webapp/src/actions/ritmo.ts
+++ b/webapp/src/actions/ritmo.ts
@@ -1,64 +1,24 @@
 "use server";
 
-import { cacheTag, cacheLife } from "next/cache";
 import { computeRitmo, type RitmoResult } from "@zeta/shared";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
-import { createCachedClient } from "@/lib/supabase/cached";
-import { getIsDemoFilter, getDemoAccountIds } from "@/lib/demo-filter";
 import {
   parseMonth,
-  monthStartStr,
   monthEndStr,
   toColombiaDateString,
 } from "@/lib/utils/date";
-import { getDashboardHeroData } from "@/actions/charts";
+import { getDashboardHeroData, getDailySpending } from "@/actions/charts";
 import type { CurrencyCode } from "@/types/domain";
 
 /**
  * Canonical "ritmo" data for the dashboard hero. Wraps `getDashboardHeroData`
- * (for liquid balance + pending obligations + next-income date) and adds the
- * per-day OUTFLOW timeline needed for the V7 hero's progress bar + calendar
- * heatmap. Calls `computeRitmo` from @zeta/shared so mobile and webapp
- * produce identical numbers by construction.
+ * (for liquid balance + pending obligations + next-income date) and reuses
+ * `getDailySpending` for the per-day OUTFLOW timeline so the hero, the
+ * charts page, and the "Patrón del mes" view all share the exact same
+ * filtering (currency, transfer exclusion, demo scope). Calls `computeRitmo`
+ * from @zeta/shared so mobile and webapp produce identical numbers by
+ * construction.
  */
-
-async function getDailyOutflowsCached(
-  userId: string,
-  accessToken: string,
-  dateFrom: string,
-  dateTo: string,
-): Promise<{ date: string; expense: number }[]> {
-  "use cache";
-  cacheTag("transactions");
-  cacheLife("zeta");
-
-  const supabase = createCachedClient(accessToken);
-  const isDemo = await getIsDemoFilter(userId);
-  const demoAccountIds = await getDemoAccountIds(supabase, userId, isDemo);
-  if (!demoAccountIds) return [];
-
-  const { data, error } = await supabase
-    .from("transactions")
-    .select("transaction_date, amount")
-    .eq("user_id", userId)
-    .in("account_id", demoAccountIds)
-    .eq("direction", "OUTFLOW")
-    .eq("is_excluded", false)
-    .is("reconciled_into_transaction_id", null)
-    .gte("transaction_date", dateFrom)
-    .lte("transaction_date", dateTo);
-
-  if (error) throw error;
-
-  const byDate = new Map<string, number>();
-  for (const row of data ?? []) {
-    const key = row.transaction_date as string;
-    byDate.set(key, (byDate.get(key) ?? 0) + (row.amount as number));
-  }
-  return Array.from(byDate.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, expense]) => ({ date, expense }));
-}
 
 export interface RitmoData extends RitmoResult {
   currency: CurrencyCode;
@@ -83,15 +43,21 @@ export async function getRitmo(
 
   try {
     const target = parseMonth(month);
-    const dateFrom = monthStartStr(target);
     const dateTo = monthEndStr(target);
     const today = toColombiaDateString(new Date());
     const usedCurrency = (currency ?? "COP") as CurrencyCode;
 
-    const [heroData, dailyOutflows] = await Promise.all([
+    // Reuse getDailySpending so the hero shares the canonical
+    // filtering with the charts page (currency_code, transfer_group_id,
+    // demo scope) — avoids parallel "almost the same" SQL diverging.
+    const [heroData, dailySpending] = await Promise.all([
       getDashboardHeroData(month, usedCurrency),
-      getDailyOutflowsCached(user.id, accessToken, dateFrom, dateTo),
+      getDailySpending(month, usedCurrency),
     ]);
+    const dailyOutflows = dailySpending.map((d) => ({
+      date: d.date,
+      expense: d.amount,
+    }));
 
     const ritmo = computeRitmo({
       today,

--- a/webapp/src/actions/ritmo.ts
+++ b/webapp/src/actions/ritmo.ts
@@ -68,6 +68,10 @@ export interface RitmoData extends RitmoResult {
   liquidBalance: number;
   /** Sum of pending obligation amounts in the window, for the secondary panel. */
   pendingObligationsTotal: number;
+  /** Next-income metadata for the "Próximo ingreso" line in the Cálculo view. */
+  nextIncomeName: string | null;
+  nextIncomeAmount: number;
+  nextIncomeDateLabel: string | null;
 }
 
 export async function getRitmo(
@@ -105,6 +109,12 @@ export async function getRitmo(
       day: "numeric",
       month: "short",
     });
+    const nextIncomeDateLabel = heroData.nextIncomeDate
+      ? new Date(`${heroData.nextIncomeDate}T12:00:00`).toLocaleDateString("es-CO", {
+          day: "numeric",
+          month: "short",
+        })
+      : null;
 
     return {
       success: true,
@@ -114,6 +124,9 @@ export async function getRitmo(
         windowEndLabel,
         liquidBalance: heroData.totalLiquid,
         pendingObligationsTotal: heroData.windowObligations,
+        nextIncomeName: heroData.nextIncomeName,
+        nextIncomeAmount: heroData.nextIncomeAmount,
+        nextIncomeDateLabel,
       },
     };
   } catch (error) {

--- a/webapp/src/actions/ritmo.ts
+++ b/webapp/src/actions/ritmo.ts
@@ -1,0 +1,123 @@
+"use server";
+
+import { cacheTag, cacheLife } from "next/cache";
+import { computeRitmo, type RitmoResult } from "@zeta/shared";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
+import { getIsDemoFilter, getDemoAccountIds } from "@/lib/demo-filter";
+import {
+  parseMonth,
+  monthStartStr,
+  monthEndStr,
+  toColombiaDateString,
+} from "@/lib/utils/date";
+import { getDashboardHeroData } from "@/actions/charts";
+import type { CurrencyCode } from "@/types/domain";
+
+/**
+ * Canonical "ritmo" data for the dashboard hero. Wraps `getDashboardHeroData`
+ * (for liquid balance + pending obligations + next-income date) and adds the
+ * per-day OUTFLOW timeline needed for the V7 hero's progress bar + calendar
+ * heatmap. Calls `computeRitmo` from @zeta/shared so mobile and webapp
+ * produce identical numbers by construction.
+ */
+
+async function getDailyOutflowsCached(
+  userId: string,
+  accessToken: string,
+  dateFrom: string,
+  dateTo: string,
+): Promise<{ date: string; expense: number }[]> {
+  "use cache";
+  cacheTag("transactions");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const isDemo = await getIsDemoFilter(userId);
+  const demoAccountIds = await getDemoAccountIds(supabase, userId, isDemo);
+  if (!demoAccountIds) return [];
+
+  const { data, error } = await supabase
+    .from("transactions")
+    .select("transaction_date, amount")
+    .eq("user_id", userId)
+    .in("account_id", demoAccountIds)
+    .eq("direction", "OUTFLOW")
+    .eq("is_excluded", false)
+    .is("reconciled_into_transaction_id", null)
+    .gte("transaction_date", dateFrom)
+    .lte("transaction_date", dateTo);
+
+  if (error) throw error;
+
+  const byDate = new Map<string, number>();
+  for (const row of data ?? []) {
+    const key = row.transaction_date as string;
+    byDate.set(key, (byDate.get(key) ?? 0) + (row.amount as number));
+  }
+  return Array.from(byDate.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, expense]) => ({ date, expense }));
+}
+
+export interface RitmoData extends RitmoResult {
+  currency: CurrencyCode;
+  /** End-of-month label like "31 may", for the period-bar legend. */
+  windowEndLabel: string;
+  /** Total liquid balance carried over so the UI can show "balance disponible". */
+  liquidBalance: number;
+  /** Sum of pending obligation amounts in the window, for the secondary panel. */
+  pendingObligationsTotal: number;
+}
+
+export async function getRitmo(
+  month?: string,
+  currency?: CurrencyCode,
+): Promise<{ success: true; data: RitmoData } | { success: false; error: string }> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+
+  try {
+    const target = parseMonth(month);
+    const dateFrom = monthStartStr(target);
+    const dateTo = monthEndStr(target);
+    const today = toColombiaDateString(new Date());
+    const usedCurrency = (currency ?? "COP") as CurrencyCode;
+
+    const [heroData, dailyOutflows] = await Promise.all([
+      getDashboardHeroData(month, usedCurrency),
+      getDailyOutflowsCached(user.id, accessToken, dateFrom, dateTo),
+    ]);
+
+    const ritmo = computeRitmo({
+      today,
+      endOfMonth: dateTo,
+      liquidBalance: heroData.totalLiquid,
+      nextIncomeDate: heroData.nextIncomeDate,
+      nextIncomeAmount: heroData.nextIncomeAmount,
+      pendingObligations: heroData.windowObligations,
+      dailyOutflows,
+    });
+
+    // "31 may" — short label for the period-bar legend.
+    const windowEnd = new Date(`${ritmo.windowEndDate}T12:00:00`);
+    const windowEndLabel = windowEnd.toLocaleDateString("es-CO", {
+      day: "numeric",
+      month: "short",
+    });
+
+    return {
+      success: true,
+      data: {
+        ...ritmo,
+        currency: usedCurrency,
+        windowEndLabel,
+        liquidBalance: heroData.totalLiquid,
+        pendingObligationsTotal: heroData.windowObligations,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Error al cargar el ritmo";
+    return { success: false, error: message };
+  }
+}

--- a/webapp/src/app/api/cache/onboarding-complete/route.ts
+++ b/webapp/src/app/api/cache/onboarding-complete/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { getRequestUser } from "@/app/api/_shared/auth";
 
 /**
@@ -24,10 +24,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "No autenticado" }, { status: 401 });
   }
 
-  updateTag("profile");
-  updateTag("accounts");
-  updateTag("dashboard:hero");
-  updateTag("dashboard:accounts");
+  // Route Handler context — must use `revalidateTag` (not `updateTag`)
+  // so the user's NEXT navigation sees fresh data. `updateTag` is
+  // request-scoped read-your-own-writes and doesn't survive past this
+  // webhook response. SWR semantics are fine here — eventual
+  // consistency on profile/accounts is acceptable for onboarding completion.
+  revalidateTag("profile", "zeta");
+  revalidateTag("accounts", "zeta");
+  revalidateTag("dashboard:hero", "zeta");
+  revalidateTag("dashboard:accounts", "zeta");
 
   return NextResponse.json({ ok: true });
 }

--- a/webapp/src/app/api/webhooks/email-ingest/route.ts
+++ b/webapp/src/app/api/webhooks/email-ingest/route.ts
@@ -20,7 +20,7 @@ import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
 import { autoCategorize } from "@zeta/shared";
 import { matchTransactionToDestinatario } from "@/actions/destinatarios";
 import { linkTransactionToOccurrence } from "@/actions/occurrences";
-import { revalidateFinancialViews } from "@/lib/cache/revalidation";
+import { revalidateFinancialViewsFromWebhook } from "@/lib/cache/revalidation";
 import type { Json } from "@/types/database";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -902,8 +902,11 @@ async function processEmail(ctx: {
       errorMessage: null,
     });
 
-    // Invalidate caches so dashboard reflects the new transaction
-    revalidateFinancialViews();
+    // Invalidate caches so dashboard reflects the new transaction.
+    // Route Handler context — must use `revalidateTag` (not `updateTag`)
+    // so the user's next navigation sees fresh data. See
+    // `revalidateFinancialViewsFromWebhook` docs for the why.
+    revalidateFinancialViewsFromWebhook();
     revalidateTag("email-ingest", "zeta");
 
     return NextResponse.json({ ok: true });

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -79,19 +79,31 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
   const [view, setView] = useState<ExpandedView>("calc");
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
 
-  const allowedTone =
-    data.allowedToday <= 0
-      ? "text-z-debt"
-      : data.spentFraction >= 0.85
-        ? "text-z-alert"
-        : "text-z-income";
-
+  // Status reflects the PERIOD, not today's micro-spend. A user can blow
+  // through today's allowance and still have plenty of headroom for the
+  // rest of the month — that's "Hoy a tope", not "Te pasaste".
+  // - availableTotal < 0 → period exhausted (debt red)
+  // - spentFraction >= 0.85 → period almost gone (alert amber)
+  // - allowedToday <= 0 && availableTotal > 0 → today maxed, period OK (alert)
+  // - otherwise → healthy (income green)
   const status: { label: string; tone: "income" | "alert" | "debt" } =
-    data.allowedToday <= 0
+    data.availableTotal < 0
       ? { label: "Te pasaste", tone: "debt" }
       : data.spentFraction >= 0.85
         ? { label: "Vas justo", tone: "alert" }
-        : { label: "Vas bien", tone: "income" };
+        : data.allowedToday <= 0
+          ? { label: "Hoy a tope", tone: "alert" }
+          : { label: "Vas bien", tone: "income" };
+
+  // Amount tone tracks the same period-aware status. Today-exhausted-but-
+  // period-fine renders the $0 in amber, not red — the user has more
+  // available tomorrow.
+  const allowedTone =
+    status.tone === "debt"
+      ? "text-z-debt"
+      : status.tone === "alert"
+        ? "text-z-alert"
+        : "text-z-income";
   const statusToneClass =
     status.tone === "debt"
       ? "bg-z-debt"

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import type { RitmoData } from "@/actions/ritmo";
+
+/**
+ * V7 hybrid hero — Option A canonical. Predictive-runway model:
+ *   - "Hoy puedes gastar" as the bold anchor
+ *   - Period progress bar (sage → amber → red as user burns through the
+ *     period's available balance)
+ *   - Collapsible month calendar showing daily spend buckets relative to
+ *     the user's own pace
+ *
+ * Replaces the 50/30/20 allocation hero. Allocation lens belongs in
+ * /presupuesto. See claude-ai-design/hero-runway-brainstorm.html for the
+ * design spec.
+ */
+
+interface HybridHeroProps {
+  data: RitmoData;
+  /** Initial expanded state for the calendar — persisted via localStorage. */
+  defaultExpanded?: boolean;
+}
+
+const BUCKET_CLASS: Record<string, string> = {
+  none: "bg-z-surface-2 text-z-sage-dark",
+  low: "bg-z-income/20 text-z-sage-dark",
+  med: "bg-z-alert/35 text-z-sage-dark",
+  high: "bg-z-debt/45 text-z-white",
+};
+
+const WEEKDAY_LABELS = ["L", "M", "X", "J", "V", "S", "D"]; // Spanish week, Mon-start
+
+function dayOfMonth(iso: string): number {
+  return parseInt(iso.slice(8, 10), 10);
+}
+
+function weekdayMondayStart(iso: string): number {
+  // JS getDay(): 0=Sun..6=Sat. Map to 0=Mon..6=Sun for ES calendars.
+  const d = new Date(`${iso}T12:00:00`).getDay();
+  return (d + 6) % 7;
+}
+
+export function HybridHero({ data, defaultExpanded = false }: HybridHeroProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const allowedTone =
+    data.allowedToday <= 0
+      ? "text-z-debt"
+      : data.spentFraction >= 0.85
+        ? "text-z-alert"
+        : "text-z-income";
+
+  const sub =
+    data.allowedToday <= 0
+      ? "Hoy te pasaste del cupo diario — frena para llegar al cierre."
+      : data.onTrack
+        ? "y aún llegas al cierre del período con tu colchón."
+        : "pero vas rápido — revisa los próximos días.";
+
+  return (
+    <div className="rounded-2xl border border-white/6 bg-z-surface p-5">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark mb-2">
+        Hoy puedes gastar
+      </p>
+
+      <p className={cn("text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums", allowedTone)}>
+        {formatCurrency(data.allowedToday, data.currency)}
+      </p>
+
+      <p className="mt-2 text-sm text-z-sage-light leading-snug">{sub}</p>
+
+      {/* Period progress bar — gradient mapped to spentFraction */}
+      <div className="relative mt-5 h-2.5 w-full overflow-hidden rounded-full bg-z-surface-2">
+        <div
+          className="h-full rounded-full"
+          style={{
+            width: `${Math.min(100, Math.round(data.spentFraction * 100))}%`,
+            background:
+              "linear-gradient(to right, var(--color-z-excellent, #3D9E6E) 0%, var(--color-z-sage, #768053) 30%, var(--color-z-alert, #D4A843) 70%, var(--color-z-debt, #E05545) 100%)",
+            transition: "width 0.5s ease",
+          }}
+        />
+      </div>
+      <div className="mt-2 flex items-baseline justify-between text-[11px] text-z-sage-dark tabular-nums">
+        <span>
+          {formatCurrency(data.spentMonth, data.currency)} gastados ·{" "}
+          {formatCurrency(data.availableTotal, data.currency)} restantes
+        </span>
+        <span className="font-medium text-z-sage-light">
+          {Math.round(data.spentFraction * 100)}% del período
+        </span>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/6 px-3 py-2 text-[11px] font-semibold tracking-wide text-z-sage-light hover:bg-white/[0.02]"
+        aria-expanded={expanded}
+      >
+        <span>{expanded ? "Ocultar patrón del mes" : "Ver patrón del mes"}</span>
+        <ChevronDown
+          className={cn(
+            "size-3.5 text-z-brass transition-transform",
+            expanded && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+
+      {expanded && (
+        <div className="mt-4 border-t border-dashed border-white/6 pt-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark mb-3">
+            Patrón de gasto · este mes
+          </p>
+          <CalendarHeatmap data={data} />
+          <div className="mt-3 flex flex-wrap gap-3 text-[10px] text-z-sage-dark">
+            <span className="inline-flex items-center gap-1.5">
+              <i className="size-2.5 rounded-sm bg-z-income/20" /> Día tranquilo
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <i className="size-2.5 rounded-sm bg-z-alert/35" /> Día normal
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <i className="size-2.5 rounded-sm bg-z-debt/45" /> Día caro
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CalendarHeatmap({ data }: { data: RitmoData }) {
+  // Lay out the month in a 7-column grid, Monday-first. Future days from the
+  // current month appear with low opacity. Empty leading slots align the
+  // first-of-the-month to its weekday column.
+  if (data.calendar.length === 0) return null;
+
+  const firstIso = data.calendar[0].date;
+  const leadingEmpty = weekdayMondayStart(firstIso);
+
+  return (
+    <div className="grid grid-cols-7 gap-1.5">
+      {WEEKDAY_LABELS.map((label) => (
+        <div
+          key={label}
+          className="text-center text-[9px] font-semibold uppercase tracking-wider text-z-sage-dark"
+        >
+          {label}
+        </div>
+      ))}
+      {Array.from({ length: leadingEmpty }).map((_, i) => (
+        <div key={`empty-${i}`} className="aspect-square" />
+      ))}
+      {data.calendar.map((day) => (
+        <div
+          key={day.date}
+          className={cn(
+            "flex aspect-square items-start justify-end rounded-md px-1 py-0.5 text-[9px] tabular-nums",
+            BUCKET_CLASS[day.bucket] ?? BUCKET_CLASS.none,
+            day.isFuture && "opacity-30",
+            day.isToday && "outline outline-2 outline-offset-[-2px] outline-white",
+          )}
+          title={
+            day.expense > 0
+              ? `${day.date}: ${formatCurrency(day.expense, data.currency)}`
+              : day.date
+          }
+        >
+          {dayOfMonth(day.date)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -1,27 +1,37 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import type { CurrencyCode } from "@/types/domain";
 import type { RitmoData } from "@/actions/ritmo";
 
 /**
- * V7 hybrid hero — Option A canonical. Predictive-runway model:
- *   - "Hoy puedes gastar" as the bold anchor
- *   - Period progress bar (sage → amber → red as user burns through the
- *     period's available balance)
- *   - Collapsible month calendar showing daily spend buckets relative to
- *     the user's own pace
+ * V7 hybrid hero — Option A canonical, predictive-runway model.
  *
- * Replaces the 50/30/20 allocation hero. Allocation lens belongs in
- * /presupuesto. See claude-ai-design/hero-runway-brainstorm.html for the
- * design spec.
+ *   ┌─ Primary  : "Hoy puedes gastar $N" + period-progress bar
+ *   ├─ Expand   : tab between "Cómo se calcula" (line items) and
+ *   │             "Patrón del mes" (calendar heatmap)
+ *   └─ Calendar : day cells are clickable; selection drops a detail
+ *                 strip showing that day's spend and bucket label.
+ *
+ * Replaces both the webapp 50/30/20 hero and the iOS RitmoWidget. Lives
+ * in webapp only for now; native iOS will wire to the same shared
+ * `computeRitmo` helper in a follow-up.
  */
+
+export interface PrimaryAccountSummary {
+  id: string;
+  name: string;
+  currentBalance: number;
+  currencyCode: CurrencyCode;
+}
 
 interface HybridHeroProps {
   data: RitmoData;
-  /** Initial expanded state for the calendar — persisted via localStorage. */
+  primaryAccount?: PrimaryAccountSummary;
   defaultExpanded?: boolean;
 }
 
@@ -32,20 +42,42 @@ const BUCKET_CLASS: Record<string, string> = {
   high: "bg-z-debt/45 text-z-white",
 };
 
-const WEEKDAY_LABELS = ["L", "M", "X", "J", "V", "S", "D"]; // Spanish week, Mon-start
+const BUCKET_LABEL: Record<string, string> = {
+  none: "Sin gasto",
+  low: "Día tranquilo",
+  med: "Día normal",
+  high: "Día caro",
+};
+
+const WEEKDAY_LABELS = ["L", "M", "X", "J", "V", "S", "D"];
+
+type ExpandedView = "calc" | "pattern";
 
 function dayOfMonth(iso: string): number {
   return parseInt(iso.slice(8, 10), 10);
 }
 
 function weekdayMondayStart(iso: string): number {
-  // JS getDay(): 0=Sun..6=Sat. Map to 0=Mon..6=Sun for ES calendars.
   const d = new Date(`${iso}T12:00:00`).getDay();
   return (d + 6) % 7;
 }
 
-export function HybridHero({ data, defaultExpanded = false }: HybridHeroProps) {
+function formatDayLabel(iso: string): string {
+  // e.g. "vie 21 may" — strip the locale's incidental periods and Title Case
+  // so it reads consistently across browsers (Chrome on macOS likes to
+  // capitalise the weekday).
+  const raw = new Date(`${iso}T12:00:00`).toLocaleDateString("es-CO", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+  return raw.replace(/\./g, "").toLowerCase();
+}
+
+export function HybridHero({ data, primaryAccount, defaultExpanded = false }: HybridHeroProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
+  const [view, setView] = useState<ExpandedView>("calc");
+  const [selectedDay, setSelectedDay] = useState<string | null>(null);
 
   const allowedTone =
     data.allowedToday <= 0
@@ -61,13 +93,45 @@ export function HybridHero({ data, defaultExpanded = false }: HybridHeroProps) {
         ? "y aún llegas al cierre del período con tu colchón."
         : "pero vas rápido — revisa los próximos días.";
 
+  // Cumulative outflow through each day in the month. Used to compute
+  // "remaining balance after this day" on the calendar-click detail.
+  // Indexed by date so the lookup is O(1) on selection.
+  const cumulativeByDate = useMemo(() => {
+    const map = new Map<string, number>();
+    let running = 0;
+    for (const day of data.calendar) {
+      running += day.expense;
+      map.set(day.date, running);
+    }
+    return map;
+  }, [data.calendar]);
+
+  const selectedEntry = useMemo(
+    () => (selectedDay ? data.calendar.find((d) => d.date === selectedDay) : null),
+    [selectedDay, data.calendar],
+  );
+
+  const selectedBalance = useMemo(() => {
+    if (!selectedDay || !selectedEntry) return null;
+    // Period budget minus cumulative spend through this date = headroom
+    // remaining after this day's transactions. For FUTURE days the value
+    // assumes only the past spend has fired.
+    const cumulative = cumulativeByDate.get(selectedDay) ?? 0;
+    return data.periodBudget - cumulative;
+  }, [selectedDay, selectedEntry, cumulativeByDate, data.periodBudget]);
+
   return (
     <div className="rounded-2xl border border-white/6 bg-z-surface p-5">
       <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark mb-2">
         Hoy puedes gastar
       </p>
 
-      <p className={cn("text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums", allowedTone)}>
+      <p
+        className={cn(
+          "text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums",
+          allowedTone,
+        )}
+      >
         {formatCurrency(data.allowedToday, data.currency)}
       </p>
 
@@ -85,12 +149,12 @@ export function HybridHero({ data, defaultExpanded = false }: HybridHeroProps) {
           }}
         />
       </div>
-      <div className="mt-2 flex items-baseline justify-between text-[11px] text-z-sage-dark tabular-nums">
-        <span>
+      <div className="mt-2 flex items-baseline justify-between gap-3 text-[11px] text-z-sage-dark tabular-nums">
+        <span className="truncate">
           {formatCurrency(data.spentMonth, data.currency)} gastados ·{" "}
           {formatCurrency(data.availableTotal, data.currency)} restantes
         </span>
-        <span className="font-medium text-z-sage-light">
+        <span className="shrink-0 font-medium text-z-sage-light">
           {Math.round(data.spentFraction * 100)}% del período
         </span>
       </div>
@@ -101,7 +165,7 @@ export function HybridHero({ data, defaultExpanded = false }: HybridHeroProps) {
         className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/6 px-3 py-2 text-[11px] font-semibold tracking-wide text-z-sage-light hover:bg-white/[0.02]"
         aria-expanded={expanded}
       >
-        <span>{expanded ? "Ocultar patrón del mes" : "Ver patrón del mes"}</span>
+        <span>{expanded ? "Ocultar detalle" : "Ver detalle"}</span>
         <ChevronDown
           className={cn(
             "size-3.5 text-z-brass transition-transform",
@@ -113,67 +177,233 @@ export function HybridHero({ data, defaultExpanded = false }: HybridHeroProps) {
 
       {expanded && (
         <div className="mt-4 border-t border-dashed border-white/6 pt-4">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark mb-3">
-            Patrón de gasto · este mes
-          </p>
-          <CalendarHeatmap data={data} />
-          <div className="mt-3 flex flex-wrap gap-3 text-[10px] text-z-sage-dark">
-            <span className="inline-flex items-center gap-1.5">
-              <i className="size-2.5 rounded-sm bg-z-income/20" /> Día tranquilo
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <i className="size-2.5 rounded-sm bg-z-alert/35" /> Día normal
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <i className="size-2.5 rounded-sm bg-z-debt/45" /> Día caro
-            </span>
+          {/* View tabs */}
+          <div className="mb-3 flex gap-1 rounded-lg border border-white/6 bg-z-surface-2 p-0.5">
+            <button
+              type="button"
+              onClick={() => setView("calc")}
+              className={cn(
+                "flex-1 rounded-md px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] transition-colors",
+                view === "calc"
+                  ? "bg-z-brass/20 text-z-brass"
+                  : "text-z-sage-dark hover:text-z-sage-light",
+              )}
+              aria-pressed={view === "calc"}
+            >
+              Cómo se calcula
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("pattern")}
+              className={cn(
+                "flex-1 rounded-md px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] transition-colors",
+                view === "pattern"
+                  ? "bg-z-brass/20 text-z-brass"
+                  : "text-z-sage-dark hover:text-z-sage-light",
+              )}
+              aria-pressed={view === "pattern"}
+            >
+              Patrón del mes
+            </button>
           </div>
+
+          {view === "calc" ? (
+            <CalculoView data={data} primaryAccount={primaryAccount} />
+          ) : (
+            <>
+              <CalendarHeatmap
+                data={data}
+                selectedDay={selectedDay}
+                onSelect={(date) => setSelectedDay((prev) => (prev === date ? null : date))}
+              />
+              <div className="mt-3 flex flex-wrap gap-3 text-[10px] text-z-sage-dark">
+                <span className="inline-flex items-center gap-1.5">
+                  <i className="size-2.5 rounded-sm bg-z-income/20" /> Día tranquilo
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <i className="size-2.5 rounded-sm bg-z-alert/35" /> Día normal
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <i className="size-2.5 rounded-sm bg-z-debt/45" /> Día caro
+                </span>
+              </div>
+              {selectedEntry && (
+                <div className="mt-3 rounded-lg border border-white/6 bg-z-surface-2 p-3 text-xs">
+                  <div className="flex items-baseline justify-between">
+                    <span className="font-semibold text-z-sage-light">
+                      {formatDayLabel(selectedEntry.date)}
+                    </span>
+                    <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-z-sage-dark">
+                      {BUCKET_LABEL[selectedEntry.bucket] ?? ""}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-lg font-semibold tabular-nums text-foreground">
+                    {selectedEntry.expense > 0
+                      ? `−${formatCurrency(selectedEntry.expense, data.currency)}`
+                      : "Sin gasto"}
+                  </p>
+                  {selectedBalance !== null && (
+                    <p
+                      className={cn(
+                        "mt-1 text-[11px] tabular-nums",
+                        selectedBalance < 0 ? "text-z-debt" : "text-z-sage-dark",
+                      )}
+                    >
+                      Restante después de este día:{" "}
+                      <span className="font-semibold">
+                        {formatCurrency(selectedBalance, data.currency)}
+                      </span>
+                    </p>
+                  )}
+                </div>
+              )}
+            </>
+          )}
         </div>
       )}
     </div>
   );
 }
 
-function CalendarHeatmap({ data }: { data: RitmoData }) {
-  // Lay out the month in a 7-column grid, Monday-first. Future days from the
-  // current month appear with low opacity. Empty leading slots align the
-  // first-of-the-month to its weekday column.
+/** Línea-por-línea de cómo se calcula el "Disponible" / "Hoy puedes gastar". */
+function CalculoView({
+  data,
+  primaryAccount,
+}: {
+  data: RitmoData;
+  primaryAccount?: PrimaryAccountSummary;
+}) {
+  const dailyValue = `${formatCurrency(data.availablePerDay, data.currency)}/día`;
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-white/6 bg-z-surface-2 p-3 space-y-1.5">
+        <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-z-brass">
+          Cómo se calcula
+        </p>
+        <div className="flex justify-between text-xs text-z-sage-light">
+          <span>Saldo líquido</span>
+          <span className="tabular-nums">
+            {formatCurrency(data.liquidBalance, data.currency)}
+          </span>
+        </div>
+        <div className="flex justify-between text-xs text-z-sage-light">
+          <span>− Obligaciones pendientes</span>
+          <span className="tabular-nums text-z-expense">
+            −{formatCurrency(data.pendingObligationsTotal, data.currency)}
+          </span>
+        </div>
+        <div className="flex justify-between text-xs text-z-sage-light">
+          <span>− Ya gastado</span>
+          <span className="tabular-nums text-z-expense">
+            −{formatCurrency(data.spentMonth, data.currency)}
+          </span>
+        </div>
+        <div className="flex justify-between border-t border-white/6 pt-1.5 text-xs font-semibold text-foreground">
+          <span>= Disponible</span>
+          <span
+            className={cn(
+              "tabular-nums",
+              data.availableTotal <= 0 && "text-z-debt",
+            )}
+          >
+            {formatCurrency(data.availableTotal, data.currency)}
+          </span>
+        </div>
+        <p className="text-[10px] text-muted-foreground">
+          ÷ {data.daysRemaining} días (hasta {data.windowEndLabel}) = {dailyValue}
+        </p>
+        {data.nextIncomeDateLabel && data.nextIncomeAmount > 0 && (
+          <div className="flex justify-between border-t border-white/6 pt-1.5 text-xs text-z-income">
+            <span className="truncate">
+              Próximo ingreso: {data.nextIncomeName ?? "ingreso"}
+            </span>
+            <span className="shrink-0 tabular-nums">
+              +{formatCurrency(data.nextIncomeAmount, data.currency)} el{" "}
+              {data.nextIncomeDateLabel}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {primaryAccount && (
+        <Link
+          href={`/accounts/${primaryAccount.id}`}
+          className="flex items-center justify-between rounded-lg border border-white/6 bg-black/20 p-3 transition-colors hover:bg-white/[0.04]"
+        >
+          <div className="min-w-0">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+              Cuenta principal
+            </p>
+            <p className="mt-0.5 truncate text-[12px] text-z-sage-light">
+              {primaryAccount.name}
+            </p>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <p className="text-[15px] font-bold tabular-nums text-foreground">
+              {formatCurrency(primaryAccount.currentBalance, primaryAccount.currencyCode)}
+            </p>
+            <ChevronRight className="size-3.5 text-muted-foreground/50" />
+          </div>
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function CalendarHeatmap({
+  data,
+  selectedDay,
+  onSelect,
+}: {
+  data: RitmoData;
+  selectedDay: string | null;
+  onSelect: (date: string) => void;
+}) {
   if (data.calendar.length === 0) return null;
 
   const firstIso = data.calendar[0].date;
   const leadingEmpty = weekdayMondayStart(firstIso);
 
   return (
-    <div className="grid grid-cols-7 gap-1.5">
-      {WEEKDAY_LABELS.map((label) => (
-        <div
-          key={label}
-          className="text-center text-[9px] font-semibold uppercase tracking-wider text-z-sage-dark"
-        >
-          {label}
-        </div>
-      ))}
-      {Array.from({ length: leadingEmpty }).map((_, i) => (
-        <div key={`empty-${i}`} className="aspect-square" />
-      ))}
-      {data.calendar.map((day) => (
-        <div
-          key={day.date}
-          className={cn(
-            "flex aspect-square items-start justify-end rounded-md px-1 py-0.5 text-[9px] tabular-nums",
-            BUCKET_CLASS[day.bucket] ?? BUCKET_CLASS.none,
-            day.isFuture && "opacity-30",
-            day.isToday && "outline outline-2 outline-offset-[-2px] outline-white",
-          )}
-          title={
-            day.expense > 0
-              ? `${day.date}: ${formatCurrency(day.expense, data.currency)}`
-              : day.date
-          }
-        >
-          {dayOfMonth(day.date)}
-        </div>
-      ))}
+    <div>
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark mb-2">
+        Toca un día para ver su detalle
+      </p>
+      <div className="grid grid-cols-7 gap-1.5">
+        {WEEKDAY_LABELS.map((label) => (
+          <div
+            key={label}
+            className="text-center text-[9px] font-semibold uppercase tracking-wider text-z-sage-dark"
+          >
+            {label}
+          </div>
+        ))}
+        {Array.from({ length: leadingEmpty }).map((_, i) => (
+          <div key={`empty-${i}`} className="aspect-square" />
+        ))}
+        {data.calendar.map((day) => {
+          const isSelected = day.date === selectedDay;
+          return (
+            <button
+              key={day.date}
+              type="button"
+              onClick={() => onSelect(day.date)}
+              className={cn(
+                "flex aspect-square items-start justify-end rounded-md px-1 py-0.5 text-[9px] tabular-nums transition-transform active:scale-95",
+                BUCKET_CLASS[day.bucket] ?? BUCKET_CLASS.none,
+                day.isFuture && "opacity-30",
+                day.isToday && "outline outline-2 outline-offset-[-2px] outline-white",
+                isSelected && "outline outline-2 outline-offset-[-2px] outline-z-brass",
+              )}
+              aria-pressed={isSelected}
+              aria-label={`${formatDayLabel(day.date)} — ${BUCKET_LABEL[day.bucket]}, ${day.expense > 0 ? `−${formatCurrency(day.expense, data.currency)}` : "sin gasto"}`}
+            >
+              {dayOfMonth(day.date)}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -36,9 +36,9 @@ interface HybridHeroProps {
 }
 
 const BUCKET_CLASS: Record<string, string> = {
-  none: "bg-z-surface-2 text-z-sage-dark",
-  low: "bg-z-income/20 text-z-sage-dark",
-  med: "bg-z-alert/35 text-z-sage-dark",
+  none: "bg-z-surface-2 text-z-white",
+  low: "bg-z-income/20 text-z-white",
+  med: "bg-z-alert/35 text-z-white",
   high: "bg-z-debt/45 text-z-white",
 };
 
@@ -540,7 +540,6 @@ function CalendarHeatmap({
                 "flex aspect-square items-start justify-end rounded-md px-1 py-0.5 text-[9px] tabular-nums transition-transform active:scale-95",
                 BUCKET_CLASS[day.bucket] ?? BUCKET_CLASS.none,
                 day.isFuture && "opacity-30",
-                day.isToday && "outline outline-2 outline-offset-[-2px] outline-white",
                 isSelected && "outline outline-2 outline-offset-[-2px] outline-z-brass",
               )}
               aria-pressed={isSelected}

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -149,13 +149,15 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
   }, [selectedDay, selectedEntry, cumulativeByDate, data.periodBudget]);
 
   return (
-    <div className="rounded-2xl border border-white/6 bg-z-surface p-5">
+    <div className="rounded-2xl border border-white/6 bg-z-surface-2/80 p-5">
       {/* Top row: eyebrow ("Gasto de hoy") + status pill. */}
       <div className="flex items-center justify-between gap-3">
         <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
           Gasto de hoy
         </p>
         <span
+          role="status"
+          aria-label={`Estado del gasto: ${status.label}`}
           className={cn(
             "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]",
             "bg-white/[0.04] border border-white/6",
@@ -217,7 +219,7 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
           style={{
             width: `${Math.min(100, Math.round(data.spentFraction * 100))}%`,
             background:
-              "linear-gradient(to right, var(--color-z-excellent, #3D9E6E) 0%, var(--color-z-sage, #768053) 30%, var(--color-z-alert, #D4A843) 70%, var(--color-z-debt, #E05545) 100%)",
+              "linear-gradient(to right, var(--color-z-excellent) 0%, var(--color-z-sage) 30%, var(--color-z-alert) 70%, var(--color-z-debt) 100%)",
             transition: "width 0.5s ease",
           }}
         />
@@ -245,7 +247,7 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/6 px-3 py-2 text-[11px] font-semibold tracking-wide text-z-sage-light hover:bg-white/[0.02]"
+        className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/6 px-3 py-2 text-[11px] font-semibold tracking-[0.12em] text-z-sage-light hover:bg-white/[0.02]"
         aria-expanded={expanded}
       >
         <span>{expanded ? "Ocultar detalle" : "Ver detalle"}</span>
@@ -451,10 +453,10 @@ function Sparkline({
   const pad = 3;
   const stroke =
     tone === "debt"
-      ? "var(--color-z-debt, #E05545)"
+      ? "var(--color-z-debt)"
       : tone === "alert"
-        ? "var(--color-z-alert, #D4A843)"
-        : "var(--color-z-sage, #768053)";
+        ? "var(--color-z-alert)"
+        : "var(--color-z-sage)";
 
   if (values.length === 0) return null;
 

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -86,12 +86,33 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
         ? "text-z-alert"
         : "text-z-income";
 
-  const sub =
+  const status: { label: string; tone: "income" | "alert" | "debt" } =
     data.allowedToday <= 0
-      ? "Hoy te pasaste del cupo diario — frena para llegar al cierre."
-      : data.onTrack
-        ? "y aún llegas al cierre del período con tu colchón."
-        : "pero vas rápido — revisa los próximos días.";
+      ? { label: "Te pasaste", tone: "debt" }
+      : data.spentFraction >= 0.85
+        ? { label: "Vas justo", tone: "alert" }
+        : { label: "Vas bien", tone: "income" };
+  const statusToneClass =
+    status.tone === "debt"
+      ? "bg-z-debt"
+      : status.tone === "alert"
+        ? "bg-z-alert"
+        : "bg-z-income";
+  const statusTextClass =
+    status.tone === "debt"
+      ? "text-z-debt"
+      : status.tone === "alert"
+        ? "text-z-alert"
+        : "text-z-income";
+
+  // Last-7-days OUTFLOW series for the mini sparkline — read from
+  // data.calendar so it scales with the user's actual month-to-date data.
+  // If the month is fresh (< 7 days), we just plot what we have.
+  const sparkData = useMemo(() => {
+    const slice = data.calendar.slice(-7);
+    const max = slice.reduce((m, d) => Math.max(m, d.expense), 0);
+    return { values: slice.map((d) => d.expense), max };
+  }, [data.calendar]);
 
   // Cumulative outflow through each day in the month. Used to compute
   // "remaining balance after this day" on the calendar-click detail.
@@ -122,20 +143,41 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
 
   return (
     <div className="rounded-2xl border border-white/6 bg-z-surface p-5">
-      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark mb-2">
-        Hoy puedes gastar
-      </p>
-
-      <p
-        className={cn(
-          "text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums",
-          allowedTone,
+      {/* Top row: eyebrow on the left, sparkline on the right.
+          Sparkline reads from data.calendar's last 7 days. */}
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          Hoy puedes gastar
+        </p>
+        {sparkData.values.length > 0 && (
+          <Sparkline
+            values={sparkData.values}
+            max={sparkData.max}
+            tone={status.tone}
+          />
         )}
-      >
-        {formatCurrency(data.allowedToday, data.currency)}
-      </p>
+      </div>
 
-      <p className="mt-2 text-sm text-z-sage-light leading-snug">{sub}</p>
+      <div className="mt-2 flex items-baseline justify-between gap-3">
+        <p
+          className={cn(
+            "text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums",
+            allowedTone,
+          )}
+        >
+          {formatCurrency(data.allowedToday, data.currency)}
+        </p>
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]",
+            "bg-white/[0.04] border border-white/6",
+            statusTextClass,
+          )}
+        >
+          <span className={cn("size-1.5 rounded-full", statusToneClass)} />
+          {status.label}
+        </span>
+      </div>
 
       {/* Period progress bar — gradient mapped to spentFraction */}
       <div className="relative mt-5 h-2.5 w-full overflow-hidden rounded-full bg-z-surface-2">
@@ -348,6 +390,70 @@ function CalculoView({
         </Link>
       )}
     </div>
+  );
+}
+
+/** Tiny inline sparkline of the last-N OUTFLOW series. Stroke colour tracks
+ *  the hero's status so a "Te pasaste" hero shows a red rhythm and a
+ *  "Vas bien" hero shows a sage one — same emotional cue as the main amount. */
+function Sparkline({
+  values,
+  max,
+  tone,
+}: {
+  values: number[];
+  max: number;
+  tone: "income" | "alert" | "debt";
+}) {
+  const width = 96;
+  const height = 32;
+  const pad = 3;
+  const stroke =
+    tone === "debt"
+      ? "var(--color-z-debt, #E05545)"
+      : tone === "alert"
+        ? "var(--color-z-alert, #D4A843)"
+        : "var(--color-z-sage, #768053)";
+
+  if (values.length === 0) return null;
+
+  // Single-day case: draw a flat baseline so the SVG still occupies space.
+  if (values.length === 1) {
+    return (
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} aria-hidden>
+        <line
+          x1={pad}
+          x2={width - pad}
+          y1={height / 2}
+          y2={height / 2}
+          stroke={stroke}
+          strokeWidth={2}
+          strokeLinecap="round"
+          opacity={0.6}
+        />
+      </svg>
+    );
+  }
+
+  const safeMax = max > 0 ? max : 1;
+  const step = (width - pad * 2) / (values.length - 1);
+  const points = values.map((v, i) => {
+    const x = pad + step * i;
+    const y = height - pad - (v / safeMax) * (height - pad * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} aria-hidden>
+      <polyline
+        points={points.join(" ")}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={1.75}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }
 

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -143,29 +143,12 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
 
   return (
     <div className="rounded-2xl border border-white/6 bg-z-surface p-5">
-      {/* Top row: eyebrow on the left, sparkline on the right.
-          Sparkline reads from data.calendar's last 7 days. */}
-      <div className="flex items-start justify-between gap-3">
+      {/* Top row: eyebrow on the left, status pill on the right.
+          Both are small text — they balance each other and let the big
+          amount + sparkline pair up on the row below. */}
+      <div className="flex items-center justify-between gap-3">
         <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
           Hoy puedes gastar
-        </p>
-        {sparkData.values.length > 0 && (
-          <Sparkline
-            values={sparkData.values}
-            max={sparkData.max}
-            tone={status.tone}
-          />
-        )}
-      </div>
-
-      <div className="mt-2 flex items-baseline justify-between gap-3">
-        <p
-          className={cn(
-            "text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums",
-            allowedTone,
-          )}
-        >
-          {formatCurrency(data.allowedToday, data.currency)}
         </p>
         <span
           className={cn(
@@ -177,6 +160,26 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
           <span className={cn("size-1.5 rounded-full", statusToneClass)} />
           {status.label}
         </span>
+      </div>
+
+      {/* Bottom row: big amount on the left, sparkline on the right.
+          Heavy visual elements paired so neither side looks empty. */}
+      <div className="mt-2 flex items-end justify-between gap-3">
+        <p
+          className={cn(
+            "text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums",
+            allowedTone,
+          )}
+        >
+          {formatCurrency(data.allowedToday, data.currency)}
+        </p>
+        {sparkData.values.length > 0 && (
+          <Sparkline
+            values={sparkData.values}
+            max={sparkData.max}
+            tone={status.tone}
+          />
+        )}
       </div>
 
       {/* Period progress bar — gradient mapped to spentFraction */}

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -182,8 +182,12 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
         )}
       </div>
 
-      {/* Period progress bar — gradient mapped to spentFraction */}
-      <div className="relative mt-5 h-2.5 w-full overflow-hidden rounded-full bg-z-surface-2">
+      {/* Period progress bar. The % indicator floats just above the
+          bar's right edge so it never competes with the legend below. */}
+      <div className="mt-5 flex items-end justify-end text-[10px] font-medium text-z-sage-light tabular-nums">
+        <span>{Math.round(data.spentFraction * 100)}% del período</span>
+      </div>
+      <div className="relative mt-1 h-2.5 w-full overflow-hidden rounded-full bg-z-surface-2">
         <div
           className="h-full rounded-full"
           style={{
@@ -194,15 +198,25 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
           }}
         />
       </div>
-      <div className="mt-2 flex items-baseline justify-between gap-3 text-[11px] text-z-sage-dark tabular-nums">
-        <span className="truncate">
-          {formatCurrency(data.spentMonth, data.currency)} gastados ·{" "}
-          {formatCurrency(data.availableTotal, data.currency)} restantes
-        </span>
-        <span className="shrink-0 font-medium text-z-sage-light">
-          {Math.round(data.spentFraction * 100)}% del período
-        </span>
-      </div>
+      {/* Legend below — each metric on its own line so they breathe. */}
+      <dl className="mt-3 space-y-1 text-[11px] tabular-nums">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-z-sage-dark">Gastados</dt>
+          <dd className="text-z-sage-light">
+            {formatCurrency(data.spentMonth, data.currency)}
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-z-sage-dark">Restantes</dt>
+          <dd
+            className={cn(
+              data.availableTotal < 0 ? "text-z-debt" : "text-z-sage-light",
+            )}
+          >
+            {formatCurrency(data.availableTotal, data.currency)}
+          </dd>
+        </div>
+      </dl>
 
       <button
         type="button"

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -79,31 +79,26 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
   const [view, setView] = useState<ExpandedView>("calc");
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
 
-  // Status reflects the PERIOD, not today's micro-spend. A user can blow
-  // through today's allowance and still have plenty of headroom for the
-  // rest of the month — that's "Hoy a tope", not "Te pasaste".
-  // - availableTotal < 0 → period exhausted (debt red)
-  // - spentFraction >= 0.85 → period almost gone (alert amber)
-  // - allowedToday <= 0 && availableTotal > 0 → today maxed, period OK (alert)
-  // - otherwise → healthy (income green)
+  // Status: red on overspend (today OR period), amber on period strain.
+  // Today's overspend = red because the user's ritmo is broken for the
+  // day — that's an immediate signal even if the period still has room.
+  const overspentToday = data.spentToday > data.availablePerDay;
   const status: { label: string; tone: "income" | "alert" | "debt" } =
-    data.availableTotal < 0
+    data.availableTotal < 0 || overspentToday
       ? { label: "Te pasaste", tone: "debt" }
       : data.spentFraction >= 0.85
         ? { label: "Vas justo", tone: "alert" }
-        : data.allowedToday <= 0
-          ? { label: "Hoy a tope", tone: "alert" }
-          : { label: "Vas bien", tone: "income" };
+        : { label: "Vas bien", tone: "income" };
 
-  // Amount tone tracks the same period-aware status. Today-exhausted-but-
-  // period-fine renders the $0 in amber, not red — the user has more
-  // available tomorrow.
-  const allowedTone =
+  // The big number is today's actual spend. Tone tracks status.
+  const todayTone =
     status.tone === "debt"
       ? "text-z-debt"
       : status.tone === "alert"
         ? "text-z-alert"
-        : "text-z-income";
+        : data.spentToday > 0
+          ? "text-z-income"
+          : "text-z-sage-light";
   const statusToneClass =
     status.tone === "debt"
       ? "bg-z-debt"
@@ -155,12 +150,10 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
 
   return (
     <div className="rounded-2xl border border-white/6 bg-z-surface p-5">
-      {/* Top row: eyebrow on the left, status pill on the right.
-          Both are small text — they balance each other and let the big
-          amount + sparkline pair up on the row below. */}
+      {/* Top row: eyebrow ("Gasto de hoy") + status pill. */}
       <div className="flex items-center justify-between gap-3">
         <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
-          Hoy puedes gastar
+          Gasto de hoy
         </p>
         <span
           className={cn(
@@ -174,16 +167,15 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
         </span>
       </div>
 
-      {/* Bottom row: big amount on the left, sparkline on the right.
-          Heavy visual elements paired so neither side looks empty. */}
+      {/* Bottom row: today's spend (the headline fact) + sparkline. */}
       <div className="mt-2 flex items-end justify-between gap-3">
         <p
           className={cn(
             "text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums",
-            allowedTone,
+            todayTone,
           )}
         >
-          {formatCurrency(data.allowedToday, data.currency)}
+          {formatCurrency(data.spentToday, data.currency)}
         </p>
         {sparkData.values.length > 0 && (
           <Sparkline
@@ -193,6 +185,26 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
           />
         )}
       </div>
+
+      {/* Daily allowance context line. Always rendered — it's the
+          baseline the headline is being compared against. Tone shifts
+          to amber when today is over the daily budget. */}
+      <p
+        className={cn(
+          "mt-2 text-[12px] tabular-nums",
+          overspentToday ? "text-z-alert" : "text-z-sage-light",
+        )}
+      >
+        {overspentToday ? (
+          <>
+            Por encima de {formatCurrency(data.availablePerDay, data.currency)} al día
+          </>
+        ) : (
+          <>
+            de {formatCurrency(data.availablePerDay, data.currency)} al día
+          </>
+        )}
+      </p>
 
       {/* Period progress bar. The % indicator floats just above the
           bar's right edge so it never competes with the legend below. */}

--- a/webapp/src/components/dashboard/hybrid-hero.tsx
+++ b/webapp/src/components/dashboard/hybrid-hero.tsx
@@ -1,26 +1,20 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import Link from "next/link";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
+import {
+  BUCKET_LABEL,
+  WEEKDAYS_MONDAY_START,
+  deriveRitmoStatus,
+  weekdayMondayStart,
+  type DailyBucket,
+  type RitmoStatusTone,
+} from "@zeta/shared";
 import type { CurrencyCode } from "@/types/domain";
 import type { RitmoData } from "@/actions/ritmo";
-
-/**
- * V7 hybrid hero — Option A canonical, predictive-runway model.
- *
- *   ┌─ Primary  : "Hoy puedes gastar $N" + period-progress bar
- *   ├─ Expand   : tab between "Cómo se calcula" (line items) and
- *   │             "Patrón del mes" (calendar heatmap)
- *   └─ Calendar : day cells are clickable; selection drops a detail
- *                 strip showing that day's spend and bucket label.
- *
- * Replaces both the webapp 50/30/20 hero and the iOS RitmoWidget. Lives
- * in webapp only for now; native iOS will wire to the same shared
- * `computeRitmo` helper in a follow-up.
- */
 
 export interface PrimaryAccountSummary {
   id: string;
@@ -35,21 +29,30 @@ interface HybridHeroProps {
   defaultExpanded?: boolean;
 }
 
-const BUCKET_CLASS: Record<string, string> = {
+const BUCKET_CLASS: Record<DailyBucket, string> = {
   none: "bg-z-surface-2 text-z-white",
   low: "bg-z-income/20 text-z-white",
   med: "bg-z-alert/35 text-z-white",
   high: "bg-z-debt/45 text-z-white",
 };
 
-const BUCKET_LABEL: Record<string, string> = {
-  none: "Sin gasto",
-  low: "Día tranquilo",
-  med: "Día normal",
-  high: "Día caro",
+const TONE_TEXT_CLASS: Record<RitmoStatusTone, string> = {
+  income: "text-z-income",
+  alert: "text-z-alert",
+  debt: "text-z-debt",
 };
 
-const WEEKDAY_LABELS = ["L", "M", "X", "J", "V", "S", "D"];
+const TONE_BG_CLASS: Record<RitmoStatusTone, string> = {
+  income: "bg-z-income",
+  alert: "bg-z-alert",
+  debt: "bg-z-debt",
+};
+
+const TONE_STROKE: Record<RitmoStatusTone, string> = {
+  income: "var(--color-z-sage)",
+  alert: "var(--color-z-alert)",
+  debt: "var(--color-z-debt)",
+};
 
 type ExpandedView = "calc" | "pattern";
 
@@ -57,15 +60,9 @@ function dayOfMonth(iso: string): number {
   return parseInt(iso.slice(8, 10), 10);
 }
 
-function weekdayMondayStart(iso: string): number {
-  const d = new Date(`${iso}T12:00:00`).getDay();
-  return (d + 6) % 7;
-}
-
 function formatDayLabel(iso: string): string {
-  // e.g. "vie 21 may" — strip the locale's incidental periods and Title Case
-  // so it reads consistently across browsers (Chrome on macOS likes to
-  // capitalise the weekday).
+  // Chrome on macOS title-cases the weekday and keeps a trailing period
+  // ("Vie. 21 may"); strip both so the label reads consistently.
   const raw = new Date(`${iso}T12:00:00`).toLocaleDateString("es-CO", {
     weekday: "short",
     day: "numeric",
@@ -79,38 +76,16 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
   const [view, setView] = useState<ExpandedView>("calc");
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
 
-  // Status: red on overspend (today OR period), amber on period strain.
-  // Today's overspend = red because the user's ritmo is broken for the
-  // day — that's an immediate signal even if the period still has room.
   const overspentToday = data.spentToday > data.availablePerDay;
-  const status: { label: string; tone: "income" | "alert" | "debt" } =
-    data.availableTotal < 0 || overspentToday
-      ? { label: "Te pasaste", tone: "debt" }
-      : data.spentFraction >= 0.85
-        ? { label: "Vas justo", tone: "alert" }
-        : { label: "Vas bien", tone: "income" };
-
-  // The big number is today's actual spend. Tone tracks status.
+  const status = deriveRitmoStatus(data);
+  const statusTextClass = TONE_TEXT_CLASS[status.tone];
+  const statusToneClass = TONE_BG_CLASS[status.tone];
+  // "income" tone falls through to a muted color when nothing was spent
+  // today — there's no "you spent $0" achievement to celebrate in green.
   const todayTone =
-    status.tone === "debt"
-      ? "text-z-debt"
-      : status.tone === "alert"
-        ? "text-z-alert"
-        : data.spentToday > 0
-          ? "text-z-income"
-          : "text-z-sage-light";
-  const statusToneClass =
-    status.tone === "debt"
-      ? "bg-z-debt"
-      : status.tone === "alert"
-        ? "bg-z-alert"
-        : "bg-z-income";
-  const statusTextClass =
-    status.tone === "debt"
-      ? "text-z-debt"
-      : status.tone === "alert"
-        ? "text-z-alert"
-        : "text-z-income";
+    status.tone === "income" && data.spentToday === 0
+      ? "text-z-sage-light"
+      : statusTextClass;
 
   // Last-7-days OUTFLOW series for the mini sparkline — read from
   // data.calendar so it scales with the user's actual month-to-date data.
@@ -180,7 +155,7 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
           {formatCurrency(data.spentToday, data.currency)}
         </p>
         {sparkData.values.length > 0 && (
-          <Sparkline
+          <HeroSparkline
             values={sparkData.values}
             max={sparkData.max}
             tone={status.tone}
@@ -208,11 +183,9 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
         )}
       </p>
 
-      {/* Period progress bar. The % indicator floats just above the
-          bar's right edge so it never competes with the legend below. */}
-      <div className="mt-5 flex items-end justify-end text-[10px] font-medium text-z-sage-light tabular-nums">
-        <span>{Math.round(data.spentFraction * 100)}% del período</span>
-      </div>
+      <p className="mt-5 text-right text-[10px] font-medium text-z-sage-light tabular-nums">
+        {Math.round(data.spentFraction * 100)}% del período
+      </p>
       <div className="relative mt-1 h-2.5 w-full overflow-hidden rounded-full bg-z-surface-2">
         <div
           className="h-full rounded-full"
@@ -351,7 +324,7 @@ export function HybridHero({ data, primaryAccount, defaultExpanded = false }: Hy
 }
 
 /** Línea-por-línea de cómo se calcula el "Disponible" / "Hoy puedes gastar". */
-function CalculoView({
+const CalculoView = memo(function CalculoView({
   data,
   primaryAccount,
 }: {
@@ -434,29 +407,24 @@ function CalculoView({
       )}
     </div>
   );
-}
+});
 
 /** Tiny inline sparkline of the last-N OUTFLOW series. Stroke colour tracks
  *  the hero's status so a "Te pasaste" hero shows a red rhythm and a
  *  "Vas bien" hero shows a sage one — same emotional cue as the main amount. */
-function Sparkline({
+const HeroSparkline = memo(function HeroSparkline({
   values,
   max,
   tone,
 }: {
   values: number[];
   max: number;
-  tone: "income" | "alert" | "debt";
+  tone: RitmoStatusTone;
 }) {
   const width = 96;
   const height = 32;
   const pad = 3;
-  const stroke =
-    tone === "debt"
-      ? "var(--color-z-debt)"
-      : tone === "alert"
-        ? "var(--color-z-alert)"
-        : "var(--color-z-sage)";
+  const stroke = TONE_STROKE[tone];
 
   if (values.length === 0) return null;
 
@@ -498,9 +466,9 @@ function Sparkline({
       />
     </svg>
   );
-}
+});
 
-function CalendarHeatmap({
+const CalendarHeatmap = memo(function CalendarHeatmap({
   data,
   selectedDay,
   onSelect,
@@ -520,7 +488,7 @@ function CalendarHeatmap({
         Toca un día para ver su detalle
       </p>
       <div className="grid grid-cols-7 gap-1.5">
-        {WEEKDAY_LABELS.map((label) => (
+        {WEEKDAYS_MONDAY_START.map((label) => (
           <div
             key={label}
             className="text-center text-[9px] font-semibold uppercase tracking-wider text-z-sage-dark"
@@ -554,4 +522,4 @@ function CalendarHeatmap({
       </div>
     </div>
   );
-}
+});

--- a/webapp/src/components/dashboard/zones/hero-zone.tsx
+++ b/webapp/src/components/dashboard/zones/hero-zone.tsx
@@ -53,12 +53,35 @@ export async function HeroZone({ month, currency, monthLabel }: HeroZoneProps) {
     displayOrder: account.display_order,
   }));
 
+  // Pick a "primary" account to feature in the hero's Cálculo view — same
+  // selection rule as MobileZone for visual parity.
+  const primaryAccount = (() => {
+    const primary =
+      allAccounts.find(
+        (a) =>
+          (a.account_type === "SAVINGS" || a.account_type === "CHECKING") &&
+          a.show_in_dashboard,
+      ) ??
+      allAccounts.find(
+        (a) => a.account_type === "SAVINGS" || a.account_type === "CHECKING",
+      );
+    if (!primary) return undefined;
+    return {
+      id: primary.id,
+      name: primary.name,
+      currentBalance: primary.current_balance ?? 0,
+      currencyCode: primary.currency_code as CurrencyCode,
+    };
+  })();
+
   return (
     <>
       {/* Hero + Attention — 2/3 hero, 1/3 attention */}
       <div className="grid gap-4 xl:grid-cols-[1fr_22rem]">
         <div className="space-y-3">
-          {ritmoResult.success && <HybridHero data={ritmoResult.data} />}
+          {ritmoResult.success && (
+            <HybridHero data={ritmoResult.data} primaryAccount={primaryAccount} />
+          )}
           <DebtFreeBanner data={debtCountdownData} />
         </div>
         <AttentionCard signals={attentionSnapshot.signals} className="h-fit" />

--- a/webapp/src/components/dashboard/zones/hero-zone.tsx
+++ b/webapp/src/components/dashboard/zones/hero-zone.tsx
@@ -3,7 +3,8 @@ import { get503020Allocation } from "@/actions/allocation";
 import { getDebtFreeCountdown } from "@/actions/debt-countdown";
 import { getAttentionSnapshot } from "@/actions/attention";
 import { getAccounts } from "@/actions/accounts";
-import { DashboardHero } from "@/components/dashboard/dashboard-hero";
+import { getRitmo } from "@/actions/ritmo";
+import { HybridHero } from "@/components/dashboard/hybrid-hero";
 import { DebtFreeBanner } from "@/components/dashboard/debt-free-banner";
 import { AttentionCard } from "@/components/ui/attention-card";
 import { UpcomingPayments } from "@/components/dashboard/upcoming-payments";
@@ -22,14 +23,23 @@ interface HeroZoneProps {
 }
 
 export async function HeroZone({ month, currency, monthLabel }: HeroZoneProps) {
-  const [heroData, allocationData, debtCountdownData, attentionSnapshot, accountsResult] =
-    await Promise.all([
-      getDashboardHeroData(month, currency),
-      get503020Allocation(month, currency),
-      getDebtFreeCountdown(currency),
-      getAttentionSnapshot(),
-      getAccounts(),
-    ]);
+  // Hero is now the V7 predictive-runway model (Option A, see scoping doc
+  // PR #261). Allocation lens (50/30/20) still feeds PlanTeaserCard below.
+  const [
+    heroData,
+    ritmoResult,
+    allocationData,
+    debtCountdownData,
+    attentionSnapshot,
+    accountsResult,
+  ] = await Promise.all([
+    getDashboardHeroData(month, currency),
+    getRitmo(month, currency),
+    get503020Allocation(month, currency),
+    getDebtFreeCountdown(currency),
+    getAttentionSnapshot(),
+    getAccounts(),
+  ]);
 
   const allAccounts = accountsResult.success ? accountsResult.data : [];
 
@@ -47,11 +57,10 @@ export async function HeroZone({ month, currency, monthLabel }: HeroZoneProps) {
     <>
       {/* Hero + Attention — 2/3 hero, 1/3 attention */}
       <div className="grid gap-4 xl:grid-cols-[1fr_22rem]">
-        <DashboardHero
-          data={heroData}
-          allocationData={allocationData}
-          debtFreeBanner={<DebtFreeBanner data={debtCountdownData} />}
-        />
+        <div className="space-y-3">
+          {ritmoResult.success && <HybridHero data={ritmoResult.data} />}
+          <DebtFreeBanner data={debtCountdownData} />
+        </div>
         <AttentionCard signals={attentionSnapshot.signals} className="h-fit" />
       </div>
 

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -5,7 +5,9 @@ import { getBudgetSummary } from "@/actions/budgets";
 import { getAccounts } from "@/actions/accounts";
 import { getMobileLayout } from "@/actions/dashboard-config";
 import { getLatestSnapshotDates } from "@/actions/statement-snapshots";
+import { getRitmo } from "@/actions/ritmo";
 import type { RecentTransaction } from "@/actions/transactions";
+import { HybridHero } from "@/components/dashboard/hybrid-hero";
 import { InicioRoot } from "@/components/mobile/v2/inicio/inicio-root";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { toColombiaDateString } from "@/lib/utils/date";
@@ -19,17 +21,27 @@ interface MobileZoneProps {
 }
 
 export async function MobileZone({ month, currency, recentTx }: MobileZoneProps) {
-  const [heroData, attentionItemsData, burnRateData, budgetSummary, accountsResult, dailySpending, latestSnapshotDates, mobileLayout] =
-    await Promise.all([
-      getDashboardHeroData(month, currency),
-      getAttentionItems(),
-      getBurnRate(currency),
-      getBudgetSummary(month),
-      getAccounts(),
-      getDailySpending(month, currency),
-      getLatestSnapshotDates(),
-      getMobileLayout(),
-    ]);
+  const [
+    heroData,
+    ritmoResult,
+    attentionItemsData,
+    burnRateData,
+    budgetSummary,
+    accountsResult,
+    dailySpending,
+    latestSnapshotDates,
+    mobileLayout,
+  ] = await Promise.all([
+    getDashboardHeroData(month, currency),
+    getRitmo(month, currency),
+    getAttentionItems(),
+    getBurnRate(currency),
+    getBudgetSummary(month),
+    getAccounts(),
+    getDailySpending(month, currency),
+    getLatestSnapshotDates(),
+    getMobileLayout(),
+  ]);
 
   const allAccounts = accountsResult.success ? accountsResult.data : [];
 
@@ -129,6 +141,14 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
   return (
     <>
       <MobileHeader variant="main" title="Zeta" />
+      {/* V7 hybrid hero — Option A, predictive runway. Renders ABOVE the
+          existing InicioRoot for now so users can compare; once accepted,
+          InicioRoot's hero block is removed in a follow-up PR. */}
+      {ritmoResult.success && (
+        <div className="px-4 pb-4">
+          <HybridHero data={ritmoResult.data} />
+        </div>
+      )}
       <InicioRoot
         hero={{
           availablePerDay: heroData.availableToSpend / daysRemaining,

--- a/webapp/src/components/dashboard/zones/mobile-zone.tsx
+++ b/webapp/src/components/dashboard/zones/mobile-zone.tsx
@@ -143,10 +143,12 @@ export async function MobileZone({ month, currency, recentTx }: MobileZoneProps)
       <MobileHeader variant="main" title="Zeta" />
       {/* V7 hybrid hero — Option A, predictive runway. Renders ABOVE the
           existing InicioRoot for now so users can compare; once accepted,
-          InicioRoot's hero block is removed in a follow-up PR. */}
+          InicioRoot's hero block is removed in a follow-up PR.
+          No wrapper padding — InicioRoot's parent already provides the
+          page-level horizontal margin; the hero card uses internal p-5. */}
       {ritmoResult.success && (
-        <div className="px-4 pb-4">
-          <HybridHero data={ritmoResult.data} />
+        <div className="mb-4">
+          <HybridHero data={ritmoResult.data} primaryAccount={primaryAccount} />
         </div>
       )}
       <InicioRoot

--- a/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-root.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
 import { useRouter } from "next/navigation";
 import { Plus, RotateCcw, Settings2 } from "lucide-react";
 import { toast } from "sonner";
-import { PulseWidget } from "./pulse-widget";
 import { InicioStarter } from "./inicio-starter";
 import { WidgetGrid, type WidgetRender } from "./widget-grid";
 import { AddWidgetSheet } from "./add-widget-sheet";
@@ -337,22 +336,13 @@ export function InicioRoot({
 
   return (
     <div className="space-y-4">
-      <PulseWidget
-        availablePerDay={live.hero.availablePerDay}
-        availableTotal={live.hero.availableTotal}
-        daysRemaining={live.hero.daysRemaining}
-        currency={hero.currency}
-        nextIncomeDate={live.hero.nextIncomeDate ?? hero.nextIncomeDate ?? null}
-        nextIncomeAmount={live.hero.nextIncomeAmount ?? hero.nextIncomeAmount ?? 0}
-        nextIncomeName={live.hero.nextIncomeName ?? hero.nextIncomeName ?? null}
-        incomeConfigured={live.hero.incomeConfigured ?? hero.incomeConfigured ?? false}
-        breakdown={live.hero.breakdown}
-        primaryAccount={hero.primaryAccount}
-        spark={metrics.last7Spend}
-        avgSpend={live.metrics.avgLast7}
-        expanded={activeZone === "hero"}
-        onToggle={() => toggle("hero")}
-      />
+      {/* Old PulseWidget hero ("ESTE MES · PULSO") removed 2026-05-21.
+          Replaced by the V7 HybridHero rendered above this component in
+          MobileZone (Option A predictive-runway canonical, see #264).
+          The `hero` + `metrics` props are still received but their hero-
+          related fields are no longer rendered here; `metrics.last7Spend`
+          is still consumed by downstream widgets if any. The PulseWidget
+          component file is kept as a 1-line rollback target if needed. */}
 
       <SectionDivider label="Herramientas" />
       <WidgetGrid

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -1,5 +1,21 @@
 import { updateTag, revalidateTag } from "next/cache";
 
+const FINANCIAL_TAGS = [
+  "transactions",
+  "accounts",
+  "dashboard:accounts",
+  "dashboard:charts",
+  "dashboard:budgets",
+  "dashboard:cashflow",
+  "dashboard:hero",
+  "categorize",
+  "debt",
+  "budgets",
+  "attention",
+  "occurrences",
+  "recurring",
+] as const;
+
 /**
  * Immediately expire all financial Data Cache entries. Call after any
  * mutation that creates, updates, or deletes transactions.
@@ -13,19 +29,7 @@ import { updateTag, revalidateTag } from "next/cache";
  *   updateTag("email-ingest");   // domain extra
  */
 export function revalidateFinancialViews() {
-  updateTag("transactions");
-  updateTag("accounts");
-  updateTag("dashboard:accounts");
-  updateTag("dashboard:charts");
-  updateTag("dashboard:budgets");
-  updateTag("dashboard:cashflow");
-  updateTag("dashboard:hero");
-  updateTag("categorize");
-  updateTag("debt");
-  updateTag("budgets");
-  updateTag("attention");
-  updateTag("occurrences");
-  updateTag("recurring");
+  for (const tag of FINANCIAL_TAGS) updateTag(tag);
 }
 
 /**
@@ -61,39 +65,19 @@ export function revalidateAllUserData() {
  * Route-Handler-safe variant of `revalidateFinancialViews()`. Used by
  * webhooks (`/api/webhooks/email-ingest`, telegram, cron jobs).
  *
- * `updateTag()` is the right call from Server Actions because it pairs
- * Data Cache eviction with Router Cache eviction for the *initiating
- * client* — the user gets read-your-own-writes on their very next
- * navigation. Route Handlers have no such client attachment: the
- * webhook is initiated by Bancolombia / Telegram / cron, not the user
- * the data belongs to, so there is no Router Cache to flush in the
- * same request. `revalidateTag(tag, "zeta")` persistently marks the
- * Data Cache entries stale; the user's subsequent navigation pays one
- * SWR refresh and sees fresh data. Eventual consistency is acceptable
- * for background-ingested rows.
+ * `updateTag()` pairs Data Cache eviction with Router Cache eviction
+ * for the *initiating client*, giving Server Action callers read-your-
+ * own-writes on their very next navigation. Route Handlers have no
+ * attached client (the webhook is initiated by Bancolombia / Telegram /
+ * cron, not the user the data belongs to), so the Router Cache half of
+ * `updateTag` no-ops. `revalidateTag(tag, "zeta")` persistently marks
+ * the Data Cache entries stale; the user's subsequent navigation pays
+ * one SWR refresh and sees fresh data.
  *
- * Do NOT call this from Server Actions — it bypasses the Router Cache
+ * Do NOT call this from Server Actions — it skips the Router Cache
  * eviction that `updateTag` provides, so the action's own caller would
- * still see stale data until the next full reload. The `updateTag`
- * path in `revalidateFinancialViews()` is correct for those.
- *
- * Discovered 2026-05-21 when an email-imported transaction appeared on
- * /transactions + /accounts/[id] but was missing from the dashboard
- * hero, because the prior webhook code reused `updateTag` and silently
- * no-op'd outside a Server Action context.
+ * still see stale data until the next full reload.
  */
 export function revalidateFinancialViewsFromWebhook() {
-  revalidateTag("transactions", "zeta");
-  revalidateTag("accounts", "zeta");
-  revalidateTag("dashboard:accounts", "zeta");
-  revalidateTag("dashboard:charts", "zeta");
-  revalidateTag("dashboard:budgets", "zeta");
-  revalidateTag("dashboard:cashflow", "zeta");
-  revalidateTag("dashboard:hero", "zeta");
-  revalidateTag("categorize", "zeta");
-  revalidateTag("debt", "zeta");
-  revalidateTag("budgets", "zeta");
-  revalidateTag("attention", "zeta");
-  revalidateTag("occurrences", "zeta");
-  revalidateTag("recurring", "zeta");
+  for (const tag of FINANCIAL_TAGS) revalidateTag(tag, "zeta");
 }

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -59,20 +59,28 @@ export function revalidateAllUserData() {
 
 /**
  * Route-Handler-safe variant of `revalidateFinancialViews()`. Used by
- * webhooks (`/api/webhooks/email-ingest`, telegram, cron jobs) where
- * `updateTag()` doesn't work as expected — its read-your-own-writes
- * semantics are request-scoped to the current Server Action, but a
- * webhook's request ends before any client navigates, so the user's
- * NEXT request never sees the invalidation. `revalidateTag(tag, "zeta")`
- * marks the cache entries stale for subsequent reads (stale-while-
- * revalidate is acceptable here — eventual consistency is fine for
- * background-ingested data).
+ * webhooks (`/api/webhooks/email-ingest`, telegram, cron jobs).
+ *
+ * `updateTag()` is the right call from Server Actions because it pairs
+ * Data Cache eviction with Router Cache eviction for the *initiating
+ * client* — the user gets read-your-own-writes on their very next
+ * navigation. Route Handlers have no such client attachment: the
+ * webhook is initiated by Bancolombia / Telegram / cron, not the user
+ * the data belongs to, so there is no Router Cache to flush in the
+ * same request. `revalidateTag(tag, "zeta")` persistently marks the
+ * Data Cache entries stale; the user's subsequent navigation pays one
+ * SWR refresh and sees fresh data. Eventual consistency is acceptable
+ * for background-ingested rows.
+ *
+ * Do NOT call this from Server Actions — it bypasses the Router Cache
+ * eviction that `updateTag` provides, so the action's own caller would
+ * still see stale data until the next full reload. The `updateTag`
+ * path in `revalidateFinancialViews()` is correct for those.
  *
  * Discovered 2026-05-21 when an email-imported transaction appeared on
  * /transactions + /accounts/[id] but was missing from the dashboard
- * hero. Both surfaces are tagged `"transactions"`, but only the former
- * was getting invalidated because `getRitmo` / hero queries are read by
- * subsequent navigations, not the webhook's own response.
+ * hero, because the prior webhook code reused `updateTag` and silently
+ * no-op'd outside a Server Action context.
  */
 export function revalidateFinancialViewsFromWebhook() {
   revalidateTag("transactions", "zeta");

--- a/webapp/src/lib/cache/revalidation.ts
+++ b/webapp/src/lib/cache/revalidation.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { updateTag, revalidateTag } from "next/cache";
 
 /**
  * Immediately expire all financial Data Cache entries. Call after any
@@ -55,4 +55,37 @@ export function revalidateAllUserData() {
   updateTag("cashflow-planner");
   updateTag("categories");
   updateTag("impact");
+}
+
+/**
+ * Route-Handler-safe variant of `revalidateFinancialViews()`. Used by
+ * webhooks (`/api/webhooks/email-ingest`, telegram, cron jobs) where
+ * `updateTag()` doesn't work as expected — its read-your-own-writes
+ * semantics are request-scoped to the current Server Action, but a
+ * webhook's request ends before any client navigates, so the user's
+ * NEXT request never sees the invalidation. `revalidateTag(tag, "zeta")`
+ * marks the cache entries stale for subsequent reads (stale-while-
+ * revalidate is acceptable here — eventual consistency is fine for
+ * background-ingested data).
+ *
+ * Discovered 2026-05-21 when an email-imported transaction appeared on
+ * /transactions + /accounts/[id] but was missing from the dashboard
+ * hero. Both surfaces are tagged `"transactions"`, but only the former
+ * was getting invalidated because `getRitmo` / hero queries are read by
+ * subsequent navigations, not the webhook's own response.
+ */
+export function revalidateFinancialViewsFromWebhook() {
+  revalidateTag("transactions", "zeta");
+  revalidateTag("accounts", "zeta");
+  revalidateTag("dashboard:accounts", "zeta");
+  revalidateTag("dashboard:charts", "zeta");
+  revalidateTag("dashboard:budgets", "zeta");
+  revalidateTag("dashboard:cashflow", "zeta");
+  revalidateTag("dashboard:hero", "zeta");
+  revalidateTag("categorize", "zeta");
+  revalidateTag("debt", "zeta");
+  revalidateTag("budgets", "zeta");
+  revalidateTag("attention", "zeta");
+  revalidateTag("occurrences", "zeta");
+  revalidateTag("recurring", "zeta");
 }


### PR DESCRIPTION
## Summary

Finding 2 from the [2026-05-21 parity audit](https://github.com/Cristian1911/personal_finance_manager_claude/pull/261). Mobile and webapp gave opposite verdicts on the dashboard hero ("fuera de ritmo" vs "Arriba del ritmo") because they computed different things — mobile used a rolling 7-day OUTFLOW avg, webapp used 50/30/20 allocation.

User picked **Option A** (predictive runway is canonical) and **V7 hybrid** (V2 + V5 from the [brainstorm](https://github.com/Cristian1911/personal_finance_manager_claude/pull/263)):

> "Hoy puedes gastar \$N" anchor + period progress bar that shifts green → amber → red as the user burns through the period's available balance. Month calendar heatmap hidden behind "Ver patrón del mes" affordance.

## What's in the PR

| Layer | File | What |
|---|---|---|
| Shared | `packages/shared/src/utils/ritmo.ts` | `computeRitmo()` pure function. 9 vitest cases. Inputs: today, end-of-month, liquid balance, next-income date, pending obligations, daily outflows. Returns: availablePerDay, allowedToday, spentFraction, calendar[]… |
| Webapp action | `webapp/src/actions/ritmo.ts` | `getRitmo(month, currency)` — wraps `getDashboardHeroData` + slim daily-outflows query → shared helper. Cached under `"transactions"` tag. |
| Webapp UI | `webapp/src/components/dashboard/hybrid-hero.tsx` | V7 React component. Period bar uses CSS linear gradient tied to `spentFraction`; calendar grid uses Tailwind tone tokens; today marker is white outline. |
| Wiring | `HeroZone` + `MobileZone` | Both viewports now render `<HybridHero>`. Old `DashboardHero` stays in the tree as a 1-line rollback. Old `InicioRoot` hero block still renders BELOW the new hero on mobile-viewport for side-by-side comparison until accepted. |

## What's out of scope

- **Native iOS app** (`mobile/`) still uses the old `RitmoWidget`. Will be migrated in a follow-up that points it at `@zeta/shared/utils/ritmo`.
- **Mobile `InicioRoot` hero block deletion** — left in place for visual confirmation. Once the new hero is accepted, that block is removed in a 1-PR sweep.
- **Allocation lens (50/30/20)** — the action still computes it for `PlanTeaserCard`. The hero just no longer foregrounds it.

## Live verification

At iPhone viewport on `/dashboard`, real-account data: the new hero renders **\"\$ 0\" allowed today** (red, because the user is overspent for the period), the **period bar fills 100% with the gradient** visible, the **calendar heatmap** shows the spend pattern with today marked. The old `RITMO \$31.903/día Arriba del ritmo` hero is visible BELOW for comparison — same account, opposite verdict. Exactly the bug we set out to fix.

## Test plan

- [x] `vitest` on the shared helper: 9/9 pass
- [x] `pnpm build` webapp: green
- [x] Live: `/dashboard` mobile viewport renders the new hero with real data
- [ ] Follow-up: native iOS app rewire + InicioRoot cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)