### PR TITLE
feat: persist execution time from Bancolombia email imports

### DIFF
--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -32,6 +32,21 @@ type AuthenticatedSupabase = Awaited<
 
 type ReprocessResult = "imported" | "queued" | "duplicate";
 
+/**
+ * Bancolombia emails carry the execution time as "HH:mm" (e.g. "11:20").
+ * Postgres TIME wants "HH:mm:ss" — normalise at the write boundary so email
+ * imports land with the same precision as the manual form / mobile sync.
+ * Returns null for anything that isn't a well-formed time so we never write
+ * garbage into the column.
+ */
+function normalizeEmailTime(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (/^([01]\d|2[0-3]):[0-5]\d$/.test(trimmed)) return `${trimmed}:00`;
+  if (/^([01]\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(trimmed)) return trimmed;
+  return null;
+}
+
 function stripHtml(html: string): string {
   return html
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
@@ -118,6 +133,7 @@ async function persistParsedEmail(params: {
       currency_code: currencyCode,
       direction: parsed.direction,
       transaction_date: parsed.transaction_date,
+      transaction_time: normalizeEmailTime(parsed.transaction_time),
       raw_description: parsed.raw_line,
       clean_description: parsed.merchant ?? parsed.destination ?? parsed.raw_line,
       merchant_name: parsed.merchant,
@@ -742,6 +758,7 @@ export async function approveEmailTransaction(
       currency_code: account.currency_code,
       direction: parsed.direction,
       transaction_date: parsed.transaction_date,
+      transaction_time: normalizeEmailTime(parsed.transaction_time),
       raw_description: rawDescription,
       clean_description: cleanDescription,
       merchant_name: merchantName,

--- a/webapp/src/actions/email-ingest.ts
+++ b/webapp/src/actions/email-ingest.ts
@@ -41,10 +41,9 @@ type ReprocessResult = "imported" | "queued" | "duplicate";
  */
 function normalizeEmailTime(raw: string | null | undefined): string | null {
   if (typeof raw !== "string") return null;
-  const trimmed = raw.trim();
-  if (/^([01]\d|2[0-3]):[0-5]\d$/.test(trimmed)) return `${trimmed}:00`;
-  if (/^([01]\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(trimmed)) return trimmed;
-  return null;
+  const match = raw.trim().match(/^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/);
+  if (!match) return null;
+  return `${match[1]}:${match[2]}:${match[3] ?? "00"}`;
 }
 
 function stripHtml(html: string): string {


### PR DESCRIPTION
## Qué

Las transacciones importadas por correo (Bancolombia) ahora persisten la **hora de ejecución** que el parser ya extraía, de modo que la interfaz la muestra en lugar de solo la fecha.

## Por qué

La infraestructura de hora ya existía de extremo a extremo:
- Columna `transaction_time TIME NULL` en `transactions` (migración `20260516120000_add_transaction_time.sql`).
- El parser de correo (`webapp/src/lib/parsers/bancolombia-email.ts`) ya extrae `transaction_time` (`"HH:mm"`) en sus ~14 patrones.
- La UI (tabla y detalle de transacciones) ya renderiza la hora vía `formatDateTime(date, time)`.

El **único eslabón roto** era que la acción de email-ingest descartaba el valor al insertar — los `.insert(...)` ponían `transaction_date` pero omitían `transaction_time`, así que la columna quedaba `NULL` y la UI mostraba solo la fecha.

## Cambio

En `webapp/src/actions/email-ingest.ts`:

1. Nuevo helper `normalizeEmailTime()` — normaliza `"HH:mm"` → `"HH:mm:ss"` (precisión de Postgres TIME), acepta `HH:mm:ss` ya formado y devuelve `null` ante cualquier valor malformado/vacío. Replica la convención de normalización del validador del formulario manual (`webapp/src/lib/validators/transaction.ts`).
2. `transaction_time: normalizeEmailTime(parsed.transaction_time)` en **ambos** inserts a `transactions`:
   - ruta auto-import (`persistParsedEmail`)
   - ruta confirmar-desde-pendiente (`approveEmailTransaction`)

## Alcance

- Sin migración, sin cambios de UI, sin tocar el parser — solo persistir el valor ya parseado.
- PDF sigue sin hora por diseño (extractos = solo fecha).
- La reconciliación conserva la hora del correo al fusionar con una transacción manual (EMAIL_IMPORT > MANUAL_FORM en la jerarquía de autoridad), comportamiento deseado.

## Verificación

- `pnpm build` ✅
- `server-action-reviewer` ✅ PASS — sin issues de auth/validación/caché; confirma que se cubrieron ambos (y solo) los inserts correctos.

https://claude.ai/code/session_015H6Yo7QMkwgAGAV6M5vhWv

---
_Generated by [Claude Code](https://claude.ai/code/session_015H6Yo7QMkwgAGAV6M5vhWv)_