### PR TITLE
fix(email-ingest): recognize new "Recibiste un pago por X de Y a tu cuenta" Bancolombia template

### DIFF
--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -459,6 +459,7 @@ const PATTERN_LABELS: Record<string, { label: string; icon: typeof Mail }> = {
   nomina: { label: "Nómina", icon: Banknote },
   avance: { label: "Avance", icon: CreditCard },
   transferencia_recibida: { label: "Transferencia recibida", icon: ArrowDownLeft },
+  pago_recibido_cuenta: { label: "Pago recibido", icon: ArrowDownLeft },
 };
 
 /* ─── Importar detail ────────────────────────────────────────────────────── */

--- a/webapp/src/components/transactions/pending-email-transactions.tsx
+++ b/webapp/src/components/transactions/pending-email-transactions.tsx
@@ -60,6 +60,7 @@ const PATTERN_LABELS: Record<string, { label: string; icon: typeof Mail }> = {
   nomina: { label: "Nómina", icon: Banknote },
   avance: { label: "Avance", icon: CreditCard },
   transferencia_recibida: { label: "Transferencia recibida", icon: ArrowDownLeft },
+  pago_recibido_cuenta: { label: "Pago recibido", icon: ArrowDownLeft },
 };
 
 interface PendingEmailTransactionsProps {

--- a/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
+++ b/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
@@ -230,6 +230,25 @@ describe("parseBancolombiaEmail", () => {
     expect(result!.pattern_type).toBe("qr_recibido");
   });
 
+  // Pattern 13: Pago recibido a cuenta con etiqueta (INFLOW)
+  it("parses generic payment received with account label and reversed time/date order", () => {
+    const line =
+      "Logo Bancolombia [https://example.com/logo.png] yellow-icon [https://example.com/chulo.png] ¡Listo! Todo salió bien con tus movimientos Bancolombia: Recibiste un pago por $1,100,000.00 de GIRALDO CRISTIA a tu cuenta AHORROS, el 12:43 a las 21/05/2026. ¿Tienes dudas? Encuentranos aqui:018000931987. Estamos cerca";
+    const result = parseBancolombiaEmail(line);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("INFLOW");
+    expect(result!.amount).toBe(1100000);
+    expect(result!.merchant).toBe("GIRALDO CRISTIA");
+    expect(result!.card_last4).toBe("");
+    expect(result!.card_type).toBe("Cta");
+    expect(result!.transaction_date).toBe("2026-05-21");
+    expect(result!.transaction_time).toBe("12:43");
+    expect(result!.pattern_type).toBe("pago_recibido_cuenta");
+    expect(result!.raw_line).toBe(
+      "Recibiste un pago por $1,100,000.00 de GIRALDO CRISTIA a tu cuenta AHORROS, el 12:43 a las 21/05/2026"
+    );
+  });
+
   // Unrecognized emails
   it("returns null for non-Bancolombia email", () => {
     const line = "Your Amazon order has shipped!";

--- a/webapp/src/lib/parsers/bancolombia-email.ts
+++ b/webapp/src/lib/parsers/bancolombia-email.ts
@@ -19,6 +19,7 @@ export interface ParsedEmailTransaction {
     | "pago_pse"
     | "bre_b"
     | "pago_recibido"
+    | "pago_recibido_cuenta"
     | "nomina"
     | "avance"
     | "qr_recibido"
@@ -327,6 +328,26 @@ const PATTERNS: PatternDef[] = [
       pattern_type: "pago_recibido",
     }),
   },
+  // Pattern 13: Pago recibido a cuenta con etiqueta (INFLOW) — formato Bre-B con nombre de cuenta
+  // "Recibiste un pago por $1,100,000.00 de GIRALDO CRISTIA a tu cuenta AHORROS, el 12:43 a las 21/05/2026"
+  // Note: time/date order is reversed vs other patterns ("el HH:MM a las DD/MM/YYYY")
+  {
+    type: "pago_recibido_cuenta",
+    regex:
+      /Recibiste un pago por \$([\d.,]+) de (.+?) a tu cuenta (.+?),? el (\d{2}:\d{2}) a las (\d{2}\/\d{2}\/\d{4})/,
+    extract: (m) => ({
+      direction: "INFLOW",
+      amount: parseAmount(m[1]),
+      currency: "COP",
+      merchant: m[2].trim(),
+      destination: null,
+      card_last4: "",
+      card_type: "Cta",
+      transaction_date: parseDateDMY(m[5]),
+      transaction_time: m[4],
+      pattern_type: "pago_recibido_cuenta",
+    }),
+  },
   // Pattern 9: Nomina (INFLOW)
   // "Recibiste un pago de Nomina de UNIVERSIDAD PON por $1,203,850.00 en tu cuenta de Ahorros el 27/03/2026 a las 03:32"
   {
@@ -376,7 +397,7 @@ export function parseBancolombiaEmail(
       const parsed = pattern.extract(match);
       if (parsed) {
         // Extract raw_line from the alert segment only, excluding trailing support/marketing copy.
-        const rawLineMatch = normalized.match(/Bancolombia:\s*([\s\S]+?)(?:\.\s*(?:Si tienes dudas|¿Dudas|Con codigo QR|Con Bre-b|A tu lado|Estamos cerca)|$)/);
+        const rawLineMatch = normalized.match(/Bancolombia:\s*([\s\S]+?)(?:\.\s*(?:Si tienes dudas|¿Dudas|¿Tienes dudas|Encuentranos aqui|Con codigo QR|Con Bre-b|A tu lado|Estamos cerca)|$)/);
         const raw_line = rawLineMatch ? rawLineMatch[1].trim() : normalized;
         return { ...parsed, raw_line };
       }


### PR DESCRIPTION
## Summary

A real Bancolombia email reading

> "Recibiste un pago por $1,100,000.00 de GIRALDO CRISTIA a tu cuenta AHORROS, el 12:43 a las 21/05/2026"

was getting rejected by the email-ingest pipeline with **"El correo todavía no coincide con un patrón conocido"**. This template is structurally distinct from the 13 patterns we already had:

1. `por $X` precedes the sender name (vs older `de Nomina/PROVEEDOR de X por $Y`)
2. The destination account is a text label (`AHORROS`), not `*NNNN`
3. **Time/date order is REVERSED** — `el HH:MM a las DD/MM/YYYY` instead of `el DD/MM/YYYY a las HH:MM`

## Changes

- **`webapp/src/lib/parsers/bancolombia-email.ts`** — adds 14th pattern `pago_recibido_cuenta` (INFLOW). Sender → `merchant`; `card_last4=""` (no number on the account label); `card_type="Cta"`. Also adds `¿Tienes dudas` and `Encuentranos aqui` to the `raw_line` trailing-sentinel list so the support footer in this newer template doesn't bleed into the stored description / idempotency key.
- **`webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts`** — unit test using the user's exact email body.
- **`webapp/src/components/transactions/pending-email-transactions.tsx`** + **`webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx`** — adds `pago_recibido_cuenta: { label: "Pago recibido", icon: ArrowDownLeft }` to both `PATTERN_LABELS` maps so the pending-email chip renders a Spanish label instead of the raw key.

## Review notes (via `import-flow-doctor`)

- ✅ No false-positive risk vs other INFLOW patterns — `pago_recibido` requires `PROVEEDOR`, `nomina` requires `de Nomina de`, `transferencia_recibida` requires `una transferencia`, `qr_recibido` requires `por QR`. The new pattern is the only one with reversed time/date order.
- ✅ `resolveSuggestedEmailAccountId` short-circuits cleanly when `card_last4` is empty — falls back to the inbox's default account.
- ✅ `applyAccountBalanceDelta` handles INFLOW → SAVINGS correctly.
- ✅ `pattern_type` is stored in `pending_email_transactions.parsed_data` JSONB (no enum constraint, no migration needed).
- ✅ Mobile app does not run its own email parser — reads from `pending_email_transactions` populated server-side, so no mobile-parser change needed.

## Test plan

- [x] `pnpm vitest run src/lib/parsers/__tests__/bancolombia-email.test.ts` — 19/19 pass
- [x] `pnpm build` — green
- [ ] After deploy, user hits **Reintentar** on the unrecognized email and it should parse + queue (or auto-import if the ingest address has `auto_import` enabled)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVsp2zADrBzfvGQ68x2u2F)_