### PR TITLE
docs: refresh HANDOVER + prune BACKLOG open-PRs section

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -659,20 +659,6 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
   - `mobile/app/(tabs)/import.tsx:981-989` etc. — `ImportProgress` + "Paso X de 4" eyebrow are redundant. Drop the eyebrow.
 - **Found:** agent review sweep on PR #193, 2026-04-19
 
-## Open PRs
-
-| PR | Description | Status |
-|---|---|---|
-| #98 | Demo mode with mock accounts | Open since 2026-04-08 (stale) |
-| #190 | Planner drag-and-drop envelope assignment | Open 2026-04-18 — pending UX review (see below) |
-
-### PR #190 — pending UX review before merge
-- **Long-press overlay UX feels off** — user impression when testing mobile. The "cubre $X" chip hints work but the interaction doesn't feel right yet. Re-evaluate: timing (400ms), chip layout, whether long-press is still the right gesture, or if tap-to-pick is better.
-- **No assignment removal/edit path** — old UX had per-assignment `Trash2` in the `IncomeCard` expansion. New board has no way to remove a specific color-chip assignment from an expense once assigned. Options: (a) click a color chip on the expense card → popover with "Editar monto" / "Quitar", (b) drag the chip off, (c) resurrect an "assignments panel" per jar. Evaluate during PR review.
-- **Fully-assigned expenses are inert on mobile** — long-press is guarded to no-op, but there's no alternative gesture to re-manage existing assignments beyond the `⋯` menu (which only handles Pagar/Editar/Eliminar of the expense, not its assignments).
-- **Touches:** `webapp/src/components/cashflow-planner/drag-envelope-board.tsx`, `long-press-overlay.tsx`, `expense-card-draggable.tsx`.
-- **Found:** User smoke test on PR #190, 2026-04-18.
-
 ## Session handoff — 2026-04-18
 
 ### Shipped this session (merged to main)

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,71 +1,65 @@
-# HANDOVER — 2026-05-03 — Mobile RN ↔ Webapp parity (Phase 3 wrap shipped)
+# HANDOVER — 2026-05-21 — Hero V7 + Resumen aggregates + parity walkthrough
 
-> Supersedes prior handovers. For earlier handovers see git history (`HANDOVER.md@HEAD~N`).
+> Supersedes the 2026-05-03 (Phase 3 wrap) handover. Earlier handovers in git history (`HANDOVER.md@HEAD~N`).
 
-## Status snapshot
+## What landed since the last handover (2026-05-03)
 
-| Phase | What | Status |
+| PR | Summary | Date |
 |---|---|---|
-| 0–2 | Engine drift fix, tab bar parity, clearance sweep, color codemod, page scaffolds, 3 dashboard widgets enabled | ✅ Shipped — PR #247 |
-| 3a | Planificador 4-step (Cash → Allocate → Compare → Detail), scenario A/B/C persistence | ✅ Shipped — PR #248 |
-| 3b | Deseos parity (live re-score, verdict chips, EnrichDrawer, NudgeBanner, bought section, per-row CTAs, urgency/desire chips) + Puedo-pagar parity (name, category, reset, full afford-save shape) | ✅ Shipped — PR #249 (this branch) |
-| 2 remainder | Heavy dashboard widgets (HealthZone, Flujo, Heatmap, etc.) | ⏸ Deferred |
-| 4 | Account hero variants + QuickActionsBar dialogs | ⏸ Deferred |
-| 5 | CRUD parity (destinatarios, recurrentes, categorizar, categories, etiquetas, movimientos, tx detail) | ⏸ Deferred |
-| 6 | Import wizard restoration | ⏸ Deferred |
-| 7 | Onboarding / auth / settings parity | ⏸ Deferred |
-| 8 | Webapp `/suscripciones` port | ⏸ Deferred |
+| #252 | Mobile Phase 4 account heroes — flip/pulse/graph + `QuickActionsBar` shell | 2026-05-10 |
+| #254 | Optional time-of-day + opt-in location for transactions | 2026-05-13 |
+| #255 | BACKLOG: mark type-gen regen as "do not attempt" | 2026-05-14 |
+| #257 | Mobile ↔ webapp parity audit doc (26 mobile screens × 4 batches) | 2026-05-21 |
+| #258 | Parity quick-wins — 5 cheap fixes from the 5/21 audit | 2026-05-21 |
+| #259 | Bump `expo-task-manager` + `expo-location` to SDK 55 versions | 2026-05-21 |
+| #253 | Parity audit re-sweep — BACKLOG prune (5/16 follow-up) | 2026-05-21 |
+| #260 | BACKLOG: 10 findings from the live mobile↔webapp walkthrough | 2026-05-21 |
+| #264 | **V7 hybrid runway hero — Option A canonical predictive runway** | 2026-05-21 |
+| #265 | Email-ingest — recognize new "Recibiste un pago" Bancolombia template | 2026-05-21 |
+| #262 | **Canonical Resumen del mes aggregates via `@zeta/shared`** | 2026-05-21 |
 
