### PR TITLE
Fix bottom-sheet keyboard interaction on mobile

### DIFF
--- a/webapp/src/components/categories/category-zone-picker.tsx
+++ b/webapp/src/components/categories/category-zone-picker.tsx
@@ -15,6 +15,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
 } from "@/components/ui/drawer";
 import {
@@ -23,7 +24,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { trackClientEvent } from "@/lib/utils/analytics";
 import {
@@ -369,9 +369,9 @@ export function CategoryZonePicker({
           <DrawerHeader>
             <DrawerTitle>Elegir categoría</DrawerTitle>
           </DrawerHeader>
-          <div className={cn("overflow-y-auto px-2", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
+          <DrawerBody className="px-2">
             {pickerContent}
-          </div>
+          </DrawerBody>
         </DrawerContent>
       </Drawer>
     </>

--- a/webapp/src/components/deseos/deseos-enrich-drawer.tsx
+++ b/webapp/src/components/deseos/deseos-enrich-drawer.tsx
@@ -100,7 +100,10 @@ export function DeseosEnrichDrawer({
         </DrawerHeader>
         <form
           onSubmit={handleSubmit}
-          className={cn("overflow-y-auto space-y-5 px-4", MOBILE_SHEET_SAFE_AREA_CLASS)}
+          className={cn(
+            "min-h-0 flex-1 space-y-5 overflow-y-auto overscroll-contain px-4",
+            MOBILE_SHEET_SAFE_AREA_CLASS,
+          )}
         >
           {/* Why */}
           <div className="space-y-1.5">

--- a/webapp/src/components/deseos/deseos-enrich-drawer.tsx
+++ b/webapp/src/components/deseos/deseos-enrich-drawer.tsx
@@ -10,10 +10,9 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
-import { cn } from "@/lib/utils";
 
 type DeseosEnrichDrawerProps = {
   item: ScoredWishlistItem;
@@ -95,16 +94,11 @@ export function DeseosEnrichDrawer({
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Completar: {item.name}</DrawerTitle>
-        </DrawerHeader>
-        <form
-          onSubmit={handleSubmit}
-          className={cn(
-            "min-h-0 flex-1 space-y-5 overflow-y-auto overscroll-contain px-4",
-            MOBILE_SHEET_SAFE_AREA_CLASS,
-          )}
-        >
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+          <DrawerHeader>
+            <DrawerTitle>Completar: {item.name}</DrawerTitle>
+          </DrawerHeader>
+          <DrawerBody className="space-y-5">
           {/* Why */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">
@@ -256,6 +250,7 @@ export function DeseosEnrichDrawer({
           >
             {isPending ? "Guardando..." : "Guardar y evaluar"}
           </Button>
+          </DrawerBody>
         </form>
       </DrawerContent>
     </Drawer>

--- a/webapp/src/components/destinatarios/destinatario-create-form.tsx
+++ b/webapp/src/components/destinatarios/destinatario-create-form.tsx
@@ -17,6 +17,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
   DrawerDescription,
 } from "@/components/ui/drawer";
@@ -31,7 +32,6 @@ import { tokenizeDescription } from "@/lib/utils/tokenize-description";
 import { formatCurrency } from "@/lib/utils/currency";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
-import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
 import type { ActionResult } from "@/types/actions";
 import type { CategoryWithChildren, CurrencyCode } from "@/types/domain";
 
@@ -313,9 +313,9 @@ export function DestinatarioCreateDialog({
           </DrawerTitle>
           <DrawerDescription>{description}</DrawerDescription>
         </DrawerHeader>
-        <div className={cn("overflow-y-auto px-4", MOBILE_SHEET_SAFE_AREA_CLASS)}>
+        <DrawerBody>
           <DestinatarioCreateForm {...formProps} />
-        </div>
+        </DrawerBody>
       </DrawerContent>
     </Drawer>
   );

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -13,6 +13,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
 } from "@/components/ui/drawer";
 import {
@@ -393,9 +394,9 @@ export function DestinatarioZonePicker({
               Destinatario
             </DrawerTitle>
           </DrawerHeader>
-          <div className="overflow-y-auto px-2 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+          <DrawerBody className="px-2">
             {body}
-          </div>
+          </DrawerBody>
         </DrawerContent>
       </Drawer>
       {createDialog}

--- a/webapp/src/components/layout/quick-view-menu.tsx
+++ b/webapp/src/components/layout/quick-view-menu.tsx
@@ -30,6 +30,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
 } from "@/components/ui/drawer";
 import { useCloseOnNavigate } from "@/hooks/use-close-on-navigate";
@@ -114,9 +115,9 @@ export function QuickViewMenu({ profile }: QuickViewMenuProps) {
           <DrawerHeader className="sr-only">
             <DrawerTitle>Vista rápida</DrawerTitle>
           </DrawerHeader>
-          <div className="pb-[calc(1rem+env(safe-area-inset-bottom))]">
+          <DrawerBody className="px-0">
             {content}
-          </div>
+          </DrawerBody>
         </DrawerContent>
       </Drawer>
     </>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-utilidades.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-utilidades.tsx
@@ -8,11 +8,11 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
 import { TransactionFilters } from "@/components/transactions/transaction-filters";
-import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
 import type { Account, Tag } from "@/types/domain";
 
 interface MovimientosUtilidadesProps {
@@ -84,11 +84,11 @@ export function MovimientosUtilidades({
             <DrawerHeader>
               <DrawerTitle>Filtros</DrawerTitle>
             </DrawerHeader>
-            <div className={cn("overflow-y-auto px-4 space-y-4", MOBILE_SHEET_SAFE_AREA_CLASS)}>
+            <DrawerBody className="space-y-4">
               <Suspense>
                 <TransactionFilters accounts={accounts} tags={tags} embedded />
               </Suspense>
-            </div>
+            </DrawerBody>
           </DrawerContent>
         </Drawer>
       </div>

--- a/webapp/src/components/recurring/link-picker-sheet.tsx
+++ b/webapp/src/components/recurring/link-picker-sheet.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/drawer";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { BRASS_BUTTON_CLASS, MOBILE_SHEET_SAFE_AREA_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
+import { BRASS_BUTTON_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
 import type { CurrencyCode } from "@/types/domain";
 
 export interface LinkCandidate {
@@ -78,7 +78,7 @@ export function LinkPickerSheet({
 
   return (
     <Drawer open={open} onOpenChange={handleOpenChange}>
-      <DrawerContent className={MOBILE_SHEET_SAFE_AREA_CLASS}>
+      <DrawerContent>
         <DrawerHeader className="text-left">
           <DrawerTitle>{title}</DrawerTitle>
           <DrawerDescription>{subtitle}</DrawerDescription>
@@ -93,7 +93,7 @@ export function LinkPickerSheet({
           />
         </div>
 
-        <DrawerBody className="px-4">
+        <DrawerBody safeArea={false}>
           {filtered.length === 0 && (
             <p className="py-8 text-center text-sm text-muted-foreground">
               No se encontraron coincidencias

--- a/webapp/src/components/recurring/link-picker-sheet.tsx
+++ b/webapp/src/components/recurring/link-picker-sheet.tsx
@@ -8,6 +8,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
   DrawerDescription,
   DrawerFooter,
@@ -83,7 +84,7 @@ export function LinkPickerSheet({
           <DrawerDescription>{subtitle}</DrawerDescription>
         </DrawerHeader>
 
-        <div className="px-4 pb-2">
+        <div className="shrink-0 px-4 pb-2">
           <Input
             placeholder="Buscar..."
             value={search}
@@ -92,7 +93,7 @@ export function LinkPickerSheet({
           />
         </div>
 
-        <div className="max-h-[50vh] overflow-y-auto px-4">
+        <DrawerBody className="px-4">
           {filtered.length === 0 && (
             <p className="py-8 text-center text-sm text-muted-foreground">
               No se encontraron coincidencias
@@ -166,7 +167,7 @@ export function LinkPickerSheet({
               </div>
             </button>
           )}
-        </div>
+        </DrawerBody>
 
         <DrawerFooter>
           <Button

--- a/webapp/src/components/tags/tag-zone-picker.tsx
+++ b/webapp/src/components/tags/tag-zone-picker.tsx
@@ -13,6 +13,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerTitle,
 } from "@/components/ui/drawer";
 import {
@@ -415,9 +416,9 @@ export function TagZonePicker({
               Etiquetas
             </DrawerTitle>
           </DrawerHeader>
-          <div className="overflow-y-auto px-2 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+          <DrawerBody className="px-2">
             {body}
-          </div>
+          </DrawerBody>
         </DrawerContent>
       </Drawer>
     </>

--- a/webapp/src/components/ui/drawer.tsx
+++ b/webapp/src/components/ui/drawer.tsx
@@ -64,19 +64,38 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
  * constrained scroll body lets the user reach every field (top fields included)
  * instead of the whole drawer translating off-screen and drag-to-scroll firing
  * the dismiss gesture.
+ *
+ * `safeArea` reserves the device home-indicator inset at the bottom of the
+ * scroll. Pass `safeArea={false}` when a `DrawerFooter` follows the body — the
+ * footer is the bottom-most element and already reserves the inset, so leaving
+ * it on the body would double the padding.
  */
-function DrawerBody({ className, ...props }: React.ComponentProps<"div">) {
+function DrawerBody({
+  className,
+  safeArea = true,
+  ...props
+}: React.ComponentProps<"div"> & { safeArea?: boolean }) {
   return (
     <div
       data-slot="drawer-body"
-      className={cn("min-h-0 flex-1 overflow-y-auto overscroll-contain px-4", MOBILE_SHEET_SAFE_AREA_CLASS, className)}
+      className={cn(
+        "min-h-0 flex-1 overflow-y-auto overscroll-contain px-4",
+        safeArea && MOBILE_SHEET_SAFE_AREA_CLASS,
+        className,
+      )}
       {...props}
     />
   );
 }
 
 function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="drawer-footer" className={cn("mt-auto flex shrink-0 flex-col gap-2 p-4", className)} {...props} />;
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex shrink-0 flex-col gap-2 p-4", MOBILE_SHEET_SAFE_AREA_CLASS, className)}
+      {...props}
+    />
+  );
 }
 
 function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {

--- a/webapp/src/components/ui/drawer.tsx
+++ b/webapp/src/components/ui/drawer.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 import { cn } from "@/lib/utils";
+import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
 
 function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
   return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
@@ -37,7 +38,7 @@ function DrawerContent({ className, children, ...props }: React.ComponentProps<t
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[85dvh] flex-col rounded-t-2xl border-t",
+          "bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[85dvh] flex-col overflow-hidden rounded-t-2xl border-t",
           className
         )}
         {...props}
@@ -50,11 +51,32 @@ function DrawerContent({ className, children, ...props }: React.ComponentProps<t
 }
 
 function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="drawer-header" className={cn("flex flex-col gap-1.5 px-4 pb-2", className)} {...props} />;
+  return <div data-slot="drawer-header" className={cn("flex shrink-0 flex-col gap-1.5 px-4 pb-2", className)} {...props} />;
+}
+
+/**
+ * Scrollable body for a Drawer. Owns the single internal scroll surface so the
+ * header (and an optional DrawerFooter) stay pinned while content scrolls.
+ *
+ * `min-h-0 flex-1` is required: without it the body refuses to shrink below its
+ * content height, so it never scrolls internally. When the soft keyboard opens,
+ * vaul shrinks the drawer and pins it above the keyboard — only a properly
+ * constrained scroll body lets the user reach every field (top fields included)
+ * instead of the whole drawer translating off-screen and drag-to-scroll firing
+ * the dismiss gesture.
+ */
+function DrawerBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-body"
+      className={cn("min-h-0 flex-1 overflow-y-auto overscroll-contain px-4", MOBILE_SHEET_SAFE_AREA_CLASS, className)}
+      {...props}
+    />
+  );
 }
 
 function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="drawer-footer" className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />;
+  return <div data-slot="drawer-footer" className={cn("mt-auto flex shrink-0 flex-col gap-2 p-4", className)} {...props} />;
 }
 
 function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
@@ -65,4 +87,4 @@ function DrawerDescription({ className, ...props }: React.ComponentProps<typeof 
   return <DrawerPrimitive.Description data-slot="drawer-description" className={cn("text-muted-foreground text-sm", className)} {...props} />;
 }
 
-export { Drawer, DrawerTrigger, DrawerClose, DrawerContent, DrawerHeader, DrawerFooter, DrawerTitle, DrawerDescription, DrawerOverlay, DrawerPortal };
+export { Drawer, DrawerTrigger, DrawerClose, DrawerContent, DrawerHeader, DrawerBody, DrawerFooter, DrawerTitle, DrawerDescription, DrawerOverlay, DrawerPortal };


### PR DESCRIPTION
## Problema

En móvil (navegador), al abrir un bottom sheet con campos de formulario y enfocar un input, el `Drawer` se desplazaba hacia arriba al aparecer el teclado: los campos superiores quedaban **fuera del viewport** y, al intentar arrastrar/hacer scroll para volver a verlos, se disparaba el gesto de cerrar (arrastrar hacia abajo). Reportado sobre el sheet "Crear destinatario".

## Causa raíz

El `Drawer` (vaul) encoge el contenido y lo ancla sobre el teclado vía `repositionInputs` (comportamiento por defecto). Pero los consumidores envolvían el contenido en un `<div className="overflow-y-auto">` **sin `flex-1 min-h-0`**, y `DrawerContent` no tenía `overflow-hidden`. En un contenedor flex con altura acotada, un hijo sin `min-h-0` no se encoge por debajo de su contenido, así que **nunca hay scroll interno real**: el contenido se desborda detrás del teclado y el arrastre se interpreta como cierre.

`mobile-sheet-provider.tsx` ya usaba el patrón correcto y no sufría el bug — lo tomé como referencia.

## Solución

Llevé la estructura correcta a las primitivas del `Drawer` (`drawer.tsx`):

- `DrawerContent` ahora recorta con `overflow-hidden`
- `DrawerHeader` / `DrawerFooter` son `shrink-0` (quedan fijos)
- nuevo **`DrawerBody`** que es la única superficie de scroll (`min-h-0 flex-1 overflow-y-auto overscroll-contain` + safe-area inferior)

Y migré los drawers afectados a `DrawerBody`:
- `destinatario-create-form` (el reportado), `destinatario-zone-picker`
- `category-zone-picker`, `tag-zone-picker`
- `link-picker-sheet` (recurrentes), `movimientos-utilidades` (filtros)
- `deseos-enrich-drawer`, `quick-view-menu`

Resultado: con el teclado abierto el header queda fijo, el cuerpo hace scroll interno para alcanzar todos los campos (incluidos los de arriba) y el arrastre para hacer scroll ya no cierra el drawer.

## Test plan

- [x] `tsc --noEmit` limpio
- [x] `pnpm build` pasa
- [x] Dry-merge contra `main` sin conflictos
- [ ] **Verificar en dispositivo real** (Android/iOS): el teclado virtual y el resize de `visualViewport` no son reproducibles en el entorno headless de CI, así que falta confirmar la interacción exacta del video. La corrección es estructural y replica el patrón ya probado en producción (`mobile-sheet-provider`).
- [ ] Comprobar que los pickers de categoría/etiqueta/destinatario y los filtros de movimientos siguen abriendo y haciendo scroll bien en desktop (Dialog) y móvil (Drawer).

https://claude.ai/code/session_01RRyfxmZHW3eRRmetsUUtaj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRyfxmZHW3eRRmetsUUtaj)_