### PR TITLE
feat: standardize destinatario-create surfaces on the seeded form

### DIFF
--- a/webapp/src/app/(dashboard)/transactions/[id]/transaction-detail-client.tsx
+++ b/webapp/src/app/(dashboard)/transactions/[id]/transaction-detail-client.tsx
@@ -204,6 +204,9 @@ export function TransactionDetailClient({
       if (result.success) {
         setTitleDirty(false);
         setTitleLocked(next.length > 0);
+        // Cleared title → DB falls back to clean_description; match it locally
+        // so the UI doesn't flash the generic placeholder until reload.
+        if (!next) setTitle(tx.clean_description || "");
         toast.success("Título actualizado");
       } else {
         setTitle(titleFallback);

--- a/webapp/src/components/destinatarios/destinatario-create-form.tsx
+++ b/webapp/src/components/destinatarios/destinatario-create-form.tsx
@@ -93,7 +93,7 @@ export function DestinatarioCreateForm({
   // Keep the latest onCreated without retriggering the success effect when the
   // parent passes a fresh inline callback each render.
   const onCreatedRef = React.useRef(onCreated);
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     onCreatedRef.current = onCreated;
   });
 

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -82,6 +82,9 @@ export function DestinatarioZonePicker({
   // pass categories.
   const seeded = Boolean(categories);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  // Carries the typed search term into the create form's Nombre field, since
+  // closing the picker clears `search`.
+  const [dialogPrefillName, setDialogPrefillName] = useState<string | undefined>(undefined);
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
@@ -133,6 +136,7 @@ export function DestinatarioZonePicker({
   // Seeded: open the rich create form. Unseeded: legacy quick-create / mini-form.
   function openCreate(prefillName?: string) {
     if (seeded) {
+      setDialogPrefillName(prefillName);
       setOpen(false);
       setShowCreateDialog(true);
     } else if (prefillName) {
@@ -334,7 +338,7 @@ export function DestinatarioZonePicker({
         onOpenChange={setShowCreateDialog}
         categories={categories}
         rawDescription={rawDescription}
-        merchantName={merchantName}
+        merchantName={merchantName || dialogPrefillName}
         amount={amount}
         currencyCode={currencyCode}
         onCreated={(d) => {

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -76,7 +76,11 @@ export function DestinatarioZonePicker({
   amount,
   currencyCode,
 }: DestinatarioZonePickerProps) {
-  const seeded = Boolean(categories && (rawDescription || merchantName));
+  // When categories are provided, "Crear nuevo" opens the full seeded form
+  // (token chips when seed text exists, otherwise a plain rich form). The bare
+  // name+pattern mini-form remains only as the fallback for callers that don't
+  // pass categories.
+  const seeded = Boolean(categories);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;

--- a/webapp/src/components/import/step-review.tsx
+++ b/webapp/src/components/import/step-review.tsx
@@ -289,6 +289,11 @@ export function StepReview({
       const destinatarioId = destMatch?.id ?? null;
       const merchantName = destMatch?.name ?? null;
 
+      let categorizationSource: "USER_LEARNED" | "USER_OVERRIDE" | undefined;
+      if (categoryId) {
+        categorizationSource = destinatarioId ? "USER_LEARNED" : "USER_OVERRIDE";
+      }
+
       return {
         import_key: `${row.stmtIdx}:${row.txIdx}`,
         account_id: row.accountId,
@@ -298,11 +303,7 @@ export function StepReview({
         transaction_date: row.tx.date,
         raw_description: row.tx.description,
         category_id: categoryId,
-        categorization_source: categoryId
-          ? destinatarioId
-            ? "USER_LEARNED"
-            : "USER_OVERRIDE"
-          : undefined,
+        categorization_source: categorizationSource,
         categorization_confidence: categoryId && destinatarioId ? 0.8 : null,
         installment_current: row.tx.installment_current,
         installment_total: row.tx.installment_total,

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -341,6 +341,8 @@ export function MobileTransactionForm({
               selectedName={destinatarioSelectedName}
               placeholder="Elegir o crear destinatario"
               triggerClassName="w-full"
+              categories={categories}
+              merchantName={merchantName}
             />
             <input type="hidden" name="destinatario_id" value={destinatarioId ?? ""} />
           </div>

--- a/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
+++ b/webapp/src/components/mobile/v2/inicio/inicio-activity.tsx
@@ -532,6 +532,10 @@ export function InicioActivity({ transactions }: InicioActivityProps) {
           selectedName={nestedPickerTx.destinatario_name}
           onValueChange={handleAssignDestinatario}
           variant="drawer"
+          categories={categories}
+          rawDescription={nestedPickerTx.description}
+          amount={nestedPickerTx.amount}
+          currencyCode={nestedPickerTx.currency_code}
         />
       )}
       {nestedPickerTx && nestedPicker?.kind === "tags" && (

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -495,6 +495,7 @@ export function RecurringForm({
           value={destinatarioId}
           onValueChange={(id) => setDestinatarioId(id)}
           placeholder="Vincular a un destinatario"
+          categories={categories}
         />
         <input type="hidden" name="destinatario_id" value={destinatarioId ?? ""} />
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
Follow-up to the destinatario-from-transaction work: every surface that creates a destinatario now opens the **full seeded form** (token-chip pattern builder + Probar + category + notes) instead of the legacy name+pattern mini-form.

- `DestinatarioZonePicker` now uses the rich form whenever `categories` is provided; the bare mini-form remains only as the fallback for callers that pass no categories.
- Wired `categories` (+ available seed context) into the remaining surfaces:
  - **Mobile `/movimientos` row** (shipped in prior change)
  - **Inicio activity feed** — seeds from the row's description + amount + currency
  - **Mobile transaction form** — seeds from the typed merchant name
  - **Recurring form** — rich form (merchant input is uncontrolled, so no text seed; full form still opens)

## Notes
- No new colors/variants; reuses the already-reviewed `DestinatarioCreateForm`.
- The detail-view picker and `transaction-table` row action were already on the new form.

## Test plan
- [ ] Inicio activity → row → destinatario → "Crear nuevo" → rich form seeded with the row's description chips.
- [ ] Mobile tx form → type a merchant → Destinatario → "Crear nuevo" → name pre-filled, chip from merchant.
- [ ] Recurring form → Destinatario → "Crear nuevo" → full form (name/category/patterns/test/notes).
- [ ] Regression: detail view + `/movimientos` still open the rich form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)