-## What landed this session (PR #249 — `feat/mobile-deseos-puedopagar-parity`)
+### Both ❌ CRITICAL parity findings from the 5/21 walkthrough are now resolved
+- Finding 1 (Resumen del mes aggregates disagreed by 7-33×) → **#262**. `computeMonthlyAggregates()` in `@zeta/shared` is now the single source; mobile repo + webapp action both consume it.
+- Finding 2 (Dashboard hero gave opposite verdicts) → **#264**. `computeRitmo()` + `deriveRitmoStatus()` + shared `BUCKET_LABEL` / `WEEKDAYS_MONDAY_START` / `weekdayMondayStart` in `@zeta/shared`. Both surfaces render the same V7 hybrid hero (predictive runway + clickable calendar heatmap).
 
-| Commit | Summary |
-|---|---|
-| `6dd45dd` | Wishlist scoring + enrich/mutate repo. `getFinancialSnapshot` extracted; `scoreWishlistItemWithSnapshot` mirrors webapp `scoreItemWithSnapshot`; new repo mutations (enrich/markBought/dismissNudge/delete/persistScore) all enqueue UPDATE/DELETE through `enqueueInsert/Update/Delete`. |
-| `a7f1b9c` | Deseos UI — verdict chips, EnrichDrawer, NudgeBanner (local computation: score_transition + desire_maturity), bought section (incl. `reflected`), per-row CTAs (Reevaluar / Completar / Comprado / Eliminar), urgency/desire chips. |
-| `7feebfa` | Puedo-pagar — Name field, Category picker (reuses `CategoryPickerSheet`), Reset, save-to-wishlist with `last_verdict` / `last_score` / `funding_type` / `installments` / `account_id` / `category_id` / `enriched=true`. |
-| `9f3806d` | Gate fixes: CC `available_balance` parity (`getSelectedAccountAvailable`), `getBoughtWishlistItems` includes `reflected`, `React.memo` on `DeseosRow` + `BoughtRow`, 30s TTL on `loadData` to skip rescore-write storm on every focus. |
-| `c9edeb9` | BACKLOG entries marking Phase 3 wrap done; deferred items logged. |
-| `a2f75d3` | `/simplify` pass — 10 fixes, net −77 LOC. New `mobile/components/ui/FormField.tsx` (`FieldGroup` + `SegmentedRow`); new `mobile/lib/constants/verdict.ts` (single `VERDICT_META`); `applyScore` shared helper; `getWishlistItemById` (single-row query); no-op write skip; `persistWishlistScore` branch collapse via `COALESCE`; typed urgency/funding with shared types; `formatDate` from `@zeta/shared`. |
-| `dd71fdf` | Gemini comment — rename `selectedDebtAfterPurchase` → `selectedAccountCurrentDebt`. |
+### Hero V7 specifics worth knowing
+- Headline = today's actual spend (`spentToday`), tone tracks status pill — overspend goes red on both today AND period strain.
+- Expand → two views: "Cómo se calcula" (line-by-line) and "Patrón del mes" (clickable calendar heatmap).
+- Webhook cache-invalidation fix: `revalidateFinancialViewsFromWebhook()` (uses `revalidateTag(tag, "zeta")`) for Route Handler contexts where `updateTag` no-ops on the Router Cache half.
+- All hero sub-components (`HeroSparkline`, `CalculoView`, `CalendarHeatmap` web; `Sparkline`, `CalcView`, `PatternView` native) are wrapped in `React.memo` so day selection doesn't cascade.
+- Mobile NativeWind v3 footgun documented: `bg-z-foo/N` opacity classes silently render transparent — use the pre-computed `bg-z-foo-N` tokens from `mobile/tailwind.config.js`.
 
