### PR TITLE
fix(destinatarios): auto-match person-kind destinatarios on import

### DIFF
--- a/webapp/src/actions/destinatarios.ts
+++ b/webapp/src/actions/destinatarios.ts
@@ -123,7 +123,7 @@ export async function fetchDestinatarioRules(
   const rules: DestinatarioRule[] = [];
   for (const row of data ?? []) {
     const dest = row.destinatarios;
-    if (!dest || !dest.is_active || dest.kind === "person") continue;
+    if (!dest || !dest.is_active) continue;
 
     rules.push({
       destinatario_id: row.destinatario_id,


### PR DESCRIPTION
PR #281 (Personas) added a `kind === "person"` filter to
fetchDestinatarioRules(), which silently excluded person destinatarios
from the import/email auto-matching path (matchTransactionToDestinatario).
Merchant destinatarios still matched, but persons did not — even though
their patterns were valid, as proven by the "Buscar coincidencias" button
(findUnlinkedMatches), which queries rules by id with no kind filter.

Remove the exclusion so persons and merchants auto-match identically on
import, restoring prior behavior and matching the button's results.