### PR TITLE
Fix category picker sheet cropping on subcategory expand

### DIFF
--- a/webapp/src/components/categories/category-zone-picker.tsx
+++ b/webapp/src/components/categories/category-zone-picker.tsx
@@ -413,13 +413,23 @@ export function CategoryPickerBody({
     return parent?.id ?? null;
   });
   const [showInlineCreate, setShowInlineCreate] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const expandedRowRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll expanded zone row to top of scrollable area
+  // Bring the expanded zone row near the top of the scroll surface. Scoped to
+  // this container only — `scrollIntoView` would bubble to every scrollable
+  // ancestor (DrawerBody, Dialog, window/visual viewport) and pin the row to
+  // their top too, shoving the sheet header/search off-screen and cropping it.
   useEffect(() => {
-    if (expandedZoneId && expandedRowRef.current) {
-      expandedRowRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
+    if (!expandedZoneId) return;
+    const container = scrollContainerRef.current;
+    const row = expandedRowRef.current;
+    if (!container || !row) return;
+    const target =
+      row.getBoundingClientRect().top -
+      container.getBoundingClientRect().top +
+      container.scrollTop;
+    container.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
   }, [expandedZoneId]);
 
   const query = search.trim().toLowerCase();
@@ -544,7 +554,7 @@ export function CategoryPickerBody({
       </div>
 
       {/* Content */}
-      <div className="overflow-y-auto max-h-[min(24rem,50dvh)]">
+      <div ref={scrollContainerRef} className="overflow-y-auto max-h-[min(24rem,50dvh)]">
         {query ? (
           // ----- Search results mode -----
           <div className="p-3 space-y-3">

--- a/webapp/src/components/categories/category-zone-picker.tsx
+++ b/webapp/src/components/categories/category-zone-picker.tsx
@@ -415,6 +415,10 @@ export function CategoryPickerBody({
   const [showInlineCreate, setShowInlineCreate] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const expandedRowRef = useRef<HTMLDivElement>(null);
+  // On mount the zone of the pre-selected category is already expanded, so this
+  // effect runs immediately — scroll instantly then, and only animate later
+  // user-initiated expansions, to avoid double-animating with the sheet's open.
+  const didMount = useRef(false);
 
   // Bring the expanded zone row near the top of the scroll surface. Scoped to
   // this container only — `scrollIntoView` would bubble to every scrollable
@@ -429,8 +433,15 @@ export function CategoryPickerBody({
       row.getBoundingClientRect().top -
       container.getBoundingClientRect().top +
       container.scrollTop;
-    container.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+    container.scrollTo({
+      top: Math.max(0, target),
+      behavior: didMount.current ? "smooth" : "auto",
+    });
   }, [expandedZoneId]);
+
+  useEffect(() => {
+    didMount.current = true;
+  }, []);
 
   const query = search.trim().toLowerCase();
 


### PR DESCRIPTION
Scoping the expand-row auto-scroll to the inner container. The previous
scrollIntoView({ block: "start" }) bubbled to every scrollable ancestor
(DrawerBody, Dialog, window) and pinned the row to each of their tops,
shoving the sheet header and search off-screen until a category was
selected.

https://claude.ai/code/session_01Xqb8boWhGShpHDGCdWojz1