-Mobile `tsc --noEmit` clean. Webapp build clean. `pnpm audit --audit-level high` shows 4 high in `@xmldom/xmldom` via Expo CLI dev tooling — pre-existing on `main`, not introduced.
+## Repo state
 
-Gates run: `mobile-webapp-parity` (2 issues found and fixed), `mobile-sync-doctor` (passed clean), `mobile-perf-doctor` (2 high fixed, 1 medium deferred).
+- **Local main**: synced to `origin/main`. No uncommitted changes.
+- **0 open PRs.** The 7 open PRs from earlier today were either merged (#253, #260, #262, #264 already merged before this session, #265) or closed as superseded/stale (#98 demo mode → already on main via different path, #190 planner drag-and-drop → 5+ weeks stale + conflicting, #261 + #263 → superseded by ship).
+- Test gates: `@zeta/shared` ritmo + monthly-aggregates suites pass (16/16). Webapp `pnpm build` clean. Pre-existing test failures in `auto-categorize` / `debt-stats` exist on main but are unrelated to this work.
 
-## Tracked follow-ups (from this branch)
+## Next session — pick one
 
-Logged in `BACKLOG.md` under `/deseos` and `/puedo-pagar` sections:
-- **[P0] Reflections + Insights** — needs `wishlist_reflections` SQLite schema + push/pull + repository. User chose deferred over online-only fetch. Spawn `mobile-sync-doctor` when picked up.
-- **[P1] Nudge variants `debt_milestone` + `budget_surplus`** — webapp computes server-side via cross-table queries. Port the budget cross-ref + the upcoming-payment heuristic.
-- **[P1] Per-category `budgetRemaining`** — mobile passes `categoryId` to `analyzeLocally` but the snapshot doesn't fetch the matching `budgets` row + spent-this-month sum. Webapp does this inside `scoreItemWithSnapshot`.
-- **[P1] Scroll-to-verdict** — `AppKeyboardAwareScrollView` doesn't forward refs; needs a small wrapper change first.
-- **[P2] Single-tx batch persist** in `getWishlistItemsWithFreshScores` — collapse N `withTransactionAsync` calls into one.
-- **[P2] SQL aggregate snapshot** — replace 1k-row scan in `getFinancialSnapshot` with `SELECT direction, SUM(...) GROUP BY direction`.
+### A. Mobile TX detail screen feature parity *(highest-impact UX gap)*
+**What:** From #260 walkthrough finding M4–M7: mobile TX detail is missing destinatario picker, etiquetas/tag UI, "Hacer recurrente" promote button, "Vincular" link-to-recurring action, and proper destructive "Eliminar" styling. Mobile users open this screen dozens of times a day; webapp users get the full edit surface.
+**Where:** `mobile/app/transaction/[id].tsx` mirrors `webapp/src/components/transactions/transaction-form-dialog.tsx`.
+**Scope:** Single screen; touches mobile-only UI plus existing repository methods. Spawn `mobile-webapp-parity` first.
 
-Carryover from PR #247:
-- **PaymentSheet atomic balance update** (Gemini review on PR #247, line 91) — `updateAccountBalanceRemote` reads then writes a computed value; racey under concurrent payment creation. Fix is a Supabase RPC with row-level locking. Needs `supabase-migrator`.
+### B. Remaining 7 ⚠️ items from the 5/21 walkthrough
+Tracked in `BACKLOG.md` (search for "live walkthrough findings (2026-05-21)"). Smaller individually, but together they're a session's worth of work: attention count mismatch (M5), header avatar divergence (M6), import wizard step parity 4-vs-6 (M7), mobile a11y labels (M8), webapp internal "uncategorized" count drift (M9), Ajustes typo (M10), row-expand affordance gaps (M4).
 
-## Suggested next session
+### C. Telegram webhook RPCs *(security/correctness)*
+**What:** `set_capture_token_label` + `find_capture_token_by_chat_id` SECURITY DEFINER RPCs. The current admin-client path in `webapp/src/app/api/webhooks/telegram/route.ts` silently returns NULL because admin client can't decrypt envelope-encrypted views — so `/start <token>` and `/vincular <token>` never link a chat end-to-end.
+**Scope:** Supabase migration + webhook refactor. Spawn `supabase-migrator`.
 
-Pick one:
+### D. Mobile App Store / Play compliance prep
+**What:** targetSdk, version bump, permissions audit, disclaimer strings. User-blocked on assets; tech prep can run in parallel.
 
-1. **Phase 4 — Account heroes** (UX-visible, contained). Webapp source: `webapp/src/components/accounts/{flip-zone,balance-graph-hero,spending-pulse-hero,quick-actions-bar}*`. Add `flip` for CC/SAVINGS, `pulse` for CHECKING/CASH/OTHER, `graph` for LOAN/INVESTMENT. Spawn `mobile-perf-doctor` (animations) + `zetas-front-guy`.
+### E. Deferred Phase 2 dashboard widgets *(biggest single perceived-quality jump)*
+HealthZone, Flujo, Heatmap, BurnRate, Runway, DashboardHero/StatusHeadline on mobile. Skia chart work; spawn `mobile-perf-doctor`.
 
-2. **Phase 2 remainder — heavy dashboard widgets** (HealthZone, Flujo, Heatmap, BurnRate, Runway, DashboardHero/StatusHeadline). The dashboard is the entry point — biggest single perceived-quality jump. Skia chart work. Spawn `mobile-perf-doctor`.
+## Recommended: A (TX detail mobile parity)
 
-3. **Phase 5 — CRUD parity** (highest functional gap, lowest UX risk). Start with `/destinatarios` (create/edit/merge/rules) since destinatarios are referenced from many surfaces. Spawn `mobile-webapp-parity` + `mobile-sync-doctor` per surface.
+Highest-impact single screen, contained scope, sets the rhythm for the remaining mobile parity items in section B. Once TX detail is at parity, the row-expand affordance gap (M4) collapses naturally because the deeper drawer surfaces the same controls.
 
-4. **Phase 3 follow-ups** (small, quick wins): port the `wishlist_reflections` sync table, then build `DeseosReflectionCard` + `DeseosInsights`. Or fix per-category `budgetRemaining` + scroll-to-verdict.
-
-Avoid Phase 6 (import wizard) right after Phase 3 — too much serial shipping in the same area; let user soak Phase 3 first.
-
-## How to ship this branch
-
-PR #249 is open. Once approved:
-
-```sh
-gh pr merge 249 --squash --delete-branch
-git checkout main && git pull origin main
-```
-
-Then for the next session, pick a phase from the table above and create a fresh branch (`feat/mobile-phase4-account-heroes` or similar).
+## Carry-overs still valid from the 2026-05-03 handover
+- **PaymentSheet atomic balance update** — Gemini's race-condition flag on PR #247. `updateAccountBalanceRemote` reads then writes a computed value; needs a Supabase RPC with row-level locking. Spawn `supabase-migrator`.
+- **Wishlist reflections sync table** — `wishlist_reflections` SQLite schema + push/pull + repo. Deferred from PR #249.
+- **Nudge variants `debt_milestone` + `budget_surplus`** — port webapp's cross-table heuristic.


### PR DESCRIPTION
## Summary

- Rewrites HANDOVER.md (was stuck at 2026-05-03 / Phase 3 wrap) to reflect what's shipped in the last 2.5 weeks — Phase 4 account heroes, parity audit + quick-wins + SDK bumps, today's mass merges (#253, #260, #262, #264, #265).
- Both ❌ CRITICAL parity findings from the 5/21 walkthrough are now resolved (Resumen aggregates via #262, hero verdict via #264).
- Lists 5 candidate next-sessions (A–E) with a recommendation: **TX detail mobile parity** — highest-impact single screen, sets the rhythm for the remaining ⚠️ items.
- BACKLOG.md: drops the "Open PRs" section + the now-dead PR #190 UX-review notes. Both #98 and #190 closed today.

No code change.

## Test plan

- [x] No-op diff outside the two doc files
- [x] Read both files end-to-end after the rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)