### PR TITLE
feat: subscriptions — first-class, destinatario-anchored

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1204,3 +1204,6 @@ Phase 3 (planificador 4-step + Deseos/Puedo-pagar parity) shipped via PRs #248 a
 - **[P2] Import AUTO_MERGE scoring drift** — webapp #250 fixed 1/1-cuota detection and cross-source AUTO_MERGE scoring; RN ad-hoc reconciliation builder (`import.tsx:609–720`) pre-dates these fixes.
 
 **ORPHANS to decide:** `/subscriptions` (port to webapp recommended), `capture-screenshot` + `capture-voice` + `annotate-screenshot` (RN-only by design — verify they share shared utils).
+
+## Subscriptions feature (2026-05-27, branch feat/subscriptions)
+- **[P2] `ensureCurrentOccurrences()` on render** — `/suscripciones` (and `/plan`) call it every load to idempotently generate occurrences. Acceptable now (idempotent, fast after first daily run). When recurring usage grows, move occurrence generation to a cron/scheduled function and drop the ensure from all render paths. (perf-auditor, 2026-05-27)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1207,3 +1207,7 @@ Phase 3 (planificador 4-step + Deseos/Puedo-pagar parity) shipped via PRs #248 a
 
 ## Subscriptions feature (2026-05-27, branch feat/subscriptions)
 - **[P2] `ensureCurrentOccurrences()` on render** — `/suscripciones` (and `/plan`) call it every load to idempotently generate occurrences. Acceptable now (idempotent, fast after first daily run). When recurring usage grows, move occurrence generation to a cron/scheduled function and drop the ensure from all render paths. (perf-auditor, 2026-05-27)
+
+### Subscriptions follow-ups (deferred from feat/subscriptions, 2026-05-27)
+- **[P2] Task 10 — no-destinatario detection fallback** — surface `getDestinatarioSuggestions()` repeating-charge candidates on `/suscripciones` as a "crea un destinatario para rastrear esto" nudge (links to existing destinatario-create flow; no new mutation). Catches subscriptions for merchants with no destinatario yet. NOT built — core feature ships without it.
+- **[P3] Mobile subscriptions write-path prep** (when mobile gains subscription UI): (a) recreate SQLite `subscriptions` with `currency_code TEXT NOT NULL DEFAULT 'COP'`; (b) add `"subscriptions"` to `SyncTableName` union in `mobile/lib/sync/push.ts`; (c) mirror the `subscriptions_one_live_per_destinatario` partial-unique guard locally to prevent duplicate live rows before a sync cycle. (mobile-sync-doctor, 2026-05-27)

