### PR TITLE
fix(webapp): scope AttentionCard uncategorized to current-month OUTFLOW (M9)

### DIFF
--- a/webapp/src/actions/attention.ts
+++ b/webapp/src/actions/attention.ts
@@ -4,14 +4,17 @@ import "server-only";
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
-import { toColombiaDateString } from "@/lib/utils/date";
+import { monthEndStr, monthStartStr, toColombiaDateString } from "@/lib/utils/date";
 import type { AttentionSignal, AttentionSnapshot, AttentionPage } from "@/types/attention";
 
 // ─── Cached inner function ────────────────────────────────────────────────────
 
 async function getAttentionSnapshotCached(
   accessToken: string,
-  userId: string
+  userId: string,
+  monthStart: string,
+  monthEnd: string,
+  todayStr: string,
 ): Promise<AttentionSnapshot> {
   "use cache";
   cacheTag("attention");
@@ -21,11 +24,19 @@ async function getAttentionSnapshotCached(
 
   // Run queries in parallel
   const [uncategorizedRes, destinatarioRes, overdueRemindersRes] = await Promise.all([
-    // Signal 1: Uncategorized transactions
+    // Signal 1: Uncategorized OUTFLOW transactions in the current month.
+    // Matches `computeMonthlyAggregates.uncategorizedCount` (the Resumen del
+    // mes / Movimientos definition) so /accounts and /transactions agree.
+    // INFLOW is excluded — income rarely needs a category and would inflate
+    // the signal. Backlog beyond the current month is surfaced inside
+    // /categorizar (the action surface), not in the attention card.
     supabase
       .from("transactions")
       .select("id", { count: "exact", head: true })
       .eq("user_id", userId)
+      .eq("direction", "OUTFLOW")
+      .gte("transaction_date", monthStart)
+      .lte("transaction_date", monthEnd)
       .is("category_id", null)
       .eq("is_excluded", false)
       .is("reconciled_into_transaction_id", null),
@@ -47,12 +58,12 @@ async function getAttentionSnapshotCached(
       .select("id", { count: "exact", head: true })
       .eq("user_id", userId)
       .eq("is_completed", false)
-      .lt("due_date", toColombiaDateString(new Date())),
+      .lt("due_date", todayStr),
   ]);
 
   const signals: AttentionSignal[] = [];
 
-  // Signal 1: Uncategorized transactions
+  // Signal 1: Uncategorized OUTFLOW transactions (current month).
   const uncategorizedCount = uncategorizedRes.count ?? 0;
   if (uncategorizedCount > 0) {
     signals.push({
@@ -61,8 +72,8 @@ async function getAttentionSnapshotCached(
       count: uncategorizedCount,
       label:
         uncategorizedCount === 1
-          ? "1 transacción sin categoría"
-          : `${uncategorizedCount} transacciones sin categoría`,
+          ? "1 gasto sin categoría este mes"
+          : `${uncategorizedCount} gastos sin categoría este mes`,
       priority: "action",
       actionHref: "/categorizar",
     });
@@ -134,7 +145,14 @@ export async function getAttentionSnapshot(): Promise<AttentionSnapshot> {
     return { signals: [], totalAction: 0, totalSuggestion: 0, perPage: {} };
   }
   try {
-    return await getAttentionSnapshotCached(accessToken, user.id);
+    const now = new Date();
+    return await getAttentionSnapshotCached(
+      accessToken,
+      user.id,
+      monthStartStr(now),
+      monthEndStr(now),
+      toColombiaDateString(now),
+    );
   } catch (err) {
     console.error("Error computing attention snapshot:", err);
     return { signals: [], totalAction: 0, totalSuggestion: 0, perPage: {} };

--- a/webapp/src/actions/attention.ts
+++ b/webapp/src/actions/attention.ts
@@ -4,7 +4,7 @@ import "server-only";
 import { cacheTag, cacheLife } from "next/cache";
 import { getAuthenticatedClient } from "@/lib/supabase/auth";
 import { createCachedClient } from "@/lib/supabase/cached";
-import { monthEndStr, monthStartStr, toColombiaDateString } from "@/lib/utils/date";
+import { monthEndStr, monthStartStr, parseMonth, toColombiaDateString } from "@/lib/utils/date";
 import type { AttentionSignal, AttentionSnapshot, AttentionPage } from "@/types/attention";
 
 // ─── Cached inner function ────────────────────────────────────────────────────
@@ -145,13 +145,20 @@ export async function getAttentionSnapshot(): Promise<AttentionSnapshot> {
     return { signals: [], totalAction: 0, totalSuggestion: 0, perPage: {} };
   }
   try {
+    // Anchor month bounds to Bogotá's calendar, not the server's TZ (UTC in
+    // Docker). On the last day of the month, server UTC has already rolled to
+    // the next month while Bogotá is still in the prior one — without this
+    // anchor, monthStart/monthEnd would silently shift and the uncategorized
+    // count would jump to next-month's (empty) bucket.
     const now = new Date();
+    const todayStr = toColombiaDateString(now);
+    const monthAnchor = parseMonth(todayStr.substring(0, 7));
     return await getAttentionSnapshotCached(
       accessToken,
       user.id,
-      monthStartStr(now),
-      monthEndStr(now),
-      toColombiaDateString(now),
+      monthStartStr(monthAnchor),
+      monthEndStr(monthAnchor),
+      todayStr,
     );
   } catch (err) {
     console.error("Error computing attention snapshot:", err);


### PR DESCRIPTION
## Summary

Closes M9 of the 2026-05-21 mobile↔webapp walkthrough findings.

**Before:** `/accounts` AttentionCard showed `"681 transacciones sin categorizar"` (all-time, any direction) while `/transactions` Resumen showed `"0 Categorizar"` (current-month OUTFLOW only via `computeMonthlyAggregates`). Same word, vastly different counts → confusing.

**Now:** attention card mirrors the Resumen definition — current-month OUTFLOW only, INFLOW excluded (income rarely needs a category). Both surfaces agree.

Backlog beyond the current month is still surfaced inside `/categorizar` (the action surface), not in the attention card — that's deliberate.

### Pre-existing fix, bundled

`overdueRemindersRes` previously computed `toColombiaDateString(new Date())` *inside* the cached fn, so the overdue boundary froze at cache-fill time (could drift up to an hour around midnight Bogotá). Lifted `todayStr` to the wrapper so it participates in the cache key the same way as the new `monthStart`/`monthEnd` args. Same pattern, single function — bundled rather than left as inconsistent code next to the new pattern.

### Label change
- Was: `"X transacciones sin categoría"`
- Now: `"X gastos sin categoría este mes"` — makes scope explicit

## Review notes
- `server-action-reviewer` PASS: auth, defense-in-depth, cache key stability, return type all clean.
- Cache key stability: `monthStartStr/monthEndStr` are `yyyy-MM-dd` strings that only change at month rollover — no per-second cache-miss leak.
- `"attention"` tag in `FINANCIAL_TAGS` is invalidated by `revalidateFinancialViews()` from any tx mutation.

## Test plan
- [x] `pnpm build` clean
- [ ] Manual: visit `/accounts` — count now reflects current-month uncategorized OUTFLOWs and matches `/transactions` Resumen number.
- [ ] Manual: confirm `/categorizar` page still shows all-time backlog (it uses a separate query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)