### PR TITLE
Deudas personales: reframe Personas, fix create/picker, add delete

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -58,6 +58,24 @@
 - **Fix:** DB_MIGRATIONS v11 → `ALTER TABLE budgets ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0`. Then add `budgets: ["is_demo"]` to `BOOLEAN_FIELDS` in `mobile/lib/sync/pull.ts` so pull converts `true/false → 1/0` on write.
 - **Found:** mobile-sync-doctor on PR #223, 2026-04-22.
 
+### Mobile — income metrics don't exclude personal-debt `origin` inflows (web/mobile divergence)
+- **Priority:** Medium
+- **What:** Webapp `charts.ts` excludes `pd_role='origin'` inflows from income via `.or("personal_debt_id.is.null,pd_role.neq.origin")` (a `borrowed` debt's origin INFLOW is not income). Mobile `getMonthlyAggregates` (`mobile/lib/repositories/transactions.ts`) does NOT — it selects no `personal_debt_id`/`pd_role`, and `computeMonthlyAggregates`/`AggregatableTransaction` in `packages/shared/src/utils/monthly-aggregates.ts` can't filter on them. Result: once a user links an origin INFLOW to a personal debt on web, it syncs down (schema v16 added the columns) and inflates the mobile "Resumen del mes" income vs web. Data is NOT corrupted — display-only divergence, bounded to users with `pd_role='origin'` inflows.
+- **Fix:** add `personal_debt_id: string | null` + `pd_role: string | null` to `AggregatableTransaction`; skip `isPersonalDebtOrigin(tx)` rows inside `computeMonthlyAggregates` (reuse the shared predicate); SELECT the two columns in the mobile `getMonthlyAggregates` SQL. Verify the webapp doesn't double-exclude (web filters at query level, not via this shared helper). REQUIRED before the mobile write-parity phase below.
+- **Found:** mobile-webapp-parity gate, branch feat/personal-debts, 2026-06-04.
+
+### Personal Debts (Personas) — mobile write parity (Phase 2)
+- **Priority:** Medium
+- **What:** Mobile Personas v1 is READ-ONLY (pulls + displays personal debts; not in push.ts — mirrors the subscriptions precedent). Web is the only place to create debts / record abonos for now. Phase 2 = add mobile write parity.
+- **Fix:** (1) repo `createPersonalDebt` (copy `destinatarios.ts` createXWithPattern: `Crypto.randomUUID` + `db.withTransactionAsync` INSERT + `enqueueInsert(db,"personal_debts",…)`) and `recordRepayment` — mirror the full webapp action chain: insert the repayment transaction (with `personal_debt_id`+`pd_role='repayment'`, `enqueueInsert`) AND recompute `outstanding_amount`/`status` via shared `computeOutstanding` (`enqueueUpdate`). **CRITICAL:** the repayment-tx insert must mirror `createTransaction` exactly — do NOT write local `accounts.current_balance` (mobile lets the server balance delta flow back on next pull; a local write double-applies). (2) re-add `| "personal_debts"` to `SyncTableName` in `mobile/lib/sync/push.ts`. (3) UI in `mobile/components/personas/PersonasRoot.tsx`: create-debt sheet (person picker filtered to `kind='person'` + inline person create with `kind='person'`) + record-abono modal (account picker + amount + date). (4) device-verify the sync round-trip (web↔mobile) + the v16 migration. Do the income-exclusion bug above first.
+- **Found:** scope decision, branch feat/personal-debts, 2026-06-04.
+
+### Deudas personales — Vincular "Crear deuda" cancel doesn't re-open the picker (web)
+- **Priority:** Low (P3)
+- **What:** In `movimientos-transaction-row.tsx`, "Vincular a deuda personal" → "Crear deuda personal nueva" closes the LinkPickerSheet and opens `CreatePersonalDebtSheet`. If the user dismisses the create sheet without saving, the picker stays closed — they must re-tap the chip. Acceptable for v1.
+- **Fix:** on create-sheet dismiss-without-create, re-open `personaPickerOpen`, or render the create sheet over the picker instead of swapping.
+- **Found:** zetas-front-guy, branch feat/personas-usability, 2026-06-04.
+
 ### Mobile — yearly budgets not displayed
 - **Priority:** Low
 - **What:** `getBudgetProgress` in `mobile/lib/repositories/budgets.ts` filters `b.period = 'monthly'` (hardcoded). Webapp accepts `"monthly" | "yearly"` via `budgetSchema`. Any yearly budget created on webapp is invisible on mobile.
@@ -69,6 +87,23 @@
 - **What:** PR #227 took five hardening passes (`obligation_skips`, `profiles.updated_at` type, NOT NULL currency/locale, `design_reviews`, CI `clearDatabase` FK order) because the RPC hard-codes the table list and every schema change risks silent drift. Today it's resilient to dropped tables via `to_regclass` guards, but new tables added after 2026-04-24 won't be wiped unless someone remembers to touch the RPC.
 - **Fix options:** (a) CI check that diffs `information_schema.tables WHERE table_schema='public'` against the RPC's table list and fails the build on drift; (b) rewrite the RPC to iterate `information_schema` dynamically with an allowlist of system tables to preserve; (c) accept manual upkeep and add a pre-commit reminder when `supabase/migrations/*.sql` adds a `CREATE TABLE`.
 - **Found:** 2026-04-24, PR #227.
+
+### RLS UPDATE policies missing `WITH CHECK` (defense-in-depth)
+- **Priority:** Low
+- **What:** Several per-op RLS UPDATE policies use only `USING ((select auth.uid()) = user_id)` with no matching `WITH CHECK`, so a user could UPDATE their own row and reassign `user_id` to another user (the new-row values aren't validated). Confirmed on `subscriptions` (`20260527151641_create_subscriptions.sql`); the same copy-paste pattern likely exists on other tables. `personal_debts` (20260603) was fixed at creation.
+- **Fix:** Add `WITH CHECK ((select auth.uid()) = user_id)` to every `FOR UPDATE` policy. Audit all migrations for `FOR UPDATE\n  USING` without a following `WITH CHECK`.
+- **Found:** Automated security review on PR / branch feat/personal-debts, 2026-06-03.
+
+### FAB "Nueva transacción" — premature submit + re-fires "Guardado" on every reopen (mobile webapp)
+- **Priority:** High (breaks the primary tx-creation entry point on mobile web)
+- **What:** From the mobile-web FAB → "Nueva transacción": (1) the first time, the form submits/closes before the user finishes; (2) afterward, every reopen immediately closes and fires the `toast.success("Guardado")` with no input.
+- **Confirmed (static):** single `type="submit"` button; the success handler `useEffect(() => { if (state.success) onSuccess?.(); }, [state.success])` in `mobile-transaction-form.tsx:103-107` **never resets `state.success`** — it relies entirely on full unmount to clear it. `onSuccess` = `new-transaction-page-content.tsx:25-32` (`toast` + `router.back()`). FAB uses `router.replace("/transactions/new")` + a `history.pushState`/`history.back()` sentinel (`fab-menu.tsx:42-83`). No intercepting/parallel routes; no programmatic `requestSubmit`/`.submit()`; `AmountInput` has no Enter handler.
+- **NOT yet root-caused — two candidate vectors needing one repro to disambiguate:**
+  - **Vector P (persistence):** form reappears with `state.success` still `true` (Next Router Cache reuse / bfcache / no real unmount on `router.replace`↔`router.back`) → effect re-runs `onSuccess` on open. Fix: make success fire once + reset action state (e.g. guard via a `handledRef`, or reset `state` after `onSuccess`). Related to the existing bfcache bug above (import wizard, line ~27).
+  - **Vector S (premature/implicit submit):** Enter on the mobile soft keyboard implicitly submits the single-submit-button form mid-typing. Fix: prevent implicit submission on text inputs / require explicit submit.
+- **Next step:** add temp `[FAB-DEBUG]` mount/unmount + effect logs to `mobile-transaction-form.tsx`, reproduce once on mobile-width, read console → confirm P vs S, then fix the confirmed vector. Both fixes are cheap once the vector is known.
+- **Touches:** `webapp/src/components/mobile/mobile-transaction-form.tsx`, `new-transaction-page-content.tsx`, `fab-menu.tsx`.
+- **Found:** User report, 2026-06-03 (investigation deferred — "fix later").
 
 ## Claude Design — Wireframe Handoff
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -76,6 +76,14 @@
 - **Fix:** on create-sheet dismiss-without-create, re-open `personaPickerOpen`, or render the create sheet over the picker instead of swapping.
 - **Found:** zetas-front-guy, branch feat/personas-usability, 2026-06-04.
 
+### Deudas personales — deferred cleanups (from /code-review + /simplify, 2026-06-04)
+- **Priority:** Low (P3)
+- **Central "modal-inside-Sheet" handling:** the z fix (force `variant="dialog"` + `Z_DIALOG_ABOVE_SHEET` on content+overlay) is wired per call site. A `SheetContext` that `DialogContent`/`Popover` read to auto-bump z (and pick dialog-not-drawer) would stop every future picker-in-a-Sheet re-hitting the trap. Touches `ui/sheet.tsx` + `ui/dialog.tsx`.
+- **Shared `ConfirmDialog`:** the destructive-confirm AlertDialog block is now a 3rd copy (persona-card + settings/delete-account + settings/reset-data). Extract a reusable `<ConfirmDialog>` and retrofit all three.
+- **`runPersonalDebtMutation` helper:** `cancel`/`settle`/`deletePersonalDebt` share the validate→auth→mutate→rowcheck→revalidate skeleton; collapse into one helper (watch Supabase query-builder generics). Note `settlePersonalDebt` omits `revalidateFinancialViews()` though it zeroes `outstanding_amount` — confirm intended when refactoring.
+- **`pd_role` hygiene on delete:** FK `ON DELETE SET NULL` clears `personal_debt_id` but leaves a dangling `pd_role` on the unlinked tx. Harmless today (income predicate also checks `personal_debt_id != null`); NULL it out (or a sweep migration) if any future query keys on `pd_role` alone.
+- **Found:** /code-review + /simplify, branch feat/personas-usability, 2026-06-04.
+
 ### Mobile — yearly budgets not displayed
 - **Priority:** Low
 - **What:** `getBudgetProgress` in `mobile/lib/repositories/budgets.ts` filters `b.period = 'monthly'` (hardcoded). Webapp accepts `"monthly" | "yearly"` via `budgetSchema`. Any yearly budget created on webapp is invisible on mobile.

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,23 +1,25 @@
 # Next session — start here (Personal Debts F1)
 
-You're continuing the **Personas (lend/borrow tracker)** feature. The web part is done; finish the rest.
+Continuing the **Personas (lend/borrow tracker)** feature. Web is done; mobile shipped **read-only**; writes deferred to Phase 2.
 
-## First 3 steps
-1. `git checkout feat/personal-debts` then `cd webapp && pnpm build` — must be green.
-2. Read `HANDOVER.md` (full status + gotchas) and the plan `docs/superpowers/plans/2026-06-03-personal-debts-f1.md`.
-3. Pick up the remaining tasks below (in order).
+## Status (2026-06-04 session) — all green, NOTHING committed/pushed
+
+Verification: `webapp pnpm build` ✓ · `mobile npx tsc --noEmit` ✓ · shared vitest (`personal-debt.test.ts`) ✓ · webapp vitest (`src/`) ✓. 4 review gates ran (zetas-front-guy, mobile-sync-doctor, mobile-webapp-parity, mobile-perf-doctor) — blocking findings fixed inline, rest backlogged.
+
+Done this session (uncommitted, working tree only):
+- **Task 11 — Vincular a persona** ✅ `movimientos-transaction-row.tsx`: sibling chip + 2nd `LinkPickerSheet`, gate `!personal_debt_id && !transfer_group_id`, reuses `isLinking`. (No `onCreateNew` — LinkPickerSheet hardcodes "recurrente" copy.)
+- **Task 12 Step 6 — Personas/Comercios split** ✅ `destinatario-list.tsx`: `filtered`→`{personas,comercios}`, single render-list with `col-span-full` `SECTION_EYEBROW_CLASS` headings. `kind` already flows from action+page.
+- **Task 14 — Mobile parity (READ-ONLY v1)** ✅ schema v16 (`personal_debts` + `destinatarios.kind` + `transactions.personal_debt_id/pd_role`), pull.ts registration (`is_demo` boolean), read-only repo `personal-debts.ts`, `PersonasRoot.tsx` (Debo/Me deben display), route + `_layout` + menu HubEntry. **push.ts intentionally NOT touched** (mirrors subscriptions pull-only precedent).
+- **Task 15 — gates** ✅ (build/tests/tsc + 4 agents).
 
 ## What's left
-- **Task 14 — Mobile parity** (the big one): plan L1630. Add `personal_debts` + the new columns (`transactions.personal_debt_id/pd_role`, `destinatarios.kind`) to mobile SQLite schema + sync + repo + a `/personas` route. Gates: `mobile-webapp-parity` + `mobile-sync-doctor`.
-- **Task 11 — Vincular UI**: plan L1424. The action already exists (`linkTransactionToPersonalDebt`); just wire it into the movimientos row's existing "Vincular" menu.
-- **Task 15 — Finish**: `perf-auditor` on `/personas`, then merge/PR.
-- Optional polish: Task 12 Step 6 (mgmt-list Personas/Comercios split) + the UI items noted in HANDOVER.
+1. **Decide: commit + PR.** Tree also has unrelated pre-session dirty files (`app.json`, `eas.json`, `mobile/lib/analytics/`, `mobile/lib/services/notifications/`, `weekly-digest*`, docs) — stage ONLY the personas files (listed above) for atomic commits; don't sweep the rest. Then dry-merge vs `origin/main` (likely conflicts: `database.ts`, `domain.ts`, mobile `schema.ts`) before PR.
+2. **BACKLOG (do before mobile writes):** "Mobile — income metrics don't exclude personal-debt `origin` inflows" — live web/mobile divergence; fix `monthly-aggregates.ts` + mobile `getMonthlyAggregates`.
+3. **BACKLOG Phase 2:** "Personal Debts (Personas) — mobile write parity" — repo create/recordRepayment (NO local balance write) + re-add push.ts + create/abono UI + device-verify round-trip.
+4. Optional web polish (from prior HANDOVER): Vincular create-with-origin deep-link, V5 `TOGGLE_*` constant, R1 `stat-tile` reuse, W5 double-clearance check.
 
 ## Rules (do not skip)
-- **NEVER full-regen `webapp/src/types/database.ts`** — it breaks encrypted-view inserts app-wide. Hand-add new columns.
-- Migrations for Tasks 1–3 are **already applied to remote** — do NOT re-push them.
-- **Implement inline.** Use the custom agents (supabase-migrator, server-action-reviewer, mobile-*-doctor, zetas-front-guy) only as **review gates**, not to write the code.
-- For `_enc` column adds, copy the **latest** has_auth-guarded trigger bodies (not the original `encrypt_*` migration). See HANDOVER for the exact migration files.
+- **NEVER full-regen `webapp/src/types/database.ts`** — hand-add columns.
+- Migrations Tasks 1–3 are **already applied to remote** — do NOT re-push.
+- **Implement inline.** Custom agents = review gates only.
 - Spanish UI, `pnpm` (not npm), build must pass before claiming done.
-
-When everything's green, delete this file.

--- a/docs/design-system/TOKENS.md
+++ b/docs/design-system/TOKENS.md
@@ -145,3 +145,15 @@ Muted text:       text-muted-foreground
 
 - Never use hardcoded hex for semantic colors (no `#3a3a3a`, no `#c44`)
 - Use CSS variables via Tailwind classes
+
+## Z-index layers
+
+| Layer | Class | Used by |
+|---|---|---|
+| Tab bar | `z-40` | mobile bottom tab bar |
+| Modals | `z-50` | shadcn primitives — Dialog, AlertDialog, Drawer, Popover, Dropdown, Select, Tooltip (must sit above the tab bar) |
+| Top surfaces | `z-[10000]` | `Sheet` + `FabMenu` — cover other modals |
+| Dialog-in-Sheet | `Z_DIALOG_ABOVE_SHEET` (`z-[10001]`) | a primitive opened from **inside** a Sheet (e.g. the destinatario picker in "Nueva deuda personal") — must clear `z-[10000]`. Import from `@/lib/constants/styles`; apply to both `DialogContent` and its `overlayClassName`. |
+| Toasts | sonner default (`z≈10^9`) | always on top |
+
+Rule: don't invent new raw z-values. A modal opened from inside a Sheet uses `Z_DIALOG_ABOVE_SHEET`; everything else uses the tiers above.

--- a/webapp/next.config.ts
+++ b/webapp/next.config.ts
@@ -20,6 +20,12 @@ const nextConfig: NextConfig = {
         destination: "/deudas/planificador",
         permanent: true,
       },
+      {
+        // Module reframed "Personas" → "Deudas personales".
+        source: "/personas",
+        destination: "/deudas-personales",
+        permanent: true,
+      },
     ];
   },
 };