--- a/docs/superpowers/plans/2026-05-27-subscriptions.md
+++ b/docs/superpowers/plans/2026-05-27-subscriptions.md
@@ -1,0 +1,1251 @@
+# Subscriptions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make subscriptions (Spotify, streaming, SaaS) a first-class, reviewable "what can I cut?" concept — recognized via the existing destinatario engine, tracked in a dedicated `subscriptions` table, billed through the existing recurring/occurrence lifecycle, and surfaced on a dedicated `/suscripciones` page with deterministic auto-detection.
+
+**Architecture:** B′ — three layers. (1) **Recognition** reuses destinatarios' multi-pattern rules + `default_category_id`, untouched. (2) **Subscription state** lives in a new `subscriptions` table (1:1-live per destinatario, lifecycle enum, nullable `recurring_template_id`). (3) **Billing** rides `recurring_transaction_templates` + `recurring_occurrences` when a template is linked (authoritative totals); otherwise an `estimated_amount` is shown labeled "estimado". Detection is a deterministic pure function in `@zeta/shared`, triggered after `importTransactions()`.
+
+**Tech Stack:** Next.js 15 (App Router, Server Actions, `"use cache"`), Supabase (encrypted views + RLS), Tailwind v4 + shadcn/ui, `@zeta/shared` (pure TS), Vitest, Expo/SQLite (mobile parity).
+
+**Spec:** `docs/superpowers/specs/2026-05-27-subscriptions-design.md`
+
+**Branch:** `feat/subscriptions` (already created).
+
+---
+
+## File Structure
+
+**Phase 1 — webapp foundation**
+- `supabase/migrations/<ts>_create_subscriptions.sql` — table, enum, RLS, partial-unique index, indexes, cancel-drift trigger, backfill. **(via `supabase-migrator`)**
+- `webapp/src/types/domain.ts` (modify) — `Subscription`, `SubscriptionStatus`, `SubscriptionWithDetails`.
+- `webapp/src/lib/validators/subscription.ts` (create) — Zod schemas.
+- `webapp/src/actions/subscriptions.ts` (create) — cached read + mutations + `upsertSubscriptionFromTemplate` helper.
+- `webapp/src/actions/recurring-templates.ts` (modify) — call `upsertSubscriptionFromTemplate` on create/update.
+- `webapp/src/components/recurring/recurring-form.tsx` (modify) — "Es una suscripción" toggle + required-destinatario rule.
+- `webapp/src/app/(dashboard)/suscripciones/page.tsx` (create) — server component.
+- `webapp/src/components/subscriptions/subscriptions-view.tsx` (create) — client list + hero.
+- `webapp/src/components/subscriptions/subscription-row.tsx` (create) — row + actions.
+
+**Phase 2 — detection + suggestions + mobile**
+- `packages/shared/src/utils/subscription-detector.ts` (create) — pure detector.
+- `packages/shared/src/utils/__tests__/subscription-detector.test.ts` (create) — Vitest.
+- `packages/shared/src/index.ts` (modify) — export detector.
+- `webapp/src/actions/subscriptions.ts` (modify) — `runSubscriptionDetection()` runner + idempotency guard.
+- `webapp/src/actions/import-transactions.ts` (modify) — call runner after import.
+- `webapp/src/components/subscriptions/subscription-suggestions.tsx` (create) — suggestions section.
+- `mobile/lib/db/schema.ts`, `mobile/lib/repositories/subscriptions.ts`, `mobile/lib/sync/pull.ts`, `mobile/lib/sync/push.ts` (modify/create) — mobile parity.
+
+---
+
+# PHASE 1 — Webapp foundation
+
+## Task 1: Migration — `subscriptions` table
+
+**This task MUST be done by the `supabase-migrator` agent** (encrypted FK targets, RLS, view join hints). Dispatch it with the spec's data-model section. The SQL below is the target; the agent finalizes encryption + exact syntax.
+
+**Files:**
+- Create: `supabase/migrations/<timestamp>_create_subscriptions.sql`
+- Modify: `webapp/src/types/database.ts`, `packages/shared/src/types/database.ts` (regen)
+
+- [ ] **Step 1: Generate the migration file**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta && npx supabase migration new create_subscriptions`
+
+- [ ] **Step 2: Write the migration SQL**
+
+```sql
+-- Enum
+CREATE TYPE subscription_status AS ENUM (
+  'suggested', 'active', 'trial', 'marked_for_cancellation', 'cancelled', 'dismissed'
+);
+
+CREATE TABLE subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  -- FK targets the ENCRYPTED real tables (supabase-migrator confirms _enc names)
+  destinatario_id uuid NOT NULL REFERENCES destinatarios_enc(id) ON DELETE CASCADE,
+  recurring_template_id uuid REFERENCES recurring_transaction_templates_enc(id) ON DELETE SET NULL,
+  status subscription_status NOT NULL DEFAULT 'active',
+  estimated_amount numeric,
+  currency_code text NOT NULL DEFAULT 'COP',
+  trial_ends_on date,
+  cancel_url text,
+  detected_at timestamptz,
+  dismissed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One LIVE subscription per destinatario; cancelled/dismissed kept as history
+CREATE UNIQUE INDEX subscriptions_one_live_per_destinatario
+  ON subscriptions (user_id, destinatario_id)
+  WHERE status NOT IN ('cancelled', 'dismissed');
+
+CREATE INDEX idx_subscriptions_user_id ON subscriptions (user_id);
+CREATE INDEX idx_subscriptions_destinatario_id ON subscriptions (destinatario_id);
+CREATE INDEX idx_subscriptions_recurring_template_id ON subscriptions (recurring_template_id);
+CREATE INDEX idx_subscriptions_status ON subscriptions (status);
+
+ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "subscriptions_select" ON subscriptions FOR SELECT
+  USING ((select auth.uid()) = user_id);
+CREATE POLICY "subscriptions_insert" ON subscriptions FOR INSERT
+  WITH CHECK ((select auth.uid()) = user_id);
+CREATE POLICY "subscriptions_update" ON subscriptions FOR UPDATE
+  USING ((select auth.uid()) = user_id);
+CREATE POLICY "subscriptions_delete" ON subscriptions FOR DELETE
+  USING ((select auth.uid()) = user_id);
+
+-- Cancel-drift guard: keep subscriptions.status in sync when a linked template is (de)activated
+CREATE OR REPLACE FUNCTION sync_subscription_on_template_active_change()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+    IF NEW.is_active = false THEN
+      UPDATE subscriptions
+        SET status = 'cancelled', updated_at = now()
+        WHERE recurring_template_id = NEW.id
+          AND status NOT IN ('cancelled', 'dismissed');
+    ELSE
+      UPDATE subscriptions
+        SET status = 'active', updated_at = now()
+        WHERE recurring_template_id = NEW.id
+          AND status = 'cancelled';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Attach to the ENCRYPTED base table (supabase-migrator confirms the correct table/trigger target)
+CREATE TRIGGER trg_sync_subscription_on_template_active
+  AFTER UPDATE ON recurring_transaction_templates_enc
+  FOR EACH ROW EXECUTE FUNCTION sync_subscription_on_template_active_change();
+
+-- Backfill: existing recurring templates categorized as Suscripciones that already have a destinatario
+INSERT INTO subscriptions (user_id, destinatario_id, recurring_template_id, status, currency_code)
+SELECT t.user_id, t.destinatario_id, t.id, 'active', t.currency_code
+FROM recurring_transaction_templates t
+WHERE t.category_id = 'c0000001-0012-4000-8000-000000000004'
+  AND t.destinatario_id IS NOT NULL
+  AND t.is_active = true
+ON CONFLICT DO NOTHING;
+```
+
+- [ ] **Step 3: Push the migration**
+
+Run: `cd /Users/cristian/Documents/developing/current-projects/zeta && npx supabase db push`
+Expected: migration applies cleanly.
+
+- [ ] **Step 4: Regenerate types**
+
+Run: `cd webapp && npx supabase gen types --lang=typescript --project-id tgkhaxipfgskxydotdtu > src/types/database.ts`
+Then copy/sync to `packages/shared/src/types/database.ts` per existing convention. Verify `export type Json =` header is intact and the `subscriptions` Row/Insert/Update types exist.
+
+- [ ] **Step 5: Build gate**
+
+Run: `cd webapp && pnpm build`
+Expected: PASS (new table types resolve).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations webapp/src/types/database.ts packages/shared/src/types/database.ts
+git commit -m "feat(subscriptions): create subscriptions table, RLS, cancel-drift trigger, backfill"
+```
+
+---
+
+## Task 2: Domain types + validators
+
+**Files:**
+- Modify: `webapp/src/types/domain.ts`
+- Create: `webapp/src/lib/validators/subscription.ts`
+
+- [ ] **Step 1: Add domain types**
+
+In `webapp/src/types/domain.ts`, add (mirror existing `type X = Database["public"]["Tables"][...]["Row"]` aliases in that file):
+
+```typescript
+export type Subscription = Database["public"]["Tables"]["subscriptions"]["Row"];
+export type SubscriptionStatus = Database["public"]["Enums"]["subscription_status"];
+
+export type SubscriptionWithDetails = Subscription & {
+  destinatario_name: string;
+  default_category_id: string | null;
+  category_name: string | null;
+  // billing (null when no linked template)
+  template_amount: number | null;
+  template_frequency: string | null;
+  next_occurrence_date: string | null;
+  monthly_expected: number | null; // from occurrences; null => use estimated_amount
+};
+```
+
+- [ ] **Step 2: Add Zod validators**
+
+Create `webapp/src/lib/validators/subscription.ts`:
+
+```typescript
+import { z } from "zod";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const updateSubscriptionSchema = z.object({
+  trial_ends_on: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  ),
+  cancel_url: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().url().optional(),
+  ),
+});
+
+export const subscriptionIdSchema = z.string().regex(UUID, "ID inválido");
+```
+
+- [ ] **Step 3: Build gate**
+
+Run: `cd webapp && pnpm build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/types/domain.ts webapp/src/lib/validators/subscription.ts
+git commit -m "feat(subscriptions): domain types + validators"
+```
+
+---
+
+## Task 3: Cached read — `getSubscriptions`
+
+**Files:**
+- Create: `webapp/src/actions/subscriptions.ts`
+
+Mirror the cached-read pattern from `webapp/src/actions/charts.ts` (`getMonthlyCashflowCached`): a public wrapper calls `getAuthenticatedClient()` for `accessToken`, then a `"use cache"` inner fn uses `createCachedClient(accessToken)`.
+
+- [ ] **Step 1: Write the cached read**
+
+Create `webapp/src/actions/subscriptions.ts`:
+
+```typescript
+"use server";
+
+import { cacheTag, cacheLife, updateTag } from "next/cache";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
+import type { ActionResult } from "@/types/actions";
+import type { SubscriptionWithDetails } from "@/types/domain";
+
+async function getSubscriptionsCached(
+  accessToken: string,
+  userId: string,
+): Promise<SubscriptionWithDetails[]> {
+  "use cache";
+  cacheTag("subscriptions");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  // Join through views with explicit FK hints (plain joins through encrypted views return empty)
+  const { data, error } = await supabase
+    .from("subscriptions")
+    .select(`
+      *,
+      destinatarios!subscriptions_destinatario_id_fkey ( name, default_category_id ),
+      recurring_transaction_templates!subscriptions_recurring_template_id_fkey ( amount, frequency )
+    `)
+    .eq("user_id", userId)
+    .not("status", "in", "(dismissed,cancelled)") // audit shows current bleed; history excluded
+    .order("created_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  return data.map((row) => ({
+    ...row,
+    destinatario_name: row.destinatarios?.name ?? "—",
+    default_category_id: row.destinatarios?.default_category_id ?? null,
+    category_name: null, // filled by caller if needed
+    template_amount: row.recurring_transaction_templates?.amount ?? null,
+    template_frequency: row.recurring_transaction_templates?.frequency ?? null,
+    next_occurrence_date: null, // filled by page from occurrences
+    monthly_expected: null,
+  })) as unknown as SubscriptionWithDetails[];
+}
+
+export async function getSubscriptions(): Promise<ActionResult<SubscriptionWithDetails[]>> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const data = await getSubscriptionsCached(accessToken, user.id);
+    return { success: true, data };
+  } catch {
+    return { success: false, error: "Error al cargar las suscripciones" };
+  }
+}
+```
+
+> NOTE: confirm the exact FK constraint names (`subscriptions_destinatario_id_fkey`, etc.) from the migration `supabase-migrator` produced, and the join-through-view syntax, before relying on the join. If the view join is awkward, fall back to a two-query approach (fetch subscriptions, then batch-fetch destinatarios by id).
+
+- [ ] **Step 2: Build gate**
+
+Run: `cd webapp && pnpm build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/actions/subscriptions.ts
+git commit -m "feat(subscriptions): cached getSubscriptions read"
+```
+
+---
+
+## Task 4: Mutation actions
+
+**Files:**
+- Modify: `webapp/src/actions/subscriptions.ts`
+
+Mirror the mutation pattern from `webapp/src/actions/destinatarios.ts`: `getAuthenticatedClient()`, `.eq("user_id", user.id)`, `updateTag(...)` at the end.
+
+- [ ] **Step 1: Add `dismissSubscription`**
+
+```typescript
+import { subscriptionIdSchema, updateSubscriptionSchema } from "@/lib/validators/subscription";
+
+export async function dismissSubscription(id: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success) return { success: false, error: "ID inválido" };
+
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({ status: "dismissed", dismissed_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true };
+}
+```
+
+- [ ] **Step 2: Add `markForCancellation` and `cancelSubscription`**
+
+```typescript
+export async function markForCancellation(id: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success) return { success: false, error: "ID inválido" };
+
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({ status: "marked_for_cancellation" })
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .in("status", ["active", "trial"]);
+
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true };
+}
+
+// Real cancellation: deactivate the linked template (the DB trigger flips status to 'cancelled');
+// if there is no linked template, set status directly.
+export async function cancelSubscription(id: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success) return { success: false, error: "ID inválido" };
+
+  const { data: sub, error: readErr } = await supabase
+    .from("subscriptions")
+    .select("id, recurring_template_id")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+  if (readErr || !sub) return { success: false, error: "Suscripción no encontrada" };
+
+  if (sub.recurring_template_id) {
+    const { error: tErr } = await supabase
+      .from("recurring_transaction_templates")
+      .update({ is_active: false })
+      .eq("id", sub.recurring_template_id)
+      .eq("user_id", user.id);
+    if (tErr) return { success: false, error: tErr.message };
+    // trigger sets subscriptions.status = 'cancelled'
+  } else {
+    const { error: sErr } = await supabase
+      .from("subscriptions")
+      .update({ status: "cancelled" })
+      .eq("id", id)
+      .eq("user_id", user.id);
+    if (sErr) return { success: false, error: sErr.message };
+  }
+
+  updateTag("subscriptions");
+  revalidateFinancialViews();
+  return { success: true };
+}
+```
+
+- [ ] **Step 3: Add `updateSubscription` (metadata)**
+
+```typescript
+export async function updateSubscription(id: string, formData: FormData): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success) return { success: false, error: "ID inválido" };
+
+  const parsed = updateSubscriptionSchema.safeParse({
+    trial_ends_on: formData.get("trial_ends_on"),
+    cancel_url: formData.get("cancel_url"),
+  });
+  if (!parsed.success) return { success: false, error: parsed.error.issues[0].message };
+
+  const status = parsed.data.trial_ends_on ? "trial" : undefined;
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({
+      trial_ends_on: parsed.data.trial_ends_on ?? null,
+      cancel_url: parsed.data.cancel_url ?? null,
+      ...(status ? { status } : {}),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true };
+}
+```
+
+- [ ] **Step 4: Add `upsertSubscriptionFromTemplate` helper (used by recurring-templates action in Task 5)**
+
+```typescript
+// Internal helper (not "use server"-exported as an action target; called from recurring-templates.ts).
+// Upserts an active subscription row for a template flagged as a subscription, or cancels it when un-flagged.
+export async function upsertSubscriptionFromTemplate(
+  supabase: Awaited<ReturnType<typeof getAuthenticatedClient>>["supabase"],
+  userId: string,
+  template: { id: string; destinatario_id: string | null; currency_code: string },
+  isSubscription: boolean,
+): Promise<void> {
+  if (isSubscription) {
+    if (!template.destinatario_id) return; // guarded earlier; defensive
+    const { data: existing } = await supabase
+      .from("subscriptions")
+      .select("id, status")
+      .eq("user_id", userId)
+      .eq("destinatario_id", template.destinatario_id)
+      .not("status", "in", "(cancelled,dismissed)")
+      .maybeSingle();
+
+    if (existing) {
+      await supabase
+        .from("subscriptions")
+        .update({ recurring_template_id: template.id, status: "active" })
+        .eq("id", existing.id)
+        .eq("user_id", userId);
+    } else {
+      await supabase.from("subscriptions").insert({
+        user_id: userId,
+        destinatario_id: template.destinatario_id,
+        recurring_template_id: template.id,
+        status: "active",
+        currency_code: template.currency_code,
+      });
+    }
+  } else {
+    // un-flagged: cancel any live subscription linked to this template
+    await supabase
+      .from("subscriptions")
+      .update({ status: "cancelled" })
+      .eq("user_id", userId)
+      .eq("recurring_template_id", template.id)
+      .not("status", "in", "(cancelled,dismissed)");
+  }
+}
+```
+
+- [ ] **Step 5: Build gate**
+
+Run: `cd webapp && pnpm build`
+Expected: PASS.
+
+- [ ] **Step 6: Run `server-action-reviewer` agent on `webapp/src/actions/subscriptions.ts`**
+
+Confirm auth, defense-in-depth `.eq("user_id")`, `updateTag` (not `revalidateTag`), `ActionResult` return shapes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webapp/src/actions/subscriptions.ts
+git commit -m "feat(subscriptions): dismiss/mark/cancel/update actions + upsertSubscriptionFromTemplate"
+```
+
+---
+
+## Task 5: Recurring form toggle + action wiring
+
+**Files:**
+- Modify: `webapp/src/components/recurring/recurring-form.tsx`
+- Modify: `webapp/src/actions/recurring-templates.ts`
+
+- [ ] **Step 1: Read both files first**
+
+The form already has a `destinatarioId` state + `DestinatarioZonePicker`, and submits via `useActionState`. Read `recurring-form.tsx` and `recurring-templates.ts` to locate the destinatario field and the create/update success points (per the patterns gathered: create at `recurring-templates.ts:~308`, update at `~387`).
+
+- [ ] **Step 2: Add the toggle to the form**
+
+Add a controlled boolean + a hidden input so it serializes into `FormData`. Place it near the direction/category fields. The form receives `seed?.isSubscription` (the edit page computes this from a linked subscription — see Step 5):
+
+```tsx
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+
+// state (near other useState hooks)
+const [isSubscription, setIsSubscription] = useState(seed?.isSubscription ?? false);
+
+// JSX (near direction/category)
+<div className="flex items-center justify-between rounded-lg border border-white/6 bg-z-surface-2 px-3 py-2.5">
+  <div className="space-y-0.5">
+    <Label htmlFor="is_subscription_toggle" className="text-z-sage-light">Es una suscripción</Label>
+    <p className="text-xs text-z-sage-light/60">Spotify, streaming, apps — opcional y cancelable.</p>
+  </div>
+  <Switch
+    id="is_subscription_toggle"
+    checked={isSubscription}
+    onCheckedChange={setIsSubscription}
+  />
+</div>
+<input type="hidden" name="is_subscription" value={isSubscription ? "true" : "false"} />
+```
+
+- [ ] **Step 3: Client-side guard — subscription requires a destinatario**
+
+In the form's submit wrapper (the `useActionState` async fn), before calling the action, block when `isSubscription && !destinatarioId`:
+
+```tsx
+async (prevState, formData) => {
+  if (formData.get("is_subscription") === "true" && !destinatarioId) {
+    return { success: false, error: "Una suscripción necesita un destinatario." };
+  }
+  const result = await action(prevState, formData);
+  if (result.success) onSuccess?.(result.data);
+  return result;
+}
+```
+
+- [ ] **Step 4: Wire the action to upsert the subscription**
+
+In `recurring-templates.ts`, in BOTH `createRecurringTemplate` and `updateRecurringTemplate`, after the successful upsert (where `result.data` is the saved template) and before `revalidateFinancialViews()`, add:
+
+```typescript
+import { upsertSubscriptionFromTemplate } from "@/actions/subscriptions";
+import { updateTag } from "next/cache";
+
+// server-side guard (defense in depth — client guard can be bypassed)
+const isSubscription = formData.get("is_subscription") === "true";
+if (isSubscription && !result.data.destinatario_id) {
+  return { success: false, error: "Una suscripción necesita un destinatario." };
+}
+
+await upsertSubscriptionFromTemplate(
+  supabase,
+  user.id,
+  { id: result.data.id, destinatario_id: result.data.destinatario_id, currency_code: result.data.currency_code },
+  isSubscription,
+);
+updateTag("subscriptions");
+```
+
+- [ ] **Step 5: Seed `isSubscription` on edit**
+
+In the recurring template **edit** page/loader, fetch whether a live subscription exists for the template (`status NOT IN ('cancelled','dismissed')`) and pass `isSubscription` into `recurring-form`'s `seed`. (Read the edit page to find where `seed` is assembled; add a `getSubscriptionForTemplate(templateId)` read to `subscriptions.ts` returning a boolean if convenient.)
+
+- [ ] **Step 6: Build gate + UI review**
+
+Run: `cd webapp && pnpm build` → PASS.
+Run the `zetas-front-guy` agent on the modified `recurring-form.tsx` (token usage, Switch, Spanish strings).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webapp/src/components/recurring/recurring-form.tsx webapp/src/actions/recurring-templates.ts webapp/src/actions/subscriptions.ts
+git commit -m "feat(subscriptions): recurring-form subscription toggle + action wiring"
+```
+
+---
+
+## Task 6: `/suscripciones` page
+
+**Files:**
+- Create: `webapp/src/app/(dashboard)/suscripciones/page.tsx`
+- Create: `webapp/src/components/subscriptions/subscriptions-view.tsx`
+- Create: `webapp/src/components/subscriptions/subscription-row.tsx`
+
+- [ ] **Step 1: Page server component (computes occurrence-based totals)**
+
+Create `webapp/src/app/(dashboard)/suscripciones/page.tsx`. Mirror the dashboard page shape. Call `ensureCurrentOccurrences()` BEFORE reading occurrences (recurring-doctor rule):
+
+```tsx
+import { getSubscriptions } from "@/actions/subscriptions";
+import { ensureCurrentOccurrences, getOccurrencesForMonth } from "@/actions/occurrences";
+import { getPreferredCurrency } from "@/actions/profile";
+import { SubscriptionsView } from "@/components/subscriptions/subscriptions-view";
+
+export default async function SuscripcionesPage() {
+  await ensureCurrentOccurrences();
+  const [subsRes, occRes, currency] = await Promise.all([
+    getSubscriptions(),
+    getOccurrencesForMonth(),
+    getPreferredCurrency(),
+  ]);
+
+  const subs = subsRes.success ? subsRes.data : [];
+  const occurrences = occRes.success ? occRes.data : [];
+
+  // Authoritative monthly total = sum expected_amount of occurrences whose template is a linked subscription.
+  const subTemplateIds = new Set(subs.map((s) => s.recurring_template_id).filter(Boolean) as string[]);
+  const authoritativeMonthly = occurrences
+    .filter((o) => subTemplateIds.has(o.template_id) && o.direction === "OUTFLOW")
+    .reduce((sum, o) => sum + o.expected_amount, 0);
+
+  // Estimated bleed = subs WITHOUT a template, using estimated_amount.
+  const estimatedMonthly = subs
+    .filter((s) => !s.recurring_template_id && s.estimated_amount)
+    .reduce((sum, s) => sum + (s.estimated_amount ?? 0), 0);
+
+  return (
+    <SubscriptionsView
+      subscriptions={subs}
+      occurrences={occurrences}
+      authoritativeMonthly={authoritativeMonthly}
+      estimatedMonthly={estimatedMonthly}
+      currency={currency}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Client view (hero + active list)**
+
+Create `webapp/src/components/subscriptions/subscriptions-view.tsx` — `"use client"`. Hero shows authoritative monthly + `× 12` annualized; estimado shown as a separate secondary line only when `estimatedMonthly > 0`. Uses `formatCurrency`. Apply `MOBILE_TAB_BAR_CLEARANCE_CLASS` to the scroll container. Map subscriptions to `<SubscriptionRow>`. Reuse `Card`/`Badge` from `@/components/ui/`. Group by status: active/trial first, marked_for_cancellation flagged, suggestions handled in Task 9.
+
+```tsx
+"use client";
+import { Card } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils/currency";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { SubscriptionRow } from "./subscription-row";
+import type { SubscriptionWithDetails } from "@/types/domain";
+import type { RecurringOccurrence } from "@/actions/occurrences";
+
+export function SubscriptionsView({ subscriptions, occurrences, authoritativeMonthly, estimatedMonthly, currency }: {
+  subscriptions: SubscriptionWithDetails[];
+  occurrences: RecurringOccurrence[];
+  authoritativeMonthly: number;
+  estimatedMonthly: number;
+  currency: string;
+}) {
+  const nextByTemplate = new Map<string, string>();
+  for (const o of occurrences) {
+    if (o.status === "pending" && !nextByTemplate.has(o.template_id)) {
+      nextByTemplate.set(o.template_id, o.occurrence_date);
+    }
+  }
+  const tracked = subscriptions.filter((s) => s.status !== "suggested");
+
+  return (
+    <div className={`space-y-4 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
+      <Card className="p-5">
+        <p className="text-sm text-z-sage-light/70">Gasto mensual en suscripciones</p>
+        <p className="text-3xl font-semibold text-z-sage-light">{formatCurrency(authoritativeMonthly, currency)}</p>
+        <p className="text-sm text-z-sage-light/60">{formatCurrency(authoritativeMonthly * 12, currency)} al año</p>
+        {estimatedMonthly > 0 && (
+          <p className="mt-1 text-xs text-z-sage-light/50">
+            + {formatCurrency(estimatedMonthly, currency)}/mes estimado (sin programar)
+          </p>
+        )}
+      </Card>
+
+      <div className="space-y-2">
+        {tracked.map((s) => (
+          <SubscriptionRow
+            key={s.id}
+            subscription={s}
+            currency={currency}
+            nextDate={s.recurring_template_id ? nextByTemplate.get(s.recurring_template_id) ?? null : null}
+          />
+        ))}
+        {tracked.length === 0 && (
+          <p className="py-8 text-center text-sm text-z-sage-light/60">
+            No tienes suscripciones registradas todavía.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Row component with actions**
+
+Create `webapp/src/components/subscriptions/subscription-row.tsx` — `"use client"`. Shows name, amount (`template_amount ?? estimated_amount`, with "estimado" badge when no template), next charge date, status badge. Actions in a dropdown: Marcar para cancelar (`markForCancellation`), Cancelar (`cancelSubscription`), and Formalizar when `!recurring_template_id`. Use `startTransition` + `router.refresh()` after each action (same-page revalidation). Use `BRASS_BUTTON_CLASS`/`GHOST_BUTTON_CLASS` for buttons, tokens only.
+
+```tsx
+"use client";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { cancelSubscription, markForCancellation } from "@/actions/subscriptions";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import type { SubscriptionWithDetails } from "@/types/domain";
+
+export function SubscriptionRow({ subscription: s, currency, nextDate }: {
+  subscription: SubscriptionWithDetails;
+  currency: string;
+  nextDate: string | null;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const amount = s.template_amount ?? s.estimated_amount ?? 0;
+
+  const run = (fn: () => Promise<unknown>) => start(async () => { await fn(); router.refresh(); });
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-white/6 bg-z-surface-2 p-3">
+      <div>
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-z-sage-light">{s.destinatario_name}</span>
+          {!s.recurring_template_id && <Badge variant="outline">estimado</Badge>}
+          {s.status === "marked_for_cancellation" && <Badge variant="outline">por cancelar</Badge>}
+          {s.status === "trial" && <Badge variant="outline">prueba</Badge>}
+        </div>
+        <p className="text-sm text-z-sage-light/60">
+          {formatCurrency(amount, currency)}{nextDate ? ` · próx. ${formatDate(nextDate)}` : ""}
+        </p>
+      </div>
+      <div className="flex gap-2">
+        {s.status !== "marked_for_cancellation" && (
+          <button disabled={pending} onClick={() => run(() => markForCancellation(s.id))}
+            className="text-xs text-z-sage-light/70 hover:text-z-sage-light">Marcar</button>
+        )}
+        <button disabled={pending} onClick={() => run(() => cancelSubscription(s.id))}
+          className="text-xs text-z-danger hover:underline">Cancelar</button>
+      </div>
+    </div>
+  );
+}
+```
+
+> "Formalizar" action (create a template for an estimated sub) is wired in Phase 2 (Task 9) alongside the suggestion-confirm flow, since both create a template from detected data.
+
+- [ ] **Step 4: Build gate + reviews**
+
+Run: `cd webapp && pnpm build` → PASS.
+Run `zetas-front-guy` (tokens, Spanish, tab-bar clearance) and `perf-auditor` (cached reads, no uncached query on the render path) on the new page + components.
+
+- [ ] **Step 5: Manual verification**
+
+Run `cd webapp && pnpm dev` (check :3000 is free first), navigate to `/suscripciones`. Confirm backfilled subs (if any) render and the monthly total is non-zero when a Suscripciones-categorized recurring template exists.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webapp/src/app/\(dashboard\)/suscripciones webapp/src/components/subscriptions
+git commit -m "feat(subscriptions): /suscripciones page, view, and row actions"
+```
+
+---
+
+# PHASE 2 — Detection + suggestions + mobile parity
+
+## Task 7: Pure detector in `@zeta/shared` (TDD)
+
+**Files:**
+- Create: `packages/shared/src/utils/subscription-detector.ts`
+- Test: `packages/shared/src/utils/__tests__/subscription-detector.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/shared/src/utils/__tests__/subscription-detector.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { detectSubscriptions, type DetectorTransaction } from "../subscription-detector";
+
+const tx = (destinatario_id: string | null, date: string, amount: number): DetectorTransaction => ({
+  destinatario_id, transaction_date: date, amount, currency_code: "COP", direction: "OUTFLOW",
+});
+
+describe("detectSubscriptions", () => {
+  it("detects a stable monthly charge as a candidate", () => {
+    const txs = [tx("d1", "2026-03-05", 16900), tx("d1", "2026-04-05", 16900), tx("d1", "2026-05-05", 17900)];
+    const result = detectSubscriptions(txs, new Set());
+    expect(result).toHaveLength(1);
+    expect(result[0].destinatario_id).toBe("d1");
+    expect(result[0].occurrence_count).toBe(3);
+    expect(result[0].median_amount).toBe(16900);
+  });
+
+  it("ignores groups with fewer than 3 charges", () => {
+    const txs = [tx("d1", "2026-04-05", 16900), tx("d1", "2026-05-05", 16900)];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+
+  it("ignores non-monthly cadence", () => {
+    const txs = [tx("d1", "2026-01-05", 16900), tx("d1", "2026-03-05", 16900), tx("d1", "2026-05-05", 16900)];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+
+  it("ignores unstable amounts", () => {
+    const txs = [tx("d1", "2026-03-05", 10000), tx("d1", "2026-04-05", 50000), tx("d1", "2026-05-05", 90000)];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+
+  it("excludes destinatarios that already have a subscription", () => {
+    const txs = [tx("d1", "2026-03-05", 16900), tx("d1", "2026-04-05", 16900), tx("d1", "2026-05-05", 16900)];
+    expect(detectSubscriptions(txs, new Set(["d1"]))).toHaveLength(0);
+  });
+
+  it("ignores transactions with no destinatario and INFLOWs", () => {
+    const txs: DetectorTransaction[] = [
+      tx(null, "2026-03-05", 16900), tx(null, "2026-04-05", 16900), tx(null, "2026-05-05", 16900),
+      { destinatario_id: "d2", transaction_date: "2026-03-05", amount: 16900, currency_code: "COP", direction: "INFLOW" },
+    ];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/shared && pnpm vitest run src/utils/__tests__/subscription-detector.test.ts`
+Expected: FAIL — module not found / `detectSubscriptions` undefined.
+
+- [ ] **Step 3: Implement the detector**
+
+Create `packages/shared/src/utils/subscription-detector.ts`:
+
+```typescript
+export interface DetectorTransaction {
+  destinatario_id: string | null;
+  transaction_date: string; // YYYY-MM-DD
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+}
+
+export interface SubscriptionCandidate {
+  destinatario_id: string;
+  occurrence_count: number;
+  median_amount: number;
+  median_gap_days: number;
+  currency_code: string;
+}
+
+export interface DetectOptions {
+  minOccurrences?: number;
+  minGapDays?: number;
+  maxGapDays?: number;
+  amountTolerance?: number;
+}
+
+const DEFAULTS: Required<DetectOptions> = {
+  minOccurrences: 3, minGapDays: 28, maxGapDays: 34, amountTolerance: 0.1,
+};
+
+function median(nums: number[]): number {
+  const s = [...nums].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function daysBetween(a: string, b: string): number {
+  const ms = Date.parse(`${b}T12:00:00`) - Date.parse(`${a}T12:00:00`);
+  return Math.round(ms / 86_400_000);
+}
+
+export function detectSubscriptions(
+  transactions: DetectorTransaction[],
+  excludedDestinatarioIds: Set<string>,
+  options?: DetectOptions,
+): SubscriptionCandidate[] {
+  const o = { ...DEFAULTS, ...options };
+  const groups = new Map<string, DetectorTransaction[]>();
+
+  for (const t of transactions) {
+    if (t.direction !== "OUTFLOW" || !t.destinatario_id) continue;
+    if (excludedDestinatarioIds.has(t.destinatario_id)) continue;
+    const arr = groups.get(t.destinatario_id) ?? [];
+    arr.push(t);
+    groups.set(t.destinatario_id, arr);
+  }
+
+  const candidates: SubscriptionCandidate[] = [];
+  for (const [destinatarioId, txs] of groups) {
+    if (txs.length < o.minOccurrences) continue;
+    const sorted = [...txs].sort((a, b) => a.transaction_date.localeCompare(b.transaction_date));
+
+    const gaps: number[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      gaps.push(daysBetween(sorted[i - 1].transaction_date, sorted[i].transaction_date));
+    }
+    const medGap = median(gaps);
+    if (medGap < o.minGapDays || medGap > o.maxGapDays) continue;
+
+    const amounts = sorted.map((t) => t.amount);
+    const medAmount = median(amounts);
+    const stable = amounts.every((a) => Math.abs(a - medAmount) <= medAmount * o.amountTolerance);
+    if (!stable) continue;
+
+    candidates.push({
+      destinatario_id: destinatarioId,
+      occurrence_count: sorted.length,
+      median_amount: medAmount,
+      median_gap_days: medGap,
+      currency_code: sorted[0].currency_code,
+    });
+  }
+  return candidates;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/shared && pnpm vitest run src/utils/__tests__/subscription-detector.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Export from the package**
+
+In `packages/shared/src/index.ts`, add:
+
+```typescript
+export { detectSubscriptions } from "./utils/subscription-detector";
+export type { DetectorTransaction, SubscriptionCandidate, DetectOptions } from "./utils/subscription-detector";
+```
+
+- [ ] **Step 6: Build gate**
+
+Run: `cd webapp && pnpm build` → PASS (shared types resolve in webapp).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/shared/src/utils/subscription-detector.ts packages/shared/src/utils/__tests__/subscription-detector.test.ts packages/shared/src/index.ts
+git commit -m "feat(subscriptions): deterministic detector in @zeta/shared (TDD)"
+```
+
+---
+
+## Task 8: Detection runner + import hook
+
+**Files:**
+- Modify: `webapp/src/actions/subscriptions.ts`
+- Modify: `webapp/src/actions/import-transactions.ts`
+
+- [ ] **Step 1: Add `runSubscriptionDetection` to `subscriptions.ts`**
+
+Loads recent OUTFLOW transactions with a destinatario, the set of destinatarios that already have ANY subscription row (idempotency guard — never re-suggest dismissed/cancelled/active), runs the pure detector, inserts `suggested` rows.
+
+```typescript
+import { detectSubscriptions, type DetectorTransaction } from "@zeta/shared";
+
+export async function runSubscriptionDetection(): Promise<ActionResult<{ created: number }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  // 1. recent OUTFLOW transactions with a destinatario (last ~12 months)
+  const since = new Date(); since.setMonth(since.getMonth() - 12);
+  const { data: txs } = await supabase
+    .from("transactions")
+    .select("destinatario_id, transaction_date, amount, currency_code, direction")
+    .eq("user_id", user.id)
+    .eq("direction", "OUTFLOW")
+    .not("destinatario_id", "is", null)
+    .gte("transaction_date", since.toISOString().slice(0, 10));
+
+  // 2. destinatarios that already have ANY subscription row (any status => skip; sticky dismissal)
+  const { data: existing } = await supabase
+    .from("subscriptions")
+    .select("destinatario_id")
+    .eq("user_id", user.id);
+  const excluded = new Set((existing ?? []).map((r) => r.destinatario_id));
+
+  const candidates = detectSubscriptions((txs ?? []) as DetectorTransaction[], excluded);
+  if (candidates.length === 0) return { success: true, data: { created: 0 } };
+
+  const rows = candidates.map((c) => ({
+    user_id: user.id,
+    destinatario_id: c.destinatario_id,
+    status: "suggested" as const,
+    estimated_amount: c.median_amount,
+    currency_code: c.currency_code,
+    detected_at: new Date().toISOString(),
+  }));
+
+  // ON CONFLICT DO NOTHING via the partial-unique index protects against races.
+  const { data: inserted, error } = await supabase
+    .from("subscriptions")
+    .insert(rows)
+    .select("id");
+  if (error && error.code !== "23505") return { success: false, error: error.message };
+
+  updateTag("subscriptions");
+  return { success: true, data: { created: inserted?.length ?? 0 } };
+}
+```
+
+> The `excluded` set already filters out destinatarios with any row, so re-runs never resurrect a dismissed suggestion. The `23505` guard covers concurrent inserts.
+
+- [ ] **Step 2: Hook into the import flow**
+
+Read `webapp/src/actions/import-transactions.ts`, find where the import succeeds and calls `revalidateFinancialViews()` / `updateTag(...)` before the final return. Add the detection call there (fire it before the revalidation calls so the `subscriptions` tag update is included):
+
+```typescript
+import { runSubscriptionDetection } from "@/actions/subscriptions";
+
+// after inserts succeed, before the existing revalidate block:
+await runSubscriptionDetection();
+```
+
+> Detection is best-effort: wrap in try/catch if the import action treats thrown errors as failures, so a detection hiccup never fails an otherwise-successful import.
+
+- [ ] **Step 3: Build gate + review**
+
+Run: `cd webapp && pnpm build` → PASS.
+Run `server-action-reviewer` on `subscriptions.ts` and `import-flow-doctor` on the import-transactions change (confirm detection runs after idempotent inserts, doesn't double-fire, doesn't break the import result).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add webapp/src/actions/subscriptions.ts webapp/src/actions/import-transactions.ts
+git commit -m "feat(subscriptions): detection runner + post-import hook"
+```
+
+---
+
+## Task 9: Suggestions section + confirm/formalize
+
+**Files:**
+- Create: `webapp/src/components/subscriptions/subscription-suggestions.tsx`
+- Modify: `webapp/src/actions/subscriptions.ts` (add `confirmSubscription`, `formalizeSubscription`)
+- Modify: `webapp/src/components/subscriptions/subscriptions-view.tsx` (render suggestions)
+
+- [ ] **Step 1: Add `confirmSubscription` action**
+
+Promotes a `suggested` row to `active`. Optionally creates a pre-filled recurring template from the detected amount and links it (so totals become occurrence-based). Minimal version: promote to `active`, keep `estimated_amount` (template creation offered separately via Formalizar to avoid a heavy confirm).
+
+```typescript
+export async function confirmSubscription(id: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success) return { success: false, error: "ID inválido" };
+
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({ status: "active" })
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .eq("status", "suggested");
+
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true };
+}
+```
+
+- [ ] **Step 2: Add `formalizeSubscription` action**
+
+Creates a recurring template (MONTHLY, OUTFLOW) pre-filled from the subscription's destinatario + `estimated_amount`, links it via `recurring_template_id`. Reuse the existing template-insert helper from `recurring-templates.ts` if exported; otherwise insert directly with the same fields, then call `ensureCurrentOccurrences()`.
+
+```typescript
+import { ensureCurrentOccurrences } from "@/actions/occurrences";
+
+export async function formalizeSubscription(id: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const { data: sub } = await supabase
+    .from("subscriptions")
+    .select("id, destinatario_id, estimated_amount, currency_code, recurring_template_id, destinatarios!subscriptions_destinatario_id_fkey(name, default_category_id)")
+    .eq("id", id).eq("user_id", user.id).single();
+  if (!sub) return { success: false, error: "Suscripción no encontrada" };
+  if (sub.recurring_template_id) return { success: true }; // already formalized
+
+  // pick a default account — require the user to choose in UI ideally; minimal: first active non-debt account
+  const { data: acct } = await supabase
+    .from("accounts").select("id").eq("user_id", user.id).eq("is_active", true).limit(1).single();
+  if (!acct) return { success: false, error: "No hay cuenta disponible" };
+
+  const { data: tpl, error: tErr } = await supabase
+    .from("recurring_transaction_templates")
+    .insert({
+      user_id: user.id,
+      account_id: acct.id,
+      destinatario_id: sub.destinatario_id,
+      category_id: sub.destinatarios?.default_category_id ?? null,
+      merchant_name: sub.destinatarios?.name ?? "Suscripción",
+      amount: sub.estimated_amount ?? 0,
+      currency_code: sub.currency_code,
+      direction: "OUTFLOW",
+      frequency: "MONTHLY",
+      is_active: true,
+    })
+    .select("id").single();
+  if (tErr || !tpl) return { success: false, error: tErr?.message ?? "Error" };
+
+  await supabase.from("subscriptions")
+    .update({ recurring_template_id: tpl.id, status: "active" })
+    .eq("id", id).eq("user_id", user.id);
+
+  await ensureCurrentOccurrences();
+  updateTag("subscriptions");
+  revalidateFinancialViews();
+  return { success: true };
+}
+```
+
+> Account selection: the minimal version picks the first active account. If the recurring form is easy to reuse as a modal pre-filled from the subscription, prefer routing "Formalizar" to that form instead (better UX, lets the user pick account + day). Decide during implementation; both produce a linked template.
+
+- [ ] **Step 3: Suggestions component**
+
+Create `webapp/src/components/subscriptions/subscription-suggestions.tsx` — `"use client"`. Renders `status === "suggested"` rows with destinatario name + `estimated_amount` + "Esto parece una suscripción". Two buttons: **Rastrear** (`confirmSubscription`) and **Descartar** (`dismissSubscription`). `startTransition` + `router.refresh()`.
+
+- [ ] **Step 4: Render suggestions in the view**
+
+In `subscriptions-view.tsx`, split `subscriptions` into `suggested` vs tracked; render `<SubscriptionSuggestions suggestions={suggested} currency={currency} />` above the tracked list when non-empty.
+
+- [ ] **Step 5: Build gate + reviews**
+
+Run: `cd webapp && pnpm build` → PASS.
+Run `server-action-reviewer` (new actions), `zetas-front-guy` (suggestions UI), `recurring-doctor` (formalize creates a proper template + occurrences).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webapp/src/actions/subscriptions.ts webapp/src/components/subscriptions
+git commit -m "feat(subscriptions): suggestions section, confirm + formalize"
+```
+
+---
+
+## Task 10: No-destinatario fallback nudge
+
+**Files:**
+- Modify: `webapp/src/components/subscriptions/subscription-suggestions.tsx`
+- (Read) `webapp/src/actions/destinatarios.ts` — `getDestinatarioSuggestions`
+
+- [ ] **Step 1: Surface destinatario suggestions as a secondary nudge**
+
+For repeating charges with no destinatario, the existing `getDestinatarioSuggestions()` returns candidates (`{ matchCount, samples }`-style). In the `/suscripciones` page server component, also fetch these and pass to the suggestions component as a separate "Crea un destinatario para rastrear esto" block. Confirming routes the user to the destinatario-create flow (which already learns a rule); after creating + categorizing as Suscripciones, the normal detector picks it up on the next import.
+
+> Keep this lightweight — it's a nudge linking to the existing destinatario-create surface, not a new mutation. Do not duplicate destinatario-creation logic.
+
+- [ ] **Step 2: Build gate + review**
+
+Run: `cd webapp && pnpm build` → PASS. Run `zetas-front-guy`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add webapp/src/app/\(dashboard\)/suscripciones webapp/src/components/subscriptions
+git commit -m "feat(subscriptions): no-destinatario fallback nudge"
+```
+
+---
+
+## Task 11: Mobile parity
+
+**Run `mobile-webapp-parity` BEFORE starting (data-shape parity) and `mobile-sync-doctor` AFTER (sync correctness).**
+
+**Files:**
+- Modify: `mobile/lib/db/schema.ts`
+- Create: `mobile/lib/repositories/subscriptions.ts`
+- Modify: `mobile/lib/sync/pull.ts`, `mobile/lib/sync/push.ts`
+
+- [ ] **Step 1: Add SQLite schema (view-aligned columns, not `_enc`)**
+
+In `mobile/lib/db/schema.ts`, add (mirror the destinatarios CREATE TABLE; booleans → INTEGER, dates → TEXT, enum → TEXT):
+
+```typescript
+`CREATE TABLE IF NOT EXISTS subscriptions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  destinatario_id TEXT NOT NULL,
+  recurring_template_id TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  estimated_amount REAL,
+  currency_code TEXT NOT NULL DEFAULT 'COP',
+  trial_ends_on TEXT,
+  cancel_url TEXT,
+  detected_at TEXT,
+  dismissed_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (destinatario_id) REFERENCES destinatarios(id),
+  FOREIGN KEY (recurring_template_id) REFERENCES recurring_transaction_templates(id)
+)`,
+```
+
+- [ ] **Step 2: Register in pull + push sync**
+
+Add `"subscriptions"` to the `SYNC_TABLES` array in `mobile/lib/sync/pull.ts` and the equivalent list in `mobile/lib/sync/push.ts`. Pull reads the `subscriptions` **view** (decrypted columns); push must exclude DB-computed fields (`created_at`/`updated_at` are server-managed) and go through the view.
+
+- [ ] **Step 3: Repository read**
+
+Create `mobile/lib/repositories/subscriptions.ts` mirroring `destinatarios.ts`:
+
+```typescript
+import { getDatabase } from "../db/database";
+
+export async function getActiveSubscriptions() {
+  const db = await getDatabase();
+  return db.getAllAsync(
+    `SELECT s.*, d.name AS destinatario_name, t.amount AS template_amount, t.frequency AS template_frequency
+     FROM subscriptions s
+     LEFT JOIN destinatarios d ON s.destinatario_id = d.id
+     LEFT JOIN recurring_transaction_templates t ON s.recurring_template_id = t.id
+     WHERE s.status NOT IN ('dismissed', 'cancelled')
+     ORDER BY s.created_at DESC`
+  );
+}
+```
+
+- [ ] **Step 4: Verify mobile typecheck/build**
+
+Run the mobile typecheck (per `mobile/package.json` — e.g. `cd mobile && pnpm tsc --noEmit` or the project's lint script). Expected: PASS.
+
+- [ ] **Step 5: `mobile-sync-doctor` review**
+
+Confirm: schema columns match the Supabase **view** (not `_enc`), boolean/enum/date mapping correct, push payload excludes server-managed fields, pull hits the view.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/db/schema.ts mobile/lib/repositories/subscriptions.ts mobile/lib/sync/pull.ts mobile/lib/sync/push.ts
+git commit -m "feat(subscriptions): mobile SQLite schema, repository, and sync registration"
+```
+
+---
+
+## Final gates (before PR)
+
+- [ ] `cd /Users/cristian/Documents/developing/current-projects/zeta && pnpm install` (root — lockfile sync if any dep changed; none expected).
+- [ ] `cd webapp && pnpm build` → PASS.
+- [ ] `cd packages/shared && pnpm vitest run` → PASS (detector tests).
+- [ ] `pnpm audit --audit-level high` (root) → no new high/critical.
+- [ ] Dry-merge against main: `git fetch origin main && git merge --no-commit --no-ff origin/main`, resolve/inspect, then `git merge --abort`.
+- [ ] Review gates run and clean: `supabase-migrator` (Task 1), `server-action-reviewer` (Tasks 4/8/9), `zetas-front-guy` (Tasks 5/6/9/10), `perf-auditor` (Task 6), `recurring-doctor` (Tasks 6/9), `import-flow-doctor` (Task 8), `mobile-webapp-parity` + `mobile-sync-doctor` (Task 11).
+- [ ] Open PR to `main` with summary + spec link.
+
+## Deferred (Phase 3 — separate spec, NOT in this plan)
+
+Active management: trial-ending alerts (`trial_ends_on`), price-increase detection, cancel-flow UX with `cancel_url`, mobile suggestion UI. The columns exist; the workflows are out of scope here.

--- a/docs/superpowers/specs/2026-05-27-subscriptions-design.md
+++ b/docs/superpowers/specs/2026-05-27-subscriptions-design.md
@@ -1,0 +1,315 @@
+# Subscriptions — Design
+
+**Date:** 2026-05-27
+**Status:** Approved (design forks confirmed with user)
+
+## Problem
+
+Zeta already models **recurring obligations** (internet, mobile plan, home services)
+via `recurring_transaction_templates` + `recurring_occurrences`. But a large, growing
+class of recurring spend — **subscriptions** (Spotify, YouTube Premium, streaming,
+SaaS) — is *optional and discardable*, and the app treats it no differently from a
+fixed obligation.
+
+Today the only distinction is **implicit and category-driven**:
+
+- A leaf category **"Suscripciones"** exists under the **"Estilo de Vida"** parent,
+  `is_essential = false` (so it lands in the Wants/30% bucket of the 50/30/20 plan).
+  Category id `c0000001-0012-4000-8000-000000000004`
+  (`supabase/migrations/20260329121902_expand_category_tree.sql`).
+- The Ritmo-YNAB tag system tags streaming/entertainment as **"Calidad de Vida"**
+  (`supabase/migrations/20260329122607_create_tag_system.sql`).
+
+There is **no explicit subscription concept** anywhere — no flag, no metadata, no
+dedicated surface. The recurring form (`webapp/src/components/recurring/recurring-form.tsx`)
+has no "this is optional/cancellable" affordance. So the app can *store* a subscription
+but never **treats** it as a managed, reviewable, "what can I cut?" class: no
+subscription total, no cancel-candidate view, no detection of forgotten subscriptions.
+
+**Goal:** make subscriptions a first-class, **phased** concept — classification +
+a dedicated audit surface + (later) active management — built on the data model the
+app already trusts most.
+
+## Decided design forks (confirmed with user)
+
+| Fork | Decision |
+|------|----------|
+| Core job | **First-class, phased** — classification + audit view + (deferred) active management. Data model built to support all three. |
+| Source | **Manual + auto-detect** — user flags/creates subscriptions, *and* a deterministic detector surfaces candidates from imported transaction history. |
+| Architecture anchor | **B′ — destinatario recognition + a dedicated `subscriptions` table.** Recognition reuses the proven multi-pattern destinatario engine; subscription state lives in its own thin table; billing rides the existing recurring template/occurrence lifecycle (optional link). |
+| Billing link | **Optional** — `recurring_template_id` is nullable. With a template, totals come from `recurring_occurrences` (authoritative). Without one, an `estimated_amount` is shown, clearly labeled "estimado". |
+| Audit surface | **Dedicated `/suscripciones` page.** Entry points (bandeja / dashboard widget / plan CTA / nav) deferred — built standalone. |
+| Detection | **Deterministic, no AI**, grouped by `destinatario_id`. Monthly cadence only; annual/quarterly are manual-only. |
+
+## Why B′ (the anchor decision)
+
+Destinatarios are already the app's most reliable categorization/detection mechanism,
+and they already provide the multi-pattern recognition a subscription detector needs —
+so the feature **reuses** that engine rather than rebuilding a fragile merchant-string
+matcher:
+
+- **Multi-pattern is real.** `destinatario_rules`
+  (`supabase/migrations/20260310044637_create_destinatarios_and_rules.sql`) holds *many*
+  patterns per destinatario (`match_type` ∈ `contains|exact`, `priority`, first-match-wins).
+  Three Netflix merchant strings collapse to one Netflix destinatario.
+  Matcher: `packages/shared/src/utils/destinatario-matcher.ts`.
+- **The link is persisted.** `transactions.destinatario_id` is set on import, on manual
+  entry (which *learns* a rule — `webapp/src/actions/categorize.ts` `assignDestinatario`),
+  and via bulk retroactive apply (`bulkApplyDestinatarioMatches`,
+  `applyDestinatarioRules` in `webapp/src/actions/destinatarios.ts`).
+- **Reliable categorization is built in.** `destinatarios.default_category_id`
+  auto-applies a category to matched transactions (`USER_LEARNED`) — the same path that
+  routes a subscription into Suscripciones → Wants.
+- **The recurring system is already destinatario-aware.**
+  `recurring_transaction_templates.destinatario_id`
+  (`supabase/migrations/20260417170859_add_destinatario_id_to_recurring_templates.sql`)
+  exists, and the occurrence matcher anchors on **destinatario + account** rather than
+  amount proximity.
+- **A suggestion engine already exists.** `getDestinatarioSuggestions()` /
+  `detectDestinatarioSuggestions()` group un-matched repeating charges into candidates —
+  reusable as the no-destinatario fallback path for detection.
+
+We do **not** bolt subscription state onto destinatarios (overloads a shared entity,
+forces a 6-step encrypted ALTER on a hot table) nor onto the recurring template (forces
+a template on every subscription, double-flag risk). Instead, a dedicated table holds it.
+
+## The three layers
+
+1. **Recognition — destinatarios, untouched.** Multi-pattern `destinatario_rules` +
+   `default_category_id` reused as-is. Answers "who is this merchant" reliably.
+
+2. **Subscription state — new `subscriptions` table** (one *live* row per destinatario;
+   cancelled/dismissed rows kept as history). Holds the lifecycle + subscription-specific
+   metadata. The *existence of a non-terminal row* is the subscription flag — nothing
+   double-flagged on destinatario or template.
+
+3. **Billing — recurring template (optional link).** When linked, amount / next charge /
+   total come from `recurring_occurrences` (authoritative source of truth). When not,
+   `estimated_amount` (median of recent charges) is shown, labeled "estimado", with a
+   one-tap "Formalizar" to create the schedule.
+
+## Data model
+
+### New table `subscriptions`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid PK | |
+| `user_id` | uuid FK profiles | RLS + defense-in-depth `.eq("user_id", …)` |
+| `destinatario_id` | uuid FK destinatarios | the recognition anchor; see partial-unique rule below |
+| `recurring_template_id` | uuid FK recurring_transaction_templates **NULL** | optional billing schedule |
+| `status` | enum | `suggested \| active \| trial \| marked_for_cancellation \| cancelled \| dismissed` |
+| `estimated_amount` | numeric NULL | median of recent charges; used only when no template |
+| `currency_code` | text | |
+| `trial_ends_on` | date NULL | phase-3 metadata |
+| `cancel_url` | text NULL | phase-3 metadata |
+| `detected_at` | timestamptz NULL | set when auto-detected |
+| `dismissed_at` | timestamptz NULL | sticky dismissal memory |
+| `created_at` / `updated_at` | timestamptz | |
+
+- **Lifecycle in one enum.** A detected candidate is a `suggested` row; dismissal sets
+  `status = dismissed` (+ `dismissed_at`) so the detector never re-nags. Confirmation
+  promotes to `active`/`trial`.
+- **Encryption:** `cancel_url` (and any free-text notes) may be PII → run the table
+  through `supabase-migrator`, which decides which columns need the `_enc` envelope.
+  Because this is a **new** table, encryption is a clean fresh setup, **not** a 6-step
+  ALTER on `destinatarios_enc`.
+- **No new columns on `destinatarios_enc` or `recurring_transaction_templates`.**
+
+**Partial-unique rule (resubscription-safe).** One *live* subscription per destinatario,
+but history preserved: a cancelled/dismissed row must not block a later resubscription.
+
+```sql
+CREATE UNIQUE INDEX subscriptions_one_live_per_destinatario
+  ON subscriptions (user_id, destinatario_id)
+  WHERE status NOT IN ('cancelled', 'dismissed');
+```
+
+So resubscribing after a cancel = a **new** `active` row (the old `cancelled` row stays
+as history); re-detecting a dismissed merchant is blocked by the dismissal guard below,
+not by this index.
+
+### Migration
+
+- `supabase migration new create_subscriptions` — table, enum, RLS
+  (`(select auth.uid()) = user_id`), the partial-unique index above, plus indexes on
+  `user_id`, `destinatario_id`, `recurring_template_id`, `status`.
+- **FK precision for `supabase-migrator`:** both `destinatarios` and
+  `recurring_transaction_templates` are **encrypted** (`_enc` real tables + decrypting
+  views). The FKs must target the **`_enc`** tables (`destinatarios_enc`,
+  `recurring_transaction_templates_enc`), matching the existing
+  `recurring → destinatarios_enc` FK pattern. Reads on `/suscripciones` that join through
+  the views must use the **`!fk_name` join-hint** syntax (plain joins through views
+  silently return empty).
+- Regenerate `webapp/src/types/database.ts` and `packages/shared/src/types/database.ts`.
+- **Spawn `supabase-migrator`** (RLS, encryption decision, FK targets, view join hints).
+
+### Backfill (one-shot, in the same migration)
+
+Seed `status = active` rows for existing **recurring templates categorized as
+Suscripciones (`c0000001-0012-…`) that already carry a `destinatario_id`**, linking
+`recurring_template_id` + `destinatario_id`. Templates without a destinatario, and
+category-only matches with no schedule, are **not** force-seeded — they surface through
+detection instead. Conservative: no false positives, but the audit view is not empty on
+first open.
+
+## Detection — `packages/shared/src/subscription-detector.ts`
+
+Deterministic, rule-based (no AI, per project constraint). Pure function consumed by
+both webapp and mobile (lives in `@zeta/shared`).
+
+**Primary path — group by `destinatario_id`.** For each destinatario's OUTFLOW
+transactions, qualify as a candidate when:
+
+- **≥ 3** charges
+- **monthly cadence:** median gap between consecutive charges ∈ **[28, 34] days**
+- **stable amount:** within **±10%** of the median (tolerates FX / price bumps)
+- no `active`/`trial` `subscriptions` row already exists for that destinatario
+
+Qualified groups upsert a `status = suggested` row carrying `estimated_amount`
+(median), `currency_code`, `detected_at`.
+
+**Fallback path — no destinatario.** For repeating charges with `destinatario_id IS NULL`,
+reuse `getDestinatarioSuggestions()` to group by cleaned description; surface as a
+"create destinatario + track as subscription" nudge (so the user gains both a
+destinatario *and* a subscription in one step).
+
+**Trigger / timing.** Detection runs **after `importTransactions()` completes**
+(`webapp/src/actions/import.ts`) — new transactions just arrived, so that is the natural
+moment to (re)scan and upsert `suggested` rows. Detection is a **write** path and must
+never run inside a Server Component render: the `/suscripciones` page only **reads**
+already-persisted `suggested` rows. (A future cron path is possible but out of scope.)
+
+**Re-detection idempotency (protects sticky dismissal).** The detector upserts keyed on
+`(user_id, destinatario_id)`. It only ever **inserts a new `suggested` row when no row
+exists** for that destinatario. If a row already exists in **any** status
+(`dismissed`, `cancelled`, `active`, `trial`, `marked_for_cancellation`, or a prior
+`suggested`), the detector does **nothing** — it must not undismiss, re-suggest, or
+overwrite. This makes dismissal permanent and avoids re-nagging.
+
+**Non-goal:** no auto-detection of ANNUAL/quarterly cadence (too few data points per
+year) — those are manual-only. Thresholds are intentionally conservative and tunable.
+
+**Total bleed is occurrence-based.** The audit total sums `expected_amount` from
+`recurring_occurrences` of linked active templates — never raw `transactions`. The page
+data loader **calls `ensureCurrentOccurrences()` before reading** (per the
+recurring-doctor rule: idempotent `ON CONFLICT DO NOTHING`), so landing right after a
+month rolls over does not undercount. Template-less subscriptions contribute
+`estimated_amount` shown on a **separate "estimado" line**, never silently merged into
+the authoritative total.
+
+## Audit surface — `/suscripciones`
+
+New route + page (Server Component, server-first data fetch; `"use cache"` +
+`cacheTag("subscriptions")` + `cacheLife("zeta")` for the reads).
+
+- **Total-bleed hero:** authoritative monthly total + annualized projection; `estimado`
+  shown as a distinct secondary line. Framed against the Wants/30% bucket.
+- **Active list:** per row — destinatario name/icon, amount, next charge date (from
+  occurrences), status badge. Row actions: **Formalizar** (template-less → create
+  schedule), **Marcar para cancelar**, **Cancelar**, **Editar**.
+- **Suggestions section:** detected `suggested` rows → "Esto parece una suscripción —
+  ¿rastrearla?". Confirm → promote to `active` (+ optionally pre-filled recurring
+  template). Dismiss → `status = dismissed` (sticky).
+- **Entry points = OPEN QUESTION** (bandeja / dashboard widget / plan-page CTA /
+  top-level nav). Page is built standalone; entry wired at implementation.
+
+Reuse existing UI primitives from `webapp/src/components/ui/` (cards, badges, stat
+displays) per the design-system rules. All strings Spanish. Tokens only — no hardcoded
+colors. Mobile tab-bar clearance + focus-mode rules apply.
+
+## Server actions — `webapp/src/actions/subscriptions.ts`
+
+`(prevState, formData) => Promise<ActionResult<T>>` shape, `getAuthenticatedClient()`,
+defense-in-depth `.eq("user_id", user.id)`, `updateTag("subscriptions")` (+
+`updateTag` for any affected financial views) on every mutation.
+
+- `confirmSubscription(suggestionId | destinatarioId)` — promote/create `active` row;
+  optionally create+link a recurring template pre-filled from detected cadence/amount
+  (single transactional action — flag + template together).
+- `dismissSubscription(id)` — `status = dismissed`, `dismissed_at = now()`.
+- `markForCancellation(id)` / `cancelSubscription(id)` — see cancel rules below.
+- `formalizeSubscription(id)` — create+link a recurring template for a template-less sub.
+- `updateSubscription(id, …)` — edit `trial_ends_on` / `cancel_url` / status.
+- Reads via `getSubscriptions()` (cached) feeding the page + any widget.
+
+## Recurring form integration
+
+`webapp/src/components/recurring/recurring-form.tsx` — add an **"Es una suscripción"**
+toggle. On save (in `webapp/src/actions/recurring-templates.ts`), upsert the
+`subscriptions` row (`status = active`/`trial`) linked to the saved template + its
+destinatario. Toggle reveals optional `trial_ends_on` / `cancel_url` inputs. A recurring
+template still requires a destinatario for the subscription link (the form already
+exposes the destinatario picker).
+
+## Budget integration — no new math
+
+Subscriptions categorize via the destinatario's `default_category_id` → Suscripciones →
+`is_essential = false` → Wants/30%, already wired in
+`webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx` and `get503020Allocation`.
+The audit page **frames** that subset; it never adds a parallel allocation bucket
+(no double-counting).
+
+## Cancel rules (no drift)
+
+- `marked_for_cancellation` = **visual intent only** — does **not** stop occurrence
+  generation.
+- **Real cancellation** = recurring template `is_active = false` **and**
+  `subscriptions.status = cancelled`, performed together in `cancelSubscription`.
+- **Drift guard (any path).** A user can also deactivate a subscription-linked template
+  directly through the existing recurring form (or mobile). To keep the two entities in
+  sync regardless of entry point, a DB trigger on `recurring_transaction_templates`
+  UPDATE syncs the linked subscription: when a linked template flips `is_active → false`,
+  set the subscription's `status = cancelled` (if not already terminal); when it flips
+  back `→ true`, restore `status = active`. The DB trigger (not just the action) is what
+  makes "one authoritative stopped-billing path" actually true across web, mobile, and
+  direct edits.
+
+## Mobile parity (hard gate)
+
+The new `subscriptions` table must be mirrored on mobile per the parity rule:
+
+- Mobile SQLite schema (`mobile/lib/db/schema.ts`) + repository
+  (`mobile/lib/repositories/subscriptions.ts`) + pull/push sync
+  (`mobile/lib/sync/pull.ts`, `push.ts`) — view-aligned columns (not `_enc`), enum +
+  date mapping, boolean handling.
+- Push payload must exclude any DB-/trigger-computed fields and go through the view.
+- The detector lives in `@zeta/shared` (cross-consumed). Suggestion **UI** is
+  webapp-first; mobile mirrors in a later pass.
+- **Spawn `mobile-webapp-parity` (before any mobile write) and `mobile-sync-doctor`
+  (when adding the synced table).**
+
+## Phasing
+
+- **Phase 1 (webapp):** `subscriptions` table + enum + RLS + backfill · recurring-form
+  toggle + action wiring · `/suscripciones` page (active list + occurrence-based total)
+  · manual confirm/cancel paths.
+- **Phase 2:** `subscription-detector.ts` + no-destinatario fallback · suggestions
+  section + sticky dismissal · mobile parity for the new table.
+- **Phase 3 (separate spec, deferred — out of scope here):** active management —
+  trial-ending alerts, price-increase detection, cancel-flow UX. The nullable
+  `trial_ends_on` / `cancel_url` columns already enable it.
+
+## Review gates (per CLAUDE.md)
+
+- `supabase-migrator` — the migration (RLS, encryption decision, view/FK joins).
+- `server-action-reviewer` — `subscriptions.ts` actions (auth, validation, `updateTag`).
+- `perf-auditor` + `zetas-front-guy` — the `/suscripciones` page.
+- `recurring-doctor` — confirm totals query `recurring_occurrences`, and that
+  confirm/formalize auto-link via `findMatchingOccurrence()`.
+- `mobile-webapp-parity` + `mobile-sync-doctor` — the synced table (phase 2).
+- `import-flow-doctor` — if detection touches the import path.
+
+## Open questions
+
+1. **Entry points / placement** of `/suscripciones` (bandeja, dashboard widget, plan
+   CTA, nav) — decide at implementation.
+2. **Encryption** of `subscriptions` columns (`cancel_url`?) — `supabase-migrator` decides.
+3. **Detection on mobile** in phase 2, or webapp-only initially?
+
+## Non-goals
+
+- No ML / AI categorization or detection (deterministic only).
+- No phase-3 active-management workflows in this spec.
+- No changes to the 50/30/20 budget math.
+- No annual/quarterly auto-detection.

