### PR TITLE
feat(deudas-personales): personas usability pass

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -82,7 +82,8 @@
 - **Shared `ConfirmDialog`:** the destructive-confirm AlertDialog block is now a 3rd copy (persona-card + settings/delete-account + settings/reset-data). Extract a reusable `<ConfirmDialog>` and retrofit all three.
 - **`runPersonalDebtMutation` helper:** `cancel`/`settle`/`deletePersonalDebt` share the validate→auth→mutate→rowcheck→revalidate skeleton; collapse into one helper (watch Supabase query-builder generics). Note `settlePersonalDebt` omits `revalidateFinancialViews()` though it zeroes `outstanding_amount` — confirm intended when refactoring.
 - **`pd_role` hygiene on delete:** FK `ON DELETE SET NULL` clears `personal_debt_id` but leaves a dangling `pd_role` on the unlinked tx. Harmless today (income predicate also checks `personal_debt_id != null`); NULL it out (or a sweep migration) if any future query keys on `pd_role` alone.
-- **Found:** /code-review + /simplify, branch feat/personas-usability, 2026-06-04.
+- **`AppDataProvider` value not memoized (perf, app-wide):** `webapp/src/components/providers/app-data-provider.tsx` passes the raw `data` object straight to `Context.Provider`, so any parent re-render makes a new reference and re-renders every consumer — including every `MovimientosTransactionRow` subscribing via `useDestinatarios()`. Wrap `data` in `useMemo` keyed on its arrays. Surfaced by /simplify efficiency pass when the row started reading `useDestinatarios()`; pre-existing infra, not specific to deudas-personales.
+- **Found:** /code-review + /simplify, branch feat/personas-usability, 2026-06-04 (AppDataProvider note added 2026-06-05).
 
 ### Mobile — yearly budgets not displayed
 - **Priority:** Low

--- a/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-transaction-row.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/actions/occurrences";
 import type { CandidateOccurrence } from "@/actions/occurrences";
 import { getPersonalDebts, linkTransactionToPersonalDebt } from "@/actions/personal-debts";
+import { useDestinatarios } from "@/components/providers/app-data-provider";
 import { toast } from "sonner";
 import type { TransactionWithAccount, CategoryWithChildren, CurrencyCode } from "@/types/domain";
 