--- a/webapp/src/actions/personal-debts.ts
+++ b/webapp/src/actions/personal-debts.ts
@@ -234,6 +234,32 @@ export async function cancelPersonalDebt(id: string): Promise<ActionResult<undef
   return { success: true, data: undefined };
 }
 
+// ============================================================
+// Delete (hard) — removes the debt record entirely. Linked transactions are
+// auto-unlinked via FK (transactions.personal_debt_id ON DELETE SET NULL); they
+// remain as regular transactions.
+// ============================================================
+export async function deletePersonalDebt(id: string): Promise<ActionResult<undefined>> {
+  if (!personalDebtIdSchema.safeParse(id).success) {
+    return { success: false, error: "ID inválido" };
+  }
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const { data, error } = await supabase
+    .from("personal_debts")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select("id");
+  if (error) return { success: false, error: "Error al eliminar la deuda" };
+  if (!data || data.length === 0) return { success: false, error: "Deuda no encontrada" };
+
+  revalidateFinancialViews();
+  updateTag("personal-debts");
+  return { success: true, data: undefined };
+}
+
 export async function settlePersonalDebt(id: string): Promise<ActionResult<undefined>> {
   if (!personalDebtIdSchema.safeParse(id).success) {
     return { success: false, error: "ID inválido" };

--- a/webapp/src/app/(dashboard)/categorizar/page.tsx
+++ b/webapp/src/app/(dashboard)/categorizar/page.tsx
@@ -111,6 +111,15 @@ export default async function CategorizarPage() {
             </Button>
           </CardContent>
         </Card>
+
+        <div className="grid grid-cols-2 gap-2">
+          <Button asChild className={`w-full ${GHOST_BUTTON_CLASS}`}>
+            <Link href="/destinatarios">Destinatarios</Link>
+          </Button>
+          <Button asChild className={`w-full ${GHOST_BUTTON_CLASS}`}>
+            <Link href="/deudas-personales">Deudas personales</Link>
+          </Button>
+        </div>
       </div>
 
       <div className="hidden lg:block space-y-6">
@@ -129,6 +138,9 @@ export default async function CategorizarPage() {
               className={GHOST_BUTTON_CLASS}
             >
               <Link href="/destinatarios">Ver destinatarios</Link>
+            </Button>
+            <Button asChild className={GHOST_BUTTON_CLASS}>
+              <Link href="/deudas-personales">Deudas personales</Link>
             </Button>
             <Button asChild className={BRASS_BUTTON_CLASS}>
               <Link href={actionCard.href}>

--- a/webapp/src/app/(dashboard)/deudas-personales/page.tsx
+++ b/webapp/src/app/(dashboard)/deudas-personales/page.tsx
@@ -1,0 +1,26 @@
+import { connection } from "next/server";
+import { getPersonalDebts, getPersonalDebtsOverview } from "@/actions/personal-debts";
+import { getPreferredCurrency } from "@/actions/profile";
+import { PersonasRoot } from "@/components/personas/personas-root";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+
+export default async function PersonasPage() {
+  await connection();
+  const [debtsRes, overviewRes, currency] = await Promise.all([
+    getPersonalDebts(),
+    getPersonalDebtsOverview(),
+    getPreferredCurrency(),
+  ]);
+  const debts = debtsRes.success ? debtsRes.data : [];
+  const overview = overviewRes.success
+    ? overviewRes.data
+    : { iOwe: { total: 0, byPerson: [] }, owedToMe: { total: 0, byPerson: [] }, overdue: [] };
+  return (
+    <div className={`space-y-6 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
+      <h1 className="text-2xl font-semibold tracking-tight text-z-sage-light lg:text-3xl">
+        Deudas personales
+      </h1>
+      <PersonasRoot debts={debts} overview={overview} currency={currency} />
+    </div>
+  );
+}

--- a/webapp/src/app/(dashboard)/personas/page.tsx
+++ b/webapp/src/app/(dashboard)/personas/page.tsx
@@ -1,26 +1,6 @@
-import { connection } from "next/server";
-import { getPersonalDebts, getPersonalDebtsOverview } from "@/actions/personal-debts";
-import { getPreferredCurrency } from "@/actions/profile";
-import { PersonasRoot } from "@/components/personas/personas-root";
-import { MOBILE_TAB_BAR_CLEARANCE_CLASS } from "@/lib/constants/styles";
+import { redirect } from "next/navigation";
 
-export default async function PersonasPage() {
-  await connection();
-  const [debtsRes, overviewRes, currency] = await Promise.all([
-    getPersonalDebts(),
-    getPersonalDebtsOverview(),
-    getPreferredCurrency(),
-  ]);
-  const debts = debtsRes.success ? debtsRes.data : [];
-  const overview = overviewRes.success
-    ? overviewRes.data
-    : { iOwe: { total: 0, byPerson: [] }, owedToMe: { total: 0, byPerson: [] }, overdue: [] };
-  return (
-    <div className={`space-y-6 ${MOBILE_TAB_BAR_CLEARANCE_CLASS}`}>
-      <h1 className="text-2xl font-semibold tracking-tight text-z-sage-light lg:text-3xl">
-        Personas
-      </h1>
-      <PersonasRoot debts={debts} overview={overview} currency={currency} />
-    </div>
-  );
+// Legacy path — the module was reframed from "Personas" to "Deudas personales".
+export default function PersonasRedirect() {
+  redirect("/deudas-personales");
 }

--- a/webapp/src/app/(dashboard)/personas/page.tsx
+++ b/webapp/src/app/(dashboard)/personas/page.tsx
@@ -1,6 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Legacy path — the module was reframed from "Personas" to "Deudas personales".
-export default function PersonasRedirect() {
-  redirect("/deudas-personales");
-}

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -393,7 +393,9 @@ export function DestinatarioZonePicker({
       <>
         {!hideTrigger && triggerButton}
         <Dialog open={open} onOpenChange={setOpen}>
-          <DialogContent className="flex max-h-[70vh] w-full max-w-sm flex-col gap-0 overflow-hidden p-0">
+          {/* z-[10001]: this variant is used inside the create-deuda Sheet
+              (z-10000); the default Dialog z-50 would render behind it. */}
+          <DialogContent className="z-[10001] flex max-h-[70vh] w-full max-w-sm flex-col gap-0 overflow-hidden p-0">
             <DialogHeader className="border-b px-4 py-3">
               <DialogTitle className="flex items-center gap-2">
                 <UserRound className="size-4 text-z-brass" />

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -204,6 +204,7 @@ export function DestinatarioZonePicker({
     </button>
   ) : (
     <Button
+      type="button"
       variant="outline"
       role="combobox"
       aria-expanded={open}

--- a/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
+++ b/webapp/src/components/destinatarios/destinatario-zone-picker.tsx
@@ -22,7 +22,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { GHOST_BUTTON_CLASS, BRASS_GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { GHOST_BUTTON_CLASS, BRASS_GHOST_BUTTON_CLASS, Z_DIALOG_ABOVE_SHEET } from "@/lib/constants/styles";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useDestinatarios } from "@/components/providers/app-data-provider";
 import { createDestinatario, getRecentDestinatarios, addDestinatarioRule } from "@/actions/destinatarios";
@@ -393,9 +393,16 @@ export function DestinatarioZonePicker({
       <>
         {!hideTrigger && triggerButton}
         <Dialog open={open} onOpenChange={setOpen}>
-          {/* z-[10001]: this variant is used inside the create-deuda Sheet
-              (z-10000); the default Dialog z-50 would render behind it. */}
-          <DialogContent className="z-[10001] flex max-h-[70vh] w-full max-w-sm flex-col gap-0 overflow-hidden p-0">
+          {/* This variant is used inside the create-deuda Sheet (z-[10000]); the
+              default Dialog z-50 would render behind it. Lift both content and
+              overlay above the sheet. */}
+          <DialogContent
+            overlayClassName={Z_DIALOG_ABOVE_SHEET}
+            className={cn(
+              Z_DIALOG_ABOVE_SHEET,
+              "flex max-h-[70vh] w-full max-w-sm flex-col gap-0 overflow-hidden p-0",
+            )}
+          >
             <DialogHeader className="border-b px-4 py-3">
               <DialogTitle className="flex items-center gap-2">
                 <UserRound className="size-4 text-z-brass" />

--- a/webapp/src/components/mobile/mobile-link-grid.tsx
+++ b/webapp/src/components/mobile/mobile-link-grid.tsx
@@ -13,6 +13,7 @@ import {
   PiggyBank,
   Settings,
   Tag,
+  Users,
   Wallet,
   type LucideIcon,
 } from "lucide-react";
@@ -42,6 +43,11 @@ const ORGANIZAR_GROUP: Group = {
 
 const PLAN_TILE: Tile = { href: "/plan", icon: PiggyBank, label: "Plan" };
 const DEUDAS_TILE: Tile = { href: "/deudas", icon: Landmark, label: "Deudas" };
+const DEUDAS_PERSONALES_TILE: Tile = {
+  href: "/deudas-personales",
+  icon: Users,
+  label: "Deudas personales",
+};
 const RECURRENTES_TILE: Tile = {
   href: "/plan?tab=recurrentes",
   icon: CalendarClock,
@@ -61,6 +67,7 @@ export function MobileLinkGrid() {
   // The active third tab lives in the bottom nav — surface the OTHER one in the grid.
   const planificarTiles: Tile[] = [
     focus === "DEBT" ? PLAN_TILE : DEUDAS_TILE,
+    DEUDAS_PERSONALES_TILE,
     RECURRENTES_TILE,
     DESEOS_TILE,
     PUEDO_PAGAR_TILE,

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -124,20 +124,26 @@ export function MovimientosTransactionRow({
 
   function handleConfirmPersonaLink(debtId: string, fromCreate = false) {
     setPersonaPickerOpen(false);
+    // The debt may already be created (fromCreate); always give feedback so the
+    // user isn't left with a dangling debt and no breadcrumb — including when the
+    // link action throws (network) rather than returning { success: false }.
+    const danglingMsg =
+      "Deuda creada, pero no se pudo vincular. Búscala en Deudas personales para vincularla.";
     startLinkTransition(async () => {
-      const result = await linkTransactionToPersonalDebt(debtId, tx.id);
-      if (result.success) {
-        toast.success("Transacción vinculada a deuda personal");
-        router.refresh();
-      } else if (fromCreate) {
-        // The debt was already created; surface that so the user isn't left with
-        // a dangling debt and no breadcrumb.
-        toast.error(
-          "Deuda creada, pero no se pudo vincular. Búscala en Deudas personales para vincularla.",
-        );
-        router.refresh();
-      } else {
-        toast.error(result.error ?? "No se pudo vincular");
+      try {
+        const result = await linkTransactionToPersonalDebt(debtId, tx.id);
+        if (result.success) {
+          toast.success("Transacción vinculada a deuda personal");
+          router.refresh();
+        } else if (fromCreate) {
+          toast.error(danglingMsg);
+          router.refresh();
+        } else {
+          toast.error(result.error ?? "No se pudo vincular");
+        }
+      } catch {
+        toast.error(fromCreate ? danglingMsg : "No se pudo vincular");
+        if (fromCreate) router.refresh();
       }
     });
   }

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -5,7 +5,7 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
-import { Pencil, ArrowDownLeft, ArrowUpRight, Link2, Repeat, Users } from "lucide-react";
+import { Pencil, ArrowDownLeft, ArrowUpRight, Link2, Repeat, Users, UserPlus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
@@ -30,6 +30,10 @@ const DestinatarioZonePicker = dynamic(
 );
 const TagZonePicker = dynamic(
   () => import("@/components/tags/tag-zone-picker").then(m => ({ default: m.TagZonePicker })),
+  { ssr: false }
+);
+const CreatePersonalDebtSheet = dynamic(
+  () => import("@/components/personas/create-personal-debt-sheet").then(m => ({ default: m.CreatePersonalDebtSheet })),
   { ssr: false }
 );
 
@@ -59,9 +63,10 @@ export function MovimientosTransactionRow({
   const [occurrenceCandidates, setOccurrenceCandidates] = useState<CandidateOccurrence[]>([]);
   const [isLinking, startLinkTransition] = useTransition();
 
-  // Link to persona (personal debt) state — reuses isLinking/startLinkTransition
+  // Link to deuda personal (personal debt) state — reuses isLinking/startLinkTransition
   const [personaPickerOpen, setPersonaPickerOpen] = useState(false);
   const [personaCandidates, setPersonaCandidates] = useState<LinkCandidate[]>([]);
+  const [personaCreateOpen, setPersonaCreateOpen] = useState(false);
 
   const canLink = linkableAccountIds?.has(tx.account_id) && !tx.recurrence_group_id;
   const canLinkPersona = !tx.personal_debt_id && !tx.transfer_group_id;
@@ -122,7 +127,7 @@ export function MovimientosTransactionRow({
     startLinkTransition(async () => {
       const result = await linkTransactionToPersonalDebt(debtId, tx.id);
       if (result.success) {
-        toast.success("Transacción vinculada a persona");
+        toast.success("Transacción vinculada a deuda personal");
       } else {
         toast.error(result.error ?? "No se pudo vincular");
       }
@@ -331,7 +336,7 @@ export function MovimientosTransactionRow({
               className={cn(MOBILE_ACTION_BUTTON_CLASS, "inline-flex items-center gap-1 rounded-full hover:bg-z-brass/12")}
             >
               <Users className="size-2.5" />
-              Vincular a persona
+              Vincular a deuda personal
             </button>
           )}
 
@@ -371,16 +376,33 @@ export function MovimientosTransactionRow({
         />
       )}
 
-      {/* Link to persona picker sheet */}
+      {/* Link to deuda personal picker sheet */}
       {personaPickerOpen && (
         <LinkPickerSheet
           open={personaPickerOpen}
           onOpenChange={setPersonaPickerOpen}
-          title="Vincular a persona"
+          title="Vincular a deuda personal"
           subtitle={`${description} · ${formatCurrency(tx.amount, tx.currency_code as CurrencyCode)}`}
           candidates={personaCandidates}
           onConfirm={handleConfirmPersonaLink}
           isPending={isLinking}
+          onCreateNew={() => {
+            setPersonaPickerOpen(false);
+            setPersonaCreateOpen(true);
+          }}
+          createNewLabel="Crear deuda personal nueva"
+          createNewSublabel="Registra la deuda y vincula esta transacción"
+          createNewIcon={<UserPlus className="size-4 text-z-brass" aria-hidden="true" />}
+        />
+      )}
+
+      {/* Create deuda personal + auto-link this transaction */}
+      {personaCreateOpen && (
+        <CreatePersonalDebtSheet
+          open={personaCreateOpen}
+          onOpenChange={setPersonaCreateOpen}
+          currency={tx.currency_code as CurrencyCode}
+          onCreated={handleConfirmPersonaLink}
         />
       )}
     </div>

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -122,12 +122,20 @@ export function MovimientosTransactionRow({
     });
   }
 
-  function handleConfirmPersonaLink(debtId: string) {
+  function handleConfirmPersonaLink(debtId: string, fromCreate = false) {
     setPersonaPickerOpen(false);
     startLinkTransition(async () => {
       const result = await linkTransactionToPersonalDebt(debtId, tx.id);
       if (result.success) {
         toast.success("Transacción vinculada a deuda personal");
+        router.refresh();
+      } else if (fromCreate) {
+        // The debt was already created; surface that so the user isn't left with
+        // a dangling debt and no breadcrumb.
+        toast.error(
+          "Deuda creada, pero no se pudo vincular. Búscala en Deudas personales para vincularla.",
+        );
+        router.refresh();
       } else {
         toast.error(result.error ?? "No se pudo vincular");
       }
@@ -402,7 +410,7 @@ export function MovimientosTransactionRow({
           open={personaCreateOpen}
           onOpenChange={setPersonaCreateOpen}
           currency={tx.currency_code as CurrencyCode}
-          onCreated={handleConfirmPersonaLink}
+          onCreated={(debtId) => handleConfirmPersonaLink(debtId, true)}
         />
       )}
     </div>

--- a/webapp/src/components/personas/create-personal-debt-sheet.tsx
+++ b/webapp/src/components/personas/create-personal-debt-sheet.tsx
@@ -115,6 +115,11 @@ export function CreatePersonalDebtSheet({
               triggerClassName="w-full"
               kindFilter={["person"]}
               createKind="person"
+              // This sheet is a radix Dialog (modal); the picker's default mobile
+              // vaul Drawer renders as a sibling portal that the modal's
+              // pointer-events lock makes unreachable. A nested radix Dialog
+              // stacks correctly inside the sheet.
+              variant="dialog"
             />
           </div>
 

--- a/webapp/src/components/personas/create-personal-debt-sheet.tsx
+++ b/webapp/src/components/personas/create-personal-debt-sheet.tsx
@@ -20,12 +20,16 @@ interface CreatePersonalDebtSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   currency: CurrencyCode;
+  /** When provided, called with the new debt id instead of toasting success —
+   *  lets callers (e.g. "Vincular a deuda personal") link a transaction to it. */
+  onCreated?: (debtId: string) => void;
 }
 
 export function CreatePersonalDebtSheet({
   open,
   onOpenChange,
   currency,
+  onCreated,
 }: CreatePersonalDebtSheetProps) {
   const router = useRouter();
   const today = format(new Date(), "yyyy-MM-dd");
@@ -57,12 +61,18 @@ export function CreatePersonalDebtSheet({
     startTransition(async () => {
       const res = await createPersonalDebt(undefined, formData);
       if (res.success) {
-        toast.success("Cuenta creada");
         reset();
         onOpenChange(false);
-        router.refresh();
+        if (onCreated) {
+          // Caller (auto-link flow) runs its own server action + revalidation —
+          // don't refresh here or the row renders before the link resolves.
+          onCreated(res.data.id);
+        } else {
+          toast.success("Deuda creada");
+          router.refresh();
+        }
       } else {
-        toast.error(res.error ?? "Error al crear la cuenta");
+        toast.error(res.error ?? "Error al crear la deuda");
       }
     });
   }
@@ -74,7 +84,7 @@ export function CreatePersonalDebtSheet({
         className={cn("max-h-[90dvh] overflow-y-auto", MOBILE_SHEET_SAFE_AREA_CLASS)}
       >
         <SheetHeader>
-          <SheetTitle>Nueva cuenta con persona</SheetTitle>
+          <SheetTitle>Nueva deuda personal</SheetTitle>
         </SheetHeader>
         <form action={handleSubmit} className="space-y-4 pt-2">
           <div className="grid grid-cols-2 gap-2">
@@ -130,7 +140,7 @@ export function CreatePersonalDebtSheet({
           </div>
 
           <Button type="submit" className={cn(BRASS_BUTTON_CLASS, "w-full")} disabled={pending}>
-            {pending ? "Guardando..." : "Crear cuenta"}
+            {pending ? "Guardando..." : "Crear deuda"}
           </Button>
         </form>
       </SheetContent>

--- a/webapp/src/components/personas/persona-card.tsx
+++ b/webapp/src/components/personas/persona-card.tsx
@@ -177,10 +177,7 @@ export function PersonaCard({ persona, currency }: PersonaCardProps) {
             <AlertDialogAction
               className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS)}
               disabled={pending}
-              onClick={(e) => {
-                e.preventDefault();
-                runAction(() => deletePersonalDebt(persona.id), "Deuda eliminada");
-              }}
+              onClick={() => runAction(() => deletePersonalDebt(persona.id), "Deuda eliminada")}
             >
               Eliminar
             </AlertDialogAction>

--- a/webapp/src/components/personas/persona-card.tsx
+++ b/webapp/src/components/personas/persona-card.tsx
@@ -3,15 +3,25 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import { GHOST_BUTTON_CLASS, DESTRUCTIVE_GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
 import { formatCurrency } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date";
-import { settlePersonalDebt, cancelPersonalDebt } from "@/actions/personal-debts";
+import { settlePersonalDebt, cancelPersonalDebt, deletePersonalDebt } from "@/actions/personal-debts";
 import { RecordRepaymentDialog } from "./record-repayment-dialog";
 import type { PersonalDebtWithDetails, CurrencyCode } from "@/types/domain";
 
@@ -24,6 +34,7 @@ export function PersonaCard({ persona, currency }: PersonaCardProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [repayOpen, setRepayOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [pending, startTransition] = useTransition();
 
   const code = (persona.currency_code ?? currency) as CurrencyCode;
@@ -102,34 +113,45 @@ export function PersonaCard({ persona, currency }: PersonaCardProps) {
           </dl>
           {persona.notes && <p className="text-xs text-muted-foreground">{persona.notes}</p>}
 
-          {isActive && (
-            <div className="flex flex-wrap gap-2 pt-1">
-              <Button
-                size="sm"
-                className={cn(GHOST_BUTTON_CLASS)}
-                disabled={pending}
-                onClick={() => setRepayOpen(true)}
-              >
-                Registrar abono
-              </Button>
-              <Button
-                size="sm"
-                className={cn(GHOST_BUTTON_CLASS)}
-                disabled={pending}
-                onClick={() => runAction(() => settlePersonalDebt(persona.id), "Cuenta saldada")}
-              >
-                Saldar
-              </Button>
-              <Button
-                size="sm"
-                className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS)}
-                disabled={pending}
-                onClick={() => runAction(() => cancelPersonalDebt(persona.id), "Cuenta cancelada")}
-              >
-                Cancelar
-              </Button>
-            </div>
-          )}
+          <div className="flex flex-wrap gap-2 pt-1">
+            {isActive && (
+              <>
+                <Button
+                  size="sm"
+                  className={cn(GHOST_BUTTON_CLASS)}
+                  disabled={pending}
+                  onClick={() => setRepayOpen(true)}
+                >
+                  Registrar abono
+                </Button>
+                <Button
+                  size="sm"
+                  className={cn(GHOST_BUTTON_CLASS)}
+                  disabled={pending}
+                  onClick={() => runAction(() => settlePersonalDebt(persona.id), "Cuenta saldada")}
+                >
+                  Saldar
+                </Button>
+                <Button
+                  size="sm"
+                  className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS)}
+                  disabled={pending}
+                  onClick={() => runAction(() => cancelPersonalDebt(persona.id), "Cuenta cancelada")}
+                >
+                  Cancelar
+                </Button>
+              </>
+            )}
+            <Button
+              size="sm"
+              className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS)}
+              disabled={pending}
+              onClick={() => setDeleteOpen(true)}
+            >
+              <Trash2 className="mr-1 size-3.5" />
+              Eliminar
+            </Button>
+          </div>
         </div>
       )}
 
@@ -139,6 +161,32 @@ export function PersonaCard({ persona, currency }: PersonaCardProps) {
         personalDebtId={persona.id}
         personName={persona.destinatario_name}
       />
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar esta deuda?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Se eliminará la deuda con {persona.destinatario_name} de forma permanente.
+              Las transacciones vinculadas se conservan, pero dejarán de estar asociadas a
+              esta deuda. Esta acción no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              className={cn(DESTRUCTIVE_GHOST_BUTTON_CLASS)}
+              disabled={pending}
+              onClick={(e) => {
+                e.preventDefault();
+                runAction(() => deletePersonalDebt(persona.id), "Deuda eliminada");
+              }}
+            >
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/webapp/src/components/personas/personas-root.tsx
+++ b/webapp/src/components/personas/personas-root.tsx
@@ -45,7 +45,7 @@ export function PersonasRoot({ debts, overview, currency }: PersonasRootProps) {
       <div className="flex justify-end">
         <Button className={cn(BRASS_BUTTON_CLASS)} onClick={() => setCreateOpen(true)}>
           <Plus className="mr-1.5 size-4" />
-          Nueva cuenta con persona
+          Nueva deuda personal
         </Button>
       </div>
 

--- a/webapp/src/components/recurring/link-picker-sheet.tsx
+++ b/webapp/src/components/recurring/link-picker-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { CalendarPlus, Link2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -41,6 +41,10 @@ interface LinkPickerSheetProps {
   isLoadingAll?: boolean;
   /** Secondary action: offer to create a brand-new template from this tx. */
   onCreateNew?: () => void;
+  /** Copy + icon for the create-new affordance (defaults to the recurrente case). */
+  createNewLabel?: string;
+  createNewSublabel?: string;
+  createNewIcon?: ReactNode;
 }
 
 export function LinkPickerSheet({
@@ -55,6 +59,9 @@ export function LinkPickerSheet({
   onShowAll,
   isLoadingAll,
   onCreateNew,
+  createNewLabel = "Crear nueva recurrente",
+  createNewSublabel = "Promueve esta transacción a una plantilla mensual",
+  createNewIcon,
 }: LinkPickerSheetProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -155,14 +162,16 @@ export function LinkPickerSheet({
               className="mt-3 flex w-full items-center gap-3 rounded-lg border border-dashed border-z-brass/30 bg-z-brass/5 px-3 py-3 text-left transition-colors hover:bg-z-brass/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-z-brass/60"
             >
               <div className="flex h-9 w-9 items-center justify-center rounded-full border border-z-brass/30 bg-z-brass/10">
-                <CalendarPlus className="size-4 text-z-brass" aria-hidden="true" />
+                {createNewIcon ?? (
+                  <CalendarPlus className="size-4 text-z-brass" aria-hidden="true" />
+                )}
               </div>
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-z-brass">
-                  Crear nueva recurrente
+                  {createNewLabel}
                 </p>
                 <p className="truncate text-xs text-muted-foreground">
-                  Promueve esta transacción a una plantilla mensual
+                  {createNewSublabel}
                 </p>
               </div>
             </button>

--- a/webapp/src/components/ui/dialog.tsx
+++ b/webapp/src/components/ui/dialog.tsx
@@ -49,15 +49,19 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  /** Extra classes for the backdrop — e.g. a z-index bump when the dialog is
+   *  opened from inside a Sheet so the scrim dims the sheet, not hides behind it. */
+  overlayClassName?: string
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/webapp/src/lib/constants/navigation.ts
+++ b/webapp/src/lib/constants/navigation.ts
@@ -52,7 +52,7 @@ export const WORKSPACE_NAV: NavItem[] = [
   { title: "Importar", href: "/import", icon: FileUp },
   { title: "Cuentas", href: "/accounts", icon: Wallet },
   { title: "Deudas", href: "/deudas", icon: Landmark },
-  { title: "Personas", href: "/personas", icon: Users },
+  { title: "Deudas personales", href: "/deudas-personales", icon: Users },
 ];
 
 export const BOTTOM_NAV: NavItem[] = [

--- a/webapp/src/lib/constants/styles.ts
+++ b/webapp/src/lib/constants/styles.ts
@@ -21,6 +21,18 @@ export const DESTRUCTIVE_BUTTON_CLASS =
 export const DESTRUCTIVE_GHOST_BUTTON_CLASS =
   "border-z-debt/25 bg-black/10 text-z-expense hover:bg-z-debt/10";
 
+/**
+ * Z-index layers (see CLAUDE.md "z-index discipline"):
+ *   z-40            mobile tab bar
+ *   z-50            shadcn primitives (Dialog, Popover, Drawer, Select, …)
+ *   z-[10000]       Sheet + FabMenu (top layer — cover other modals)
+ *   Z_DIALOG_ABOVE_SHEET  a primitive opened from INSIDE a Sheet must clear z-[10000].
+ * Use this for any Dialog/Popover/Drawer rendered within a Sheet (e.g. the
+ * destinatario picker inside "Nueva deuda personal"). Toasts (sonner, z≈10^9)
+ * still sit above it.
+ */
+export const Z_DIALOG_ABOVE_SHEET = "z-[10001]";
+
 /** Shared page shell spacing */
 export const PAGE_STACK_CLASS = "space-y-6 lg:space-y-8";
 


### PR DESCRIPTION
## What

Reframes the **Personas** module to **Deudas personales** (it's a personal-debt ledger, not a contacts module) and fixes the flows that made it unusable on mobile, plus adds hard-delete.

### Reframe
- Route `/personas` → `/deudas-personales` (config-level 308 redirect for old bookmarks).
- Nav entry, page title, create-sheet copy, mobile "Más" hub tile, bandeja links — all "Deudas personales". (The `/destinatarios` "Personas" contacts tab is a separate feature, untouched.)

### Reachability + create (the bugs)
- **Mobile access:** added a "Deudas personales" tile to the `/gestionar` (Más) hub + quick links on the bandeja page — `/personas` was never in the mobile webapp nav.
- **Picker dead-end — root cause was twofold:**
  1. The picker trigger was a typeless shadcn `<Button>` → `type="submit"` inside the create `<form>`, so tapping it submitted the form ("Elige una persona"). Fixed with `type="button"`.
  2. The picker `Dialog` (z-50) rendered **behind** the `Sheet` (z-10000) — present in the DOM but invisible/untappable. Fixed by lifting it to `Z_DIALOG_ABOVE_SHEET` (z-[10001]) on content **and** overlay; named constant + a z-layer table in TOKENS.md.
- **Vincular → create + auto-link:** the "Vincular a deuda personal" sheet now offers "Crear deuda personal nueva" → creates the debt and auto-links the transaction (with hardened feedback if linking throws/fails).

### Delete (requested)
- `deletePersonalDebt()` action (auth + defense-in-depth `user_id`; linked transactions auto-unlink via FK `ON DELETE SET NULL`) + an "Eliminar" button with a confirm dialog on every debt card — works for active, settled, and cancelled, so old/cancelled debts can be cleaned up.

## Review
Ran `/code-review` + `/simplify` on the branch:
- Correctness: try/catch on the link action (thrown-error feedback), removed `preventDefault` on the delete confirm (double-click guard). No blocking bugs.
- Simplify: moved the `/personas` redirect to `next.config`. Deferred cleanups (central SheetContext z-handling, shared ConfirmDialog, mutation helper, `pd_role` hygiene) recorded in BACKLOG.

## Verification
- `cd webapp && pnpm build` → exit 0, 0 type errors.
- Driven in a real browser (chrome-devtools, hit-tested with `elementFromPoint` + screenshots): picker opens above the sheet and is genuinely tappable; person selection populates the field; delete confirm renders on a Cancelada debt; `/personas` → 308 → `/deudas-personales` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)