--- a/mobile/lib/db/schema.ts
+++ b/mobile/lib/db/schema.ts
@@ -503,7 +503,7 @@ export const DB_MIGRATIONS: DbMigration[] = [
         recurring_template_id TEXT,
         status TEXT NOT NULL DEFAULT 'active',
         estimated_amount REAL,
-        currency_code TEXT,
+        currency_code TEXT NOT NULL DEFAULT 'COP',
         trial_ends_on TEXT,
         cancel_url TEXT,
         detected_at TEXT,

--- a/mobile/lib/db/schema.ts
+++ b/mobile/lib/db/schema.ts
@@ -489,6 +489,34 @@ export const DB_MIGRATIONS: DbMigration[] = [
       `ALTER TABLE transactions ADD COLUMN categorization_confidence REAL`,
     ],
   },
+  {
+    version: 15,
+    statements: [
+      // ── Subscriptions: read-only pull-only sync ───────────────────────────
+      // Mirrors the plain (non-encrypted) `subscriptions` Supabase table.
+      // Mobile has no UI for subscriptions yet — only synced for future reads.
+      // Do NOT add to push.ts (mobile produces no subscription mutations).
+      `CREATE TABLE IF NOT EXISTS subscriptions (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        destinatario_id TEXT NOT NULL,
+        recurring_template_id TEXT,
+        status TEXT NOT NULL DEFAULT 'active',
+        estimated_amount REAL,
+        currency_code TEXT,
+        trial_ends_on TEXT,
+        cancel_url TEXT,
+        detected_at TEXT,
+        dismissed_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY (destinatario_id) REFERENCES destinatarios(id),
+        FOREIGN KEY (recurring_template_id) REFERENCES recurring_transaction_templates(id)
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_subscriptions_user_status ON subscriptions(user_id, status)`,
+      `CREATE INDEX IF NOT EXISTS idx_subscriptions_destinatario ON subscriptions(destinatario_id)`,
+    ],
+  },
 ];
 
 export const LATEST_DB_VERSION =