@@ -151,6 +152,17 @@ export function MovimientosTransactionRow({
   // Optimistic local state
   const [localCategory, setLocalCategory] = useState(tx.category);
   const [localDestinatario, setLocalDestinatario] = useState(tx.destinatario);
+
+  // Prefill source for the "crear deuda personal" sheet: only seed the persona
+  // when the assigned destinatario is actually a person — merchants/companies
+  // aren't valid debt counterparties. (Direction/amount/date are read straight
+  // off the tx at the call site below.)
+  const destinatarios = useDestinatarios();
+  const debtCounterparty =
+    localDestinatario &&
+    destinatarios.some((d) => d.id === localDestinatario.id && d.kind === "person")
+      ? localDestinatario
+      : null;
 
   const description =
     tx.merchant_name ||
@@ -293,7 +305,7 @@ export function MovimientosTransactionRow({
               "text-[10px] h-auto py-1 px-2.5 rounded-full border font-medium",
               categoryName
                 ? "border-z-brass/20 bg-z-brass/8 text-z-brass hover:bg-z-brass/12"
-                : "border-white/8 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]",
+                : "border-white/6 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]",
             )}
           />
 
@@ -313,7 +325,7 @@ export function MovimientosTransactionRow({
               "rounded-full text-[10px] h-auto py-1 px-2.5 font-medium",
               localDestinatario
                 ? "border-z-brass/20 bg-z-brass/8 text-z-brass hover:bg-z-brass/12"
-                : "border-white/8 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]"
+                : "border-white/6 bg-white/[0.03] text-muted-foreground hover:bg-white/[0.06]"
             )}
           />
 
@@ -357,7 +369,7 @@ export function MovimientosTransactionRow({
           {/* Edit link */}
           <Link
             href={`/transactions/${tx.id}`}
-            className="inline-flex items-center gap-1 rounded-full border border-white/8 bg-white/[0.03] px-2.5 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-white/[0.06]"
+            className="inline-flex items-center gap-1 rounded-full border border-white/6 bg-white/[0.03] px-2.5 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-white/[0.06]"
           >
             <Pencil className="size-2.5" />
             Editar
@@ -416,6 +428,12 @@ export function MovimientosTransactionRow({
           open={personaCreateOpen}
           onOpenChange={setPersonaCreateOpen}
           currency={tx.currency_code as CurrencyCode}
+          // INFLOW = money came in → someone lent it to me → I owe them ("borrowed").
+          defaultDirection={tx.direction === "INFLOW" ? "borrowed" : "lent"}
+          defaultAmount={tx.amount}
+          defaultDestinatarioId={debtCounterparty?.id ?? null}
+          defaultDestinatarioName={debtCounterparty?.name ?? null}
+          defaultOpenedOn={tx.transaction_date}
           onCreated={(debtId) => handleConfirmPersonaLink(debtId, true)}
         />
       )}

--- a/webapp/src/components/personas/create-personal-debt-sheet.tsx
+++ b/webapp/src/components/personas/create-personal-debt-sheet.tsx
@@ -12,7 +12,12 @@ import { AmountInput } from "@/components/ui/amount-input";
 import { DatePicker } from "@/components/ui/date-picker";
 import { DestinatarioZonePicker } from "@/components/destinatarios/destinatario-zone-picker";
 import { cn } from "@/lib/utils";
-import { BRASS_BUTTON_CLASS, MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
+import {
+  BRASS_BUTTON_CLASS,
+  BRASS_GHOST_BUTTON_CLASS,
+  GHOST_BUTTON_CLASS,
+  MOBILE_SHEET_SAFE_AREA_CLASS,
+} from "@/lib/constants/styles";
 import { createPersonalDebt } from "@/actions/personal-debts";
 import type { CurrencyCode } from "@/types/domain";
 
@@ -23,6 +28,13 @@ interface CreatePersonalDebtSheetProps {
   /** When provided, called with the new debt id instead of toasting success —
    *  lets callers (e.g. "Vincular a deuda personal") link a transaction to it. */
   onCreated?: (debtId: string) => void;
+  /** Prefill — used when creating from a transaction. */
+  defaultDirection?: "borrowed" | "lent";
+  defaultAmount?: number;
+  defaultDestinatarioId?: string | null;
+  defaultDestinatarioName?: string | null;
+  /** yyyy-MM-dd — defaults to today. */
+  defaultOpenedOn?: string;
 }
 
 export function CreatePersonalDebtSheet({
@@ -30,21 +42,27 @@ export function CreatePersonalDebtSheet({
   onOpenChange,
   currency,
   onCreated,
+  defaultDirection = "borrowed",
+  defaultAmount,
+  defaultDestinatarioId = null,
+  defaultDestinatarioName = null,
+  defaultOpenedOn,
 }: CreatePersonalDebtSheetProps) {
   const router = useRouter();
   const today = format(new Date(), "yyyy-MM-dd");
-  const [destinatarioId, setDestinatarioId] = useState<string | null>(null);
-  const [destinatarioName, setDestinatarioName] = useState<string | null>(null);
-  const [direction, setDirection] = useState<"borrowed" | "lent">("borrowed");
-  const [openedOn, setOpenedOn] = useState(today);
+  const initialOpenedOn = defaultOpenedOn ?? today;
+  const [destinatarioId, setDestinatarioId] = useState<string | null>(defaultDestinatarioId);
+  const [destinatarioName, setDestinatarioName] = useState<string | null>(defaultDestinatarioName);
+  const [direction, setDirection] = useState<"borrowed" | "lent">(defaultDirection);
+  const [openedOn, setOpenedOn] = useState(initialOpenedOn);
   const [dueDate, setDueDate] = useState<string>("");
   const [pending, startTransition] = useTransition();
 
   function reset() {
-    setDestinatarioId(null);
-    setDestinatarioName(null);
-    setDirection("borrowed");
-    setOpenedOn(today);
+    setDestinatarioId(defaultDestinatarioId);
+    setDestinatarioName(defaultDestinatarioName);
+    setDirection(defaultDirection);
+    setOpenedOn(initialOpenedOn);
     setDueDate("");
   }
 
@@ -83,10 +101,11 @@ export function CreatePersonalDebtSheet({
         side="bottom"
         className={cn("max-h-[90dvh] overflow-y-auto", MOBILE_SHEET_SAFE_AREA_CLASS)}
       >
-        <SheetHeader>
-          <SheetTitle>Nueva deuda personal</SheetTitle>
-        </SheetHeader>
-        <form action={handleSubmit} className="space-y-4 pt-2">
+        <div className="mx-auto w-full max-w-md px-5">
+          <SheetHeader className="px-0 pt-1">
+            <SheetTitle>Nueva deuda personal</SheetTitle>
+          </SheetHeader>
+          <form action={handleSubmit} className="space-y-4 pb-4 pt-2">
           <div className="grid grid-cols-2 gap-2">
             <DirectionButton
               active={direction === "borrowed"}
@@ -123,7 +142,7 @@ export function CreatePersonalDebtSheet({
             />
           </div>
 
-          <AmountInput name="principal_amount" currency={currency} />
+          <AmountInput name="principal_amount" currency={currency} defaultValue={defaultAmount} />
 
           <div className="space-y-2">
             <Label>Fecha de apertura</Label>
@@ -147,7 +166,8 @@ export function CreatePersonalDebtSheet({
           <Button type="submit" className={cn(BRASS_BUTTON_CLASS, "w-full")} disabled={pending}>
             {pending ? "Guardando..." : "Crear deuda"}
           </Button>
-        </form>
+          </form>
+        </div>
       </SheetContent>
     </Sheet>
   );
@@ -170,7 +190,7 @@ function DirectionButton({
       onClick={onClick}
       className={cn(
         "rounded-lg border px-3 py-2 text-left transition-colors",
-        active ? "border-z-brass/40 bg-z-brass/10" : "border-white/6 bg-z-surface-2",
+        active ? BRASS_GHOST_BUTTON_CLASS : GHOST_BUTTON_CLASS,
       )}
     >
       <span className="block text-sm font-medium">{label}</span>

--- a/webapp/src/components/personas/create-personal-debt-sheet.tsx
+++ b/webapp/src/components/personas/create-personal-debt-sheet.tsx
@@ -58,14 +58,6 @@ export function CreatePersonalDebtSheet({
   const [dueDate, setDueDate] = useState<string>("");
   const [pending, startTransition] = useTransition();
 
-  function reset() {
-    setDestinatarioId(defaultDestinatarioId);
-    setDestinatarioName(defaultDestinatarioName);
-    setDirection(defaultDirection);
-    setOpenedOn(initialOpenedOn);
-    setDueDate("");
-  }
-
   function handleSubmit(formData: FormData) {
     if (!destinatarioId) {
       toast.error("Elige una persona");
@@ -79,7 +71,8 @@ export function CreatePersonalDebtSheet({
     startTransition(async () => {
       const res = await createPersonalDebt(undefined, formData);
       if (res.success) {
-        reset();
+        // Both callers mount this sheet conditionally, so it unmounts on close
+        // and re-initializes from defaults on the next open — no manual reset.
         onOpenChange(false);
         if (onCreated) {
           // Caller (auto-link flow) runs its own server action + revalidation —

--- a/webapp/src/components/personas/personas-root.tsx
+++ b/webapp/src/components/personas/personas-root.tsx
@@ -73,7 +73,10 @@ export function PersonasRoot({ debts, overview, currency }: PersonasRootProps) {
         </>
       )}
 
-      <CreatePersonalDebtSheet open={createOpen} onOpenChange={setCreateOpen} currency={currency} />
+      {/* Conditionally mounted so internal state resets on every open. */}
+      {createOpen && (
+        <CreatePersonalDebtSheet open={createOpen} onOpenChange={setCreateOpen} currency={currency} />
+      )}
     </div>
   );
 }

--- a/webapp/src/components/ui/amount-input.tsx
+++ b/webapp/src/components/ui/amount-input.tsx
@@ -34,7 +34,7 @@ export function AmountInput({
         placeholder="0"
         className={cn(
           "border-none bg-transparent text-center shadow-none",
-          "text-[32px] font-extrabold tracking-tight",
+          "text-[32px] font-extrabold tracking-tight tabular-nums",
           "h-auto py-2",
           "focus-visible:ring-0 focus-visible:border-none",
           "placeholder:text-muted-foreground/30",


### PR DESCRIPTION
## Resumen

Pase de usabilidad sobre el módulo **Deudas personales** (antes "Personas"): hace el flujo de crear/vincular deudas desde una transacción fluido y arregla varios footguns de UI en el camino.

## Cambios principales

- **Prefill al crear deuda desde una transacción** (último commit): "Vincular a deuda personal" → "Crear deuda personal nueva" ahora hereda de la transacción:
  - **dirección**: INFLOW → *Debo* (alguien me prestó), OUTFLOW → *Me deben*
  - **monto**: `tx.amount`
  - **fecha de apertura**: `tx.transaction_date`
  - **persona**: el destinatario asignado, solo si su `kind` es `person`
  - Centra y agrega padding al contenido del bottom-sheet (antes pegado a los bordes); toggle Debo/Me deben usa los tokens `BRASS_GHOST`/`GHOST`; `AmountInput` gana `tabular-nums` (compartido).
- **Eliminar** una deuda personal (no solo cancelar).
- **Reframe del módulo** Personas → Deudas personales, con redirect `/personas → /deudas-personales` vía `next.config`, y entrada en el hub móvil "Más".
- **Fixes de picker dentro del sheet**: trigger que enviaba el form padre (`type=button`), z-index del dialog del picker por debajo del sheet, y la persona inalcanzable dentro del sheet de creación.
- Feedback de auto-link + refresh tras vincular.

## Verificación
- `pnpm build` limpio.
- Revisado con `zetas-front-guy` (tokens/variantes) y pase `/simplify` (4 agentes) — cleanups aplicados, resto justificado.
- Dry-merge contra `main` sin conflictos.

## Deuda diferida (en BACKLOG.md)
- `AppDataProvider` no memoiza su `value` → re-renders en cascada de filas suscritas (infra preexistente, fuera de este diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)