### PR TITLE
fix(personas): write kind=person on create + person/merchant toggles

### DIFF
--- a/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
+++ b/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
@@ -104,11 +104,13 @@ export function CreateDestinatarioDialog({
             />
           </div>
 
-          <div className="space-y-2">
-            <Label>Tipo</Label>
+          <div className="space-y-2" role="radiogroup" aria-labelledby="dest-create-tipo-label">
+            <Label id="dest-create-tipo-label">Tipo</Label>
             <div className="grid grid-cols-2 gap-2">
               <button
                 type="button"
+                role="radio"
+                aria-checked={kind === "merchant"}
                 onClick={() => setKind("merchant")}
                 className={cn(
                   "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
@@ -121,6 +123,8 @@ export function CreateDestinatarioDialog({
               </button>
               <button
                 type="button"
+                role="radio"
+                aria-checked={kind === "person"}
                 onClick={() => setKind("person")}
                 className={cn(
                   "rounded-lg border px-3 py-2 text-left text-sm transition-colors",

--- a/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
+++ b/webapp/src/components/destinatarios/create-destinatario-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
+import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import type { ActionResult } from "@/types/actions";
 import type { CategoryWithChildren, CurrencyCode } from "@/types/domain";
@@ -34,6 +35,7 @@ export function CreateDestinatarioDialog({
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [categoryId, setCategoryId] = useState<string | null>(null);
+  const [kind, setKind] = useState<"merchant" | "person">("merchant");
   const [isActive, setIsActive] = useState(true);
   const [patterns, setPatterns] = useState("");
   const [testResult, setTestResult] = useState<PatternTestResult | null>(null);
@@ -48,6 +50,7 @@ export function CreateDestinatarioDialog({
     router.refresh();
     setOpen(false);
     setCategoryId(null);
+    setKind("merchant");
     setIsActive(true);
     setPatterns("");
     setTestResult(null);
@@ -100,6 +103,37 @@ export function CreateDestinatarioDialog({
               required
             />
           </div>
+
+          <div className="space-y-2">
+            <Label>Tipo</Label>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => setKind("merchant")}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                  kind === "merchant"
+                    ? "border-z-brass/40 bg-z-brass/10"
+                    : "border-white/6 bg-z-surface-2",
+                )}
+              >
+                Comercio
+              </button>
+              <button
+                type="button"
+                onClick={() => setKind("person")}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                  kind === "person"
+                    ? "border-z-brass/40 bg-z-brass/10"
+                    : "border-white/6 bg-z-surface-2",
+                )}
+              >
+                Persona
+              </button>
+            </div>
+          </div>
+          <input type="hidden" name="kind" value={kind} />
 
           <div className="space-y-2">
             <Label>Categoría por defecto</Label>

--- a/webapp/src/components/destinatarios/destinatario-detail.tsx
+++ b/webapp/src/components/destinatarios/destinatario-detail.tsx
@@ -13,6 +13,7 @@ import {
   Link2,
 } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -162,6 +163,7 @@ function EditForm({
   categoryMap: Record<string, string>;
 }) {
   const [isActive, setIsActive] = useState(destinatario.is_active);
+  const [kind, setKind] = useState<"merchant" | "person">(destinatario.kind ?? "merchant");
   const [ruleImpact, setRuleImpact] = useState<{ matchCount: number } | null>(null);
   const [applyingRules, startApplyTransition] = useTransition();
 
@@ -277,6 +279,40 @@ function EditForm({
               placeholder="Notas opcionales..."
             />
           </div>
+
+          <div className="space-y-2">
+            <Label>Tipo</Label>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => setKind("merchant")}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                  kind === "merchant"
+                    ? "border-z-brass/40 bg-z-brass/10"
+                    : "border-white/6 bg-z-surface-2",
+                )}
+              >
+                Comercio
+              </button>
+              <button
+                type="button"
+                onClick={() => setKind("person")}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                  kind === "person"
+                    ? "border-z-brass/40 bg-z-brass/10"
+                    : "border-white/6 bg-z-surface-2",
+                )}
+              >
+                Persona
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Las personas aparecen en cuentas personales; los comercios se usan para categorizar.
+            </p>
+          </div>
+          <input type="hidden" name="kind" value={kind} />
 
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">

--- a/webapp/src/components/destinatarios/destinatario-detail.tsx
+++ b/webapp/src/components/destinatarios/destinatario-detail.tsx
@@ -280,11 +280,13 @@ function EditForm({
             />
           </div>
 
-          <div className="space-y-2">
-            <Label>Tipo</Label>
+          <div className="space-y-2" role="radiogroup" aria-labelledby="dest-detail-tipo-label">
+            <Label id="dest-detail-tipo-label">Tipo</Label>
             <div className="grid grid-cols-2 gap-2">
               <button
                 type="button"
+                role="radio"
+                aria-checked={kind === "merchant"}
                 onClick={() => setKind("merchant")}
                 className={cn(
                   "rounded-lg border px-3 py-2 text-left text-sm transition-colors",
@@ -297,6 +299,8 @@ function EditForm({
               </button>
               <button
                 type="button"
+                role="radio"
+                aria-checked={kind === "person"}
                 onClick={() => setKind("person")}
                 className={cn(
                   "rounded-lg border px-3 py-2 text-left text-sm transition-colors",

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -60,6 +60,13 @@ interface DestinatarioZonePickerProps {
   currencyCode?: CurrencyCode | null;
   /** Restrict the list to these destinatario kinds (e.g. ["person"]). Omit = all. */
   kindFilter?: DestinatarioKind[];
+  /**
+   * Kind to assign when creating a new destinatario from this picker. Without
+   * it, createDestinatario defaults to "merchant" — which a person-only
+   * kindFilter would then immediately hide, making creation appear to fail.
+   * Defaults to the sole kindFilter entry when exactly one is given.
+   */
+  createKind?: DestinatarioKind;
 }
 
 export function DestinatarioZonePicker({
@@ -79,7 +86,12 @@ export function DestinatarioZonePicker({
   amount,
   currencyCode,
   kindFilter,
+  createKind,
 }: DestinatarioZonePickerProps) {
+  // When exactly one kind is being filtered, default new rows to that kind so
+  // creation isn't immediately hidden by the same filter.
+  const effectiveCreateKind =
+    createKind ?? (kindFilter?.length === 1 ? kindFilter[0] : undefined);
   // When categories are provided, "Crear nuevo" opens the full seeded form
   // (token chips when seed text exists, otherwise a plain rich form). The bare
   // name+pattern mini-form remains only as the fallback for callers that don't
@@ -157,6 +169,7 @@ export function DestinatarioZonePicker({
     startCreateTransition(async () => {
       const fd = new FormData();
       fd.set("name", name);
+      if (effectiveCreateKind) fd.set("kind", effectiveCreateKind);
       const result = await createDestinatario({ success: false, error: "" }, fd);
       if (result.success) {
         if (pattern?.trim()) {

--- a/webapp/src/components/personas/create-personal-debt-sheet.tsx
+++ b/webapp/src/components/personas/create-personal-debt-sheet.tsx
@@ -104,6 +104,7 @@ export function CreatePersonalDebtSheet({
               placeholder="Elegir o crear persona"
               triggerClassName="w-full"
               kindFilter={["person"]}
+              createKind="person"
             />
           </div>
 


### PR DESCRIPTION
## Problem

The personas "create person" flow silently failed: every person created from the personal-debt sheet was written as a **merchant**, then immediately hidden by the same person-only filter — so it looked like "I cannot create a Person."

Root cause: `DestinatarioZonePicker` accepted a `kindFilter` for **reading** the list, but had no way to set `kind` on **create**. `handleCreate` called `createDestinatario` with only `name`, and the validator defaults `kind` → `"merchant"`. No webapp path ever wrote `kind: "person"` (verified by grep). Migrations were already applied to prod, so it was pure app logic.

## Fix

- **destinatario-zone-picker**: add `createKind` prop; auto-derive from a single-entry `kindFilter`; `handleCreate` now sets `kind` on the FormData.
- **create-personal-debt-sheet**: pass `createKind="person"`.
- **destinatario-detail** + **create-destinatario-dialog**: add a Comercio/Persona toggle (hidden `kind` input) so existing destinatarios can be re-typed and standalone persons created from the management page. (`updateDestinatario` already accepted `kind`.)

## Verification

- `pnpm build` clean.
- Manual e2e in mobile viewport (demo mode): created a person via the picker → it now appears in the person-filtered list (pre-fix: zero matches) → created the personal debt → renders under DEBO with correct totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)