--- a/mobile/lib/repositories/subscriptions.ts
+++ b/mobile/lib/repositories/subscriptions.ts
@@ -1,0 +1,45 @@
+import { getDatabase } from "../db/database";
+
+export type SubscriptionRow = {
+  id: string;
+  user_id: string;
+  destinatario_id: string;
+  recurring_template_id: string | null;
+  status: string;
+  estimated_amount: number | null;
+  currency_code: string | null;
+  trial_ends_on: string | null;
+  cancel_url: string | null;
+  detected_at: string | null;
+  dismissed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SubscriptionWithDetails = SubscriptionRow & {
+  destinatario_name: string | null;
+  template_amount: number | null;
+  template_frequency: string | null;
+};
+
+/**
+ * Returns active subscriptions (excludes dismissed and cancelled),
+ * joined with destinatario name and recurring template details.
+ * Read-only — mobile produces no subscription mutations.
+ */
+export async function getActiveSubscriptions(): Promise<
+  SubscriptionWithDetails[]
+> {
+  const db = await getDatabase();
+  return db.getAllAsync<SubscriptionWithDetails>(
+    `SELECT s.*,
+       d.name AS destinatario_name,
+       t.amount AS template_amount,
+       t.frequency AS template_frequency
+     FROM subscriptions s
+     LEFT JOIN destinatarios d ON s.destinatario_id = d.id
+     LEFT JOIN recurring_transaction_templates t ON s.recurring_template_id = t.id
+     WHERE s.status NOT IN ('dismissed', 'cancelled')
+     ORDER BY s.created_at DESC`
+  );
+}

--- a/mobile/lib/sync/pull.ts
+++ b/mobile/lib/sync/pull.ts
@@ -23,6 +23,7 @@ const SYNC_TABLES = [
   "planning_periods",
   "planning_entries",
   "planning_assignments",
+  "subscriptions",
 ] as const;
 
 type SyncTable = (typeof SYNC_TABLES)[number];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -25,3 +25,4 @@ export * from "./utils/dashboard-layout";
 export * from "./utils/account-balance";
 export * from "./utils/monthly-aggregates";
 export * from "./utils/ritmo";
+export * from "./utils/subscription-detector";

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -587,6 +587,69 @@ export type Database = {
           },
         ]
       }
