### PR TITLE
feat(mobile): silent destinatario auto-match during PDF import (M7)

### DIFF
--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -62,6 +62,12 @@ import {
   getReconciliationCandidateById,
   getReconciliationCandidates,
 } from "../../lib/repositories/transactions";
+import { getDestinatarioRulesForMatching } from "../../lib/repositories/destinatarios";
+import {
+  matchDestinatario,
+  prepareDestinatarioRules,
+  type PreparedDestinatarioRule,
+} from "@zeta/shared";
 import {
   DEBT_PAYMENT_CATEGORY_ID,
   isDebtInflow,
@@ -737,6 +743,17 @@ export default function ImportScreen() {
         (reconciliationPreview?.review ?? []).map((item) => [item.importIndex, item])
       );
 
+      // Pre-prepare destinatario rules once — mirrors webapp `step-review.tsx`
+      // silent destinatario assignment. If the user has no rules yet, prepared
+      // is empty and the per-tx match returns null (no-op).
+      let preparedRules: PreparedDestinatarioRule[] = [];
+      try {
+        const rules = await getDestinatarioRulesForMatching();
+        preparedRules = prepareDestinatarioRules(rules);
+      } catch (err) {
+        console.warn("Skipping destinatario auto-match (rules load failed):", err);
+      }
+
       for (const index of Array.from(selected).sort((a, b) => a - b)) {
         const t = parsedData.transactions[index];
         if (!t) continue;
@@ -746,16 +763,45 @@ export default function ImportScreen() {
         });
         const forcedCategoryId = isDebtPayment ? DEBT_PAYMENT_CATEGORY_ID : null;
 
+        // Destinatario auto-match — webapp runs this unconditionally for every
+        // tx (including debt-payment inflows). When the user has no rules
+        // (`preparedRules.length === 0`) the match is a guaranteed no-op.
+        const destMatch =
+          preparedRules.length > 0
+            ? matchDestinatario(t.description, preparedRules)
+            : null;
+        const destinatarioId = destMatch?.destinatario_id ?? null;
+        const matchedCategoryId = destMatch?.category_id ?? null;
+        // Forced debt-payment category wins over a destinatario-suggested
+        // category — the user's CC payment is semantically the debt category,
+        // even if a rule happened to match the description.
+        const effectiveCategoryId = forcedCategoryId ?? matchedCategoryId;
+        // Mirror webapp: USER_LEARNED when category comes from a destinatario
+        // rule match. Other cases fall through to createTransaction's default
+        // (USER_CREATED / SYSTEM_DEFAULT).
+        const categorizationSource =
+          !forcedCategoryId && matchedCategoryId ? "USER_LEARNED" : undefined;
+        // Webapp stamps 0.8 when category AND destinatario both came from the
+        // match (step-review.tsx). Mirror here so cross-platform rows agree.
+        const categorizationConfidence =
+          !forcedCategoryId && matchedCategoryId && destinatarioId ? 0.8 : null;
+
         try {
           const txId = await createTransaction({
             user_id: userId,
             account_id: selectedAccount.id,
-            category_id: forcedCategoryId,
+            category_id: effectiveCategoryId,
+            categorization_source: categorizationSource,
+            categorization_confidence: categorizationConfidence,
+            destinatario_id: destinatarioId,
             amount: t.amount,
             currency_code: parsedData.currency ?? selectedAccount.currency_code ?? "COP",
             direction: t.direction,
             description: t.description,
-            merchant_name: t.description,
+            // Match webapp: merchant_name is only set when a destinatario rule
+            // supplies a clean name. Otherwise null (raw_description carries
+            // the bank's string).
+            merchant_name: destMatch?.destinatario_name ?? null,
             raw_description: t.description,
             transaction_date: t.date,
             provider: "OCR",
@@ -770,7 +816,7 @@ export default function ImportScreen() {
               manualTransaction: autoMatch.candidate,
               pdfTransactionId: txId,
               score: autoMatch.score,
-              pdfCategoryId: forcedCategoryId,
+              pdfCategoryId: effectiveCategoryId,
               pdfNotes: null,
             });
             autoMerged++;
@@ -783,7 +829,7 @@ export default function ImportScreen() {
               manualTransaction: reviewMatch.candidate,
               pdfTransactionId: txId,
               score: reviewMatch.score,
-              pdfCategoryId: forcedCategoryId,
+              pdfCategoryId: effectiveCategoryId,
               pdfNotes: null,
             });
             manualMerged++;

--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -776,15 +776,23 @@ export default function ImportScreen() {
         // category — the user's CC payment is semantically the debt category,
         // even if a rule happened to match the description.
         const effectiveCategoryId = forcedCategoryId ?? matchedCategoryId;
-        // Mirror webapp: USER_LEARNED when category comes from a destinatario
-        // rule match. Other cases fall through to createTransaction's default
-        // (USER_CREATED / SYSTEM_DEFAULT).
+        // Mirror webapp step-review.tsx lines 246-250: USER_LEARNED when the
+        // category and a destinatario both came from the match. Webapp's
+        // USER_OVERRIDE branch is effectively dead in import (its `categoryId`
+        // only ever comes from a destinatario hit, so a categoryId without a
+        // destinatarioId can't happen). Mobile additionally has a forced
+        // debt-payment category — when paired with a destinatario match the
+        // result is still USER_LEARNED; when no destinatario matched, we leave
+        // the source undefined so createTransaction's default (USER_CREATED)
+        // fires, matching how a manual debt-payment entry would look.
         const categorizationSource =
-          !forcedCategoryId && matchedCategoryId ? "USER_LEARNED" : undefined;
+          effectiveCategoryId && destinatarioId ? "USER_LEARNED" : undefined;
         // Webapp stamps 0.8 when category AND destinatario both came from the
-        // match (step-review.tsx). Mirror here so cross-platform rows agree.
+        // match (step-review.tsx line 251). Mirror exactly — forced debt
+        // category + matched destinatario gets 0.8 too, since webapp uses the
+        // effective categoryId in its check.
         const categorizationConfidence =
-          !forcedCategoryId && matchedCategoryId && destinatarioId ? 0.8 : null;
+          effectiveCategoryId && destinatarioId ? 0.8 : null;
 
         try {
           const txId = await createTransaction({

--- a/mobile/lib/db/schema.ts
+++ b/mobile/lib/db/schema.ts
@@ -479,6 +479,16 @@ export const DB_MIGRATIONS: DbMigration[] = [
       `CREATE INDEX IF NOT EXISTS idx_location_pings_consumed ON location_pings(consumed, captured_at)`,
     ],
   },
+  {
+    version: 14,
+    statements: [
+      // Categorization confidence (REAL 0..1) — populated by the import flow
+      // when a destinatario rule supplies the category (mirrors webapp's
+      // step-review.tsx, which stamps 0.8 for category+destinatario matches).
+      // Pushed to Supabase via sync_queue so cross-platform rows agree.
+      `ALTER TABLE transactions ADD COLUMN categorization_confidence REAL`,
+    ],
+  },
 ];
 
 export const LATEST_DB_VERSION =

--- a/mobile/lib/repositories/destinatarios.ts
+++ b/mobile/lib/repositories/destinatarios.ts
@@ -1,4 +1,5 @@
 import * as Crypto from "expo-crypto";
+import type { DestinatarioRule } from "@zeta/shared";
 import { getDatabase } from "../db/database";
 import { enqueueInsert } from "../sync/queue";
 
@@ -72,6 +73,44 @@ export async function getRulesForDestinatario(
      ORDER BY priority DESC`,
     [destinatarioId]
   );
+}
+
+/**
+ * Join active destinatarios + rules into the `DestinatarioRule[]` shape that
+ * `prepareDestinatarioRules` / `matchDestinatario` (from `@zeta/shared`) accept.
+ * Used by the PDF import flow to silently auto-assign destinatarios + their
+ * preferred category (parity with webapp `step-review.tsx`).
+ */
+export async function getDestinatarioRulesForMatching(): Promise<DestinatarioRule[]> {
+  const db = await getDatabase();
+  const rows = await db.getAllAsync<{
+    destinatario_id: string;
+    destinatario_name: string;
+    default_category_id: string | null;
+    match_type: string;
+    pattern: string;
+    priority: number;
+  }>(
+    `SELECT
+       d.id AS destinatario_id,
+       d.name AS destinatario_name,
+       d.default_category_id,
+       r.match_type,
+       r.pattern,
+       r.priority
+     FROM destinatario_rules r
+     JOIN destinatarios d ON r.destinatario_id = d.id
+     WHERE d.is_active = 1
+     ORDER BY r.priority DESC`
+  );
+  return rows.map((r) => ({
+    destinatario_id: r.destinatario_id,
+    destinatario_name: r.destinatario_name,
+    default_category_id: r.default_category_id,
+    match_type: r.match_type === "exact" ? "exact" : "contains",
+    pattern: r.pattern,
+    priority: r.priority,
+  }));
 }
 
 export type CreateDestinatarioParams = {

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -71,6 +71,18 @@ export type CreateTransactionParams = {
   raw_description?: string | null;
   category_id?: string | null;
   destinatario_id?: string | null;
+  /**
+   * Override the default `categorization_source` derivation. When omitted,
+   * falls back to `USER_CREATED` (with `category_id`) or `SYSTEM_DEFAULT`.
+   * Import flow passes `USER_LEARNED` when a destinatario rule provides
+   * the category (mirrors webapp `step-review.tsx`).
+   */
+  categorization_source?: string | null;
+  /**
+   * 0..1 confidence the category is correct. Import flow passes `0.8` when a
+   * destinatario rule supplies the category (mirrors webapp).
+   */
+  categorization_confidence?: number | null;
   notes?: string | null;
   provider?: DataProvider;
   capture_method?: TransactionCaptureMethod;
@@ -115,8 +127,12 @@ function buildInsertPayload(id: string, now: string, params: CreateTransactionPa
     // Mirror webapp persistTransaction (webapp/src/actions/transactions.ts):
     // mark as USER_CREATED only when the caller passes a category; otherwise
     // fall back to SYSTEM_DEFAULT so dashboards that filter on this column
-    // count mobile-created rows the same as webapp-created rows.
-    categorization_source: params.category_id ? "USER_CREATED" : "SYSTEM_DEFAULT",
+    // count mobile-created rows the same as webapp-created rows. Callers
+    // (e.g. PDF import) can override when the source is more specific.
+    categorization_source:
+      params.categorization_source ??
+      (params.category_id ? "USER_CREATED" : "SYSTEM_DEFAULT"),
+    categorization_confidence: params.categorization_confidence ?? null,
     destinatario_id: params.destinatario_id ?? null,
     amount: params.amount,
     currency_code: params.currency_code,
@@ -170,17 +186,19 @@ export async function createTransaction(params: CreateTransactionParams): Promis
   await db.withTransactionAsync(async () => {
     await db.runAsync(
       `INSERT INTO transactions
-        (id, user_id, account_id, category_id, categorization_source, destinatario_id, amount, currency_code, direction,
+        (id, user_id, account_id, category_id, categorization_source, categorization_confidence, destinatario_id,
+         amount, currency_code, direction,
          description, merchant_name, raw_description, transaction_date, transaction_time, location_id, status, idempotency_key,
          is_excluded, is_subscription, notes, provider, capture_method, capture_input_text, reconciled_into_transaction_id,
          reconciliation_score, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         payload.id,
         payload.user_id,
         payload.account_id,
         payload.category_id,
         payload.categorization_source,
+        payload.categorization_confidence,
         payload.destinatario_id,
         payload.amount,
         payload.currency_code,

--- a/mobile/lib/repositories/transactions.ts
+++ b/mobile/lib/repositories/transactions.ts
@@ -45,6 +45,8 @@ export type TransactionRow = {
   is_subscription: number;
   is_recurring: number;
   recurrence_group_id: string | null;
+  categorization_source: string | null;
+  categorization_confidence: number | null;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
## Summary

Closes M7 of the 2026-05-21 mobile↔webapp walkthrough findings. The audit observation ("mobile wizard 4 vs webapp 6 steps, Destinatarios step missing") was already stale — webapp was refactored to a mobile-first 4-step wizard in PR #209. The real gap was that webapp's review step **silently** assigns destinatarios + their preferred category (per `STEP_DESCRIPTIONS.review`: "Categorías y destinatarios se asignan en silencio"). Mobile never ran the matcher, so imported transactions landed with `destinatario_id = NULL`, no category from destinatarios, and raw bank strings in `merchant_name`.

## What changed

- **`mobile/lib/repositories/destinatarios.ts`** — new `getDestinatarioRulesForMatching()` joining `destinatarios` + `destinatario_rules` into the `DestinatarioRule[]` shape from `@zeta/shared`.
- **`mobile/lib/repositories/transactions.ts`** — `CreateTransactionParams` accepts optional `categorization_source` + `categorization_confidence` overrides; both forwarded to local INSERT + sync_queue payload.
- **`mobile/lib/db/schema.ts`** — migration v14 adds `transactions.categorization_confidence REAL` (column already exists in Supabase; needed locally for the explicit INSERT column list).
- **`mobile/app/(tabs)/import.tsx`** — `handleImport` loads + prepares rules once, runs `matchDestinatario` per tx, stamps `destinatario_id`, inherits matched `category_id` (with `USER_LEARNED` source and `0.8` confidence), overrides `merchant_name` with the destinatario's clean name. Forced debt-payment category still wins. Effective category also propagates into `applyReconciliationMerge.pdfCategoryId`.
- **`merchant_name`** default now `null` when no match (was raw description) — matches webapp's "merchant_name only when curated" convention.

## Review notes

`mobile-webapp-parity` agent identified 3 divergences, all resolved before commit:
1. HIGH — `merchant_name ?? null` (was `t.description`)
2. MEDIUM — `categorization_confidence: 0.8` now stamped (was missing)
3. MEDIUM — debt-payment skip rule removed (webapp runs matcher unconditionally; forced category still wins)

## Test plan
- [x] mobile `tsc --noEmit` clean
- [ ] Manual: import a Bancolombia PDF — transactions with a known destinatario rule (e.g. "Rappi") should land with destinatario assigned, category from destinatario, and `merchant_name` = destinatario name.
- [ ] Manual: import with 0 rules — flow unchanged, no destinatario assignment, no errors.
- [ ] Manual: debt CC payment — still gets `DEBT_PAYMENT_CATEGORY_ID` even if a rule matches the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)