### PR TITLE
feat(subscriptions): allow multiple subscriptions per destinatario

### DIFF
--- a/supabase/migrations/20260527180000_allow_multiple_subscriptions_per_destinatario.sql
+++ b/supabase/migrations/20260527180000_allow_multiple_subscriptions_per_destinatario.sql
@@ -1,0 +1,98 @@
+-- ============================================================================
+-- Allow multiple LIVE subscriptions per destinatario
+--
+-- Some merchants bill several distinct products under one identical statement
+-- descriptor (e.g. Google Play: "GOOGLE *PLAY YOUTUBE" for YouTube Premium,
+-- Google One, in-app subscriptions, ...). The destinatario matcher is purely
+-- text-based, so all of these necessarily collapse to ONE "Google Play"
+-- destinatario. Each product is still its own recurring template (different
+-- amount), so the natural uniqueness anchor for a subscription is the
+-- recurring template, NOT the destinatario.
+--
+-- This migration relaxes the one-live-per-destinatario rule to one-live-per-
+-- template, while keeping auto-detection's "one suggestion per merchant"
+-- invariant (the detector groups by destinatario and cannot tell products
+-- apart). The cancel-drift reactivation guard is re-scoped from destinatario
+-- to template to match the new index.
+--
+-- Data safety: the OLD index already guaranteed at most one live row per
+-- destinatario, and a template maps to exactly one destinatario, so no
+-- existing rows can violate the new per-template index. No data backfill.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1. Replace the per-destinatario live index with a per-template live index.
+--    recurring_template_id IS NULL rows (freshly detected suggestions that
+--    haven't been formalized) are intentionally excluded — their uniqueness
+--    is handled by the suggestion index below.
+-- ----------------------------------------------------------------------------
+DROP INDEX IF EXISTS subscriptions_one_live_per_destinatario;
+
+CREATE UNIQUE INDEX subscriptions_one_live_per_template
+  ON public.subscriptions (user_id, recurring_template_id)
+  WHERE status NOT IN ('cancelled', 'dismissed')
+    AND recurring_template_id IS NOT NULL;
+
+-- ----------------------------------------------------------------------------
+-- 2. Preserve "at most one open auto-suggestion per merchant".
+--    Detection (runSubscriptionDetection) already dedups by destinatario in
+--    app code; this index keeps that invariant at the DB level so concurrent
+--    detection runs can't produce duplicate suggestions for the same merchant.
+--    Only 'suggested' rows participate — once confirmed/linked they move out
+--    of this partial set and the per-template index takes over.
+-- ----------------------------------------------------------------------------
+CREATE UNIQUE INDEX subscriptions_one_suggestion_per_destinatario
+  ON public.subscriptions (user_id, destinatario_id)
+  WHERE status = 'suggested';
+
+-- ----------------------------------------------------------------------------
+-- 3. Re-scope the cancel-drift reactivation guard from destinatario to
+--    template.
+--
+--    Under the old per-destinatario index the guard blocked reactivation when
+--    ANY other live sub shared the destinatario. With multiple subs per
+--    destinatario now allowed, that would WRONGLY block reactivating template
+--    A's sub just because template B (same merchant) is live. The correct
+--    guard is per-template, mirroring the new unique index.
+--
+--    Reactivation now targets the single most-recently-cancelled sub for the
+--    template, and only if no live sub already exists for that template — so
+--    accumulated cancelled rows (from repeated flag/unflag cycles) can never
+--    produce two live rows and trip the unique index.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.sync_subscription_on_template_active_change()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+    IF NEW.is_active = false THEN
+      UPDATE subscriptions
+        SET status = 'cancelled', updated_at = now()
+        WHERE recurring_template_id = NEW.id
+          AND user_id = NEW.user_id
+          AND status NOT IN ('cancelled', 'dismissed');
+    ELSE
+      UPDATE subscriptions
+        SET status = 'active', updated_at = now()
+        WHERE id = (
+          SELECT id FROM subscriptions
+          WHERE recurring_template_id = NEW.id
+            AND user_id = NEW.user_id
+            AND status = 'cancelled'
+          ORDER BY updated_at DESC, created_at DESC
+          LIMIT 1
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM subscriptions x
+          WHERE x.user_id = NEW.user_id
+            AND x.recurring_template_id = NEW.id
+            AND x.status NOT IN ('cancelled', 'dismissed')
+        );
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMIT;

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -283,14 +283,28 @@ export async function formalizeSubscription(
 
   // If the user already has an active recurring template for this destinatario, link it
   // instead of creating a second one (which would double the occurrence generation).
-  const { data: existingTpl } = await supabase
+  // Skip templates that already back a live subscription — a merchant can have
+  // several subscriptions, but each is anchored to a distinct template, so
+  // re-using one would collide with subscriptions_one_live_per_template.
+  const { data: liveSubs } = await supabase
+    .from("subscriptions")
+    .select("recurring_template_id")
+    .eq("user_id", user.id)
+    .eq("destinatario_id", sub.destinatario_id)
+    .not("recurring_template_id", "is", null)
+    .not("status", "in", "(cancelled,dismissed)");
+  const usedTemplateIds = new Set(
+    (liveSubs ?? []).map((r) => r.recurring_template_id),
+  );
+  const { data: activeTpls } = await supabase
     .from("recurring_transaction_templates")
     .select("id")
     .eq("user_id", user.id)
     .eq("destinatario_id", sub.destinatario_id)
-    .eq("is_active", true)
-    .limit(1)
-    .maybeSingle();
+    .eq("is_active", true);
+  const existingTpl = (activeTpls ?? []).find(
+    (t) => !usedTemplateIds.has(t.id),
+  );
   if (existingTpl) {
     const { error: linkExistingErr } = await supabase
       .from("subscriptions")
@@ -384,33 +398,62 @@ export async function upsertSubscriptionFromTemplate(
 ): Promise<void> {
   if (isSubscription) {
     if (!template.destinatario_id) return;
-    const { data: existing } = await supabase
+
+    // A subscription is anchored to its recurring template, not the merchant —
+    // one merchant (destinatario) can bill several distinct products, each its
+    // own template + subscription (e.g. Google Play: YouTube Premium + One).
+
+    // 1. This template already has a live subscription — keep it active.
+    const { data: byTemplate } = await supabase
       .from("subscriptions")
-      .select("id, status")
+      .select("id")
       .eq("user_id", userId)
-      .eq("destinatario_id", template.destinatario_id)
+      .eq("recurring_template_id", template.id)
       .not("status", "in", "(cancelled,dismissed)")
       .maybeSingle();
-    if (existing) {
+    if (byTemplate) {
       await supabase
         .from("subscriptions")
-        .update({ recurring_template_id: template.id, status: "active" })
-        .eq("id", existing.id)
+        .update({ status: "active" })
+        .eq("id", byTemplate.id)
         .eq("user_id", userId);
     } else {
-      const { error: insertErr } = await supabase.from("subscriptions").insert({
-        user_id: userId,
-        destinatario_id: template.destinatario_id,
-        recurring_template_id: template.id,
-        status: "active",
-        currency_code: template.currency_code,
-      });
-      // 23505 = a concurrent detection row already covers this destinatario — benign.
-      if (insertErr && insertErr.code !== "23505") {
-        console.error(
-          "[upsertSubscriptionFromTemplate] insert failed",
-          insertErr.message,
-        );
+      // 2. Adopt an un-linked detection suggestion for this merchant (if any)
+      //    so a detected charge becomes this template's subscription instead of
+      //    leaving a duplicate suggestion behind.
+      const { data: orphan } = await supabase
+        .from("subscriptions")
+        .select("id")
+        .eq("user_id", userId)
+        .eq("destinatario_id", template.destinatario_id)
+        .is("recurring_template_id", null)
+        .not("status", "in", "(cancelled,dismissed)")
+        .order("created_at", { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      if (orphan) {
+        await supabase
+          .from("subscriptions")
+          .update({ recurring_template_id: template.id, status: "active" })
+          .eq("id", orphan.id)
+          .eq("user_id", userId);
+      } else {
+        // 3. Fresh subscription row for this template.
+        const { error: insertErr } = await supabase.from("subscriptions").insert({
+          user_id: userId,
+          destinatario_id: template.destinatario_id,
+          recurring_template_id: template.id,
+          status: "active",
+          currency_code: template.currency_code,
+        });
+        // 23505 = a concurrent write already created the live row for this
+        // template — benign, the row we wanted exists.
+        if (insertErr && insertErr.code !== "23505") {
+          console.error(
+            "[upsertSubscriptionFromTemplate] insert failed",
+            insertErr.message,
+          );
+        }
       }
     }
   } else {

--- a/webapp/src/actions/subscriptions.ts
+++ b/webapp/src/actions/subscriptions.ts
@@ -286,23 +286,26 @@ export async function formalizeSubscription(
   // Skip templates that already back a live subscription — a merchant can have
   // several subscriptions, but each is anchored to a distinct template, so
   // re-using one would collide with subscriptions_one_live_per_template.
-  const { data: liveSubs } = await supabase
-    .from("subscriptions")
-    .select("recurring_template_id")
-    .eq("user_id", user.id)
-    .eq("destinatario_id", sub.destinatario_id)
-    .not("recurring_template_id", "is", null)
-    .not("status", "in", "(cancelled,dismissed)");
+  // Both reads are independent — run them in parallel to cut a round-trip.
+  const [liveSubsRes, activeTplsRes] = await Promise.all([
+    supabase
+      .from("subscriptions")
+      .select("recurring_template_id")
+      .eq("user_id", user.id)
+      .eq("destinatario_id", sub.destinatario_id)
+      .not("recurring_template_id", "is", null)
+      .not("status", "in", "(cancelled,dismissed)"),
+    supabase
+      .from("recurring_transaction_templates")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("destinatario_id", sub.destinatario_id)
+      .eq("is_active", true),
+  ]);
   const usedTemplateIds = new Set(
-    (liveSubs ?? []).map((r) => r.recurring_template_id),
+    (liveSubsRes.data ?? []).map((r) => r.recurring_template_id),
   );
-  const { data: activeTpls } = await supabase
-    .from("recurring_transaction_templates")
-    .select("id")
-    .eq("user_id", user.id)
-    .eq("destinatario_id", sub.destinatario_id)
-    .eq("is_active", true);
-  const existingTpl = (activeTpls ?? []).find(
+  const existingTpl = (activeTplsRes.data ?? []).find(
     (t) => !usedTemplateIds.has(t.id),
   );
   if (existingTpl) {


### PR DESCRIPTION
## Problema

Algunos comerciantes facturan **varios productos bajo un descriptor idéntico** en el extracto — p. ej. Google Play emite `GOOGLE *PLAY YOUTUBE` para YouTube Premium, Google One, suscripciones in-app, etc. El matcher de destinatarios es 100% por texto, así que todas estas transacciones **colapsan necesariamente a un único destinatario** "Google Play".

La feature de Suscripciones imponía **una suscripción viva por destinatario** (`subscriptions_one_live_per_destinatario`), por lo que solo uno de esos productos podía rastrearse como suscripción — `upsertSubscriptionFromTemplate` re-apuntaba en silencio la única fila al último template editado.

## Solución

Anclar la suscripción a su **template recurrente** en vez de al comerciante. Un comerciante puede tener N suscripciones, cada una respaldada por un template distinto (con su propio monto).

### Migración `20260527180000_allow_multiple_subscriptions_per_destinatario.sql`
- Reemplaza `subscriptions_one_live_per_destinatario` por `subscriptions_one_live_per_template` — una suscripción viva **por template** (`recurring_template_id` no nulo).
- Agrega `subscriptions_one_suggestion_per_destinatario` — preserva "una sugerencia automática por comerciante" (la detección agrupa por destinatario y no distingue productos por texto).
- Re-escopa el guard de reactivación del trigger `sync_subscription_on_template_active_change` de destinatario → template: reactiva como mucho la fila cancelada más reciente del template, y solo si no hay otra viva — nunca puede disparar el índice único.

### `webapp/src/actions/subscriptions.ts`
- `upsertSubscriptionFromTemplate` ahora keyea por `recurring_template_id`; si no hay fila para el template, **adopta una sugerencia huérfana** del comerciante (template nulo) antes de insertar una nueva.
- `formalizeSubscription` excluye templates que ya respaldan una suscripción viva al linkear (evita chocar con el nuevo índice por-template).

## Sin cambios necesarios
- **Detección automática** — correcta tal cual (una sugerencia por comerciante es lo deseable).
- **UI web/mobile** — keyean por `id` y muestran el monto por fila; renderizan múltiples filas por comerciante sin problema.
- **Mobile sync** — read-only, sin columnas nuevas; la relajación de índice es backward-compatible.

## Data safety
El índice viejo ya garantizaba ≤1 fila viva por destinatario, y un template mapea a exactamente un destinatario → ninguna fila existente puede violar el nuevo índice por-template. **No requiere backfill.**

## Verificación
- `pnpm build` ✅
- Revisión manual del diff (correctitud vs. índices, auth/defense-in-depth, cache `updateTag`, `.maybeSingle()` seguro, 23505 manejado).
- ⚠️ **Aplicar la migración**: `npx supabase db push` (no aplicada a remoto desde la sesión).

🤖 Generated with [Claude Code](https://claude.com/claude-code)