+      subscriptions: {
+        Row: {
+          cancel_url: string | null
+          created_at: string
+          currency_code: string
+          destinatario_id: string
+          detected_at: string | null
+          dismissed_at: string | null
+          estimated_amount: number | null
+          id: string
+          recurring_template_id: string | null
+          status: Database["public"]["Enums"]["subscription_status"]
+          trial_ends_on: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          cancel_url?: string | null
+          created_at?: string
+          currency_code?: string
+          destinatario_id: string
+          detected_at?: string | null
+          dismissed_at?: string | null
+          estimated_amount?: number | null
+          id?: string
+          recurring_template_id?: string | null
+          status?: Database["public"]["Enums"]["subscription_status"]
+          trial_ends_on?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          cancel_url?: string | null
+          created_at?: string
+          currency_code?: string
+          destinatario_id?: string
+          detected_at?: string | null
+          dismissed_at?: string | null
+          estimated_amount?: number | null
+          id?: string
+          recurring_template_id?: string | null
+          status?: Database["public"]["Enums"]["subscription_status"]
+          trial_ends_on?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "subscriptions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "subscriptions_recurring_template_id_fkey"
+            columns: ["recurring_template_id"]
+            isOneToOne: false
+            referencedRelation: "recurring_transaction_templates"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       transactions: {
         Row: {
           account_id: string
@@ -843,6 +906,13 @@ export type Database = {
         | "ONCE"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
+      subscription_status:
+        | "suggested"
+        | "active"
+        | "trial"
+        | "marked_for_cancellation"
+        | "cancelled"
+        | "dismissed"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1008,6 +1078,14 @@ export const Constants = {
       ],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],
+      subscription_status: [
+        "suggested",
+        "active",
+        "trial",
+        "marked_for_cancellation",
+        "cancelled",
+        "dismissed",
+      ],
     },
   },
 } as const

--- a/packages/shared/src/utils/__tests__/subscription-detector.test.ts
+++ b/packages/shared/src/utils/__tests__/subscription-detector.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { detectSubscriptions, type DetectorTransaction } from "../subscription-detector";
+
+const tx = (
+  destinatario_id: string | null,
+  date: string,
+  amount: number,
+): DetectorTransaction => ({
+  destinatario_id,
+  transaction_date: date,
+  amount,
+  currency_code: "COP",
+  direction: "OUTFLOW",
+});
+
+describe("detectSubscriptions", () => {
+  it("detects a stable monthly charge as a candidate", () => {
+    const txs = [
+      tx("d1", "2026-03-05", 16900),
+      tx("d1", "2026-04-05", 16900),
+      tx("d1", "2026-05-05", 17900),
+    ];
+    const result = detectSubscriptions(txs, new Set());
+    expect(result).toHaveLength(1);
+    expect(result[0].destinatario_id).toBe("d1");
+    expect(result[0].occurrence_count).toBe(3);
+    expect(result[0].median_amount).toBe(16900);
+  });
+
+  it("ignores groups with fewer than 3 charges", () => {
+    const txs = [tx("d1", "2026-04-05", 16900), tx("d1", "2026-05-05", 16900)];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+
+  it("ignores non-monthly cadence", () => {
+    const txs = [
+      tx("d1", "2026-01-05", 16900),
+      tx("d1", "2026-03-05", 16900),
+      tx("d1", "2026-05-05", 16900),
+    ];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+
+  it("ignores unstable amounts", () => {
+    const txs = [
+      tx("d1", "2026-03-05", 10000),
+      tx("d1", "2026-04-05", 50000),
+      tx("d1", "2026-05-05", 90000),
+    ];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+
+  it("excludes destinatarios that already have a subscription", () => {
+    const txs = [
+      tx("d1", "2026-03-05", 16900),
+      tx("d1", "2026-04-05", 16900),
+      tx("d1", "2026-05-05", 16900),
+    ];
+    expect(detectSubscriptions(txs, new Set(["d1"]))).toHaveLength(0);
+  });
+
+  it("ignores transactions with no destinatario and INFLOWs", () => {
+    const txs: DetectorTransaction[] = [
+      tx(null, "2026-03-05", 16900),
+      tx(null, "2026-04-05", 16900),
+      tx(null, "2026-05-05", 16900),
+      {
+        destinatario_id: "d2",
+        transaction_date: "2026-03-05",
+        amount: 16900,
+        currency_code: "COP",
+        direction: "INFLOW",
+      },
+    ];
+    expect(detectSubscriptions(txs, new Set())).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/utils/subscription-detector.ts
+++ b/packages/shared/src/utils/subscription-detector.ts
@@ -1,0 +1,97 @@
+/**
+ * Deterministic subscription detector (no ML, per project constraint).
+ *
+ * Groups OUTFLOW transactions by `destinatario_id` (the reliable, multi-pattern
+ * recognition anchor) and flags groups that look like a monthly subscription:
+ * a stable amount charged on a roughly-monthly cadence. Annual/quarterly cadences
+ * are intentionally NOT detected (too few data points) — those are manual-only.
+ */
+
+export interface DetectorTransaction {
+  destinatario_id: string | null;
+  transaction_date: string; // YYYY-MM-DD
+  amount: number;
+  currency_code: string;
+  direction: "INFLOW" | "OUTFLOW";
+}
+
+export interface SubscriptionCandidate {
+  destinatario_id: string;
+  occurrence_count: number;
+  median_amount: number;
+  median_gap_days: number;
+  currency_code: string;
+}
+
+export interface DetectOptions {
+  minOccurrences?: number;
+  minGapDays?: number;
+  maxGapDays?: number;
+  amountTolerance?: number;
+}
+
+const DEFAULTS: Required<DetectOptions> = {
+  minOccurrences: 3,
+  minGapDays: 28,
+  maxGapDays: 34,
+  amountTolerance: 0.1,
+};
+
+function median(nums: number[]): number {
+  const s = [...nums].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function daysBetween(a: string, b: string): number {
+  const ms = Date.parse(`${b}T12:00:00`) - Date.parse(`${a}T12:00:00`);
+  return Math.round(ms / 86_400_000);
+}
+
+export function detectSubscriptions(
+  transactions: DetectorTransaction[],
+  excludedDestinatarioIds: Set<string>,
+  options?: DetectOptions,
+): SubscriptionCandidate[] {
+  const o = { ...DEFAULTS, ...options };
+  const groups = new Map<string, DetectorTransaction[]>();
+
+  for (const t of transactions) {
+    if (t.direction !== "OUTFLOW" || !t.destinatario_id) continue;
+    if (excludedDestinatarioIds.has(t.destinatario_id)) continue;
+    const arr = groups.get(t.destinatario_id) ?? [];
+    arr.push(t);
+    groups.set(t.destinatario_id, arr);
+  }
+
+  const candidates: SubscriptionCandidate[] = [];
+  for (const [destinatarioId, txs] of groups) {
+    if (txs.length < o.minOccurrences) continue;
+    const sorted = [...txs].sort((a, b) =>
+      a.transaction_date.localeCompare(b.transaction_date),
+    );
+
+    const gaps: number[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      gaps.push(daysBetween(sorted[i - 1].transaction_date, sorted[i].transaction_date));
+    }
+    const medGap = median(gaps);
+    if (medGap < o.minGapDays || medGap > o.maxGapDays) continue;
+
+    const amounts = sorted.map((t) => t.amount);
+    const medAmount = median(amounts);
+    const stable = amounts.every(
+      (a) => Math.abs(a - medAmount) <= medAmount * o.amountTolerance,
+    );
+    if (!stable) continue;
+
+    candidates.push({
+      destinatario_id: destinatarioId,
+      occurrence_count: sorted.length,
+      median_amount: medAmount,
+      median_gap_days: medGap,
+      currency_code: sorted[0].currency_code,
+    });
+  }
+  return candidates;
+}

--- a/supabase/migrations/20260527151641_create_subscriptions.sql
+++ b/supabase/migrations/20260527151641_create_subscriptions.sql
@@ -1,0 +1,197 @@
+-- ============================================================================
+-- Create subscriptions table (Subscriptions feature — Task 1)
+--
+-- A subscription = one LIVE row per destinatario (Spotify / streaming / SaaS),
+-- tracked separately from essential recurring obligations. Recognition reuses
+-- the destinatario engine; billing optionally rides the recurring template /
+-- occurrence lifecycle via recurring_template_id.
+--
+-- Design decisions (see docs/superpowers/specs/2026-05-27-subscriptions-design.md):
+--   * PLAIN table (no _enc envelope). The most identifying field is
+--     destinatario_id, which already points at the encrypted destinatarios_enc
+--     table — the merchant identity is protected there. cancel_url adds no
+--     incremental sensitivity beyond what the FK already exposes, and keeping
+--     this table plain materially simplifies mobile sync (no view / INSTEAD OF
+--     triggers / zeta_decrypt_as ceremony). The public name `subscriptions` is
+--     the queryable table itself, so mobile reads the view-aligned name as-is.
+--   * FKs to encrypted base tables: destinatario_id -> destinatarios_enc(id),
+--     recurring_template_id -> recurring_transaction_templates_enc(id), matching
+--     the existing recurring -> destinatarios_enc FK in
+--     20260417170859_add_destinatario_id_to_recurring_templates.sql.
+--   * user_id -> auth.users(id): `profiles` is now an encrypted view (cannot FK
+--     to a view); recent tables (transaction_locations_enc, wishlist_items) all
+--     reference auth.users(id).
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- Enum: subscription lifecycle
+-- ----------------------------------------------------------------------------
+CREATE TYPE subscription_status AS ENUM (
+  'suggested',
+  'active',
+  'trial',
+  'marked_for_cancellation',
+  'cancelled',
+  'dismissed'
+);
+
+-- ----------------------------------------------------------------------------
+-- Table
+-- ----------------------------------------------------------------------------
+CREATE TABLE public.subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL
+    REFERENCES auth.users(id) ON DELETE CASCADE,
+  destinatario_id uuid NOT NULL
+    REFERENCES public.destinatarios_enc(id) ON DELETE CASCADE,
+  recurring_template_id uuid
+    REFERENCES public.recurring_transaction_templates_enc(id) ON DELETE SET NULL,
+  status subscription_status NOT NULL DEFAULT 'active',
+  estimated_amount numeric,
+  currency_code text NOT NULL DEFAULT 'COP',
+  trial_ends_on date,
+  cancel_url text,
+  detected_at timestamptz,
+  dismissed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.subscriptions IS
+  'One LIVE subscription per destinatario (cancelled/dismissed kept as history). Plain table — destinatario_id (the identifying field) is protected via the encrypted destinatarios_enc FK. Synced to mobile via this name directly (no _enc/view).';
+
+-- ----------------------------------------------------------------------------
+-- Indexes
+-- ----------------------------------------------------------------------------
+-- One LIVE subscription per destinatario; cancelled/dismissed kept as history,
+-- so resubscribing after a cancel creates a NEW active row (old row preserved).
+CREATE UNIQUE INDEX subscriptions_one_live_per_destinatario
+  ON public.subscriptions (user_id, destinatario_id)
+  WHERE status NOT IN ('cancelled', 'dismissed');
+
+CREATE INDEX idx_subscriptions_user_id
+  ON public.subscriptions (user_id);
+CREATE INDEX idx_subscriptions_destinatario_id
+  ON public.subscriptions (destinatario_id);
+CREATE INDEX idx_subscriptions_recurring_template_id
+  ON public.subscriptions (recurring_template_id)
+  WHERE recurring_template_id IS NOT NULL;
+CREATE INDEX idx_subscriptions_status
+  ON public.subscriptions (status);
+
+-- ----------------------------------------------------------------------------
+-- updated_at maintenance (moddatetime, matching every other core table)
+-- ----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS moddatetime WITH SCHEMA extensions;
+
+DROP TRIGGER IF EXISTS set_updated_at ON public.subscriptions;
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.subscriptions
+  FOR EACH ROW
+  EXECUTE FUNCTION extensions.moddatetime(updated_at);
+
+-- ----------------------------------------------------------------------------
+-- RLS (fast-path auth pattern; defense-in-depth .eq("user_id", ...) in app)
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "subscriptions_select"
+  ON public.subscriptions FOR SELECT
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "subscriptions_insert"
+  ON public.subscriptions FOR INSERT
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "subscriptions_update"
+  ON public.subscriptions FOR UPDATE
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "subscriptions_delete"
+  ON public.subscriptions FOR DELETE
+  USING ((select auth.uid()) = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.subscriptions TO authenticated;
+GRANT ALL ON public.subscriptions TO postgres, service_role;
+
+-- ----------------------------------------------------------------------------
+-- Cancel-drift guard
+--
+-- Keeps subscriptions.status in sync when a linked recurring template is
+-- (de)activated through ANY entry point (recurring form, mobile, direct edit).
+-- The trigger lives on recurring_transaction_templates_enc (the real base
+-- table) as AFTER UPDATE: the view's INSTEAD OF UPDATE trigger writes to _enc,
+-- which then fires this AFTER UPDATE row trigger — and direct _enc writes
+-- (mobile sync / future cron) are covered too. is_active is a plaintext column
+-- on _enc, so no decryption is involved.
+--
+-- SECURITY DEFINER (running as function owner) intentionally bypasses RLS on
+-- subscriptions: the sync must apply regardless of which session triggered the
+-- template change.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.sync_subscription_on_template_active_change()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+    IF NEW.is_active = false THEN
+      UPDATE public.subscriptions
+        SET status = 'cancelled', updated_at = now()
+        WHERE recurring_template_id = NEW.id
+          AND status NOT IN ('cancelled', 'dismissed');
+    ELSE
+      UPDATE public.subscriptions
+        SET status = 'active', updated_at = now()
+        WHERE recurring_template_id = NEW.id
+          AND status = 'cancelled';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_subscription_on_template_active
+  ON public.recurring_transaction_templates_enc;
+CREATE TRIGGER trg_sync_subscription_on_template_active
+  AFTER UPDATE ON public.recurring_transaction_templates_enc
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_subscription_on_template_active_change();
+
+-- ----------------------------------------------------------------------------
+-- Backfill (one-shot)
+--
+-- Seed status='active' rows for existing recurring templates that are
+-- categorized as "Suscripciones" (c0000001-0012-...-000000000004) and already
+-- carry a destinatario_id. Read directly from the _enc base table: the
+-- migration runs with no JWT, and every column needed is plaintext on _enc
+-- (user_id, destinatario_id, id, category_id, is_active, currency_code), so
+-- reading the decrypting view is both unnecessary and would risk NULLs. The
+-- currency_code enum is cast to text to match the subscriptions.currency_code
+-- column type.
+--
+-- ON CONFLICT targets the partial unique index explicitly so re-running the
+-- migration (or overlap with later detection) is a no-op rather than an error.
+-- ----------------------------------------------------------------------------
+INSERT INTO public.subscriptions (
+  user_id, destinatario_id, recurring_template_id, status, currency_code
+)
+SELECT
+  t.user_id,
+  t.destinatario_id,
+  t.id,
+  'active',
+  t.currency_code::text
+FROM public.recurring_transaction_templates_enc t
+WHERE t.category_id = 'c0000001-0012-4000-8000-000000000004'
+  AND t.destinatario_id IS NOT NULL
+  AND t.is_active = true
+ON CONFLICT (user_id, destinatario_id)
+  WHERE status NOT IN ('cancelled', 'dismissed')
+  DO NOTHING;
+
+COMMIT;

--- a/supabase/migrations/20260527162236_fix_subscription_reactivation_guard.sql
+++ b/supabase/migrations/20260527162236_fix_subscription_reactivation_guard.sql
@@ -1,0 +1,42 @@
+-- Hardens the cancel-drift trigger added in 20260527151641_create_subscriptions.sql.
+--
+-- Two fixes (from final integration review):
+--   1. (Critical) The reactivation branch (template is_active false -> true) blindly set the
+--      linked subscription back to 'active'. If a SECOND live subscription already exists for the
+--      same (user_id, destinatario_id) — reachable when a template is un-flagged, a new template is
+--      created for the same merchant, then the old template is reactivated — the UPDATE violates the
+--      partial-unique index `subscriptions_one_live_per_destinatario` and the error propagates,
+--      failing the template reactivation. Guard the reactivation with a NOT EXISTS check.
+--   2. (Defense-in-depth) Both branches now also filter `user_id = NEW.user_id`, consistent with the
+--      project rule of scoping every mutation by user_id even when a FK makes cross-user impossible.
+
+CREATE OR REPLACE FUNCTION sync_subscription_on_template_active_change()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+    IF NEW.is_active = false THEN
+      UPDATE subscriptions
+        SET status = 'cancelled', updated_at = now()
+        WHERE recurring_template_id = NEW.id
+          AND user_id = NEW.user_id
+          AND status NOT IN ('cancelled', 'dismissed');
+    ELSE
+      -- Only reactivate if no OTHER live subscription exists for the same destinatario,
+      -- otherwise the partial-unique index would reject the update.
+      UPDATE subscriptions s
+        SET status = 'active', updated_at = now()
+        WHERE s.recurring_template_id = NEW.id
+          AND s.user_id = NEW.user_id
+          AND s.status = 'cancelled'
+          AND NOT EXISTS (
+            SELECT 1 FROM subscriptions x
+            WHERE x.user_id = s.user_id
+              AND x.destinatario_id = s.destinatario_id
+              AND x.status NOT IN ('cancelled', 'dismissed')
+              AND x.id <> s.id
+          );
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/webapp/src/actions/import-transactions.ts
+++ b/webapp/src/actions/import-transactions.ts
@@ -27,6 +27,7 @@ import { trackProductEvent } from "@/actions/product-events";
 import { linkTransactionToOccurrence, ensureCurrentOccurrences } from "@/actions/occurrences";
 import { parseSubPayments as parseSubPaymentsShared } from "@/lib/utils/sub-payments";
 import { applyAccountBalanceDelta } from "@/lib/utils/account-balance";
+import { runSubscriptionDetection } from "@/actions/subscriptions";
 
 type DebtKind = "credit_card" | "loan";
 type CurrencyCode = Database["public"]["Enums"]["currency_code"];
@@ -1241,6 +1242,13 @@ export async function importTransactions(
       console.error("Failed to auto-tag imported transactions:", tagError.message);
       details.push(`Auto-etiquetado parcial: ${tagError.message}`);
     }
+  }
+
+  // Best-effort subscription detection — never fails the import
+  try {
+    await runSubscriptionDetection();
+  } catch {
+    // detection is best-effort; never fail the import on it
   }
 
   revalidateFinancialViews();

--- a/webapp/src/actions/recurring-templates.ts
+++ b/webapp/src/actions/recurring-templates.ts
@@ -19,6 +19,7 @@ import {
 } from "@zeta/shared";
 import { addDays, endOfMonth, startOfMonth } from "date-fns";
 import { toISODateString } from "@/lib/utils/date";
+import { upsertSubscriptionFromTemplate } from "@/actions/subscriptions";
 import { z } from "zod";
 import { uuidStr } from "@/lib/validators/shared";
 import type { ActionResult } from "@/types/actions";
@@ -315,6 +316,17 @@ export async function createRecurringTemplate(
   const result = await insertRecurringTemplateFromFormData(formData, user, supabase);
   if (!result.success) return result;
 
+  const isSubscription = formData.get("is_subscription") === "true";
+  if (isSubscription && !result.data.destinatario_id) {
+    return { success: false, error: "Una suscripción necesita un destinatario." };
+  }
+  await upsertSubscriptionFromTemplate(
+    supabase,
+    user.id,
+    { id: result.data.id, destinatario_id: result.data.destinatario_id, currency_code: result.data.currency_code },
+    isSubscription,
+  );
+
   await ensureCurrentOccurrences();
   // Full fan-out: a new template affects charts, budgets, debt projections,
   // and account metrics — not just recurring/occurrences.
@@ -459,6 +471,17 @@ export async function updateRecurringTemplate(
     .single();
 
   if (error) return { success: false, error: error.message };
+
+  const isSubscription = formData.get("is_subscription") === "true";
+  if (isSubscription && !data.destinatario_id) {
+    return { success: false, error: "Una suscripción necesita un destinatario." };
+  }
+  await upsertSubscriptionFromTemplate(
+    supabase,
+    user.id,
+    { id: data.id, destinatario_id: data.destinatario_id, currency_code: data.currency_code },
+    isSubscription,
+  );
 
   await ensureCurrentOccurrences();
 

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -31,7 +31,8 @@ async function getSubscriptionsCached(
     .not("status", "in", "(dismissed,cancelled)")
     .order("created_at", { ascending: false });
 
-  if (error || !data) return [];
+  if (error) throw error; // surfaces to getSubscriptions() catch -> Spanish error
+  if (!data) return [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return data.map((row: any) => ({
@@ -86,13 +87,16 @@ export async function markForCancellation(
   if (!user) return { success: false, error: "No autenticado" };
   if (!subscriptionIdSchema.safeParse(id).success)
     return { success: false, error: "ID inválido" };
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("subscriptions")
     .update({ status: "marked_for_cancellation" })
     .eq("id", id)
     .eq("user_id", user.id)
-    .in("status", ["active", "trial"]);
+    .in("status", ["active", "trial"])
+    .select("id");
   if (error) return { success: false, error: error.message };
+  if (!data || data.length === 0)
+    return { success: false, error: "La suscripción no está activa" };
   updateTag("subscriptions");
   return { success: true, data: undefined };
 }
@@ -207,4 +211,5 @@ export async function upsertSubscriptionFromTemplate(
       .eq("recurring_template_id", template.id)
       .not("status", "in", "(cancelled,dismissed)");
   }
+  updateTag("subscriptions");
 }

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -166,6 +166,23 @@ export async function updateSubscription(
 }
 
 /**
+ * Returns true if there is an active (non-cancelled, non-dismissed) subscription
+ * linked to the given recurring template.
+ */
+export async function getSubscriptionForTemplate(templateId: string): Promise<boolean> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return false;
+  const { data } = await supabase
+    .from("subscriptions")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("recurring_template_id", templateId)
+    .not("status", "in", "(cancelled,dismissed)")
+    .maybeSingle();
+  return !!data;
+}
+
+/**
  * Helper called from recurring-templates.ts (Task 5).
  * NOT a form-action target.
  */

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -280,11 +280,14 @@ export async function formalizeSubscription(
   if (!sub) return { success: false, error: "Suscripción no encontrada" };
   if (sub.recurring_template_id) return { success: true, data: undefined };
 
+  // Prefer a non-debt account: an OUTFLOW subscription template on a CREDIT_CARD/LOAN
+  // would be misread as a debt payment. Fall back to any active account only if needed.
   const { data: acct } = await supabase
     .from("accounts")
     .select("id")
     .eq("user_id", user.id)
     .eq("is_active", true)
+    .not("account_type", "in", "(CREDIT_CARD,LOAN)")
     .limit(1)
     .maybeSingle();
   if (!acct)

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/validators/subscription";
 import type { ActionResult } from "@/types/actions";
 import type { SubscriptionWithDetails } from "@/types/domain";
+import { detectSubscriptions, type DetectorTransaction } from "@zeta/shared";
 
 async function getSubscriptionsCached(
   accessToken: string,
@@ -182,6 +183,58 @@ export async function getSubscriptionForTemplate(templateId: string): Promise<bo
     .not("status", "in", "(cancelled,dismissed)")
     .maybeSingle();
   return !!data;
+}
+
+/**
+ * Runs subscription auto-detection over the last 12 months of OUTFLOW transactions.
+ * Called after every PDF/email import — best-effort, failures never surface to the user.
+ * Destinatarios that already have ANY subscriptions row (any status) are excluded so
+ * dismissed/cancelled suggestions are never re-surfaced and active ones are not duplicated.
+ */
+export async function runSubscriptionDetection(): Promise<ActionResult<{ created: number }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const since = new Date();
+  since.setMonth(since.getMonth() - 12);
+
+  const { data: txs } = await supabase
+    .from("transactions")
+    .select("destinatario_id, transaction_date, amount, currency_code, direction")
+    .eq("user_id", user.id)
+    .eq("direction", "OUTFLOW")
+    .not("destinatario_id", "is", null)
+    .gte("transaction_date", since.toISOString().slice(0, 10));
+
+  // Destinatarios that already have ANY subscriptions row (any status) — never re-suggest
+  // (preserves sticky dismissal AND avoids duplicating active/cancelled ones).
+  const { data: existing } = await supabase
+    .from("subscriptions")
+    .select("destinatario_id")
+    .eq("user_id", user.id);
+  const excluded = new Set((existing ?? []).map((r) => r.destinatario_id));
+
+  const candidates = detectSubscriptions((txs ?? []) as DetectorTransaction[], excluded);
+  if (candidates.length === 0) return { success: true, data: { created: 0 } };
+
+  const rows = candidates.map((c) => ({
+    user_id: user.id,
+    destinatario_id: c.destinatario_id,
+    status: "suggested" as const,
+    estimated_amount: c.median_amount,
+    currency_code: c.currency_code,
+    detected_at: new Date().toISOString(),
+  }));
+
+  const { data: inserted, error } = await supabase
+    .from("subscriptions")
+    .insert(rows)
+    .select("id");
+  if (error && error.code !== "23505")
+    return { success: false, error: error.message };
+
+  updateTag("subscriptions");
+  return { success: true, data: { created: inserted?.length ?? 0 } };
 }
 
 /**

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -1,0 +1,210 @@
+"use server";
+
+import { cacheTag, cacheLife, updateTag } from "next/cache";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
+import { revalidateFinancialViews } from "@/lib/cache/revalidation";
+import {
+  subscriptionIdSchema,
+  updateSubscriptionSchema,
+} from "@/lib/validators/subscription";
+import type { ActionResult } from "@/types/actions";
+import type { SubscriptionWithDetails } from "@/types/domain";
+
+async function getSubscriptionsCached(
+  accessToken: string,
+  userId: string,
+): Promise<SubscriptionWithDetails[]> {
+  "use cache";
+  cacheTag("subscriptions");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data, error } = await supabase
+    .from("subscriptions")
+    .select(`
+      *,
+      destinatario:destinatarios!subscriptions_destinatario_id_fkey ( name, default_category_id ),
+      template:recurring_transaction_templates!subscriptions_recurring_template_id_fkey ( amount, frequency )
+    `)
+    .eq("user_id", userId)
+    .not("status", "in", "(dismissed,cancelled)")
+    .order("created_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return data.map((row: any) => ({
+    ...row,
+    destinatario_name: row.destinatario?.name ?? "—",
+    default_category_id: row.destinatario?.default_category_id ?? null,
+    category_name: null,
+    template_amount: row.template?.amount ?? null,
+    template_frequency: row.template?.frequency ?? null,
+    next_occurrence_date: null,
+    monthly_expected: null,
+  })) as SubscriptionWithDetails[];
+}
+
+export async function getSubscriptions(): Promise<
+  ActionResult<SubscriptionWithDetails[]>
+> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return { success: false, error: "No autenticado" };
+  try {
+    const data = await getSubscriptionsCached(accessToken, user.id);
+    return { success: true, data };
+  } catch {
+    return { success: false, error: "Error al cargar las suscripciones" };
+  }
+}
+
+export async function dismissSubscription(
+  id: string,
+): Promise<ActionResult<undefined>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success)
+    return { success: false, error: "ID inválido" };
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({
+      status: "dismissed",
+      dismissed_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true, data: undefined };
+}
+
+export async function markForCancellation(
+  id: string,
+): Promise<ActionResult<undefined>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success)
+    return { success: false, error: "ID inválido" };
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({ status: "marked_for_cancellation" })
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .in("status", ["active", "trial"]);
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true, data: undefined };
+}
+
+export async function cancelSubscription(
+  id: string,
+): Promise<ActionResult<undefined>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success)
+    return { success: false, error: "ID inválido" };
+  const { data: sub, error: readErr } = await supabase
+    .from("subscriptions")
+    .select("id, recurring_template_id")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+  if (readErr || !sub) return { success: false, error: "Suscripción no encontrada" };
+  if (sub.recurring_template_id) {
+    const { error: tErr } = await supabase
+      .from("recurring_transaction_templates")
+      .update({ is_active: false })
+      .eq("id", sub.recurring_template_id)
+      .eq("user_id", user.id);
+    if (tErr) return { success: false, error: tErr.message };
+    // DB trigger sets subscriptions.status = 'cancelled'
+  } else {
+    const { error: sErr } = await supabase
+      .from("subscriptions")
+      .update({ status: "cancelled" })
+      .eq("id", id)
+      .eq("user_id", user.id);
+    if (sErr) return { success: false, error: sErr.message };
+  }
+  updateTag("subscriptions");
+  revalidateFinancialViews();
+  return { success: true, data: undefined };
+}
+
+export async function updateSubscription(
+  id: string,
+  formData: FormData,
+): Promise<ActionResult<undefined>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success)
+    return { success: false, error: "ID inválido" };
+  const parsed = updateSubscriptionSchema.safeParse({
+    trial_ends_on: formData.get("trial_ends_on"),
+    cancel_url: formData.get("cancel_url"),
+  });
+  if (!parsed.success)
+    return { success: false, error: parsed.error.issues[0].message };
+  const status = parsed.data.trial_ends_on ? "trial" : undefined;
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({
+      trial_ends_on: parsed.data.trial_ends_on ?? null,
+      cancel_url: parsed.data.cancel_url ?? null,
+      ...(status ? { status } : {}),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+  if (error) return { success: false, error: error.message };
+  updateTag("subscriptions");
+  return { success: true, data: undefined };
+}
+
+/**
+ * Helper called from recurring-templates.ts (Task 5).
+ * NOT a form-action target.
+ */
+export async function upsertSubscriptionFromTemplate(
+  supabase: Awaited<ReturnType<typeof getAuthenticatedClient>>["supabase"],
+  userId: string,
+  template: {
+    id: string;
+    destinatario_id: string | null;
+    currency_code: string;
+  },
+  isSubscription: boolean,
+): Promise<void> {
+  if (isSubscription) {
+    if (!template.destinatario_id) return;
+    const { data: existing } = await supabase
+      .from("subscriptions")
+      .select("id, status")
+      .eq("user_id", userId)
+      .eq("destinatario_id", template.destinatario_id)
+      .not("status", "in", "(cancelled,dismissed)")
+      .maybeSingle();
+    if (existing) {
+      await supabase
+        .from("subscriptions")
+        .update({ recurring_template_id: template.id, status: "active" })
+        .eq("id", existing.id)
+        .eq("user_id", userId);
+    } else {
+      await supabase.from("subscriptions").insert({
+        user_id: userId,
+        destinatario_id: template.destinatario_id,
+        recurring_template_id: template.id,
+        status: "active",
+        currency_code: template.currency_code,
+      });
+    }
+  } else {
+    await supabase
+      .from("subscriptions")
+      .update({ status: "cancelled" })
+      .eq("user_id", userId)
+      .eq("recurring_template_id", template.id)
+      .not("status", "in", "(cancelled,dismissed)");
+  }
+}

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -9,6 +9,7 @@ import {
   updateSubscriptionSchema,
 } from "@/lib/validators/subscription";
 import { ensureCurrentOccurrences } from "@/actions/occurrences";
+import { toColombiaDateString } from "@/lib/utils/date";
 import type { ActionResult } from "@/types/actions";
 import type { SubscriptionWithDetails } from "@/types/domain";
 import type { Database } from "@/types/database";
@@ -206,7 +207,7 @@ export async function runSubscriptionDetection(): Promise<ActionResult<{ created
     .eq("user_id", user.id)
     .eq("direction", "OUTFLOW")
     .not("destinatario_id", "is", null)
-    .gte("transaction_date", since.toISOString().slice(0, 10));
+    .gte("transaction_date", toColombiaDateString(since));
 
   // Destinatarios that already have ANY subscriptions row (any status) — never re-suggest
   // (preserves sticky dismissal AND avoids duplicating active/cancelled ones).
@@ -305,8 +306,8 @@ export async function formalizeSubscription(
   }
 
   // Prefer a non-debt account: an OUTFLOW subscription template on a CREDIT_CARD/LOAN
-  // would be misread as a debt payment. Fall back to any active account only if needed.
-  const { data: acct } = await supabase
+  // would be misread as a debt payment.
+  let { data: acct } = await supabase
     .from("accounts")
     .select("id")
     .eq("user_id", user.id)
@@ -314,6 +315,17 @@ export async function formalizeSubscription(
     .not("account_type", "in", "(CREDIT_CARD,LOAN)")
     .limit(1)
     .maybeSingle();
+  // Fall back to any active account if the user only has debt accounts.
+  if (!acct) {
+    const { data: fallbackAcct } = await supabase
+      .from("accounts")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .limit(1)
+      .maybeSingle();
+    acct = fallbackAcct;
+  }
   if (!acct)
     return {
       success: false,
@@ -322,7 +334,7 @@ export async function formalizeSubscription(
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dest = sub.destinatario as any;
-  const today = new Date().toISOString().slice(0, 10);
+  const today = toColombiaDateString(new Date());
   const { data: tpl, error: tErr } = await supabase
     .from("recurring_transaction_templates")
     .insert({

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -280,6 +280,30 @@ export async function formalizeSubscription(
   if (!sub) return { success: false, error: "Suscripción no encontrada" };
   if (sub.recurring_template_id) return { success: true, data: undefined };
 
+  // If the user already has an active recurring template for this destinatario, link it
+  // instead of creating a second one (which would double the occurrence generation).
+  const { data: existingTpl } = await supabase
+    .from("recurring_transaction_templates")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("destinatario_id", sub.destinatario_id)
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+  if (existingTpl) {
+    const { error: linkExistingErr } = await supabase
+      .from("subscriptions")
+      .update({ recurring_template_id: existingTpl.id, status: "active" })
+      .eq("id", id)
+      .eq("user_id", user.id);
+    if (linkExistingErr)
+      return { success: false, error: linkExistingErr.message };
+    await ensureCurrentOccurrences();
+    updateTag("subscriptions");
+    revalidateFinancialViews();
+    return { success: true, data: undefined };
+  }
+
   // Prefer a non-debt account: an OUTFLOW subscription template on a CREDIT_CARD/LOAN
   // would be misread as a debt payment. Fall back to any active account only if needed.
   const { data: acct } = await supabase
@@ -362,13 +386,20 @@ export async function upsertSubscriptionFromTemplate(
         .eq("id", existing.id)
         .eq("user_id", userId);
     } else {
-      await supabase.from("subscriptions").insert({
+      const { error: insertErr } = await supabase.from("subscriptions").insert({
         user_id: userId,
         destinatario_id: template.destinatario_id,
         recurring_template_id: template.id,
         status: "active",
         currency_code: template.currency_code,
       });
+      // 23505 = a concurrent detection row already covers this destinatario — benign.
+      if (insertErr && insertErr.code !== "23505") {
+        console.error(
+          "[upsertSubscriptionFromTemplate] insert failed",
+          insertErr.message,
+        );
+      }
     }
   } else {
     await supabase

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -23,7 +23,9 @@ async function getSubscriptionsCached(
   const { data, error } = await supabase
     .from("subscriptions")
     .select(`
-      *,
+      id, status, recurring_template_id, estimated_amount,
+      destinatario_id, currency_code, trial_ends_on, cancel_url,
+      created_at, updated_at, detected_at, dismissed_at,
       destinatario:destinatarios!subscriptions_destinatario_id_fkey ( name, default_category_id ),
       template:recurring_transaction_templates!subscriptions_recurring_template_id_fkey ( amount, frequency )
     `)

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -8,8 +8,10 @@ import {
   subscriptionIdSchema,
   updateSubscriptionSchema,
 } from "@/lib/validators/subscription";
+import { ensureCurrentOccurrences } from "@/actions/occurrences";
 import type { ActionResult } from "@/types/actions";
 import type { SubscriptionWithDetails } from "@/types/domain";
+import type { Database } from "@/types/database";
 import { detectSubscriptions, type DetectorTransaction } from "@zeta/shared";
 
 async function getSubscriptionsCached(
@@ -235,6 +237,96 @@ export async function runSubscriptionDetection(): Promise<ActionResult<{ created
 
   updateTag("subscriptions");
   return { success: true, data: { created: inserted?.length ?? 0 } };
+}
+
+export async function confirmSubscription(
+  id: string,
+): Promise<ActionResult<undefined>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success)
+    return { success: false, error: "ID inválido" };
+  const { data, error } = await supabase
+    .from("subscriptions")
+    .update({ status: "active" })
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .eq("status", "suggested")
+    .select("id");
+  if (error) return { success: false, error: error.message };
+  if (!data || data.length === 0)
+    return { success: false, error: "La sugerencia ya no está disponible" };
+  updateTag("subscriptions");
+  return { success: true, data: undefined };
+}
+
+export async function formalizeSubscription(
+  id: string,
+): Promise<ActionResult<undefined>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+  if (!subscriptionIdSchema.safeParse(id).success)
+    return { success: false, error: "ID inválido" };
+
+  const { data: sub } = await supabase
+    .from("subscriptions")
+    .select(`
+      id, destinatario_id, estimated_amount, currency_code, recurring_template_id,
+      destinatario:destinatarios!subscriptions_destinatario_id_fkey ( name, default_category_id )
+    `)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+  if (!sub) return { success: false, error: "Suscripción no encontrada" };
+  if (sub.recurring_template_id) return { success: true, data: undefined };
+
+  const { data: acct } = await supabase
+    .from("accounts")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+  if (!acct)
+    return {
+      success: false,
+      error: "No hay una cuenta disponible para programar la suscripción",
+    };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dest = sub.destinatario as any;
+  const today = new Date().toISOString().slice(0, 10);
+  const { data: tpl, error: tErr } = await supabase
+    .from("recurring_transaction_templates")
+    .insert({
+      user_id: user.id,
+      account_id: acct.id,
+      destinatario_id: sub.destinatario_id,
+      category_id: (dest?.default_category_id ?? null) as string | null,
+      merchant_name: (dest?.name ?? "Suscripción") as string,
+      amount: sub.estimated_amount ?? 0,
+      currency_code: sub.currency_code as Database["public"]["Enums"]["currency_code"],
+      direction: "OUTFLOW" as Database["public"]["Enums"]["transaction_direction"],
+      frequency: "MONTHLY" as Database["public"]["Enums"]["recurrence_frequency"],
+      start_date: today,
+      is_active: true,
+    })
+    .select("id")
+    .single();
+  if (tErr || !tpl)
+    return { success: false, error: tErr?.message ?? "Error al crear la plantilla" };
+
+  const { error: linkErr } = await supabase
+    .from("subscriptions")
+    .update({ recurring_template_id: tpl.id, status: "active" })
+    .eq("id", id)
+    .eq("user_id", user.id);
+  if (linkErr) return { success: false, error: linkErr.message };
+
+  await ensureCurrentOccurrences();
+  updateTag("subscriptions");
+  revalidateFinancialViews();
+  return { success: true, data: undefined };
 }
 
 /**

--- a/webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx
+++ b/webapp/src/app/(dashboard)/recurrentes/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { MobileHeader } from "@/components/mobile/v2/mobile-header";
 import { RecurringForm } from "@/components/recurring/recurring-form";
 import { getRecurringTemplate } from "@/actions/recurring-templates";
+import { getSubscriptionForTemplate } from "@/actions/subscriptions";
 import { getAccounts } from "@/actions/accounts";
 import { getCategories } from "@/actions/categories";
 import { MOBILE_TAB_BAR_CLEARANCE_CLASS, PAGE_STACK_CLASS } from "@/lib/constants/styles";
@@ -13,11 +14,13 @@ export default async function EditRecurrentePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const [templateResult, accountsResult, categoriesResult] = await Promise.all([
-    getRecurringTemplate(id),
-    getAccounts(),
-    getCategories(),
-  ]);
+  const [templateResult, accountsResult, categoriesResult, isSubscription] =
+    await Promise.all([
+      getRecurringTemplate(id),
+      getAccounts(),
+      getCategories(),
+      getSubscriptionForTemplate(id),
+    ]);
 
   if (!templateResult.success) notFound();
 
@@ -35,6 +38,7 @@ export default async function EditRecurrentePage({
       <div className={cn("px-4", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
         <RecurringForm
           template={template}
+          initialIsSubscription={isSubscription}
           accounts={accounts}
           categories={categories}
         />

--- a/webapp/src/app/(dashboard)/suscripciones/page.tsx
+++ b/webapp/src/app/(dashboard)/suscripciones/page.tsx
@@ -1,0 +1,44 @@
+import { connection } from "next/server";
+import { getSubscriptions } from "@/actions/subscriptions";
+import { ensureCurrentOccurrences, getOccurrencesForMonth } from "@/actions/occurrences";
+import { getPreferredCurrency } from "@/actions/profile";
+import { SubscriptionsView } from "@/components/subscriptions/subscriptions-view";
+
+export default async function SuscripcionesPage() {
+  await connection();
+  await ensureCurrentOccurrences();
+
+  const [subsRes, occRes, currency] = await Promise.all([
+    getSubscriptions(),
+    getOccurrencesForMonth(),
+    getPreferredCurrency(),
+  ]);
+
+  const subs = subsRes.success ? subsRes.data : [];
+  const occurrences = occRes.success ? occRes.data : [];
+
+  const subTemplateIds = new Set(
+    subs.map((s) => s.recurring_template_id).filter(Boolean) as string[],
+  );
+
+  const authoritativeMonthly = occurrences
+    .filter((o) => subTemplateIds.has(o.template_id) && o.direction === "OUTFLOW")
+    .reduce((sum, o) => sum + o.expected_amount, 0);
+
+  const estimatedMonthly = subs
+    .filter((s) => !s.recurring_template_id && s.estimated_amount)
+    .reduce((sum, s) => sum + (s.estimated_amount ?? 0), 0);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold text-z-sage-light">Suscripciones</h1>
+      <SubscriptionsView
+        subscriptions={subs}
+        occurrences={occurrences}
+        authoritativeMonthly={authoritativeMonthly}
+        estimatedMonthly={estimatedMonthly}
+        currency={currency}
+      />
+    </div>
+  );
+}

--- a/webapp/src/app/(dashboard)/suscripciones/page.tsx
+++ b/webapp/src/app/(dashboard)/suscripciones/page.tsx
@@ -31,7 +31,9 @@ export default async function SuscripcionesPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold text-z-sage-light">Suscripciones</h1>
+      <h1 className="text-2xl font-semibold tracking-tight text-z-sage-light lg:text-3xl">
+        Suscripciones
+      </h1>
       <SubscriptionsView
         subscriptions={subs}
         occurrences={occurrences}

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BRASS_BUTTON_CLASS, BRASS_GHOST_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
@@ -50,6 +51,7 @@ export function RecurringForm({
   accounts,
   categories,
   onSuccess,
+  initialIsSubscription,
 }: {
   template?: RecurringTemplate;
   /** Seed state when creating a new template with known data (e.g. promoting a transaction). Ignored when `template` is present. */
@@ -61,6 +63,8 @@ export function RecurringForm({
   /** Called with the saved template on success. Receives undefined when the
    * action succeeded but didn't return the row (legacy actions). */
   onSuccess?: (template: RecurringTemplate | undefined) => void;
+  /** Whether this template is currently tracked as a subscription. Seeded by the edit page. */
+  initialIsSubscription?: boolean;
 }) {
   const action = template
     ? updateRecurringTemplate.bind(null, template.id)
@@ -71,6 +75,9 @@ export function RecurringForm({
     FormData
   >(
     async (prevState, formData) => {
+      if (formData.get("is_subscription") === "true" && !destinatarioId) {
+        return { success: false, error: "Una suscripción necesita un destinatario." };
+      }
       const result = await action(prevState, formData);
       if (result.success) onSuccess?.(result.data);
       return result;
@@ -99,6 +106,7 @@ export function RecurringForm({
   const [destinatarioId, setDestinatarioId] = useState<string | null>(
     seed?.destinatario_id ?? null
   );
+  const [isSubscription, setIsSubscription] = useState(initialIsSubscription ?? false);
   const [frequency, setFrequency] = useState<string>(
     seed?.frequency ?? "MONTHLY"
   );
@@ -502,6 +510,15 @@ export function RecurringForm({
           Al pagar, la matcher anclará al destinatario antes de comparar por monto — evita que una transferencia del mismo valor se vincule por error.
         </p>
       </div>
+
+      <div className="flex items-center justify-between rounded-lg border border-white/6 bg-z-surface-2 px-3 py-2.5">
+        <div className="space-y-0.5">
+          <Label htmlFor="is_subscription_toggle" className="text-z-sage-light">Es una suscripción</Label>
+          <p className="text-xs text-z-sage-light/60">Spotify, streaming, apps — opcional y cancelable.</p>
+        </div>
+        <Switch id="is_subscription_toggle" checked={isSubscription} onCheckedChange={setIsSubscription} />
+      </div>
+      <input type="hidden" name="is_subscription" value={isSubscription ? "true" : "false"} />
 
       <div className="space-y-2">
         <Label htmlFor="description">Notas</Label>

--- a/webapp/src/components/recurring/recurring-form.tsx
+++ b/webapp/src/components/recurring/recurring-form.tsx
@@ -511,7 +511,7 @@ export function RecurringForm({
         </p>
       </div>
 
-      <div className="flex items-center justify-between rounded-lg border border-white/6 bg-z-surface-2 px-3 py-2.5">
+      <div className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2 px-3 py-2.5">
         <div className="space-y-0.5">
           <Label htmlFor="is_subscription_toggle" className="text-z-sage-light">Es una suscripción</Label>
           <p className="text-xs text-z-sage-light/60">Spotify, streaming, apps — opcional y cancelable.</p>

--- a/webapp/src/components/subscriptions/subscription-row.tsx
+++ b/webapp/src/components/subscriptions/subscription-row.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { cancelSubscription, markForCancellation } from "@/actions/subscriptions";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatDate } from "@/lib/utils/date";
+import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
+
+interface SubscriptionRowProps {
+  subscription: SubscriptionWithDetails;
+  currency: CurrencyCode;
+  nextDate: string | null;
+}
+
+export function SubscriptionRow({
+  subscription: s,
+  currency,
+  nextDate,
+}: SubscriptionRowProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  const amount = s.template_amount ?? s.estimated_amount ?? 0;
+
+  const run = (fn: () => Promise<unknown>) =>
+    start(async () => {
+      await fn();
+      router.refresh();
+    });
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-white/6 bg-z-surface-2 p-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium text-z-sage-light">{s.destinatario_name}</span>
+          {!s.recurring_template_id && (
+            <Badge variant="outline">estimado</Badge>
+          )}
+          {s.status === "marked_for_cancellation" && (
+            <Badge variant="outline">por cancelar</Badge>
+          )}
+          {s.status === "trial" && (
+            <Badge variant="outline">prueba</Badge>
+          )}
+        </div>
+        <p className="text-sm text-z-sage-light/60">
+          {formatCurrency(amount, currency)}
+          {nextDate ? ` · próx. ${formatDate(nextDate)}` : ""}
+        </p>
+      </div>
+
+      <div className="ml-3 flex shrink-0 gap-3">
+        {s.status !== "marked_for_cancellation" && (
+          <button
+            disabled={pending}
+            onClick={() => run(() => markForCancellation(s.id))}
+            className="text-xs text-z-sage-light/70 hover:text-z-sage-light disabled:opacity-50"
+          >
+            Marcar
+          </button>
+        )}
+        <button
+          disabled={pending}
+          onClick={() => run(() => cancelSubscription(s.id))}
+          className="text-xs text-z-expense hover:underline disabled:opacity-50"
+        >
+          Cancelar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/subscriptions/subscription-row.tsx
+++ b/webapp/src/components/subscriptions/subscription-row.tsx
@@ -6,6 +6,11 @@ import { Badge } from "@/components/ui/badge";
 import { cancelSubscription, markForCancellation } from "@/actions/subscriptions";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
+import { cn } from "@/lib/utils";
+import {
+  GHOST_BUTTON_CLASS,
+  DESTRUCTIVE_GHOST_BUTTON_CLASS,
+} from "@/lib/constants/styles";
 import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
 
 interface SubscriptionRowProps {
@@ -13,6 +18,9 @@ interface SubscriptionRowProps {
   currency: CurrencyCode;
   nextDate: string | null;
 }
+
+const ROW_ACTION_CLASS =
+  "rounded-lg border px-2.5 py-1 text-xs transition-colors disabled:opacity-50";
 
 export function SubscriptionRow({
   subscription: s,
@@ -31,7 +39,7 @@ export function SubscriptionRow({
     });
 
   return (
-    <div className="flex items-center justify-between rounded-lg border border-white/6 bg-z-surface-2 p-3">
+    <div className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2 px-3 py-2.5">
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-medium text-z-sage-light">{s.destinatario_name}</span>
@@ -39,24 +47,28 @@ export function SubscriptionRow({
             <Badge variant="outline">estimado</Badge>
           )}
           {s.status === "marked_for_cancellation" && (
-            <Badge variant="outline">por cancelar</Badge>
+            <Badge variant="outline" className="surface-expense">
+              por cancelar
+            </Badge>
           )}
           {s.status === "trial" && (
-            <Badge variant="outline">prueba</Badge>
+            <Badge variant="outline" className="surface-alert">
+              prueba
+            </Badge>
           )}
         </div>
-        <p className="text-sm text-z-sage-light/60">
+        <p className="text-sm tabular-nums text-z-sage-light/60">
           {formatCurrency(amount, currency)}
           {nextDate ? ` · próx. ${formatDate(nextDate)}` : ""}
         </p>
       </div>
 
-      <div className="ml-3 flex shrink-0 gap-3">
+      <div className="ml-3 flex shrink-0 gap-2">
         {s.status !== "marked_for_cancellation" && (
           <button
             disabled={pending}
             onClick={() => run(() => markForCancellation(s.id))}
-            className="text-xs text-z-sage-light/70 hover:text-z-sage-light disabled:opacity-50"
+            className={cn(ROW_ACTION_CLASS, GHOST_BUTTON_CLASS)}
           >
             Marcar
           </button>
@@ -64,7 +76,7 @@ export function SubscriptionRow({
         <button
           disabled={pending}
           onClick={() => run(() => cancelSubscription(s.id))}
-          className="text-xs text-z-expense hover:underline disabled:opacity-50"
+          className={cn(ROW_ACTION_CLASS, DESTRUCTIVE_GHOST_BUTTON_CLASS)}
         >
           Cancelar
         </button>

--- a/webapp/src/components/subscriptions/subscription-row.tsx
+++ b/webapp/src/components/subscriptions/subscription-row.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { cancelSubscription, markForCancellation } from "@/actions/subscriptions";
 import { formatCurrency } from "@/lib/utils/currency";
@@ -11,6 +9,7 @@ import {
   GHOST_BUTTON_CLASS,
   DESTRUCTIVE_GHOST_BUTTON_CLASS,
 } from "@/lib/constants/styles";
+import { ROW_ACTION_CLASS, useRowAction } from "./use-row-action";
 import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
 
 interface SubscriptionRowProps {
@@ -19,24 +18,14 @@ interface SubscriptionRowProps {
   nextDate: string | null;
 }
 
-const ROW_ACTION_CLASS =
-  "rounded-lg border px-2.5 py-1 text-xs transition-colors disabled:opacity-50";
-
 export function SubscriptionRow({
   subscription: s,
   currency,
   nextDate,
 }: SubscriptionRowProps) {
-  const router = useRouter();
-  const [pending, start] = useTransition();
+  const { pending, run } = useRowAction();
 
   const amount = s.template_amount ?? s.estimated_amount ?? 0;
-
-  const run = (fn: () => Promise<unknown>) =>
-    start(async () => {
-      await fn();
-      router.refresh();
-    });
 
   return (
     <div className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2 px-3 py-2.5">

--- a/webapp/src/components/subscriptions/subscription-suggestions.tsx
+++ b/webapp/src/components/subscriptions/subscription-suggestions.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { confirmSubscription, dismissSubscription } from "@/actions/subscriptions";
+import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
+
+interface SubscriptionSuggestionsProps {
+  suggestions: SubscriptionWithDetails[];
+  currency: CurrencyCode;
+}
+
+const ROW_ACTION_CLASS =
+  "rounded-lg border px-2.5 py-1 text-xs transition-colors disabled:opacity-50";
+
+const MUTED_GHOST_CLASS =
+  "border-white/6 bg-black/10 text-z-sage-light/50 hover:bg-white/5 hover:text-z-sage-light/70";
+
+export function SubscriptionSuggestions({
+  suggestions,
+  currency,
+}: SubscriptionSuggestionsProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  if (suggestions.length === 0) return null;
+
+  const run = (fn: () => Promise<unknown>) =>
+    start(async () => {
+      await fn();
+      router.refresh();
+    });
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-medium uppercase tracking-wider text-z-sage-light/50">
+        Sugerencias
+      </p>
+      {suggestions.map((s) => (
+        <div
+          key={s.id}
+          className="flex items-center justify-between rounded-xl border border-white/6 bg-z-surface-2 px-3 py-2.5"
+        >
+          <div className="min-w-0 flex-1">
+            <span className="font-medium text-z-sage-light">{s.destinatario_name}</span>
+            <p className="text-sm tabular-nums text-z-sage-light/60">
+              {formatCurrency(s.estimated_amount ?? 0, currency)}
+              {" · "}
+              <span className="text-z-sage-light/40">Parece una suscripción</span>
+            </p>
+          </div>
+
+          <div className="ml-3 flex shrink-0 gap-2">
+            <button
+              disabled={pending}
+              onClick={() => run(() => confirmSubscription(s.id))}
+              className={cn(ROW_ACTION_CLASS, GHOST_BUTTON_CLASS)}
+            >
+              Rastrear
+            </button>
+            <button
+              disabled={pending}
+              onClick={() => run(() => dismissSubscription(s.id))}
+              className={cn(ROW_ACTION_CLASS, MUTED_GHOST_CLASS)}
+            >
+              Descartar
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/subscriptions/subscription-suggestions.tsx
+++ b/webapp/src/components/subscriptions/subscription-suggestions.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import {
@@ -10,6 +8,7 @@ import {
   SECTION_EYEBROW_CLASS,
 } from "@/lib/constants/styles";
 import { confirmSubscription, dismissSubscription } from "@/actions/subscriptions";
+import { ROW_ACTION_CLASS, useRowAction } from "./use-row-action";
 import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
 
 interface SubscriptionSuggestionsProps {
@@ -17,23 +16,13 @@ interface SubscriptionSuggestionsProps {
   currency: CurrencyCode;
 }
 
-const ROW_ACTION_CLASS =
-  "rounded-lg border px-2.5 py-1 text-xs transition-colors disabled:opacity-50";
-
 export function SubscriptionSuggestions({
   suggestions,
   currency,
 }: SubscriptionSuggestionsProps) {
-  const router = useRouter();
-  const [pending, start] = useTransition();
+  const { pending, run } = useRowAction();
 
   if (suggestions.length === 0) return null;
-
-  const run = (fn: () => Promise<unknown>) =>
-    start(async () => {
-      await fn();
-      router.refresh();
-    });
 
   return (
     <div className="space-y-2">

--- a/webapp/src/components/subscriptions/subscription-suggestions.tsx
+++ b/webapp/src/components/subscriptions/subscription-suggestions.tsx
@@ -4,7 +4,11 @@ import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import {
+  GHOST_BUTTON_CLASS,
+  BRASS_GHOST_BUTTON_CLASS,
+  SECTION_EYEBROW_CLASS,
+} from "@/lib/constants/styles";
 import { confirmSubscription, dismissSubscription } from "@/actions/subscriptions";
 import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
 
@@ -15,9 +19,6 @@ interface SubscriptionSuggestionsProps {
 
 const ROW_ACTION_CLASS =
   "rounded-lg border px-2.5 py-1 text-xs transition-colors disabled:opacity-50";
-
-const MUTED_GHOST_CLASS =
-  "border-white/6 bg-black/10 text-z-sage-light/50 hover:bg-white/5 hover:text-z-sage-light/70";
 
 export function SubscriptionSuggestions({
   suggestions,
@@ -36,9 +37,7 @@ export function SubscriptionSuggestions({
 
   return (
     <div className="space-y-2">
-      <p className="text-xs font-medium uppercase tracking-wider text-z-sage-light/50">
-        Sugerencias
-      </p>
+      <p className={SECTION_EYEBROW_CLASS}>Sugerencias</p>
       {suggestions.map((s) => (
         <div
           key={s.id}
@@ -49,7 +48,7 @@ export function SubscriptionSuggestions({
             <p className="text-sm tabular-nums text-z-sage-light/60">
               {formatCurrency(s.estimated_amount ?? 0, currency)}
               {" · "}
-              <span className="text-z-sage-light/40">Parece una suscripción</span>
+              <span className="text-z-sage-dark">Parece una suscripción</span>
             </p>
           </div>
 
@@ -57,14 +56,14 @@ export function SubscriptionSuggestions({
             <button
               disabled={pending}
               onClick={() => run(() => confirmSubscription(s.id))}
-              className={cn(ROW_ACTION_CLASS, GHOST_BUTTON_CLASS)}
+              className={cn(ROW_ACTION_CLASS, BRASS_GHOST_BUTTON_CLASS)}
             >
               Rastrear
             </button>
             <button
               disabled={pending}
               onClick={() => run(() => dismissSubscription(s.id))}
-              className={cn(ROW_ACTION_CLASS, MUTED_GHOST_CLASS)}
+              className={cn(ROW_ACTION_CLASS, GHOST_BUTTON_CLASS)}
             >
               Descartar
             </button>

--- a/webapp/src/components/subscriptions/subscriptions-view.tsx
+++ b/webapp/src/components/subscriptions/subscriptions-view.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/constants/styles";
 import { cn } from "@/lib/utils";
 import { SubscriptionRow } from "./subscription-row";
+import { SubscriptionSuggestions } from "./subscription-suggestions";
 import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
 import type { RecurringOccurrence } from "@/actions/occurrences";
 
@@ -32,6 +33,7 @@ export function SubscriptionsView({
     }
   }
 
+  const suggested = subscriptions.filter((s) => s.status === "suggested");
   const tracked = subscriptions.filter((s) => s.status !== "suggested");
 
   return (
@@ -50,6 +52,10 @@ export function SubscriptionsView({
           </p>
         )}
       </div>
+
+      {suggested.length > 0 && (
+        <SubscriptionSuggestions suggestions={suggested} currency={currency} />
+      )}
 
       <div className="space-y-2">
         {tracked.map((s) => (

--- a/webapp/src/components/subscriptions/subscriptions-view.tsx
+++ b/webapp/src/components/subscriptions/subscriptions-view.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils/currency";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { SubscriptionRow } from "./subscription-row";
+import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
+import type { RecurringOccurrence } from "@/actions/occurrences";
+
+interface SubscriptionsViewProps {
+  subscriptions: SubscriptionWithDetails[];
+  occurrences: RecurringOccurrence[];
+  authoritativeMonthly: number;
+  estimatedMonthly: number;
+  currency: CurrencyCode;
+}
+
+export function SubscriptionsView({
+  subscriptions,
+  occurrences,
+  authoritativeMonthly,
+  estimatedMonthly,
+  currency,
+}: SubscriptionsViewProps) {
+  const nextByTemplate = new Map<string, string>();
+  for (const o of occurrences) {
+    if (o.status === "pending" && !nextByTemplate.has(o.template_id)) {
+      nextByTemplate.set(o.template_id, o.occurrence_date);
+    }
+  }
+
+  const tracked = subscriptions.filter((s) => s.status !== "suggested");
+
+  return (
+    <div className={`space-y-4 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
+      <Card className="p-5">
+        <p className="text-sm text-z-sage-light/70">Gasto mensual en suscripciones</p>
+        <p className="text-3xl font-semibold text-z-sage-light">
+          {formatCurrency(authoritativeMonthly, currency)}
+        </p>
+        <p className="text-sm text-z-sage-light/60">
+          {formatCurrency(authoritativeMonthly * 12, currency)} al año
+        </p>
+        {estimatedMonthly > 0 && (
+          <p className="mt-1 text-xs text-z-sage-light/50">
+            + {formatCurrency(estimatedMonthly, currency)}/mes estimado (sin programar)
+          </p>
+        )}
+      </Card>
+
+      <div className="space-y-2">
+        {tracked.map((s) => (
+          <SubscriptionRow
+            key={s.id}
+            subscription={s}
+            currency={currency}
+            nextDate={
+              s.recurring_template_id
+                ? (nextByTemplate.get(s.recurring_template_id) ?? null)
+                : null
+            }
+          />
+        ))}
+        {tracked.length === 0 && (
+          <p className="py-8 text-center text-sm text-z-sage-light/60">
+            No tienes suscripciones registradas todavía.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/subscriptions/subscriptions-view.tsx
+++ b/webapp/src/components/subscriptions/subscriptions-view.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { Card } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/utils/currency";
-import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import {
+  MOBILE_TAB_BAR_CLEARANCE_CLASS,
+  PANEL_SURFACE_CLASS,
+} from "@/lib/constants/styles";
+import { cn } from "@/lib/utils";
 import { SubscriptionRow } from "./subscription-row";
 import type { SubscriptionWithDetails, CurrencyCode } from "@/types/domain";
 import type { RecurringOccurrence } from "@/actions/occurrences";
@@ -33,20 +36,20 @@ export function SubscriptionsView({
 
   return (
     <div className={`space-y-4 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
-      <Card className="p-5">
+      <div className={cn(PANEL_SURFACE_CLASS, "p-5")}>
         <p className="text-sm text-z-sage-light/70">Gasto mensual en suscripciones</p>
-        <p className="text-3xl font-semibold text-z-sage-light">
+        <p className="text-3xl font-semibold tabular-nums text-z-sage-light">
           {formatCurrency(authoritativeMonthly, currency)}
         </p>
-        <p className="text-sm text-z-sage-light/60">
+        <p className="text-sm tabular-nums text-z-sage-light/60">
           {formatCurrency(authoritativeMonthly * 12, currency)} al año
         </p>
         {estimatedMonthly > 0 && (
-          <p className="mt-1 text-xs text-z-sage-light/50">
+          <p className="mt-1 text-xs tabular-nums text-z-sage-light/50">
             + {formatCurrency(estimatedMonthly, currency)}/mes estimado (sin programar)
           </p>
         )}
-      </Card>
+      </div>
 
       <div className="space-y-2">
         {tracked.map((s) => (

--- a/webapp/src/components/subscriptions/use-row-action.ts
+++ b/webapp/src/components/subscriptions/use-row-action.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+/** Shared styling for the small inline action buttons on subscription rows. */
+export const ROW_ACTION_CLASS =
+  "rounded-lg border px-2.5 py-1 text-xs transition-colors disabled:opacity-50";
+
+interface RowAction {
+  pending: boolean;
+  run: (fn: () => Promise<{ success: boolean; error?: string }>) => void;
+}
+
+/**
+ * Runs a subscription action inside a transition: shows a toast on failure,
+ * refreshes the route on success. Shared by subscription-row and
+ * subscription-suggestions.
+ */
+export function useRowAction(): RowAction {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function run(fn: () => Promise<{ success: boolean; error?: string }>): void {
+    start(async () => {
+      const res = await fn();
+      if (!res.success) {
+        toast.error(res.error ?? "Ocurrió un error");
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return { pending, run };
+}

--- a/webapp/src/lib/validators/subscription.ts
+++ b/webapp/src/lib/validators/subscription.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const updateSubscriptionSchema = z.object({
+  trial_ends_on: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  ),
+  cancel_url: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().url().optional(),
+  ),
+});
+
+export const subscriptionIdSchema = z.string().regex(UUID, "ID inválido");

--- a/webapp/src/lib/validators/subscription.ts
+++ b/webapp/src/lib/validators/subscription.ts
@@ -9,7 +9,7 @@ export const updateSubscriptionSchema = z.object({
   ),
   cancel_url: z.preprocess(
     (v) => (v === "" || v == null ? undefined : v),
-    z.string().url().optional(),
+    z.url().optional(),
   ),
 });
 

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -2578,6 +2578,83 @@ export type Database = {
           },
         ]
       }
+      subscriptions: {
+        Row: {
+          cancel_url: string | null
+          created_at: string
+          currency_code: string
+          destinatario_id: string
+          detected_at: string | null
+          dismissed_at: string | null
+          estimated_amount: number | null
+          id: string
+          recurring_template_id: string | null
+          status: Database["public"]["Enums"]["subscription_status"]
+          trial_ends_on: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          cancel_url?: string | null
+          created_at?: string
+          currency_code?: string
+          destinatario_id: string
+          detected_at?: string | null
+          dismissed_at?: string | null
+          estimated_amount?: number | null
+          id?: string
+          recurring_template_id?: string | null
+          status?: Database["public"]["Enums"]["subscription_status"]
+          trial_ends_on?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          cancel_url?: string | null
+          created_at?: string
+          currency_code?: string
+          destinatario_id?: string
+          detected_at?: string | null
+          dismissed_at?: string | null
+          estimated_amount?: number | null
+          id?: string
+          recurring_template_id?: string | null
+          status?: Database["public"]["Enums"]["subscription_status"]
+          trial_ends_on?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "subscriptions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "subscriptions_destinatario_id_fkey"
+            columns: ["destinatario_id"]
+            isOneToOne: false
+            referencedRelation: "destinatarios_enc"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "subscriptions_recurring_template_id_fkey"
+            columns: ["recurring_template_id"]
+            isOneToOne: false
+            referencedRelation: "recurring_transaction_templates"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "subscriptions_recurring_template_id_fkey"
+            columns: ["recurring_template_id"]
+            isOneToOne: false
+            referencedRelation: "recurring_transaction_templates_enc"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tag_groups: {
         Row: {
           color: string | null
@@ -3638,6 +3715,13 @@ export type Database = {
       nav_focus: "PLAN" | "DEBT"
       transaction_direction: "INFLOW" | "OUTFLOW"
       transaction_status: "PENDING" | "POSTED" | "CANCELLED"
+      subscription_status:
+        | "suggested"
+        | "active"
+        | "trial"
+        | "marked_for_cancellation"
+        | "cancelled"
+        | "dismissed"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -3816,6 +3900,14 @@ export const Constants = {
       occurrence_status: ["pending", "paid", "skipped"],
       transaction_direction: ["INFLOW", "OUTFLOW"],
       transaction_status: ["PENDING", "POSTED", "CANCELLED"],
+      subscription_status: [
+        "suggested",
+        "active",
+        "trial",
+        "marked_for_cancellation",
+        "cancelled",
+        "dismissed",
+      ],
     },
   },
 } as const

--- a/webapp/src/types/domain.ts
+++ b/webapp/src/types/domain.ts
@@ -42,6 +42,19 @@ export type PendingEmailStatement = Tables<"pending_email_statements">;
 export type WishlistItem = Tables<"wishlist_items">;
 export type WishlistReflection = Tables<"wishlist_reflections">;
 
+export type Subscription = Tables<"subscriptions">;
+export type SubscriptionStatus = Enums<"subscription_status">;
+
+export type SubscriptionWithDetails = Subscription & {
+  destinatario_name: string;
+  default_category_id: string | null;
+  category_name: string | null;
+  template_amount: number | null;
+  template_frequency: string | null;
+  next_occurrence_date: string | null;
+  monthly_expected: number | null;
+};
+
 // Cashflow planner
 export type PlanningPeriodPreset = "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "CUSTOM";
 export type PlanningEntryType = "INCOME" | "EXPENSE";


### PR DESCRIPTION
## What

Makes **subscriptions** (Spotify, streaming, SaaS) a first-class, reviewable "what can I cut?" concept — distinct from essential recurring obligations. Architecture **B′ (destinatario-anchored)**: a subscription is a row in a new `subscriptions` table, 1:1-live per destinatario, with an optional link to a recurring template for billing. Recognition reuses the existing multi-pattern destinatario engine; totals come from `recurring_occurrences` when a template is linked (authoritative), else a labeled `estimado`.

- Spec: `docs/superpowers/specs/2026-05-27-subscriptions-design.md`
- Plan: `docs/superpowers/plans/2026-05-27-subscriptions.md`

## Changes

- **DB**: `subscriptions` table (plain — `destinatario_id` FK to `destinatarios_enc` already protects merchant identity), enum, RLS, cancel-drift trigger (kept in sync across web/mobile/direct edits), one-shot backfill of existing Suscripciones-categorized templates. Trigger hardened against a partial-unique reactivation edge case + `user_id` scoping.
- **Actions** (`actions/subscriptions.ts`): cached read; dismiss / mark-for-cancellation / cancel / update; confirm / formalize; `runSubscriptionDetection`; `upsertSubscriptionFromTemplate` helper.
- **Recurring form**: "Es una suscripción" toggle wired into create/update (requires a destinatario, both client + server guarded).
- **`/suscripciones` page**: occurrence-based monthly/annual total + separate estimado line, tracked list with row actions, auto-detected suggestions section (Rastrear / Descartar).
- **Detector** (`@zeta/shared/subscription-detector`): deterministic, no AI — groups by `destinatario_id`, monthly cadence (28–34d) + stable amount (±10%) + ≥3 occurrences; annual/quarterly are manual-only. 6 unit tests.
- **Import hook**: best-effort detection after `importTransactions()`.
- **Mobile**: read-only SQLite sync mirror (schema v15, pull, repository).

## Review gates (all passed)

supabase-migrator · server-action-reviewer · import-flow-doctor · recurring-doctor · zetas-front-guy ×2 · perf-auditor · mobile-sync-doctor · final integration review (3 fixes applied: link-existing-template on formalize, surface upsert insert errors, trigger reactivation guard).

## Verification

- `pnpm build` (webapp) — clean
- `@zeta/shared` detector tests — 6/6 green
- `pnpm audit --audit-level high` — 0 high/critical
- Dry-merge vs `main` — clean
- DB migrations pushed to `tgkhaxipfgskxydotdtu`

> Note: pre-existing `auto-categorize`/`debt-stats` test failures on `main` are unrelated (those files are byte-identical to main).

## Deferred (BACKLOG.md)

- Task 10: no-destinatario detection fallback nudge
- Mobile subscriptions write-path prep (NOT NULL currency, push registration, local unique guard)
- Phase 3 (separate spec): trial-end alerts, price-increase detection, cancel-flow UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)