### PR TITLE
feat(presupuesto): Simular cambio — scenario budget sandbox

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -568,6 +568,16 @@ Source of truth: `claude-ai-design/Zeta Wireframes.html`. Variant A (Safe) ships
   2. **getNonDebtAccounts still fetched eagerly** (Low) — now cached, but it's only needed when the user opens the Plata extra sheet (Plan lens). Move out of MobileDebtSection/DesktopDebtSection `Promise.all`; let `ExtraPaymentTrigger` fetch on interaction or wrap in Suspense.
   3. **Nested PANEL_INSET_CLASS in deudas-hero breakdown** (Low) — double rounded-2xl borders; inner surface should step down to rounded-xl (zetas-front-guy W4).
 
+### Simular cambio (presupuesto) — deferred review findings (2026-06-10, branch feat/presupuesto-simular-cambio)
+- **Priority:** Low–Medium
+- **From:** server-action-reviewer + zetas-front-guy + perf-auditor gates on the budget-scenario sandbox.
+- **What:**
+  1. **Category-ownership validation in shared budget paths** (Medium) — `applyBudgetScenario` now validates line category ids against own+system categories, but the pre-existing `upsertBudgetForCategory`/`bulkUpsertBudgets` in `webapp/src/actions/budget.ts` still upsert client-supplied `category_id` without ownership check (FK only). Harden both with the same `.or(\`user_id.eq.\${user.id},user_id.is.null\`)` check.
+  2. **getCushionBalance() scalar action** (Low) — `plan-tab-presupuesto.tsx` fetches the full `getAccounts()` payload just to sum CHECKING+SAVINGS balances for the scenario colchón. Add a dedicated cached function returning only the scalar; also reusable by health-meters (same computation).
+  3. **Segmented-control class constants** (Low) — the Real/Simulación toggle (`scenario-section.tsx`) and the savings-rate control (`scenario-startup.tsx`) repeat the same pill-tab pattern inline; zetas-front-guy suggests `SEGMENTED_TAB_*` constants in `styles.ts` (plus a gold-active variant). Also the dashed gold add-row button appears twice → `SCENARIO_ADD_ROW_CLASS`.
+  4. **Vehículo template** (Low) — entry sheet ships with Mudanza + Desde cero; design also proposed Vehículo (cuota, gasolina, seguro). Add once slug mapping for vehicle categories is decided.
+  5. **Demo-mode unique-constraint collision (pre-existing)** (Low) — `budgets` unique key `(user_id, category_id, period)` doesn't include `is_demo`, so a real-mode upsert can overwrite a demo row for the same category. Affects all budget upsert paths, not just scenarios.
+
 ### packages/shared — pre-existing test failures on main (found 2026-06-09)
 - **Priority:** Medium
 - **What:** `pnpm test` in packages/shared fails on main: `auto-categorize.test.ts` 39 failed, `debt-stats.test.ts` 1 failed. Pre-date the deudas-lenses branch (verified via stash). CI presumably doesn't run shared tests or would have caught it. Triage whether the tests or the implementation drifted (likely category kit/keyword changes).

--- a/claude-ai-design/presupuesto-simular-cambio/Presupuesto - Simular cambio.html
+++ b/claude-ai-design/presupuesto-simular-cambio/Presupuesto - Simular cambio.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Zeta · Presupuesto — Simular cambio</title>
+<link rel="stylesheet" href="_ds/zeta-design-system-019dcbea-f04a-7d4c-b73b-b05e420673e5/colors_and_type.css" />
+<style>
+  html, body { margin: 0; background: #e8e4de; }
+  button { font-family: var(--font-sans); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="_ds/zeta-design-system-019dcbea-f04a-7d4c-b73b-b05e420673e5/_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel" src="presupuesto/design-canvas.jsx"></script>
+<script type="text/babel" src="presupuesto/zeta-ui.jsx"></script>
+<script type="text/babel" src="presupuesto/data.jsx"></script>
+<script type="text/babel" src="presupuesto/section-a.jsx"></script>
+<script type="text/babel" src="presupuesto/section-b.jsx"></script>
+<script type="text/babel" src="presupuesto/section-c.jsx"></script>
+<script type="text/babel" src="presupuesto/section-d.jsx"></script>
+<script type="text/babel" src="presupuesto/section-e.jsx"></script>
+<script type="text/babel">
+
+function App() {
+  return (
+    <DesignCanvas>
+
+      {/* ── A · Entrada + modo ────────────────────────────── */}
+      <DCSection
+        id="sec-a"
+        title="A · Entrada + estado de modo"
+        subtitle="Cómo empieza la simulación y cómo la página grita 'esto no es tu presupuesto real'. Acento oro de alerta = sandbox; nada del layout real se rediseña."
+      >
+        <DCArtboard id="a1" label="A1 · El héroe se transforma" width={390} height={780} style={{ height: "auto" }}>
+          <Frame data-screen-label="A1 heroe se transforma">
+            <EntradaA1 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="a2" label="A2 · Banner persistente + zona sandbox" width={390} height={620} style={{ height: "auto" }}>
+          <Frame data-screen-label="A2 banner persistente">
+            <EntradaA2 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="a3" label="A3 · Plantillas + selector de modo" width={390} height={920} style={{ height: "auto" }}>
+          <Frame data-screen-label="A3 plantillas y selector">
+            <EntradaA3 />
+          </Frame>
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── B · Editor del escenario ──────────────────────── */}
+      <DCSection
+        id="sec-b"
+        title="B · Editor del escenario"
+        subtitle="Borrador editable: actual → escenario, chip de delta, prom 3m como ancla de realidad. Toca un monto para editarlo en línea. Arriendo entra con 'nuevo'; Mercado sube; Restaurantes muestra un recorte."
+      >
+        <DCArtboard id="b1" label="B1 · Lista plana, edición en línea" width={390} height={900} style={{ height: "auto" }}>
+          <Frame data-screen-label="B1 editor lista plana">
+            <EditorB1 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="b2" label="B2 · Agrupado: Nuevos / Cambian / Igual" width={390} height={760} style={{ height: "auto" }}>
+          <Frame data-screen-label="B2 editor agrupado">
+            <EditorB2 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="b3" label="B3 · Ancla de realidad como barra" width={390} height={980} style={{ height: "auto" }}>
+          <Frame data-screen-label="B3 editor ancla realidad">
+            <EditorB3 />
+          </Frame>
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── C · Veredicto ─────────────────────────────────── */}
+      <DCSection
+        id="sec-c"
+        title="C · Veredicto — la respuesta"
+        subtitle="¿Cuánto necesito, qué parte del ingreso se va, dónde recorto? C1 desglosa la cuenta completa y los recortes son de un toque (¡pruébalos!). C2 lo cuenta sobre las barras 50/30/20. C3 lo fija al pie del editor."
+      >
+        <DCArtboard id="c1" label="C1 · La cuenta completa — no alcanza" width={390} height={820} style={{ height: "auto" }}>
+          <Frame data-screen-label="C1 veredicto no alcanza">
+            <StateTag>No alcanza · toca "Aplicar" para recortar en vivo</StateTag>
+            <VerdictC1 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="c1b" label="C1 · La cuenta completa — funciona" width={390} height={860} style={{ height: "auto" }}>
+          <Frame data-screen-label="C1b veredicto funciona">
+            <StateTag>Funciona · todos los recortes aplicados</StateTag>
+            <VerdictC1 defaultApplied={["restaurantes", "salidas", "ahorro", "suscripciones", "muebles"]} />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="c2" label="C2 · Sobre las barras 50/30/20" width={390} height={840} style={{ height: "auto" }}>
+          <Frame data-screen-label="C2 veredicto barras">
+            <StateTag>No alcanza · barra fantasma = actual</StateTag>
+            <VerdictC2 />
+            <StateTag>Funciona · con recortes aplicados</StateTag>
+            <VerdictC2 fits={true} />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="c3" label="C3 · Barra fija + hoja" width={390} height={980} style={{ height: "auto" }}>
+          <Frame data-screen-label="C3 veredicto barra fija">
+            <VerdictC3 />
+          </Frame>
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── D · Gastos de arranque ────────────────────────── */}
+      <DCSection
+        id="sec-d"
+        title="D · Gastos de arranque"
+        subtitle="Las compras de una sola vez (nevera, muebles, cocina) viven aparte de las líneas mensuales: veredicto del motor de Deseos + plan de fondeo. D2 es interactivo: cambia el ritmo de ahorro y el colchón."
+      >
+        <DCArtboard id="d1" label="D1 · Lista con plan de fondeo" width={390} height={720} style={{ height: "auto" }}>
+          <Frame data-screen-label="D1 arranque lista">
+            <ArranqueD1 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="d2" label="D2 · Línea de tiempo (interactiva)" width={390} height={720} style={{ height: "auto" }}>
+          <Frame data-screen-label="D2 arranque timeline">
+            <ArranqueD2 />
+          </Frame>
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── E · Aplicar / comparar ────────────────────────── */}
+      <DCSection
+        id="sec-e"
+        title="E · Aplicar / comparar"
+        subtitle="El momento de compromiso: hoja de comparación actual vs escenario con confirmación 'desde julio' (E1), o guardar la simulación como borrador con nombre para volver después (E2)."
+      >
+        <DCArtboard id="e1" label="E1 · Hoja de comparación" width={390} height={880} style={{ height: "auto" }}>
+          <Frame data-screen-label="E1 hoja comparacion">
+            <AplicarE1 />
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="e2" label="E2 · Borrador con nombre" width={390} height={1000} style={{ height: "auto" }}>
+          <Frame data-screen-label="E2 borrador nombrado">
+            <AplicarE2 />
+          </Frame>
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/data.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/data.jsx
@@ -1,0 +1,283 @@
+// Presupuesto · "Simular cambio" — datos de muestra + primitivas compartidas
+// Matemática del escenario (documentada para consistencia entre secciones):
+//   Ingreso 4.500.000 · presupuesto actual 2.690.000 · restante 1.810.000
+//   Escenario (sin recortes) 4.805.000 → brecha de presupuesto −305.000
+//   Sobregasto real (prom 3m > presupuesto en líneas no tocadas):
+//     Transporte +15.000 · Restaurantes +85.000 · Salidas +60.000 = 160.000
+//   Reserva de arranque: 615.000/mes (arranque 3.450.000 listo en 6 meses)
+//   FALTA TOTAL = 305 + 160 + 615 = 1.080.000/mes  ← veredicto
+//   Recortes: Restaurantes −150 (alivio 235) · Salidas −120 (alivio 180)
+//     · Ahorro −300 · Suscripciones −45 · Aplazar muebles (alivio 340)
+//   Todos aplicados → sobra 20.000/mes. Escenario con recortes: 4.235.000.
+
+const PINGRESO = 4500000;
+Z.expense = "#E8875A";
+
+const PCATS = [
+  { id: "arriendo",      name: "Arriendo",      cur: null,   scen: 1500000, prom: null,   nuevo: true,  grupo: "nec" },
+  { id: "servicios",     name: "Servicios",     cur: null,   scen: 220000,  prom: null,   nuevo: true,  grupo: "nec" },
+  { id: "internet",      name: "Internet",      cur: null,   scen: 95000,   prom: null,   nuevo: true,  grupo: "nec" },
+  { id: "mercado",       name: "Mercado",       cur: 350000, scen: 650000,  prom: 410000, grupo: "nec" },
+  { id: "transporte",    name: "Transporte",    cur: 280000, scen: 280000,  prom: 295000, grupo: "nec" },
+  { id: "restaurantes",  name: "Restaurantes",  cur: 300000, scen: 300000,  prom: 385000, grupo: "gusto" },
+  { id: "suscripciones", name: "Suscripciones", cur: 95000,  scen: 95000,   prom: 95000,  grupo: "gusto" },
+  { id: "salidas",       name: "Salidas",       cur: 250000, scen: 250000,  prom: 310000, grupo: "gusto" },
+  { id: "deudas",        name: "Deudas",        cur: 815000, scen: 815000,  prom: 815000, fijo: true, grupo: "nec" },
+  { id: "ahorro",        name: "Ahorro",        cur: 600000, scen: 600000,  prom: 600000, grupo: "ahorro" },
+];
+
+const PTOT = {
+  cur: 2690000,
+  scen: 4805000,          // sin recortes
+  scenCut: 4235000,       // con recortes (rest −150, salidas −120, ahorro −300)
+  restanteCur: 1810000,
+  brechaPresupuesto: 305000,
+  sobregasto: 160000,
+  reservaArranque: 615000,
+  falta: 1080000,
+  sobraConTodo: 20000,
+};
+
+// Candidatos a recorte — "alivio" = recorte + sobregasto que desaparece (+ reserva si aplaza)
+const PCUTS = [
+  { id: "restaurantes", name: "Restaurantes", recorte: 150000, alivio: 235000, de: 300000, a: 150000, prom: 385000, nota: "Tu promedio real es $ 385.000 — recorte exigente" },
+  { id: "salidas",      name: "Salidas",      recorte: 120000, alivio: 180000, de: 250000, a: 130000, prom: 310000, nota: "Tu promedio real es $ 310.000" },
+  { id: "ahorro",       name: "Ahorro",       recorte: 300000, alivio: 300000, de: 600000, a: 300000, prom: 600000, nota: "Pausa parcial mientras te estabilizas" },
+  { id: "suscripciones", name: "Suscripciones", recorte: 45000, alivio: 45000, de: 95000, a: 50000, prom: 95000, nota: "2 servicios que casi no usas" },
+  { id: "muebles",      name: "Aplazar muebles de sala", recorte: 0, alivio: 340000, aplaza: true, nota: "La reserva de arranque baja de $ 615.000 a $ 275.000/mes" },
+];
+
+// Gastos de arranque (one-time) — verdicto del motor de Deseos
+const PARRANQUE = [
+  { id: "cocina",  name: "Cocina y menaje", monto: 450000,  verdict: "COMPRA",      score: 84, deseo: false },
+  { id: "nevera",  name: "Nevera",          monto: 1200000, verdict: "CON CUIDADO", score: 58, deseo: true },
+  { id: "muebles", name: "Muebles de sala", monto: 1800000, verdict: "ESPERA",      score: 31, deseo: true },
+];
+const PCOLCHON = 1700000;
+const PARR_TOTAL = 3450000;
+
+// 50/30/20 — montos por grupo (target = % del ingreso)
+const PALLOC = {
+  targets: { nec: 2250000, gusto: 1350000, ahorro: 900000 },
+  cur:     { nec: 1445000, gusto: 645000,  ahorro: 600000 },
+  scen:    { nec: 3560000, gusto: 645000,  ahorro: 600000 },
+  scenCut: { nec: 3560000, gusto: 375000,  ahorro: 300000 },
+};
+
+// ── Acento de simulación (oro de alerta, sandbox) ─────────────
+const SCEN = {
+  c: Z.alert,
+  border: "rgba(212,168,67,0.35)",
+  borderSoft: "rgba(212,168,67,0.22)",
+  bg: "rgba(212,168,67,0.07)",
+  bgStrong: "rgba(212,168,67,0.12)",
+};
+
+// ── Iconos extra (trazo Lucide 1.75) ──────────────────────────
+const PIcons = {
+  home: <><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" /></>,
+  lock: <><rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></>,
+  scissors: <><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><line x1="20" y1="4" x2="8.12" y2="15.88" /><line x1="14.47" y1="14.48" x2="20" y2="20" /><line x1="8.12" y1="8.12" x2="12" y2="12" /></>,
+  check: <polyline points="20 6 9 17 4 12" />,
+  x: <><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></>,
+  plus: <><path d="M12 5v14" /><path d="M5 12h14" /></>,
+  heart: <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />,
+  sliders: <><line x1="21" y1="4" x2="14" y2="4" /><line x1="10" y1="4" x2="3" y2="4" /><line x1="21" y1="12" x2="12" y2="12" /><line x1="8" y1="12" x2="3" y2="12" /><line x1="21" y1="20" x2="16" y2="20" /><line x1="12" y1="20" x2="3" y2="20" /><line x1="14" y1="2" x2="14" y2="6" /><line x1="8" y1="10" x2="8" y2="14" /><line x1="16" y1="18" x2="16" y2="22" /></>,
+  alertTri: <><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" /></>,
+  fridge: <><rect x="6" y="2" width="12" height="20" rx="2" /><line x1="6" y1="10" x2="18" y2="10" /><line x1="9" y1="5" x2="9" y2="7" /><line x1="9" y1="13" x2="9" y2="16" /></>,
+  sofa: <><path d="M20 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v3" /><path d="M2 13v3a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-3a2 2 0 0 0-4 0v1H6v-1a2 2 0 0 0-4 0z" /><line x1="5" y1="18" x2="5" y2="20" /><line x1="19" y1="18" x2="19" y2="20" /></>,
+  chefhat: <><path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" /><line x1="6" y1="17" x2="18" y2="17" /></>,
+  bookmark: <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />,
+  car: <><path d="M19 17h2c.6 0 1-.4 1-1v-3c0-.9-.7-1.7-1.5-1.9C18.7 10.6 16 10 16 10s-1.3-1.4-2.2-2.3c-.5-.4-1.1-.7-1.8-.7H5c-.6 0-1.1.4-1.4.9l-1.4 2.9A3.7 3.7 0 0 0 2 12v4c0 .6.4 1 1 1h2" /><circle cx="7" cy="17" r="2" /><circle cx="17" cy="17" r="2" /><path d="M9 17h6" /></>,
+  rotate: <><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" /><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" /><path d="M3 21v-5h5" /></>,
+};
+
+// ── Chips y badges ────────────────────────────────────────────
+function DeltaChip({ v, style }) {
+  // v > 0 = más gasto (naranja) · v < 0 = recorte (verde)
+  const up = v > 0;
+  const c = up ? Z.expense || "#E8875A" : Z.income;
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", padding: "2px 7px", borderRadius: 999,
+      fontSize: 10, fontWeight: 700, fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap", flexShrink: 0,
+      color: c, background: `${up ? "rgba(232,135,90,0.10)" : "rgba(92,184,138,0.10)"}`,
+      border: `1px solid ${up ? "rgba(232,135,90,0.30)" : "rgba(92,184,138,0.30)"}`, ...style,
+    }}>{up ? "+" : "−"}$ {Math.abs(v).toLocaleString("es-CO")}</span>
+  );
+}
+
+function NuevoBadge() {
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", padding: "1px 6px", borderRadius: 5,
+      fontSize: 9, fontWeight: 700, letterSpacing: "0.10em", textTransform: "uppercase",
+      color: SCEN.c, background: SCEN.bgStrong, border: `1px solid ${SCEN.borderSoft}`, flexShrink: 0,
+    }}>nuevo</span>
+  );
+}
+
+function FijoBadge() {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 3, fontSize: 9, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: Z.sageDark, flexShrink: 0 }}>
+      <ZIcon d={PIcons.lock} size={10} sw={2} /> fijo
+    </span>
+  );
+}
+
+const AFFORD_TONES = {
+  "COMPRA":         { c: Z.income,  b: "rgba(92,184,138,0.35)", bg: "rgba(92,184,138,0.08)" },
+  "CON CUIDADO":    { c: Z.alert,   b: "rgba(212,168,67,0.35)", bg: "rgba(212,168,67,0.08)" },
+  "ESPERA":         { c: "#E8875A", b: "rgba(232,135,90,0.35)", bg: "rgba(232,135,90,0.08)" },
+  "NO RECOMENDADO": { c: Z.debt,    b: "rgba(224,85,69,0.35)",  bg: "rgba(224,85,69,0.08)" },
+};
+function AffordChip({ verdict, style }) {
+  const t = AFFORD_TONES[verdict];
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", padding: "2px 7px", borderRadius: 999,
+      fontSize: 9, fontWeight: 700, letterSpacing: "0.08em", whiteSpace: "nowrap", flexShrink: 0,
+      color: t.c, border: `1px solid ${t.b}`, background: t.bg, ...style,
+    }}>{verdict}</span>
+  );
+}
+
+function ScenTag({ children = "Simulación · Mudanza", style }) {
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 999,
+      fontSize: 10, fontWeight: 700, letterSpacing: "0.06em",
+      color: SCEN.c, background: SCEN.bgStrong, border: `1px solid ${SCEN.border}`, whiteSpace: "nowrap", ...style,
+    }}>
+      <ZIcon d={PIcons.sliders} size={11} sw={2} />
+      {children}
+    </span>
+  );
+}
+
+// "prom 3m $ 410.000" — ancla de realidad
+function PromLine({ prom, scen, size = 10 }) {
+  if (prom == null) return <span style={{ fontSize: size, color: Z.sageDark }}>sin historial</span>;
+  const warn = prom > scen;
+  return (
+    <span style={{ fontSize: size, color: warn ? Z.alert : Z.sageDark, fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+      prom 3m <span style={{ fontWeight: 600 }}>{fmtCOP(prom)}</span>
+    </span>
+  );
+}
+
+// ── Chrome de página ──────────────────────────────────────────
+function PageHead({ tag }) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 8, paddingTop: 2 }}>
+      <div>
+        <Eyebrow>Plan</Eyebrow>
+        <div style={{ fontSize: 24, fontWeight: 600, letterSpacing: "-0.02em", color: Z.white, marginTop: 4 }}>Presupuesto</div>
+      </div>
+      {tag}
+    </div>
+  );
+}
+
+function MonthSel({ label = "Junio 2026" }) {
+  const arrow = (pts) => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"><polyline points={pts} /></svg>
+  );
+  return (
+    <div style={{
+      display: "inline-flex", alignItems: "center", gap: 8, alignSelf: "flex-start",
+      padding: "6px 10px", borderRadius: 10, border: `1px solid ${Z.border}`,
+      background: "#111", color: Z.sageLight, fontSize: 12, fontWeight: 500,
+    }}>
+      {arrow("15 18 9 12 15 6")}
+      {label}
+      {arrow("9 18 15 12 9 6")}
+    </div>
+  );
+}
+
+// Héroe real (estado actual del presupuesto)
+function HeroReal({ style }) {
+  return (
+    <ZCard style={{
+      background: "radial-gradient(circle at top left, rgba(63,70,50,0.22), transparent 42%), linear-gradient(180deg, rgba(27,30,27,0.96), rgba(18,20,18,0.98))",
+      ...style,
+    }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Eyebrow>Ingreso mensual</Eyebrow>
+        <StateChip tone="neutral">Flexible</StateChip>
+      </div>
+      <div style={{ marginTop: 6 }}>
+        <Num v={fmtCOP(PINGRESO)} size={30} weight={800} />
+      </div>
+      <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 10, color: Z.sageDark }}>Asignado</div>
+          <Num v={fmtCOP(PTOT.cur)} size={14} weight={600} color={Z.sageLight} />
+        </div>
+        <div style={{ flex: 1, textAlign: "right" }}>
+          <div style={{ fontSize: 10, color: Z.sageDark }}>Restante</div>
+          <Num v={fmtCOP(PTOT.restanteCur)} size={14} weight={600} color={Z.income} />
+        </div>
+      </div>
+      <div style={{ marginTop: 10 }}>
+        <UsageBar pct={(PTOT.cur / PINGRESO) * 100} color={Z.brass} height={5} />
+      </div>
+    </ZCard>
+  );
+}
+
+// Hoja inferior dentro de un artboard: página atenuada detrás + sheet
+function PSheet({ children, behind, style }) {
+  return (
+    <div style={{ position: "relative", margin: -16, minHeight: 560, display: "flex", flexDirection: "column", justifyContent: "flex-end", overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 0, padding: 16, display: "flex", flexDirection: "column", gap: 12, filter: "brightness(0.45)", pointerEvents: "none" }}>
+        {behind}
+      </div>
+      <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.45)" }}></div>
+      <div style={{
+        position: "relative", borderTopLeftRadius: 20, borderTopRightRadius: 20,
+        background: "#181C18", border: `1px solid ${Z.border}`, borderBottom: "none",
+        padding: "12px 16px 20px", boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)", ...style,
+      }}>
+        <div style={{ width: 36, height: 4, borderRadius: 2, background: "rgba(255,255,255,0.14)", margin: "0 auto 12px" }}></div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// Barra 50/30/20 con fantasma (actual) + marca de meta
+function AllocBar({ label, scenV, curV, target, color }) {
+  const pct = (v) => Math.min(108, (v / PINGRESO) * 100);
+  const over = scenV > target;
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 4 }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: Z.sageLight }}>{label}</span>
+        <span style={{ fontSize: 11, fontVariantNumeric: "tabular-nums" }}>
+          <span style={{ fontWeight: 700, color: over ? Z.debt : color }}>{Math.round((scenV / PINGRESO) * 100)}%</span>
+          <span style={{ color: Z.sageDark }}> · meta {Math.round((target / PINGRESO) * 100)}%</span>
+        </span>
+      </div>
+      <div style={{ position: "relative", height: 10, borderRadius: 999, background: "rgba(255,255,255,0.06)", overflow: "visible" }}>
+        {/* fantasma: actual */}
+        <div style={{ position: "absolute", top: 0, left: 0, height: "100%", width: `${pct(curV)}%`, borderRadius: 999, background: "rgba(217,204,185,0.16)" }}></div>
+        {/* escenario */}
+        <div style={{ position: "absolute", top: 2, left: 0, height: 6, width: `${pct(scenV)}%`, borderRadius: 999, background: over ? Z.debt : color, transition: "width 200ms" }}></div>
+        {/* meta */}
+        <div style={{ position: "absolute", top: -2, bottom: -2, left: `${pct(target)}%`, width: 2, borderRadius: 1, background: "rgba(246,240,227,0.55)" }}></div>
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 3, fontSize: 9, color: Z.sageDark, fontVariantNumeric: "tabular-nums" }}>
+        <span>actual {fmtM(curV)}</span>
+        <span>escenario <span style={{ color: over ? Z.debt : Z.sageLight, fontWeight: 600 }}>{fmtM(scenV)}</span></span>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  PINGRESO, PCATS, PTOT, PCUTS, PARRANQUE, PCOLCHON, PARR_TOTAL, PALLOC,
+  SCEN, PIcons, AFFORD_TONES, DeltaChip, NuevoBadge, FijoBadge, AffordChip, ScenTag,
+  PromLine, PageHead, MonthSel, HeroReal, PSheet, AllocBar,
+});

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/design-canvas.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/design-canvas.jsx
@@ -1,0 +1,974 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+
+/* BEGIN USAGE */
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Exports (to window): DesignCanvas, DCSection, DCArtboard, DCPostIt.
+// Artboards are reorderable (grip-drag), deletable, labels/titles are
+// inline-editable, and any artboard can be opened in a fullscreen focus
+// overlay (←/→/Esc). State persists to a .design-canvas.state.json sidecar
+// via the host bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+//
+// Artboards are static design frames, not scroll regions — never use
+// height: 100% + overflow: auto/scroll on inner elements; size each artboard
+// to fit its content (explicit pixel height, or let it grow).
+/* END USAGE */
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    // isolation:isolate contains artboard content's z-indexes so a
+    // z-indexed child (sticky navbar etc.) can't paint over .dc-header or
+    // the .dc-menu popover that drops into the top of the card.
+    '.dc-card{isolation:isolate;transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    // Per-artboard header: grip + label on the left, delete/expand on the
+    // right. Single flex row; when the artboard's on-screen width is too
+    // narrow for both the label yields (ellipsis, then hidden entirely below
+    // ~4ch via the container query) and the buttons stay on the row.
+    '.dc-header{position:absolute;bottom:100%;left:-4px;margin-bottom:calc(4px * var(--dc-inv-zoom,1));z-index:2;',
+    '  display:flex;align-items:center;container-type:inline-size}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px;flex:1 1 auto;min-width:0}',
+    '.dc-grip{flex:0 0 auto;cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s,opacity .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{flex:1 1 auto;min-width:0;cursor:pointer;border-radius:4px;padding:3px 6px;',
+    '  display:flex;align-items:center;transition:background .12s;overflow:hidden}',
+    // Below ~4ch of label room: hide the label entirely, and drop the grip to
+    // hover-only (same reveal rule as .dc-btns) so a narrow header is clean
+    // until the card is moused.
+    '@container (max-width: 110px){',
+    '  .dc-labeltext{display:none}',
+    '  .dc-grip{opacity:0}',
+    '  [data-dc-slot]:hover .dc-grip{opacity:1}',
+    '}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-labeltext .dc-editable{overflow:hidden;text-overflow:ellipsis;max-width:100%}',
+    '.dc-labeltext .dc-editable:focus{overflow:visible;text-overflow:clip}',
+    '.dc-btns{flex:0 0 auto;margin-left:auto;display:flex;gap:2px;opacity:0;transition:opacity .12s}',
+    '[data-dc-slot]:hover .dc-btns,.dc-btns:has(.dc-menu){opacity:1}',
+    '.dc-expand,.dc-kebab{width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center;',
+    '  font:inherit;transition:background .12s,color .12s}',
+    '.dc-expand:hover,.dc-kebab:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    // Slot hosting an open menu floats above later siblings (which otherwise
+    // paint on top — same z-index:auto, later DOM order) so the popup isn't
+    // clipped by the next card.
+    '[data-dc-slot]:has(.dc-menu){z-index:10}',
+    '.dc-menu{position:absolute;top:100%;right:0;margin-top:4px;background:#fff;border-radius:8px;',
+    '  box-shadow:0 8px 28px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);padding:4px;min-width:160px;z-index:10}',
+    '.dc-menu button{display:block;width:100%;padding:7px 10px;border:0;background:transparent;',
+    '  border-radius:5px;font-family:inherit;font-size:13px;font-weight:500;line-height:1.2;',
+    '  color:#29261b;cursor:pointer;text-align:left;transition:background .12s;white-space:nowrap}',
+    '.dc-menu button:hover{background:rgba(0,0,0,.05)}',
+    '.dc-menu hr{border:0;border-top:1px solid rgba(0,0,0,.08);margin:4px 2px}',
+    '.dc-menu .dc-danger{color:#c96442}',
+    '.dc-menu .dc-danger:hover{background:rgba(201,100,66,.1)}',
+    // Chrome (titles / labels / buttons) counter-scales against the viewport
+    // zoom so it stays a constant on-screen size. --dc-inv-zoom is set by
+    // DCViewport on every transform update and inherits to all descendants —
+    // any overlay inside the world (e.g. a TweaksPanel on an artboard) can use
+    // it the same way.
+    //
+    // The header uses transform:scale (out-of-flow, so layout impact doesn't
+    // matter) with its world-space width set to card-width / inv-zoom so that
+    // after counter-scaling its on-screen width exactly matches the card's —
+    // that's what lets the container query + text-overflow behave against the
+    // card's visible edge at every zoom level.
+    //
+    // The section head uses CSS zoom instead of transform so its layout box
+    // grows with the counter-scale, pushing the card row down — otherwise the
+    // constant-screen-size title would overflow into the (shrinking) world-
+    // space gap and overlap the artboard headers at low zoom.
+    '.dc-header{width:calc((100% + 4px) / var(--dc-inv-zoom,1));',
+    '  transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom left}',
+    '.dc-sectionhead{zoom:var(--dc-inv-zoom,1)}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// Recursively unwrap React.Fragment so <>…</> grouping doesn't hide
+// DCSection/DCArtboard children from the type-based walks below.
+function dcFlatten(children) {
+  const out = [];
+  React.Children.forEach(children, (c) => {
+    if (c && c.type === React.Fragment) out.push(...dcFlatten(c.props.children));
+    else out.push(c);
+  });
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, hidden
+// artboards, focused artboard). Order/titles/labels/hidden persist to a
+// .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Fragments are flattened; wrapping in other
+  // elements still opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  dcFlatten(children).forEach((sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const abs = [];
+    dcFlatten(sec.props.children).forEach((ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (aid) abs.push([aid, ab]);
+    });
+    // hidden is scoped to one source revision — when the agent regenerates
+    // (artboard-ID set changes), prior deletes don't apply to new content.
+    const srcKey = abs.map(([k]) => k).join('\x1f');
+    const hidden = persisted.srcKey === srcKey ? (persisted.hidden || []) : [];
+    const srcIds = [];
+    abs.forEach(([aid, ab]) => {
+      if (hidden.includes(aid)) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+  // Persist viewport across reloads so the user lands back where they were
+  // after an agent edit or browser refresh. The sandbox origin is already
+  // per-project; pathname keeps multiple canvas files in one project apart.
+  const tfKey = 'dc-viewport:' + location.pathname;
+  const saveT = React.useRef(0);
+
+  const lastPostedScale = React.useRef();
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (!el) return;
+    el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    // Exposed for zoom-invariant chrome (labels, buttons, TweaksPanel).
+    el.style.setProperty('--dc-inv-zoom', String(1 / scale));
+    // Keep the host toolbar's % readout in sync with the canvas scale. Pan
+    // ticks leave scale unchanged — skip the cross-frame post for those.
+    if (lastPostedScale.current !== scale) {
+      lastPostedScale.current = scale;
+      window.parent.postMessage({ type: '__dc_zoom', scale }, '*');
+    }
+    clearTimeout(saveT.current);
+    saveT.current = setTimeout(() => {
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    }, 200);
+  }, [tfKey]);
+
+  React.useLayoutEffect(() => {
+    const flush = () => {
+      clearTimeout(saveT.current);
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    };
+    try {
+      const s = JSON.parse(localStorage.getItem(tfKey) || 'null');
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.scale)) {
+        tf.current = { x: s.x, y: s.y, scale: Math.min(maxScale, Math.max(minScale, s.scale)) };
+        apply();
+      }
+    } catch {}
+    // Flush on pagehide and unmount so a reload within the 200ms debounce
+    // window doesn't drop the last pan/zoom.
+    window.addEventListener('pagehide', flush);
+    return () => { window.removeEventListener('pagehide', flush); flush(); };
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // --dc-inv-zoom consumers (.dc-sectionhead's CSS zoom, each section's
+      // marginBottom) reflow on every scale change, vertically shifting the
+      // world layout — so a world point mathematically pinned under the cursor
+      // drifts as you zoom (content creeps up on zoom-in, down on zoom-out).
+      // Anchor the DOM element under the cursor instead: record its screen Y,
+      // apply the transform + --dc-inv-zoom, then cancel whatever vertical
+      // drift the reflow introduced so it stays put on screen.
+      let marker = null, markerY0 = 0;
+      if (k !== 1) {
+        const hit = document.elementFromPoint(cx, cy);
+        marker = hit && hit.closest ? hit.closest('[data-dc-slot],[data-dc-section]') : null;
+        if (marker) markerY0 = marker.getBoundingClientRect().top;
+      }
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+      if (marker) {
+        // A pure zoom around (cx, cy) maps screen Y → cy + (Y - cy) * k. Any
+        // departure after the --dc-inv-zoom reflow is the layout drift.
+        const drift = marker.getBoundingClientRect().top - (cy + (markerY0 - cy) * k);
+        if (Math.abs(drift) > 0.1) { t.y -= drift; apply(); }
+      }
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if ((e.ctrlKey || e.metaKey) && !isMouseWheel(e)) {
+        // trackpad pinch, or ctrl/cmd + smooth-scroll mouse. Notched
+        // wheels fall through to the fixed-step branch below.
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    // Host-driven zoom (toolbar % menu). Zooms around viewport centre so the
+    // visible midpoint stays fixed — matching the host's iframe-zoom feel.
+    const onHostMsg = (e) => {
+      const d = e.data;
+      if (d && d.type === '__dc_set_zoom' && typeof d.scale === 'number') {
+        const r = vp.getBoundingClientRect();
+        zoomAt(r.left + r.width / 2, r.top + r.height / 2, d.scale / tf.current.scale);
+      } else if (d && d.type === '__dc_probe') {
+        // Host's [readyGen] reset asks whether a canvas is present; it
+        // fires on the iframe's native 'load', which for canvases with
+        // images/fonts is after our mount-time announce, so re-announce.
+        // Clear the pan-tick guard so apply() re-posts the current scale
+        // even if it's unchanged — the host just reset dcScale to 1.
+        window.parent.postMessage({ type: '__dc_present' }, '*');
+        lastPostedScale.current = undefined;
+        apply();
+      }
+    };
+    window.addEventListener('message', onHostMsg);
+    // Announce canvas mode so the host toolbar proxies its % control here
+    // instead of scaling the iframe element (which would just shrink the
+    // viewport window of an infinite canvas). The apply() that follows emits
+    // the initial __dc_zoom so the toolbar % is correct before first pinch.
+    // lastPostedScale reset mirrors the __dc_probe handler: the layout
+    // effect's restore-path apply() may already have posted the restored
+    // scale (before __dc_present), so clear the guard to re-post it in order.
+    window.parent.postMessage({ type: '__dc_present' }, '*');
+    lastPostedScale.current = undefined;
+    apply();
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('message', onHostMsg);
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(dcFlatten(children));
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+  // Must match DesignCanvas's srcKey computation exactly (it filters falsy
+  // IDs), or onDelete persists a srcKey that DesignCanvas never recognizes.
+  const allIds = artboards.map((a) => a.props.id ?? a.props.label).filter(Boolean);
+  const srcKey = allIds.join('\x1f');
+  const hidden = sec.srcKey === srcKey ? (sec.hidden || []) : [];
+  const srcOrder = allIds.filter((k) => !hidden.includes(k));
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  // marginBottom counter-scales so the on-screen gap between sections stays
+  // constant — otherwise at low zoom the (world-space) gap collapses while
+  // the screen-constant sectionhead below it doesn't, and the title reads as
+  // belonging to the section above. paddingBottom below is just enough for
+  // the 24px artboard-header (abs-positioned above each card) plus ~8px, so
+  // the title sits tight against its own row at every zoom.
+  return (
+    <div data-dc-section={sid}
+      style={{ marginBottom: 'calc(80px * var(--dc-inv-zoom, 1))', position: 'relative' }}>
+      <div style={{ padding: '0 60px' }}>
+        <div className="dc-sectionhead" style={{ paddingBottom: 36 }}>
+          <DCEditable tag="div" value={sec.title ?? title}
+            onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+            style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+          {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onDelete={() => ctx && ctx.patchSection(sid, (x) => ({
+              hidden: [...(x.srcKey === srcKey ? (x.hidden || []) : []), k],
+              srcKey,
+            }))}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+// Per-artboard export (kind: 'png' | 'html'). Both paths share the same
+// self-contained clone: computed styles baked in, @font-face / <img> /
+// inline-style background-image urls inlined as data URIs. PNG wraps the
+// clone in foreignObject→canvas at 3× the artboard's natural width×height
+// (same pipeline the host uses for page captures); HTML wraps it in a
+// minimal standalone document. Both are independent of viewport zoom.
+async function dcExport(node, w, h, name, kind) {
+  try { await document.fonts.ready; } catch {}
+  const toDataURL = (url) => fetch(url).then((r) => r.blob()).then((b) => new Promise((res) => {
+    const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => res(url); fr.readAsDataURL(b);
+  })).catch(() => url);
+
+  // Collect @font-face rules. ss.cssRules throws SecurityError on
+  // cross-origin sheets (e.g. fonts.googleapis.com) — in that case fetch
+  // the CSS text directly (those endpoints send ACAO:*) and regex-extract
+  // the blocks. @import and @media/@supports are walked so nested
+  // @font-face rules aren't missed.
+  const fontRules = [], pending = [], seen = new Set();
+  const scrapeCss = (href) => {
+    if (seen.has(href)) return; seen.add(href);
+    pending.push(fetch(href).then((r) => r.text()).then((css) => {
+      for (const m of css.match(/@font-face\s*{[^}]*}/g) || []) fontRules.push({ css: m, base: href });
+      for (const m of css.matchAll(/@import\s+(?:url\()?['"]?([^'")\s;]+)/g))
+        scrapeCss(new URL(m[1], href).href);
+    }).catch(() => {}));
+  };
+  const walk = (rules, base) => {
+    for (const r of rules) {
+      if (r.type === CSSRule.FONT_FACE_RULE) fontRules.push({ css: r.cssText, base });
+      else if (r.type === CSSRule.IMPORT_RULE && r.styleSheet) {
+        const ibase = r.styleSheet.href || base;
+        try { walk(r.styleSheet.cssRules, ibase); } catch { scrapeCss(ibase); }
+      } else if (r.cssRules) walk(r.cssRules, base);
+    }
+  };
+  for (const ss of document.styleSheets) {
+    const base = ss.href || location.href;
+    try { walk(ss.cssRules, base); } catch { if (ss.href) scrapeCss(ss.href); }
+  }
+  while (pending.length) await pending.shift();
+  const fontCss = (await Promise.all(fontRules.map(async (rule) => {
+    let out = rule.css, m; const re = /url\((['"]?)([^'")]+)\1\)/g;
+    while ((m = re.exec(rule.css))) {
+      if (m[2].indexOf('data:') === 0) continue;
+      let abs; try { abs = new URL(m[2], rule.base).href; } catch { continue; }
+      out = out.split(m[0]).join('url("' + await toDataURL(abs) + '")');
+    }
+    return out;
+  }))).join('\n');
+
+  const cloneStyled = (src) => {
+    if (src.nodeType === 8 || (src.nodeType === 1 && src.tagName === 'SCRIPT')) return document.createTextNode('');
+    const dst = src.cloneNode(false);
+    if (src.nodeType === 1) {
+      const cs = getComputedStyle(src); let txt = '';
+      for (let i = 0; i < cs.length; i++) txt += cs[i] + ':' + cs.getPropertyValue(cs[i]) + ';';
+      dst.setAttribute('style', txt + 'animation:none;transition:none;');
+      if (src.tagName === 'CANVAS') try { const im = document.createElement('img'); im.src = src.toDataURL(); im.setAttribute('style', txt); return im; } catch {}
+    }
+    for (let c = src.firstChild; c; c = c.nextSibling) dst.appendChild(cloneStyled(c));
+    return dst;
+  };
+  const clone = cloneStyled(node);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  // Drop the card's own shadow/radius so the export is a flush w×h rect;
+  // the artboard's own background (if any) is already in the computed style.
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0';
+
+  const jobs = [];
+  clone.querySelectorAll('img').forEach((el) => {
+    const s = el.getAttribute('src');
+    if (s && s.indexOf('data:') !== 0) jobs.push(toDataURL(el.src).then((d) => el.setAttribute('src', d)));
+  });
+  [clone, ...clone.querySelectorAll('*')].forEach((el) => {
+    const bg = el.style.backgroundImage; if (!bg) return;
+    let m; const re = /url\(["']?([^"')]+)["']?\)/g;
+    while ((m = re.exec(bg))) {
+      const tok = m[0], url = m[1];
+      if (url.indexOf('data:') === 0) continue;
+      jobs.push(toDataURL(url).then((d) => { el.style.backgroundImage = el.style.backgroundImage.split(tok).join('url("' + d + '")'); }));
+    }
+  });
+  await Promise.all(jobs);
+
+  const xml = new XMLSerializer().serializeToString(clone);
+  const save = (blob, ext) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name + '.' + ext; a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  if (kind === 'html') {
+    const html = '<!doctype html><html><head><meta charset="utf-8"><title>' + name + '</title>' +
+      (fontCss ? '<style>' + fontCss + '</style>' : '') +
+      '</head><body style="margin:0">' + xml + '</body></html>';
+    return save(new Blob([html], { type: 'text/html' }), 'html');
+  }
+
+  // PNG: the SVG's own width/height must be the output resolution — an
+  // <img>-loaded SVG rasterizes at its intrinsic size, so sizing it at 1×
+  // and ctx.scale()-ing up would just upscale a 1× bitmap. viewBox maps the
+  // w×h foreignObject onto the px·w × px·h SVG canvas so the browser renders
+  // the HTML at full resolution.
+  const px = 3;
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w * px + '" height="' + h * px +
+    '" viewBox="0 0 ' + w + ' ' + h + '"><foreignObject width="' + w + '" height="' + h + '">' +
+    (fontCss ? '<style><![CDATA[' + fontCss + ']]></style>' : '') + xml + '</foreignObject></svg>';
+  const img = new Image();
+  await new Promise((res, rej) => {
+    img.onload = res; img.onerror = () => rej(new Error('svg load failed'));
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  });
+  const cv = document.createElement('canvas');
+  cv.width = w * px; cv.height = h * px;
+  cv.getContext('2d').drawImage(img, 0, 0);
+  cv.toBlob((blob) => save(blob, 'png'), 'image/png');
+}
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus, onDelete }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+  const cardRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  // ⋯ menu: close on any outside pointerdown. Two-click delete lives inside
+  // the menu — first click arms the row, second commits; closing disarms.
+  React.useEffect(() => {
+    if (!menuOpen) { setConfirming(false); return; }
+    const off = (e) => { if (!menuRef.current || !menuRef.current.contains(e.target)) setMenuOpen(false); };
+    document.addEventListener('pointerdown', off, true);
+    return () => document.removeEventListener('pointerdown', off, true);
+  }, [menuOpen]);
+
+  const doExport = (kind) => {
+    setMenuOpen(false);
+    if (!cardRef.current) return;
+    const name = String(label || id || 'artboard').replace(/[^\w\s.-]+/g, '_');
+    dcExport(cardRef.current, width, height, name, kind)
+      .catch((e) => console.error('[design-canvas] export failed:', e));
+  };
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-header" data-omelette-chrome="" style={{ color: DC.label }} onPointerDown={(e) => e.stopPropagation()}>
+        <div className="dc-labelrow">
+          <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+            <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+          </div>
+          <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+            <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+              style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+          </div>
+        </div>
+        <div className="dc-btns">
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            <button className="dc-kebab" title="More" onClick={() => setMenuOpen((o) => !o)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="2.5" cy="6" r="1.1"/><circle cx="6" cy="6" r="1.1"/><circle cx="9.5" cy="6" r="1.1"/></svg>
+            </button>
+            {menuOpen && (
+              <div className="dc-menu" onPointerDown={(e) => e.stopPropagation()}>
+                <button onClick={() => doExport('png')}>Download PNG</button>
+                <button onClick={() => doExport('html')}>Download HTML</button>
+                <hr />
+                <button className="dc-danger"
+                  onClick={() => { if (confirming) { setMenuOpen(false); onDelete(); } else setConfirming(true); }}>
+                  {confirming ? 'Click again to delete' : 'Delete'}
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="dc-expand" onClick={onFocus} title="Focus">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+          </button>
+        </div>
+      </div>
+      <div ref={cardRef} className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    // Sections whose artboards are all deleted have slotIds:[] — step past
+    // them to the next non-empty section so ↑/↓ doesn't dead-end.
+    const n = sectionOrder.length;
+    for (let i = 1; i < n; i++) {
+      const ns = sectionOrder[(((secIdx + d * i) % n) + n) % n];
+      const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+      if (first) { ctx.setFocus(`${ns}/${first}`); return; }
+    }
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.filter((sid) => sectionMeta[sid].slotIds.length).map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-a.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-a.jsx
@@ -1,0 +1,206 @@
+// Sección A — Entrada a la simulación + estado de modo (3 variantes)
+const { useState: useStateSA } = React;
+
+// Héroe en modo simulación — compartido entre variantes
+function ScenHero({ actions = true, ghostReal = true, style }) {
+  return (
+    <div style={{
+      borderRadius: 16, border: `1.5px dashed ${SCEN.border}`,
+      background: `linear-gradient(180deg, ${SCEN.bg}, rgba(18,20,18,0.6))`,
+      padding: 16, ...style,
+    }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <ScenTag />
+        <span style={{ fontSize: 10, color: Z.sageDark }}>sin guardar</span>
+      </div>
+      <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 10, color: Z.sageDark }}>Ingreso</div>
+          <Num v={fmtCOP(PINGRESO)} size={15} weight={700} color={Z.sageLight} />
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 10, color: Z.sageDark }}>Escenario</div>
+          <Num v={fmtCOP(PTOT.scen)} size={15} weight={700} />
+        </div>
+        <div style={{ flex: 1, textAlign: "right" }}>
+          <div style={{ fontSize: 10, color: Z.sageDark }}>Restante</div>
+          <Num v={`−${fmtCOP(PTOT.brechaPresupuesto)}`} size={15} weight={700} color={Z.debt} />
+        </div>
+      </div>
+      <div style={{ marginTop: 10, position: "relative" }}>
+        <UsageBar pct={100} color={Z.debt} height={5} />
+        <div style={{ position: "absolute", top: -2, bottom: -2, left: `${(PINGRESO / PTOT.scen) * 100}%`, width: 2, borderRadius: 1, background: "rgba(246,240,227,0.55)" }}></div>
+      </div>
+      {ghostReal && (
+        <div style={{ marginTop: 8, fontSize: 10, color: Z.sageDark, fontVariantNumeric: "tabular-nums" }}>
+          Real: asignado {fmtCOP(PTOT.cur)} · restante <span style={{ color: Z.income }}>{fmtCOP(PTOT.restanteCur)}</span>
+        </div>
+      )}
+      {actions && (
+        <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+          <ZBtn variant="ghost" size="sm" style={{ flex: 1 }}>Descartar</ZBtn>
+          <ZBtn variant="brass" size="sm" style={{ flex: 1 }}>Aplicar…</ZBtn>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── A1 · El héroe se transforma ───────────────────────────────
+function EntradaA1() {
+  return (
+    <React.Fragment>
+      <StateTag>Real · punto de entrada bajo el héroe</StateTag>
+      <PageHead />
+      <MonthSel />
+      <HeroReal />
+      <button style={{
+        display: "flex", alignItems: "center", justifyContent: "center", gap: 8,
+        height: 40, borderRadius: 12, cursor: "pointer", fontFamily: "var(--font-sans)",
+        border: `1px dashed ${SCEN.border}`, background: SCEN.bg,
+        color: SCEN.c, fontSize: 13, fontWeight: 600, transition: "background 150ms",
+      }}>
+        <ZIcon d={PIcons.sliders} size={14} sw={2} />
+        Simular un cambio
+      </button>
+
+      <StateTag>Simulación activa · el héroe cambia de marco</StateTag>
+      <PageHead tag={<ScenTag style={{ marginBottom: 4 }}>Mudanza</ScenTag>} />
+      <MonthSel />
+      <ScenHero />
+    </React.Fragment>
+  );
+}
+
+// ── A2 · Banner persistente + zona sandbox ────────────────────
+function BannerScen({ compact = false }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 8,
+      padding: compact ? "5px 10px" : "8px 12px",
+      borderRadius: compact ? 999 : 12,
+      border: `1px solid ${SCEN.border}`, background: SCEN.bgStrong,
+    }}>
+      <span style={{ width: 7, height: 7, borderRadius: 999, background: SCEN.c, flexShrink: 0 }}></span>
+      <span style={{ flex: 1, fontSize: compact ? 11 : 12, fontWeight: 600, color: SCEN.c, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+        Simulación · Mudanza
+      </span>
+      <button style={{
+        border: "none", background: "transparent", color: Z.sageLight, fontSize: compact ? 11 : 12,
+        fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)", padding: "4px 6px",
+      }}>Descartar</button>
+      <button style={{
+        border: `1px solid ${SCEN.border}`, background: "rgba(212,168,67,0.16)", color: SCEN.c,
+        fontSize: compact ? 11 : 12, fontWeight: 700, cursor: "pointer", fontFamily: "var(--font-sans)",
+        borderRadius: 8, padding: compact ? "3px 9px" : "5px 11px", transition: "background 150ms",
+      }}>Aplicar</button>
+    </div>
+  );
+}
+
+function EntradaA2() {
+  return (
+    <React.Fragment>
+      <StateTag>Simulación activa · banner fino arriba</StateTag>
+      <BannerScen />
+      <PageHead />
+      <MonthSel />
+      {/* zona sandbox: hairline punteado dorado alrededor del contenido */}
+      <div style={{ border: `1px dashed ${SCEN.borderSoft}`, borderRadius: 18, padding: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+        <ScenHero actions={false} />
+        <ZRow style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: Z.white }}>Arriendo</span>
+            <NuevoBadge />
+          </span>
+          <Num v={fmtCOP(1500000)} size={13} />
+        </ZRow>
+        <ZRow style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: Z.white }}>Mercado</span>
+            <DeltaChip v={300000} />
+          </span>
+          <Num v={fmtCOP(650000)} size={13} />
+        </ZRow>
+      </div>
+
+      <StateTag>Al hacer scroll · banner condensado</StateTag>
+      <div style={{ display: "flex", justifyContent: "center" }}>
+        <BannerScen compact={true} />
+      </div>
+    </React.Fragment>
+  );
+}
+
+// ── A3 · Plantillas de entrada + selector de modo ─────────────
+function PlantillaRow({ icon, title, sub }) {
+  return (
+    <ZRow onClick={() => {}} style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px" }}>
+      <span style={{
+        width: 34, height: 34, borderRadius: 10, flexShrink: 0,
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+        background: SCEN.bg, border: `1px solid ${SCEN.borderSoft}`, color: SCEN.c,
+      }}>
+        <ZIcon d={icon} size={16} />
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: Z.white }}>{title}</div>
+        <div style={{ fontSize: 10, color: Z.sageDark, marginTop: 1 }}>{sub}</div>
+      </div>
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={Z.sageDark} strokeWidth="1.75" strokeLinecap="round"><polyline points="9 18 15 12 9 6" /></svg>
+    </ZRow>
+  );
+}
+
+function ModeToggle({ mode, onChange }) {
+  const opt = (key, label, active) => (
+    <button key={key} onClick={() => onChange(key)} style={{
+      flex: 1, height: 30, borderRadius: 8, fontSize: 12, fontWeight: 600, cursor: "pointer",
+      fontFamily: "var(--font-sans)", transition: "background 150ms, color 150ms",
+      border: active ? `1px solid ${key === "scen" ? SCEN.border : "rgba(147,120,68,0.35)"}` : "1px solid transparent",
+      background: active ? (key === "scen" ? SCEN.bgStrong : Z.surface3) : "transparent",
+      color: active ? (key === "scen" ? SCEN.c : Z.white) : Z.sageDark,
+      display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 5,
+    }}>
+      {key === "scen" && <span style={{ width: 6, height: 6, borderRadius: 999, background: active ? SCEN.c : Z.sageDark }}></span>}
+      {label}
+    </button>
+  );
+  return (
+    <div style={{ display: "flex", gap: 4, padding: 3, borderRadius: 11, border: `1px solid ${Z.border}`, background: "rgba(0,0,0,0.25)" }}>
+      {opt("real", "Real", mode === "real")}
+      {opt("scen", "Simulación", mode === "scen")}
+    </div>
+  );
+}
+
+function EntradaA3() {
+  const [mode, setMode] = useStateSA("scen");
+  return (
+    <React.Fragment>
+      <StateTag>Entrada · hoja de plantillas</StateTag>
+      <PSheet
+        behind={<React.Fragment><PageHead /><MonthSel /><HeroReal /></React.Fragment>}
+      >
+        <Eyebrow>Simular un cambio</Eyebrow>
+        <div style={{ fontSize: 17, fontWeight: 600, color: Z.white, marginTop: 6 }}>¿Qué cambio quieres probar?</div>
+        <div style={{ fontSize: 11, color: Z.sageDark, marginTop: 2, marginBottom: 12 }}>Tu presupuesto real no se toca hasta que apliques.</div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <PlantillaRow icon={PIcons.home} title="Mudanza" sub="Arriendo, servicios, internet" />
+          <PlantillaRow icon={PIcons.car} title="Vehículo" sub="Cuota, gasolina, seguro" />
+          <PlantillaRow icon={PIcons.sliders} title="Desde cero" sub="Copia tu presupuesto tal cual" />
+        </div>
+      </PSheet>
+
+      <StateTag>Modo como selector · toca para alternar</StateTag>
+      <PageHead />
+      <ModeToggle mode={mode} onChange={setMode} />
+      {mode === "scen" ? <ScenHero actions={false} /> : <HeroReal />}
+      <div style={{ fontSize: 10, color: Z.sageDark, textAlign: "center" }}>
+        {mode === "scen" ? "Viendo la simulación — tu presupuesto real sigue intacto" : "Viendo tu presupuesto real"}
+      </div>
+    </React.Fragment>
+  );
+}
+
+Object.assign(window, { ScenHero, BannerScen, EntradaA1, EntradaA2, EntradaA3, ModeToggle });

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-b.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-b.jsx
@@ -1,0 +1,262 @@
+// Sección B — Editor del escenario (3 variantes)
+const { useState: useStateSB } = React;
+
+// Estado editable de demo: nuevos agregados, Mercado sube, Restaurantes recortado
+const EDIT_INIT = {
+  arriendo: 1500000, servicios: 220000, internet: 95000,
+  mercado: 650000, transporte: 280000, restaurantes: 150000,
+  suscripciones: 95000, salidas: 250000, deudas: 815000, ahorro: 600000,
+};
+
+function editorTotal(vals) {
+  return Object.values(vals).reduce((a, b) => a + b, 0);
+}
+
+// Monto editable: toca → input numérico
+function EditAmount({ value, onChange, locked }) {
+  const [editing, setEditing] = useStateSB(false);
+  const [draft, setDraft] = useStateSB("");
+  if (locked) return <Num v={fmtCOP(value)} size={14} weight={600} color={Z.sageLight} />;
+  if (!editing) {
+    return (
+      <button onClick={() => { setDraft(String(value)); setEditing(true); }} style={{
+        border: "1px solid transparent", background: "transparent", cursor: "pointer", padding: "2px 4px",
+        borderRadius: 7, fontFamily: "var(--font-sans)", transition: "background 150ms",
+      }} title="Tocar para editar">
+        <Num v={fmtCOP(value)} size={14} weight={700} style={{ borderBottom: `1px dashed ${SCEN.borderSoft}`, paddingBottom: 1 }} />
+      </button>
+    );
+  }
+  const commit = () => { const n = parseInt(draft || "0", 10); onChange(isNaN(n) ? value : n); setEditing(false); };
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+      <span style={{
+        display: "inline-flex", alignItems: "center", gap: 2, padding: "3px 8px",
+        borderRadius: 8, border: `1px solid ${SCEN.border}`, background: "rgba(0,0,0,0.35)",
+      }}>
+        <span style={{ fontSize: 12, color: Z.sageDark }}>$</span>
+        <input autoFocus inputMode="numeric" value={draft}
+          onChange={(e) => setDraft(e.target.value.replace(/\D/g, ""))}
+          onKeyDown={(e) => { if (e.key === "Enter") commit(); }}
+          onBlur={commit}
+          style={{
+            width: 76, background: "transparent", border: "none", outline: "none",
+            color: Z.white, fontSize: 13, fontWeight: 700, fontVariantNumeric: "tabular-nums",
+            fontFamily: "var(--font-sans)",
+          }} />
+      </span>
+      <button onMouseDown={(e) => { e.preventDefault(); commit(); }} style={{
+        width: 24, height: 24, borderRadius: 7, border: `1px solid ${SCEN.border}`,
+        background: SCEN.bgStrong, color: SCEN.c, cursor: "pointer",
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+      }}><ZIcon d={PIcons.check} size={12} sw={2.5} /></button>
+    </span>
+  );
+}
+
+// Fila del editor: actual → escenario · delta · ancla prom 3m
+function EditorRow({ cat, value, onChange }) {
+  const delta = cat.cur == null ? null : value - cat.cur;
+  const changed = delta !== null && delta !== 0;
+  return (
+    <ZRow style={{ padding: "10px 12px" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: Z.white, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{cat.name}</span>
+          {cat.nuevo && <NuevoBadge />}
+          {cat.fijo && <FijoBadge />}
+        </span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+          {changed && (
+            <Num v={fmtCOP(cat.cur)} size={11} weight={500} color={Z.sageDark} style={{ textDecoration: "line-through", textDecorationColor: "rgba(147,140,126,0.5)" }} />
+          )}
+          {changed && (
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke={Z.sageDark} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
+          )}
+          <EditAmount value={value} onChange={onChange} locked={cat.fijo} />
+        </span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginTop: 4 }}>
+        <PromLine prom={cat.prom} scen={value} />
+        {cat.cur == null ? <DeltaChip v={value} /> : changed ? <DeltaChip v={delta} /> : <span style={{ fontSize: 10, color: "rgba(147,140,126,0.6)" }}>igual</span>}
+      </div>
+    </ZRow>
+  );
+}
+
+// Total pegado al pie del editor
+function EditorFooter({ total }) {
+  const diff = PINGRESO - total;
+  const falta = diff < 0;
+  return (
+    <div style={{
+      borderRadius: 14, border: `1px solid ${falta ? "rgba(224,85,69,0.30)" : "rgba(92,184,138,0.30)"}`,
+      background: "rgba(17,17,17,0.95)", padding: "10px 14px", position: "sticky", bottom: 8,
+    }}>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 11, color: Z.sageDark }}>Total escenario</span>
+        <Num v={fmtCOP(total)} size={17} weight={700} />
+      </div>
+      <div style={{ marginTop: 7, position: "relative" }}>
+        <UsageBar pct={(total / Math.max(total, PINGRESO)) * 100} color={falta ? Z.debt : Z.income} height={4} />
+        <div style={{ position: "absolute", top: -2, bottom: -2, left: `${(PINGRESO / Math.max(total, PINGRESO)) * 100}%`, width: 2, borderRadius: 1, background: "rgba(246,240,227,0.55)" }}></div>
+      </div>
+      <div style={{ marginTop: 6, display: "flex", justifyContent: "space-between", fontSize: 10, fontVariantNumeric: "tabular-nums" }}>
+        <span style={{ color: Z.sageDark }}>Ingreso {fmtCOP(PINGRESO)}</span>
+        <span style={{ color: falta ? Z.debt : Z.income, fontWeight: 700 }}>
+          {falta ? `−${fmtCOP(-diff)} sobre tu ingreso` : `${fmtCOP(diff)} libres`}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── B1 · Lista plana, edición en línea ────────────────────────
+function EditorB1() {
+  const [vals, setVals] = useStateSB(EDIT_INIT);
+  const set = (id) => (n) => setVals({ ...vals, [id]: n });
+  return (
+    <React.Fragment>
+      <BannerScen />
+      <MonthSel />
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {PCATS.map((c) => <EditorRow key={c.id} cat={c} value={vals[c.id]} onChange={set(c.id)} />)}
+      </div>
+      <button style={{
+        display: "flex", alignItems: "center", justifyContent: "center", gap: 7, height: 38,
+        borderRadius: 12, border: `1px dashed ${SCEN.borderSoft}`, background: "transparent",
+        color: SCEN.c, fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)",
+      }}>
+        <ZIcon d={PIcons.plus} size={13} sw={2.5} /> Agregar categoría
+      </button>
+      <EditorFooter total={editorTotal(vals)} />
+    </React.Fragment>
+  );
+}
+
+// ── B2 · Agrupado: Nuevos / Cambian / Igual ───────────────────
+function GroupHeader({ label, sub, count }) {
+  return (
+    <div className="z-divider" style={{ marginTop: 4 }}>
+      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase", color: Z.sageDark, whiteSpace: "nowrap" }}>
+        {label} <span style={{ color: "rgba(147,140,126,0.6)" }}>· {count}</span>
+      </span>
+      <span className="line"></span>
+      <span style={{ fontSize: 10, color: Z.sageLight, fontVariantNumeric: "tabular-nums", fontWeight: 600, whiteSpace: "nowrap" }}>{sub}</span>
+    </div>
+  );
+}
+
+function EditorB2() {
+  const [vals, setVals] = useStateSB(EDIT_INIT);
+  const [igualOpen, setIgualOpen] = useStateSB(false);
+  const set = (id) => (n) => setVals({ ...vals, [id]: n });
+  const byId = Object.fromEntries(PCATS.map((c) => [c.id, c]));
+  const nuevos = PCATS.filter((c) => c.nuevo);
+  const cambian = PCATS.filter((c) => !c.nuevo && vals[c.id] !== c.cur);
+  const igual = PCATS.filter((c) => !c.nuevo && vals[c.id] === c.cur);
+  const sum = (list) => list.reduce((a, c) => a + vals[c.id], 0);
+  const deltaCambian = cambian.reduce((a, c) => a + (vals[c.id] - c.cur), 0);
+  return (
+    <React.Fragment>
+      <BannerScen />
+      <MonthSel />
+
+      <GroupHeader label="Nuevos gastos" count={nuevos.length} sub={`+${fmtCOP(sum(nuevos))}`} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {nuevos.map((c) => <EditorRow key={c.id} cat={c} value={vals[c.id]} onChange={set(c.id)} />)}
+      </div>
+
+      <GroupHeader label="Cambian" count={cambian.length} sub={`${deltaCambian >= 0 ? "+" : "−"}${fmtCOP(Math.abs(deltaCambian))} neto`} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {cambian.map((c) => <EditorRow key={c.id} cat={c} value={vals[c.id]} onChange={set(c.id)} />)}
+      </div>
+
+      <GroupHeader label="Igual" count={igual.length} sub={fmtCOP(sum(igual))} />
+      <button onClick={() => setIgualOpen(!igualOpen)} style={{
+        display: "flex", alignItems: "center", justifyContent: "center", gap: 6, height: 32,
+        borderRadius: 10, border: `1px solid ${Z.border}`, background: "rgba(0,0,0,0.15)",
+        color: Z.sageDark, fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)",
+      }}>
+        {igualOpen ? "Ocultar" : "Mostrar"} {igual.length} categorías sin cambios
+        <Chevron open={igualOpen} size={13} />
+      </button>
+      <Expand open={igualOpen}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {igual.map((c) => <EditorRow key={c.id} cat={c} value={vals[c.id]} onChange={set(c.id)} />)}
+        </div>
+      </Expand>
+
+      <EditorFooter total={editorTotal(vals)} />
+    </React.Fragment>
+  );
+}
+
+// ── B3 · Ancla de realidad como barra ─────────────────────────
+// Barra: relleno = prom 3m (lo que realmente gastas) · marca = presupuesto escenario
+function RealityRow({ cat, value }) {
+  const max = Math.max(cat.prom || 0, value) * 1.15;
+  const delta = cat.cur == null ? null : value - cat.cur;
+  const overReal = cat.prom != null && cat.prom > value;
+  return (
+    <ZRow style={{ padding: "10px 12px" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7 }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: Z.white }}>{cat.name}</span>
+          {cat.nuevo && <NuevoBadge />}
+          {cat.fijo && <FijoBadge />}
+        </span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+          {delta !== null && delta !== 0 && <DeltaChip v={delta} />}
+          <Num v={fmtCOP(value)} size={14} weight={700} />
+        </span>
+      </div>
+      <div style={{ marginTop: 8, position: "relative", height: 8, borderRadius: 999, background: "rgba(255,255,255,0.06)" }}>
+        {cat.prom != null && (
+          <div style={{
+            position: "absolute", top: 1, left: 0, height: 6, borderRadius: 999,
+            width: `${(cat.prom / max) * 100}%`,
+            background: overReal ? "rgba(212,168,67,0.55)" : "rgba(118,128,83,0.55)",
+          }}></div>
+        )}
+        <div style={{ position: "absolute", top: -2, bottom: -2, left: `${(value / max) * 100}%`, width: 2, borderRadius: 1, background: Z.white }}></div>
+      </div>
+      <div style={{ marginTop: 5, display: "flex", justifyContent: "space-between", fontSize: 9, fontVariantNumeric: "tabular-nums" }}>
+        <span style={{ color: overReal ? Z.alert : Z.sageDark }}>
+          {cat.prom == null ? "sin historial — estimado" : `gastas ${fmtCOP(cat.prom)} prom 3m`}
+        </span>
+        <span style={{ color: Z.sageDark }}>presupuesto │</span>
+      </div>
+    </ZRow>
+  );
+}
+
+function EditorB3() {
+  const vals = EDIT_INIT;
+  const destacadas = ["arriendo", "mercado", "restaurantes", "transporte", "salidas"];
+  const resto = PCATS.filter((c) => !destacadas.includes(c.id));
+  return (
+    <React.Fragment>
+      <BannerScen />
+      <div style={{ fontSize: 11, color: Z.sageDark, lineHeight: 1.5 }}>
+        La barra muestra tu gasto real (prom 3m) contra el presupuesto del escenario (│). Si la barra pasa la marca, el plan choca con tus hábitos.
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {destacadas.map((id) => {
+          const c = PCATS.find((x) => x.id === id);
+          return <RealityRow key={id} cat={c} value={vals[id]} />;
+        })}
+      </div>
+      <div className="z-divider">
+        <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase", color: Z.sageDark }}>Sin fricción</span>
+        <span className="line"></span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {resto.map((c) => <RealityRow key={c.id} cat={c} value={vals[c.id]} />)}
+      </div>
+      <EditorFooter total={editorTotal(vals)} />
+    </React.Fragment>
+  );
+}
+
+Object.assign(window, { EditorB1, EditorB2, EditorB3, EditorRow, EditorFooter, EDIT_INIT });

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-c.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-c.jsx
@@ -1,0 +1,226 @@
+// Sección C — Veredicto del escenario (3 variantes, ambos estados)
+const { useState: useStateSC } = React;
+
+// ── C1 · La cuenta completa (interactivo: aplica recortes) ────
+function VerdictHero({ falta }) {
+  const ok = falta <= 0;
+  return (
+    <div style={{ textAlign: "left" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+        <span style={{
+          width: 26, height: 26, borderRadius: 999, flexShrink: 0,
+          display: "inline-flex", alignItems: "center", justifyContent: "center",
+          background: ok ? "rgba(92,184,138,0.12)" : "rgba(224,85,69,0.12)",
+          border: `1px solid ${ok ? "rgba(92,184,138,0.35)" : "rgba(224,85,69,0.35)"}`,
+          color: ok ? Z.income : Z.debt,
+        }}>
+          <ZIcon d={ok ? PIcons.check : PIcons.alertTri} size={13} sw={2.25} />
+        </span>
+        <span style={{ fontSize: 13, fontWeight: 700, color: ok ? Z.income : Z.debt }}>
+          {ok ? "El escenario funciona" : "El escenario no alcanza"}
+        </span>
+      </div>
+      <div style={{ marginTop: 8, display: "flex", alignItems: "baseline", gap: 8 }}>
+        <Num v={`${ok ? "+" : "−"}${fmtCOP(Math.abs(falta))}`} size={30} weight={800} color={ok ? Z.income : Z.debt} />
+        <span style={{ fontSize: 12, color: Z.sageDark }}>/mes</span>
+      </div>
+      <div style={{ fontSize: 11, color: Z.sageDark, marginTop: 2 }}>
+        {ok ? "te sobran después de todo el plan" : "te faltan para que el plan cierre"}
+      </div>
+    </div>
+  );
+}
+
+function BreakdownRow({ label, sub, v }) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 10, padding: "8px 0", borderBottom: `1px solid ${Z.border}` }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: 12, fontWeight: 500, color: Z.sageLight }}>{label}</div>
+        <div style={{ fontSize: 10, color: Z.sageDark, marginTop: 1 }}>{sub}</div>
+      </div>
+      <Num v={`−${fmtCOP(v)}`} size={13} weight={700} color={Z.debt} style={{ flexShrink: 0 }} />
+    </div>
+  );
+}
+
+function CutRow({ cut, applied, onToggle }) {
+  return (
+    <div style={{
+      borderRadius: 12, padding: "10px 12px",
+      border: `1px solid ${applied ? "rgba(92,184,138,0.30)" : Z.border}`,
+      background: applied ? "rgba(92,184,138,0.05)" : "#111",
+      transition: "border-color 150ms, background 150ms",
+    }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+          <ZIcon d={cut.aplaza ? PIcons.calendar : PIcons.scissors} size={13} style={{ color: applied ? Z.income : Z.sageDark }} />
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: Z.white, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{cut.name}</span>
+        </span>
+        <button onClick={onToggle} style={{
+          flexShrink: 0, height: 28, padding: "0 11px", borderRadius: 8, cursor: "pointer",
+          fontFamily: "var(--font-sans)", fontSize: 11, fontWeight: 700,
+          display: "inline-flex", alignItems: "center", gap: 5, transition: "background 150ms, color 150ms",
+          border: `1px solid ${applied ? "rgba(92,184,138,0.35)" : SCEN.border}`,
+          background: applied ? "rgba(92,184,138,0.10)" : SCEN.bg,
+          color: applied ? Z.income : SCEN.c,
+        }}>
+          {applied && <ZIcon d={PIcons.check} size={11} sw={2.5} />}
+          {applied ? "Aplicado" : "Aplicar"}
+        </button>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginTop: 5 }}>
+        <span style={{ fontSize: 10, color: Z.sageDark, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{cut.nota}</span>
+        <span style={{ fontSize: 11, fontWeight: 700, color: Z.income, fontVariantNumeric: "tabular-nums", flexShrink: 0 }}>
+          {cut.aplaza ? "" : `−${fmtCOP(cut.recorte)} · `}alivia {fmtCOP(cut.alivio)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function VerdictC1({ defaultApplied = [] }) {
+  const [applied, setApplied] = useStateSC(defaultApplied);
+  const alivio = PCUTS.filter((c) => applied.includes(c.id)).reduce((a, c) => a + c.alivio, 0);
+  const falta = PTOT.falta - alivio;
+  const ok = falta <= 0;
+  return (
+    <ZCard style={{ borderColor: ok ? "rgba(92,184,138,0.25)" : "rgba(224,85,69,0.25)" }}>
+      <VerdictHero falta={falta} />
+
+      <div style={{ marginTop: 12 }}>
+        <Eyebrow>La cuenta</Eyebrow>
+        <div style={{ marginTop: 2 }}>
+          <BreakdownRow label="Presupuesto del escenario" sub={`${fmtCOP(PTOT.scen)} contra ingreso de ${fmtCOP(PINGRESO)}`} v={PTOT.brechaPresupuesto} />
+          <BreakdownRow label="Sobregasto real esperado" sub="Donde tu prom 3m supera el presupuesto" v={PTOT.sobregasto} />
+          <BreakdownRow label="Reserva de arranque" sub={`${fmtCOP(PARR_TOTAL)} de arranque, listo en 6 meses`} v={PTOT.reservaArranque} />
+        </div>
+      </div>
+
+      <div style={{ marginTop: 14, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Eyebrow>Candidatos a recorte</Eyebrow>
+        {alivio > 0 && (
+          <span style={{ fontSize: 10, fontWeight: 700, color: Z.income, fontVariantNumeric: "tabular-nums" }}>−{fmtCOP(alivio)} aplicados</span>
+        )}
+      </div>
+      <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 6 }}>
+        {PCUTS.map((c) => (
+          <CutRow key={c.id} cut={c} applied={applied.includes(c.id)}
+            onToggle={() => setApplied(applied.includes(c.id) ? applied.filter((x) => x !== c.id) : [...applied, c.id])} />
+        ))}
+      </div>
+
+      {ok && (
+        <div style={{
+          marginTop: 10, padding: "8px 11px", borderRadius: 10, display: "flex", gap: 8, alignItems: "flex-start",
+          border: `1px solid ${SCEN.borderSoft}`, background: SCEN.bg,
+        }}>
+          <ZIcon d={PIcons.alertTri} size={13} style={{ color: SCEN.c, marginTop: 1 }} />
+          <span style={{ fontSize: 10.5, color: Z.sageLight, lineHeight: 1.5 }}>
+            Sin holgura: Restaurantes queda en {fmtCOP(150000)} y tu promedio real es {fmtCOP(385000)}. El plan exige cambiar hábitos, no solo números.
+          </span>
+        </div>
+      )}
+    </ZCard>
+  );
+}
+
+// ── C2 · Veredicto sobre las barras 50/30/20 ─────────────────
+function VerdictC2({ fits = false }) {
+  const a = fits ? PALLOC.scenCut : PALLOC.scen;
+  const total = a.nec + a.gusto + a.ahorro;
+  const diff = PINGRESO - total;
+  return (
+    <ZCard>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <Eyebrow>Escenario · 50 / 30 / 20</Eyebrow>
+        <span style={{
+          display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 999,
+          fontSize: 10, fontWeight: 700, fontVariantNumeric: "tabular-nums",
+          color: diff < 0 ? Z.debt : Z.income,
+          border: `1px solid ${diff < 0 ? "rgba(224,85,69,0.35)" : "rgba(92,184,138,0.35)"}`,
+          background: diff < 0 ? "rgba(224,85,69,0.08)" : "rgba(92,184,138,0.08)",
+        }}>
+          {diff < 0 ? `faltan ${fmtCOP(-diff)}` : `sobran ${fmtCOP(diff)}`} /mes
+        </span>
+      </div>
+      <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 14 }}>
+        <AllocBar label="Necesidades" scenV={a.nec} curV={PALLOC.cur.nec} target={PALLOC.targets.nec} color={Z.sage} />
+        <AllocBar label="Gustos" scenV={a.gusto} curV={PALLOC.cur.gusto} target={PALLOC.targets.gusto} color={Z.brass} />
+        <AllocBar label="Ahorro" scenV={a.ahorro} curV={PALLOC.cur.ahorro} target={PALLOC.targets.ahorro} color={Z.income} />
+      </div>
+      <div style={{ marginTop: 12, paddingTop: 10, borderTop: `1px solid ${Z.border}`, fontSize: 10.5, color: Z.sageDark, lineHeight: 1.5 }}>
+        {fits
+          ? <span>Necesidades queda en <span style={{ color: Z.debt, fontWeight: 600 }}>79%</span> — lejos de la meta del 50%, pero el total cabe en tu ingreso. Gustos y ahorro absorben el recorte.</span>
+          : <span>Arriendo y servicios suben Necesidades de 32% a <span style={{ color: Z.debt, fontWeight: 600 }}>79%</span>. El total supera tu ingreso: hay que recortar gustos o pausar ahorro.</span>}
+      </div>
+      {!fits && (
+        <div style={{ marginTop: 10, display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {PCUTS.slice(0, 3).map((c) => (
+            <span key={c.id} style={{
+              display: "inline-flex", alignItems: "center", gap: 5, padding: "4px 9px", borderRadius: 999,
+              fontSize: 10, fontWeight: 600, color: SCEN.c, cursor: "pointer",
+              border: `1px solid ${SCEN.borderSoft}`, background: SCEN.bg,
+            }}>
+              <ZIcon d={PIcons.scissors} size={10} />
+              {c.name.replace("Aplazar ", "")} −{fmtM(c.alivio)}
+            </span>
+          ))}
+        </div>
+      )}
+    </ZCard>
+  );
+}
+
+// ── C3 · Barra fija + hoja de detalle ─────────────────────────
+function VerdictC3Bar() {
+  return (
+    <div style={{
+      borderRadius: 14, padding: "10px 14px", display: "flex", alignItems: "center", gap: 10,
+      border: "1px solid rgba(224,85,69,0.30)",
+      background: "linear-gradient(180deg, rgba(224,85,69,0.10), rgba(17,17,17,0.97))",
+      cursor: "pointer",
+    }}>
+      <ZIcon d={PIcons.alertTri} size={15} style={{ color: Z.debt }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, color: Z.debt, fontVariantNumeric: "tabular-nums" }}>Te faltan {fmtCOP(PTOT.falta)}/mes</div>
+        <div style={{ fontSize: 10, color: Z.sageDark }}>Toca para ver por qué y dónde recortar</div>
+      </div>
+      <Chevron open={false} size={15} />
+    </div>
+  );
+}
+
+function VerdictC3() {
+  return (
+    <React.Fragment>
+      <StateTag>Colapsado · barra fija sobre el editor</StateTag>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, opacity: 0.85 }}>
+        {PCATS.slice(0, 3).map((c) => <EditorRow key={c.id} cat={c} value={EDIT_INIT[c.id]} onChange={() => {}} />)}
+      </div>
+      <VerdictC3Bar />
+
+      <StateTag>Expandido · hoja con la cuenta y recortes</StateTag>
+      <PSheet behind={
+        <React.Fragment>
+          <BannerScen />
+          {PCATS.slice(0, 4).map((c) => <EditorRow key={c.id} cat={c} value={EDIT_INIT[c.id]} onChange={() => {}} />)}
+        </React.Fragment>
+      }>
+        <VerdictHero falta={PTOT.falta} />
+        <div style={{ marginTop: 10 }}>
+          <BreakdownRow label="Presupuesto del escenario" sub={`${fmtCOP(PTOT.scen)} de ${fmtCOP(PINGRESO)}`} v={PTOT.brechaPresupuesto} />
+          <BreakdownRow label="Sobregasto real esperado" sub="prom 3m sobre presupuesto" v={PTOT.sobregasto} />
+          <BreakdownRow label="Reserva de arranque" sub="6 meses" v={PTOT.reservaArranque} />
+        </div>
+        <div style={{ marginTop: 12 }}>
+          <Eyebrow>Dónde recortar</Eyebrow>
+          <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 6 }}>
+            {PCUTS.slice(0, 3).map((c) => <CutRow key={c.id} cut={c} applied={false} onToggle={() => {}} />)}
+          </div>
+        </div>
+      </PSheet>
+    </React.Fragment>
+  );
+}
+
+Object.assign(window, { VerdictC1, VerdictC2, VerdictC3, VerdictHero, BreakdownRow, CutRow });

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-d.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-d.jsx
@@ -1,0 +1,195 @@
+// Sección D — Gastos de arranque (compras one-time) · 2 variantes
+const { useState: useStateSD } = React;
+
+const ARR_ICONS = { cocina: PIcons.chefhat, nevera: PIcons.fridge, muebles: PIcons.sofa };
+
+function DeseoBadge() {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 3, fontSize: 9, fontWeight: 600, letterSpacing: "0.06em", textTransform: "uppercase", color: Z.brass, flexShrink: 0 }}>
+      <ZIcon d={PIcons.heart} size={10} /> de Deseos
+    </span>
+  );
+}
+
+// ── D1 · Lista con plan de fondeo ─────────────────────────────
+function ArranqueItem({ item, plan }) {
+  return (
+    <ZRow style={{ padding: "11px 12px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span style={{
+          width: 32, height: 32, borderRadius: 9, flexShrink: 0,
+          display: "inline-flex", alignItems: "center", justifyContent: "center",
+          background: "rgba(255,255,255,0.04)", border: `1px solid ${Z.border}`, color: Z.sageLight,
+        }}>
+          <ZIcon d={ARR_ICONS[item.id]} size={15} />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: Z.white, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{item.name}</span>
+            {item.deseo && <DeseoBadge />}
+          </div>
+          <div style={{ marginTop: 2 }}><AffordChip verdict={item.verdict} /></div>
+        </div>
+        <Num v={fmtCOP(item.monto)} size={14} weight={700} style={{ flexShrink: 0 }} />
+      </div>
+      <div style={{
+        marginTop: 8, paddingTop: 7, borderTop: `1px solid ${Z.border}`,
+        display: "flex", alignItems: "center", gap: 6, fontSize: 10.5, color: plan.ok ? Z.income : Z.sageLight,
+      }}>
+        <ZIcon d={plan.ok ? PIcons.check : PIcons.calendar} size={11} sw={2} style={{ color: plan.ok ? Z.income : Z.sageDark }} />
+        <span style={{ lineHeight: 1.4 }}>{plan.text}</span>
+      </div>
+    </ZRow>
+  );
+}
+
+function ArranqueD1() {
+  const planes = {
+    cocina: { ok: true, text: "Tu colchón la cubre hoy" },
+    nevera: { ok: true, text: `Cubierta con tu colchón — quedan ${fmtCOP(PCOLCHON - 450000 - 1200000)} de margen` },
+    muebles: { ok: false, text: `Te faltan ${fmtCOP(1750000)} → 5 meses ahorrando ${fmtCOP(400000)}/mes` },
+  };
+  return (
+    <React.Fragment>
+      <BannerScen />
+      <ZCard>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <Eyebrow>Gastos de arranque</Eyebrow>
+          <span style={{ fontSize: 10, color: Z.sageDark }}>una sola vez</span>
+        </div>
+        <div style={{ marginTop: 6, display: "flex", alignItems: "baseline", gap: 8 }}>
+          <Num v={fmtCOP(PARR_TOTAL)} size={26} weight={800} />
+          <span style={{ fontSize: 11, color: Z.sageDark }}>· 3 compras</span>
+        </div>
+        <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: Z.sageLight }}>
+          <span style={{ width: 6, height: 6, borderRadius: 999, background: Z.income, flexShrink: 0 }}></span>
+          Con tu colchón actual ({fmtCOP(PCOLCHON)}) cubres 2 de 3
+        </div>
+        <div style={{ marginTop: 4, display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: Z.sageLight }}>
+          <span style={{ width: 6, height: 6, borderRadius: 999, background: SCEN.c, flexShrink: 0 }}></span>
+          Colchón + {fmtCOP(400000)}/mes: todo listo en 5 meses
+        </div>
+      </ZCard>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {PARRANQUE.map((it) => <ArranqueItem key={it.id} item={it} plan={planes[it.id]} />)}
+      </div>
+      <button style={{
+        display: "flex", alignItems: "center", justifyContent: "center", gap: 7, height: 38,
+        borderRadius: 12, border: `1px dashed ${SCEN.borderSoft}`, background: "transparent",
+        color: SCEN.c, fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)",
+      }}>
+        <ZIcon d={PIcons.plus} size={13} sw={2.5} /> Agregar gasto de arranque
+      </button>
+    </React.Fragment>
+  );
+}
+
+// ── D2 · Línea de tiempo de fondeo (interactiva) ──────────────
+const MESES_LBL = ["hoy", "jul", "ago", "sep", "oct", "nov", "dic", "ene", "feb", "mar"];
+
+function readyMonth(cumNeed, rate, colchon) {
+  const need = cumNeed - (colchon ? PCOLCHON : 0);
+  if (need <= 0) return 0;
+  return Math.ceil(need / rate);
+}
+
+function ArranqueD2() {
+  const [rate, setRate] = useStateSD(400000);
+  const [colchon, setColchon] = useStateSD(true);
+  let cum = 0;
+  const items = PARRANQUE.map((it) => {
+    cum += it.monto;
+    return { ...it, mes: readyMonth(cum, rate, colchon) };
+  });
+  const maxMes = Math.max(...items.map((i) => i.mes), 1);
+  const span = Math.min(MESES_LBL.length - 1, Math.max(maxMes, 5));
+  const tone = (v) => AFFORD_TONES[v].c;
+
+  return (
+    <React.Fragment>
+      <BannerScen />
+      <ZCard>
+        <Eyebrow>Plan de fondeo</Eyebrow>
+        <div style={{ marginTop: 6, display: "flex", alignItems: "baseline", gap: 8 }}>
+          <Num v={fmtCOP(PARR_TOTAL)} size={22} weight={800} />
+          <span style={{ fontSize: 11, color: maxMes === 0 ? Z.income : Z.sageLight }}>
+            todo listo {maxMes === 0 ? "hoy" : `en ${maxMes} ${maxMes === 1 ? "mes" : "meses"} (${MESES_LBL[Math.min(maxMes, MESES_LBL.length - 1)]})`}
+          </span>
+        </div>
+
+        {/* controles */}
+        <div style={{ marginTop: 12, display: "flex", gap: 4, padding: 3, borderRadius: 11, border: `1px solid ${Z.border}`, background: "rgba(0,0,0,0.25)" }}>
+          {[300000, 400000, 500000].map((r) => (
+            <button key={r} onClick={() => setRate(r)} style={{
+              flex: 1, height: 28, borderRadius: 8, fontSize: 11, fontWeight: 600, cursor: "pointer",
+              fontFamily: "var(--font-sans)", fontVariantNumeric: "tabular-nums",
+              border: rate === r ? "1px solid rgba(147,120,68,0.35)" : "1px solid transparent",
+              background: rate === r ? Z.surface3 : "transparent",
+              color: rate === r ? Z.white : Z.sageDark, transition: "background 150ms, color 150ms",
+            }}>{fmtM(r)}/mes</button>
+          ))}
+        </div>
+        <button onClick={() => setColchon(!colchon)} style={{
+          marginTop: 8, width: "100%", display: "flex", alignItems: "center", gap: 8,
+          padding: "8px 11px", borderRadius: 10, cursor: "pointer", fontFamily: "var(--font-sans)",
+          border: `1px solid ${colchon ? "rgba(92,184,138,0.30)" : Z.border}`,
+          background: colchon ? "rgba(92,184,138,0.06)" : "rgba(0,0,0,0.15)",
+          transition: "background 150ms, border-color 150ms",
+        }}>
+          <span style={{
+            width: 28, height: 16, borderRadius: 999, position: "relative", flexShrink: 0,
+            background: colchon ? Z.income : "rgba(255,255,255,0.12)", transition: "background 150ms",
+          }}>
+            <span style={{
+              position: "absolute", top: 2, left: colchon ? 14 : 2, width: 12, height: 12,
+              borderRadius: 999, background: Z.ink, transition: "left 150ms",
+            }}></span>
+          </span>
+          <span style={{ fontSize: 11.5, fontWeight: 600, color: colchon ? Z.income : Z.sageLight }}>
+            Usar colchón actual · {fmtCOP(PCOLCHON)}
+          </span>
+        </button>
+
+        {/* línea de tiempo */}
+        <div style={{ marginTop: 16, position: "relative", height: 2, background: "rgba(255,255,255,0.08)", borderRadius: 1, marginLeft: 6, marginRight: 6 }}>
+          {Array.from({ length: span + 1 }).map((_, m) => (
+            <span key={m} style={{ position: "absolute", left: `${(m / span) * 100}%`, top: -2, width: 1, height: 6, background: "rgba(255,255,255,0.14)" }}></span>
+          ))}
+          {items.map((it, idx) => (
+            <span key={it.id} title={`${it.name} · ${it.mes === 0 ? "hoy" : MESES_LBL[it.mes]}`} style={{
+              position: "absolute", left: `${(Math.min(it.mes, span) / span) * 100}%`, top: -7,
+              width: 16, height: 16, borderRadius: 999, transform: "translateX(-50%)",
+              background: Z.ink, border: `2px solid ${tone(it.verdict)}`,
+              display: "inline-flex", alignItems: "center", justifyContent: "center",
+              transition: "left 200ms",
+            }}></span>
+          ))}
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", marginTop: 10, marginLeft: 6, marginRight: 6 }}>
+          {Array.from({ length: span + 1 }).map((_, m) => (
+            <span key={m} style={{ fontSize: 8.5, fontWeight: 600, letterSpacing: "0.06em", textTransform: "uppercase", color: Z.sageDark }}>{MESES_LBL[m]}</span>
+          ))}
+        </div>
+      </ZCard>
+
+      {/* leyenda por ítem */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {items.map((it) => (
+          <ZRow key={it.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "9px 12px" }}>
+            <span style={{ width: 9, height: 9, borderRadius: 999, border: `2px solid ${tone(it.verdict)}`, flexShrink: 0 }}></span>
+            <span style={{ flex: 1, fontSize: 12.5, fontWeight: 600, color: Z.white, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{it.name}</span>
+            <Num v={fmtCOP(it.monto)} size={11.5} weight={600} color={Z.sageLight} />
+            <span style={{ fontSize: 11, fontWeight: 700, color: it.mes === 0 ? Z.income : Z.sageLight, fontVariantNumeric: "tabular-nums", width: 52, textAlign: "right", flexShrink: 0 }}>
+              {it.mes === 0 ? "hoy" : MESES_LBL[it.mes]}
+            </span>
+          </ZRow>
+        ))}
+      </div>
+      <div style={{ fontSize: 10, color: Z.sageDark, lineHeight: 1.5 }}>
+        Orden de compra sugerido por el veredicto de Deseos: primero lo que el motor aprueba.
+      </div>
+    </React.Fragment>
+  );
+}
+
+Object.assign(window, { ArranqueD1, ArranqueD2, DeseoBadge });

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-e.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/section-e.jsx
@@ -1,0 +1,184 @@
+// Sección E — Aplicar / comparar (2 variantes)
+const { useState: useStateSE } = React;
+
+// Valores finales del escenario "Mudanza" con recortes aplicados (total 4.235.000)
+const FINAL_VALS = {
+  arriendo: 1500000, servicios: 220000, internet: 95000,
+  mercado: 650000, restaurantes: 150000, salidas: 130000, ahorro: 300000,
+};
+
+function CompareRow({ name, cur, scen, nuevo }) {
+  const delta = cur == null ? null : scen - cur;
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 8, padding: "9px 11px",
+      borderRadius: 11, border: `1px solid ${SCEN.borderSoft}`, background: SCEN.bg,
+    }}>
+      <span style={{ flex: 1, display: "inline-flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+        <span style={{ fontSize: 12.5, fontWeight: 600, color: Z.white, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{name}</span>
+        {nuevo && <NuevoBadge />}
+      </span>
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+        {cur != null && (
+          <React.Fragment>
+            <Num v={fmtCOP(cur)} size={11} weight={500} color={Z.sageDark} style={{ textDecoration: "line-through", textDecorationColor: "rgba(147,140,126,0.5)" }} />
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke={Z.sageDark} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
+          </React.Fragment>
+        )}
+        <Num v={fmtCOP(scen)} size={13} weight={700} />
+        {delta != null && <DeltaChip v={delta} />}
+        {nuevo && <DeltaChip v={scen} />}
+      </span>
+    </div>
+  );
+}
+
+function CompareTotals() {
+  const col = (label, asignado, restante, tone) => (
+    <div style={{ flex: 1, borderRadius: 12, border: `1px solid ${Z.border}`, background: "rgba(0,0,0,0.18)", padding: "10px 12px" }}>
+      <div style={{ fontSize: 9.5, fontWeight: 600, letterSpacing: "0.12em", textTransform: "uppercase", color: Z.sageDark }}>{label}</div>
+      <div style={{ marginTop: 5 }}><Num v={fmtCOP(asignado)} size={15} weight={700} /></div>
+      <div style={{ fontSize: 10, marginTop: 2, fontVariantNumeric: "tabular-nums", color: Z.sageDark }}>
+        restante <span style={{ color: tone, fontWeight: 700 }}>{fmtCOP(restante)}</span>
+      </div>
+    </div>
+  );
+  return (
+    <div style={{ display: "flex", gap: 8, alignItems: "stretch" }}>
+      {col("Actual", PTOT.cur, PTOT.restanteCur, Z.income)}
+      <span style={{ alignSelf: "center", color: Z.sageDark }}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
+      </span>
+      {col("Escenario", PTOT.scenCut, PINGRESO - PTOT.scenCut, Z.income)}
+    </div>
+  );
+}
+
+// ── E1 · Hoja de comparación + aplicar desde [mes] ────────────
+function AplicarE1() {
+  const [showSame, setShowSame] = useStateSE(false);
+  const changed = PCATS.filter((c) => c.nuevo || (FINAL_VALS[c.id] != null && FINAL_VALS[c.id] !== c.cur));
+  const same = PCATS.filter((c) => !c.nuevo && FINAL_VALS[c.id] == null);
+  return (
+    <PSheet style={{ maxHeight: "none" }} behind={
+      <React.Fragment>
+        <BannerScen />
+        <MonthSel />
+        <ScenHero actions={false} ghostReal={false} />
+      </React.Fragment>
+    }>
+      <Eyebrow>Aplicar escenario</Eyebrow>
+      <div style={{ fontSize: 17, fontWeight: 600, color: Z.white, marginTop: 4 }}>Mudanza → presupuesto real</div>
+      <div style={{ marginTop: 12 }}>
+        <CompareTotals />
+      </div>
+
+      <div className="z-divider" style={{ marginTop: 14, marginBottom: 8 }}>
+        <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase", color: SCEN.c }}>Cambia · {changed.length}</span>
+        <span className="line"></span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+        {changed.map((c) => (
+          <CompareRow key={c.id} name={c.name} cur={c.cur} scen={FINAL_VALS[c.id]} nuevo={c.nuevo} />
+        ))}
+      </div>
+
+      <button onClick={() => setShowSame(!showSame)} style={{
+        marginTop: 8, width: "100%", display: "flex", alignItems: "center", justifyContent: "center", gap: 6,
+        height: 30, borderRadius: 9, border: `1px solid ${Z.border}`, background: "transparent",
+        color: Z.sageDark, fontSize: 10.5, fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)",
+      }}>
+        {same.length} categorías sin cambios <Chevron open={showSame} size={12} />
+      </button>
+      <Expand open={showSame}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 5, paddingTop: 6 }}>
+          {same.map((c) => (
+            <div key={c.id} style={{ display: "flex", justifyContent: "space-between", padding: "7px 11px", borderRadius: 10, border: `1px solid ${Z.border}`, background: "#111" }}>
+              <span style={{ fontSize: 12, color: Z.sageLight }}>{c.name}</span>
+              <Num v={fmtCOP(c.cur)} size={12} weight={600} color={Z.sageLight} />
+            </div>
+          ))}
+        </div>
+      </Expand>
+
+      <div style={{ marginTop: 14, display: "flex", gap: 8 }}>
+        <ZBtn variant="ghost" size="lg" style={{ flex: 1 }}>Cancelar</ZBtn>
+        <ZBtn variant="brass" size="lg" style={{ flex: 2 }}>Aplicar desde julio</ZBtn>
+      </div>
+      <div style={{ marginTop: 9, fontSize: 10, color: Z.sageDark, textAlign: "center", lineHeight: 1.5 }}>
+        Junio no cambia. Tu presupuesto anterior queda guardado por si quieres volver.
+      </div>
+    </PSheet>
+  );
+}
+
+// ── E2 · Guardar como borrador con nombre ─────────────────────
+function AplicarE2() {
+  return (
+    <React.Fragment>
+      <StateTag>Guardar en vez de aplicar</StateTag>
+      <PSheet behind={
+        <React.Fragment>
+          <BannerScen />
+          <MonthSel />
+          <ScenHero actions={false} ghostReal={false} />
+        </React.Fragment>
+      }>
+        <Eyebrow>Guardar simulación</Eyebrow>
+        <div style={{ fontSize: 11, color: Z.sageDark, marginTop: 4, marginBottom: 10 }}>Vuelve cuando quieras — no toca tu presupuesto.</div>
+        <div style={{
+          display: "flex", alignItems: "center", gap: 8, height: 44, padding: "0 12px",
+          borderRadius: 12, border: "1px solid rgba(217,204,185,0.16)", background: "rgba(30,34,30,0.55)",
+        }}>
+          <ZIcon d={PIcons.bookmark} size={14} style={{ color: SCEN.c }} />
+          <input defaultValue="Mudanza" style={{
+            flex: 1, background: "transparent", border: "none", outline: "none",
+            color: Z.white, fontSize: 14, fontWeight: 600, fontFamily: "var(--font-sans)",
+          }} />
+        </div>
+        <div style={{ marginTop: 10, display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+          <StateChip tone="debt">faltan {fmtM(PTOT.falta)}/mes</StateChip>
+          <StateChip tone="neutral">3 nuevos · 1 sube · 1 recorte</StateChip>
+          <StateChip tone="neutral">{fmtM(PARR_TOTAL)} de arranque</StateChip>
+        </div>
+        <div style={{ marginTop: 14, display: "flex", gap: 8 }}>
+          <ZBtn variant="ghost" size="lg" style={{ flex: 1 }}>Aplicar ahora</ZBtn>
+          <ZBtn variant="brass" size="lg" style={{ flex: 1 }}>Guardar borrador</ZBtn>
+        </div>
+      </PSheet>
+
+      <StateTag>De vuelta en el presupuesto real · borrador guardado</StateTag>
+      <PageHead />
+      <MonthSel />
+      <HeroReal />
+      <div className="z-divider">
+        <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase", color: Z.sageDark }}>Simulaciones guardadas</span>
+        <span className="line"></span>
+      </div>
+      <div style={{
+        borderRadius: 14, border: `1px dashed ${SCEN.borderSoft}`, background: SCEN.bg,
+        padding: "11px 13px", display: "flex", alignItems: "center", gap: 11,
+      }}>
+        <span style={{
+          width: 32, height: 32, borderRadius: 10, flexShrink: 0,
+          display: "inline-flex", alignItems: "center", justifyContent: "center",
+          background: SCEN.bgStrong, border: `1px solid ${SCEN.borderSoft}`, color: SCEN.c,
+        }}>
+          <ZIcon d={PIcons.home} size={15} />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: Z.white }}>Mudanza</span>
+            <span style={{ fontSize: 10, color: Z.sageDark }}>hace 2 días</span>
+          </div>
+          <div style={{ fontSize: 10.5, color: Z.debt, fontWeight: 600, fontVariantNumeric: "tabular-nums", marginTop: 2 }}>
+            faltan {fmtCOP(PTOT.falta)}/mes
+          </div>
+        </div>
+        <ZBtn variant="brass-ghost" size="sm">Continuar</ZBtn>
+      </div>
+    </React.Fragment>
+  );
+}
+
+Object.assign(window, { AplicarE1, AplicarE2, CompareRow });

--- a/claude-ai-design/presupuesto-simular-cambio/presupuesto/zeta-ui.jsx
+++ b/claude-ai-design/presupuesto-simular-cambio/presupuesto/zeta-ui.jsx
@@ -1,0 +1,252 @@
+// Zeta shared primitives — exploraciones (copiado de deudas/zeta-ui.jsx)
+// Tokens from _ds colors_and_type.css. Exported to window.
+
+const Z = {
+  ink: "#121412",
+  sage: "#768053",
+  brass: "#937844",
+  brassHot: "#B29256",
+  sageLight: "#D9CCB9",
+  sageDark: "#938C7E",
+  white: "#F6F0E3",
+  income: "#5CB88A",
+  debt: "#E05545",
+  alert: "#D4A843",
+  surface: "#171A17",
+  surface2: "#1E221E",
+  surface3: "#262B26",
+  border: "rgba(255,255,255,0.06)",
+};
+
+function fmtCOP(n) {
+  const sign = n < 0 ? "−" : "";
+  return `${sign}$ ${Math.abs(Math.round(n)).toLocaleString("es-CO")}`;
+}
+function fmtM(n) {
+  const abs = Math.abs(n);
+  if (abs >= 1000000) return `$ ${(abs / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (abs >= 1000) return `$ ${Math.round(abs / 1000)}K`;
+  return fmtCOP(n);
+}
+
+// ── Icons (Lucide-style, stroke 1.75) ─────────────────────────
+function ZIcon({ d, size = 14, sw = 1.75, style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, ...style }}>
+      {d}
+    </svg>
+  );
+}
+const IconPaths = {
+  trendDown: <><polyline points="22 17 13.5 8.5 8.5 13.5 2 7" /><polyline points="16 17 22 17 22 11" /></>,
+  trendUp: <><polyline points="22 7 13.5 15.5 8.5 10.5 2 17" /><polyline points="16 7 22 7 22 13" /></>,
+  users: <><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></>,
+  zap: <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />,
+  calendar: <><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" /></>,
+  card: <><rect x="2" y="5" width="20" height="14" rx="2" /><line x1="2" y1="10" x2="22" y2="10" /></>,
+  bank: <><line x1="3" y1="22" x2="21" y2="22" /><line x1="6" y1="18" x2="6" y2="11" /><line x1="10" y1="18" x2="10" y2="11" /><line x1="14" y1="18" x2="14" y2="11" /><line x1="18" y1="18" x2="18" y2="11" /><polygon points="12 2 20 7 4 7" /></>,
+  arrowRight: <><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></>,
+  sparkle: <path d="M12 3l1.9 5.8a2 2 0 0 0 1.3 1.3L21 12l-5.8 1.9a2 2 0 0 0-1.3 1.3L12 21l-1.9-5.8a2 2 0 0 0-1.3-1.3L3 12l5.8-1.9a2 2 0 0 0 1.3-1.3z" />,
+};
+
+function Chevron({ open, size = 16, color = Z.sageDark }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, transition: "transform 180ms ease", transform: open ? "rotate(180deg)" : "rotate(0deg)" }}>
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+function PlusToggle({ open, size = 24 }) {
+  return (
+    <span style={{
+      width: size, height: size, borderRadius: 999, flexShrink: 0,
+      display: "inline-flex", alignItems: "center", justifyContent: "center",
+      border: `1px solid rgba(147,120,68,0.20)`, background: "rgba(147,120,68,0.08)",
+      color: Z.brass, transition: "transform 180ms ease",
+      transform: open ? "rotate(45deg)" : "rotate(0deg)",
+    }}>
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>
+    </span>
+  );
+}
+
+// ── Type ──────────────────────────────────────────────────────
+function Eyebrow({ children, color, style }) {
+  return <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.18em", textTransform: "uppercase", color: color || Z.sageDark, ...style }}>{children}</div>;
+}
+function Num({ v, size = 18, weight = 600, color, style }) {
+  return <span style={{ fontVariantNumeric: "tabular-nums", fontFeatureSettings: '"tnum" 1', fontSize: size, fontWeight: weight, letterSpacing: size >= 28 ? "-0.02em" : 0, color: color || Z.white, ...style }}>{v}</span>;
+}
+
+// ── Cards ─────────────────────────────────────────────────────
+function ZCard({ children, style, onClick, active, ...rest }) {
+  return (
+    <div onClick={onClick} {...rest} style={{
+      borderRadius: 16,
+      border: `1px solid ${active ? "rgba(147,120,68,0.35)" : Z.border}`,
+      background: "rgba(30,34,30,0.8)",
+      padding: 16,
+      boxShadow: "inset 0 1px 0 rgba(255,255,255,0.03)",
+      cursor: onClick ? "pointer" : "default",
+      transition: "border-color 150ms",
+      ...style,
+    }}>{children}</div>
+  );
+}
+function ZRow({ children, style, onClick, ...rest }) {
+  return (
+    <div onClick={onClick} {...rest} style={{
+      borderRadius: 12, border: `1px solid ${Z.border}`, background: "#111",
+      padding: "8px 12px", cursor: onClick ? "pointer" : "default", ...style,
+    }}>{children}</div>
+  );
+}
+function ZStat({ children, style, onClick, active, ...rest }) {
+  return (
+    <div onClick={onClick} {...rest} style={{
+      borderRadius: 16, border: `1px solid ${active ? "rgba(147,120,68,0.35)" : Z.border}`,
+      background: "rgba(0,0,0,0.10)", padding: 16,
+      cursor: onClick ? "pointer" : "default", transition: "border-color 150ms", ...style,
+    }}>{children}</div>
+  );
+}
+
+// ── Buttons ───────────────────────────────────────────────────
+function ZBtn({ variant = "brass", size = "lg", children, icon, style, onClick }) {
+  const sizes = {
+    sm: { height: 32, padding: "0 12px", fontSize: 12 },
+    md: { height: 36, padding: "0 16px", fontSize: 13 },
+    lg: { height: 44, padding: "0 16px", fontSize: 14 },
+  };
+  const variants = {
+    brass: { background: Z.brass, color: Z.ink, border: "1px solid transparent" },
+    ghost: { background: "rgba(0,0,0,0.10)", color: Z.sageLight, border: `1px solid rgba(255,255,255,0.08)` },
+    "brass-ghost": { background: "rgba(147,120,68,0.08)", color: Z.brass, border: "1px solid rgba(147,120,68,0.20)" },
+  };
+  return (
+    <button onClick={onClick} style={{
+      display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6,
+      borderRadius: 10, fontWeight: 600, cursor: "pointer",
+      fontFamily: "var(--font-sans)", transition: "background 150ms",
+      ...sizes[size], ...variants[variant], ...style,
+    }}>{icon}{children}</button>
+  );
+}
+
+// ── Chips ─────────────────────────────────────────────────────
+function StateChip({ tone = "neutral", children, icon, style }) {
+  const tones = {
+    neutral: { c: Z.sageLight, b: "rgba(217,204,185,0.16)", bg: "rgba(18,20,18,0.4)" },
+    brass: { c: Z.brass, b: "rgba(147,120,68,0.35)", bg: "rgba(147,120,68,0.08)" },
+    income: { c: Z.income, b: "rgba(92,184,138,0.35)", bg: "rgba(92,184,138,0.08)" },
+    debt: { c: Z.debt, b: "rgba(224,85,69,0.35)", bg: "rgba(224,85,69,0.08)" },
+    alert: { c: Z.alert, b: "rgba(212,168,67,0.35)", bg: "rgba(212,168,67,0.08)" },
+  };
+  const t = tones[tone];
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 4, padding: "3px 8px",
+      borderRadius: 999, fontSize: 10, fontWeight: 600, letterSpacing: "0.02em",
+      border: `1px solid ${t.b}`, background: t.bg, color: t.c, whiteSpace: "nowrap", flexShrink: 0, ...style,
+    }}>{icon}{children}</span>
+  );
+}
+
+// ── Progress ──────────────────────────────────────────────────
+function UsageBar({ pct, color = Z.brass, height = 4, track = "rgba(255,255,255,0.06)", style }) {
+  return (
+    <div style={{ height, borderRadius: 999, background: track, overflow: "hidden", width: "100%", ...style }}>
+      <div style={{ height: "100%", width: `${Math.min(100, pct)}%`, background: color, borderRadius: 999, transition: "width 200ms" }}></div>
+    </div>
+  );
+}
+
+function Ring({ pct, size = 44, stroke = 4, color = Z.brass, children, trackColor = "rgba(255,255,255,0.08)" }) {
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={trackColor} strokeWidth={stroke} />
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={color} strokeWidth={stroke}
+          strokeDasharray={c} strokeDashoffset={c * (1 - Math.min(100, pct) / 100)} strokeLinecap="round"
+          style={{ transition: "stroke-dashoffset 200ms" }} />
+      </svg>
+      <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>{children}</div>
+    </div>
+  );
+}
+
+// ── Expand wrapper (grid-rows 0fr→1fr) ────────────────────────
+function Expand({ open, children }) {
+  return (
+    <div style={{ display: "grid", gridTemplateRows: open ? "1fr" : "0fr", transition: "grid-template-rows 200ms ease" }}>
+      <div style={{ overflow: "hidden", minHeight: 0 }}>{children}</div>
+    </div>
+  );
+}
+
+// ── Segmented control (3 lenses) ──────────────────────────────
+function Segmented({ options, value, onChange }) {
+  return (
+    <div style={{
+      display: "flex", gap: 4, padding: 3, borderRadius: 12,
+      border: `1px solid ${Z.border}`, background: "rgba(0,0,0,0.25)",
+    }}>
+      {options.map((o) => (
+        <button key={o} onClick={() => onChange && onChange(o)} style={{
+          flex: 1, height: 32, borderRadius: 9, border: "1px solid transparent",
+          background: value === o ? Z.surface3 : "transparent",
+          color: value === o ? Z.white : Z.sageDark,
+          fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)",
+          transition: "background 150ms, color 150ms",
+          borderColor: value === o ? "rgba(147,120,68,0.35)" : "transparent",
+        }}>{o}</button>
+      ))}
+    </div>
+  );
+}
+
+// ── Frame: 390px page region ──────────────────────────────────
+function Frame({ children, lens, style, ...rest }) {
+  return (
+    <div {...rest} style={{
+      width: 390, boxSizing: "border-box", background: Z.surface,
+      padding: 16, display: "flex", flexDirection: "column", gap: 12,
+      fontFamily: "var(--font-sans)", color: Z.white, position: "relative",
+      minHeight: "100%", ...style,
+    }}>
+      {lens && <Segmented options={["Carga", "Plan", "Cuentas"]} value={lens} />}
+      {children}
+    </div>
+  );
+}
+
+// Small state caption inside frames ("COLAPSADO" / "EXPANDIDO")
+function StateTag({ children }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "2px 0" }}>
+      <span style={{ fontSize: 9, fontWeight: 600, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(147,120,68,0.75)", whiteSpace: "nowrap" }}>{children}</span>
+      <span style={{ flex: 1, height: 1, background: "rgba(147,120,68,0.18)" }}></span>
+    </div>
+  );
+}
+
+// Avatar initials circle
+function Avatar({ initials, size = 28, offset = 0 }) {
+  return (
+    <span style={{
+      width: size, height: size, borderRadius: 999, flexShrink: 0,
+      marginLeft: offset, display: "inline-flex", alignItems: "center", justifyContent: "center",
+      background: Z.surface3, border: `1.5px solid ${Z.surface}`,
+      color: Z.sageLight, fontSize: size * 0.36, fontWeight: 700, letterSpacing: "0.02em",
+    }}>{initials}</span>
+  );
+}
+
+Object.assign(window, {
+  Z, fmtCOP, fmtM, ZIcon, IconPaths, Chevron, PlusToggle,
+  Eyebrow, Num, ZCard, ZRow, ZStat, ZBtn, StateChip, UsageBar, Ring,
+  Expand, Segmented, Frame, StateTag, Avatar,
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export * from "./utils/snapshot-diff";
 export * from "./utils/destinatario-matcher";
 export * from "./utils/scenario-types";
 export * from "./utils/scenario-engine";
+export * from "./utils/budget-scenario";
 export * from "./utils/salary-breakdown";
 export * from "./utils/extra-payment";
 export * from "./utils/cc-projection";

--- a/packages/shared/src/utils/__tests__/budget-scenario.test.ts
+++ b/packages/shared/src/utils/__tests__/budget-scenario.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeScenarioSummary,
+  computeCutCandidates,
+  computeDeferCandidates,
+  computeFundingTimeline,
+  computeStartupPlan,
+  applyCutToDraft,
+  isLineTouched,
+  type BudgetScenarioDraft,
+  type BudgetScenarioLine,
+} from "../budget-scenario";
+
+// Sample data from the "Mudanza" design brief
+const INCOME = 4_500_000;
+const CUSHION = 1_700_000;
+
+const line = (partial: Partial<BudgetScenarioLine> & Pick<BudgetScenarioLine, "categoryId" | "name" | "scenario" | "group">): BudgetScenarioLine => ({
+  current: null,
+  avg3m: null,
+  isFixed: false,
+  ...partial,
+});
+
+const mudanza = (): BudgetScenarioDraft => ({
+  name: "Mudanza",
+  lines: [
+    line({ categoryId: "arriendo", name: "Arriendo", scenario: 1_500_000, group: "needs" }),
+    line({ categoryId: "servicios", name: "Servicios", scenario: 220_000, group: "needs" }),
+    line({ categoryId: "internet", name: "Internet", scenario: 95_000, group: "needs" }),
+    line({ categoryId: "mercado", name: "Mercado", current: 350_000, scenario: 650_000, avg3m: 410_000, group: "needs" }),
+    line({ categoryId: "transporte", name: "Transporte", current: 280_000, scenario: 280_000, avg3m: 295_000, group: "needs" }),
+    line({ categoryId: "restaurantes", name: "Restaurantes", current: 300_000, scenario: 300_000, avg3m: 385_000, group: "wants" }),
+    line({ categoryId: "suscripciones", name: "Suscripciones", current: 95_000, scenario: 95_000, avg3m: 95_000, group: "wants" }),
+    line({ categoryId: "salidas", name: "Salidas", current: 250_000, scenario: 250_000, avg3m: 310_000, group: "wants" }),
+    line({ categoryId: "deudas", name: "Deudas", current: 815_000, scenario: 815_000, avg3m: 815_000, isFixed: true, group: "needs" }),
+    line({ categoryId: "ahorro", name: "Ahorro", current: 600_000, scenario: 600_000, avg3m: 600_000, group: "savings" }),
+  ],
+  startup: {
+    items: [
+      { id: "cocina", name: "Cocina y menaje", amount: 450_000, verdict: "BUY", wishlistItemId: null, deferred: false },
+      { id: "nevera", name: "Nevera", amount: 1_200_000, verdict: "BUY_WITH_CAUTION", wishlistItemId: "w1", deferred: false },
+      { id: "muebles", name: "Muebles de sala", amount: 1_800_000, verdict: "WAIT", wishlistItemId: "w2", deferred: false },
+    ],
+    monthlyRate: 400_000,
+    useCushion: true,
+  },
+});
+
+describe("computeScenarioSummary", () => {
+  it("decomposes the shortfall into gap + overspend + reserve, closing exactly", () => {
+    const s = computeScenarioSummary(mudanza(), INCOME, CUSHION);
+    expect(s.scenarioTotal).toBe(4_805_000);
+    expect(s.currentTotal).toBe(2_690_000);
+    expect(s.budgetGap).toBe(305_000);
+    // Untouched lines only: transporte 15k + restaurantes 85k + salidas 60k
+    expect(s.expectedOverspend).toBe(160_000);
+    // Startup: 3.450.000 − cushion 1.700.000 = 1.750.000 → 5 months @ 400k → 350k/mes
+    expect(s.startupTotal).toBe(3_450_000);
+    expect(s.startupRemaining).toBe(1_750_000);
+    expect(s.startupMonths).toBe(5);
+    expect(s.startupReserve).toBe(350_000);
+    expect(s.shortfall).toBe(305_000 + 160_000 + 350_000);
+    expect(s.fits).toBe(false);
+  });
+
+  it("edited lines stop counting overspend (commitment semantics)", () => {
+    const draft = mudanza();
+    // Mercado was raised 350k→650k (touched): avg 410k < 650k anyway.
+    // Touch restaurantes: its 85k overspend disappears.
+    draft.lines = draft.lines.map((l) =>
+      l.categoryId === "restaurantes" ? { ...l, scenario: 290_000 } : l,
+    );
+    const s = computeScenarioSummary(draft, INCOME, CUSHION);
+    expect(s.expectedOverspend).toBe(75_000); // transporte 15k + salidas 60k
+  });
+
+  it("allocation groups scenario vs current amounts", () => {
+    const s = computeScenarioSummary(mudanza(), INCOME, CUSHION);
+    expect(s.allocation.needs).toBe(3_560_000);
+    expect(s.allocation.wants).toBe(645_000);
+    expect(s.allocation.savings).toBe(600_000);
+    expect(s.currentAllocation.needs).toBe(1_445_000);
+  });
+
+  it("fits when income covers everything", () => {
+    const draft = mudanza();
+    draft.startup.items = [];
+    draft.lines = draft.lines.map((l) => ({ ...l, scenario: l.current ?? 0, avg3m: null }));
+    const s = computeScenarioSummary(draft, INCOME, CUSHION);
+    expect(s.fits).toBe(true);
+    expect(s.shortfall).toBe(2_690_000 - INCOME);
+  });
+});
+
+describe("computeCutCandidates", () => {
+  it("ranks discretionary lines (wants → savings) and matches the design figures", () => {
+    const cuts = computeCutCandidates(mudanza());
+    const byId = Object.fromEntries(cuts.map((c) => [c.categoryId, c]));
+
+    // Restaurantes: 300k → cut 150k, relief 150k + 85k overspend = 235k, demanding (avg 385k > 150k)
+    expect(byId.restaurantes).toMatchObject({ cut: 150_000, to: 150_000, relief: 235_000, demanding: true });
+    // Salidas: 250k → cut 120k (rounded), relief 120k + 60k = 180k
+    expect(byId.salidas).toMatchObject({ cut: 120_000, relief: 180_000 });
+    // Ahorro (savings group, ranked after wants): 600k → 300k, relief 300k
+    expect(byId.ahorro).toMatchObject({ cut: 300_000, relief: 300_000, demanding: false });
+
+    // wants come before savings
+    expect(cuts.findIndex((c) => c.categoryId === "restaurantes")).toBeLessThan(
+      cuts.findIndex((c) => c.categoryId === "ahorro"),
+    );
+    // fixed and needs lines never appear
+    expect(byId.deudas).toBeUndefined();
+    expect(byId.arriendo).toBeUndefined();
+  });
+
+  it("applyCutToDraft lowers the line and the verdict improves by the relief", () => {
+    const draft = mudanza();
+    const before = computeScenarioSummary(draft, INCOME, CUSHION);
+    const cut = computeCutCandidates(draft).find((c) => c.categoryId === "restaurantes")!;
+    const after = computeScenarioSummary(applyCutToDraft(draft, cut), INCOME, CUSHION);
+    expect(before.shortfall - after.shortfall).toBe(cut.relief);
+  });
+});
+
+describe("computeDeferCandidates", () => {
+  it("orders by worst verdict and computes reserve relief", () => {
+    const defers = computeDeferCandidates(mudanza(), CUSHION);
+    expect(defers[0].itemId).toBe("muebles"); // WAIT before BUY_WITH_CAUTION
+    // Without muebles: remaining = max(0, 1.650.000 − 1.700.000) = 0 → reserve 0 → relief 350k
+    expect(defers[0].relief).toBe(350_000);
+  });
+});
+
+describe("computeFundingTimeline", () => {
+  it("cushion covers early items; the rest fund at the monthly rate", () => {
+    const t = computeFundingTimeline(mudanza(), CUSHION);
+    expect(t.map((e) => e.readyInMonths)).toEqual([0, 0, 5]);
+  });
+
+  it("deferred items are excluded (null) and don't shift others", () => {
+    const draft = mudanza();
+    draft.startup.items[2].deferred = true;
+    const t = computeFundingTimeline(draft, CUSHION);
+    expect(t[2].readyInMonths).toBeNull();
+    expect(t[1].readyInMonths).toBe(0);
+  });
+
+  it("no cushion: everything funds from the rate", () => {
+    const draft = mudanza();
+    draft.startup.useCushion = false;
+    const t = computeFundingTimeline(draft, 0);
+    expect(t.map((e) => e.readyInMonths)).toEqual([2, 5, 9]);
+    expect(computeStartupPlan(draft, 0).months).toBe(9);
+  });
+});
+
+describe("isLineTouched", () => {
+  it("new lines and edited lines are touched", () => {
+    expect(isLineTouched(line({ categoryId: "x", name: "X", scenario: 100, group: "needs" }))).toBe(true);
+    expect(isLineTouched(line({ categoryId: "x", name: "X", current: 100, scenario: 100, group: "needs" }))).toBe(false);
+    expect(isLineTouched(line({ categoryId: "x", name: "X", current: 100, scenario: 90, group: "needs" }))).toBe(true);
+  });
+});

--- a/packages/shared/src/utils/budget-scenario.ts
+++ b/packages/shared/src/utils/budget-scenario.ts
@@ -1,0 +1,283 @@
+/**
+ * Budget scenario ("Simular cambio") — pure math for the scenario sandbox.
+ *
+ * A scenario clones the user's standing monthly budget into an editable draft:
+ * lines reference existing categories (a "new" line is a category that had no
+ * budget), plus a pool of one-time startup purchases (gastos de arranque).
+ * Everything is recomputed against the user's real 3-month spending averages.
+ *
+ * The verdict decomposes the monthly shortfall into three parts so the math
+ * always closes exactly:
+ *   1. budgetGap        — scenario total vs income
+ *   2. expectedOverspend — where avg3m exceeds the budget, on UNTOUCHED lines only.
+ *      Editing a line is a commitment to the new number, so touched lines stop
+ *      counting overspend — which is why a cut's relief = cut + vanished overspend.
+ *   3. startupReserve   — monthly savings needed to fund startup purchases
+ */
+
+export type ScenarioGroup = "needs" | "wants" | "savings";
+
+export interface BudgetScenarioLine {
+  /** Existing category UUID — new lines map to zero-budget categories. */
+  categoryId: string;
+  name: string;
+  /** Current standing budget. null = category had no budget (a "new" line). */
+  current: number | null;
+  /** Draft budget in the scenario. */
+  scenario: number;
+  /** Real 3-month spending average. null = no history. */
+  avg3m: number | null;
+  /** Fixed commitments (e.g. Deudas) — not editable, never a cut candidate. */
+  isFixed: boolean;
+  group: ScenarioGroup;
+}
+
+export interface BudgetScenarioStartupItem {
+  id: string;
+  name: string;
+  amount: number;
+  /** Afford-engine verdict, when the item is linked to a Deseo. */
+  verdict: "BUY" | "BUY_WITH_CAUTION" | "WAIT" | "NOT_RECOMMENDED" | null;
+  /** wishlist_items id when pulled from Deseos. */
+  wishlistItemId: string | null;
+  /** Deferred items don't count toward the startup reserve. */
+  deferred: boolean;
+}
+
+export interface BudgetScenarioDraft {
+  name: string;
+  lines: BudgetScenarioLine[];
+  startup: {
+    items: BudgetScenarioStartupItem[];
+    /** Monthly saving rate toward startup purchases. */
+    monthlyRate: number;
+    /** Whether the current liquid cushion counts toward startup funding. */
+    useCushion: boolean;
+  };
+}
+
+export interface ScenarioAllocation {
+  needs: number;
+  wants: number;
+  savings: number;
+}
+
+export interface BudgetScenarioSummary {
+  scenarioTotal: number;
+  currentTotal: number;
+  /** scenarioTotal − income (positive = over income). */
+  budgetGap: number;
+  /** Σ max(0, avg3m − scenario) over lines with history. */
+  expectedOverspend: number;
+  startupTotal: number;
+  /** Startup amount not covered by the cushion. */
+  startupRemaining: number;
+  /** Months until everything is funded at monthlyRate. */
+  startupMonths: number;
+  /** Monthly set-aside: startupRemaining spread over startupMonths. */
+  startupReserve: number;
+  /** budgetGap + expectedOverspend + startupReserve. Positive = te faltan $X/mes. */
+  shortfall: number;
+  fits: boolean;
+  allocation: ScenarioAllocation;
+  currentAllocation: ScenarioAllocation;
+}
+
+export interface ScenarioCutCandidate {
+  categoryId: string;
+  name: string;
+  /** Suggested reduction to the scenario budget. */
+  cut: number;
+  from: number;
+  to: number;
+  avg3m: number | null;
+  /** Total monthly relief if applied (cut + overspend that disappears). */
+  relief: number;
+  /** True when avg3m exceeds the suggested target — the cut demands habit change. */
+  demanding: boolean;
+}
+
+export interface ScenarioDeferCandidate {
+  itemId: string;
+  name: string;
+  amount: number;
+  /** Reserve relief from deferring this item. */
+  relief: number;
+}
+
+export interface ScenarioFundingEntry {
+  itemId: string;
+  name: string;
+  amount: number;
+  /** 0 = covered today; n = ready in n months. Deferred items get null. */
+  readyInMonths: number | null;
+}
+
+function sumAllocation(lines: BudgetScenarioLine[], pick: (l: BudgetScenarioLine) => number): ScenarioAllocation {
+  const alloc: ScenarioAllocation = { needs: 0, wants: 0, savings: 0 };
+  for (const line of lines) alloc[line.group] += pick(line);
+  return alloc;
+}
+
+function activeStartupItems(draft: BudgetScenarioDraft): BudgetScenarioStartupItem[] {
+  return draft.startup.items.filter((i) => !i.deferred);
+}
+
+/** A line is "touched" when the user changed it (or it's new). */
+export function isLineTouched(line: BudgetScenarioLine): boolean {
+  return line.current == null || line.scenario !== line.current;
+}
+
+/** Overspend a line contributes to the verdict (untouched lines only). */
+export function lineOverspend(line: BudgetScenarioLine): number {
+  if (isLineTouched(line) || line.avg3m == null) return 0;
+  return Math.max(0, line.avg3m - line.scenario);
+}
+
+export function computeStartupPlan(
+  draft: BudgetScenarioDraft,
+  cushion: number,
+): { total: number; remaining: number; months: number; reserve: number } {
+  const total = activeStartupItems(draft).reduce((s, i) => s + i.amount, 0);
+  const covered = draft.startup.useCushion ? Math.max(0, cushion) : 0;
+  const remaining = Math.max(0, total - covered);
+  const rate = draft.startup.monthlyRate;
+  const months = remaining > 0 && rate > 0 ? Math.ceil(remaining / rate) : 0;
+  const reserve = months > 0 ? remaining / months : 0;
+  return { total, remaining, months, reserve: Math.round(reserve) };
+}
+
+export function computeScenarioSummary(
+  draft: BudgetScenarioDraft,
+  income: number,
+  cushion: number,
+): BudgetScenarioSummary {
+  const scenarioTotal = draft.lines.reduce((s, l) => s + l.scenario, 0);
+  const currentTotal = draft.lines.reduce((s, l) => s + (l.current ?? 0), 0);
+  const budgetGap = scenarioTotal - income;
+
+  const expectedOverspend = draft.lines.reduce(
+    (s, l) => s + lineOverspend(l),
+    0,
+  );
+
+  const startup = computeStartupPlan(draft, cushion);
+  const shortfall = budgetGap + expectedOverspend + startup.reserve;
+
+  return {
+    scenarioTotal,
+    currentTotal,
+    budgetGap,
+    expectedOverspend,
+    startupTotal: startup.total,
+    startupRemaining: startup.remaining,
+    startupMonths: startup.months,
+    startupReserve: startup.reserve,
+    shortfall,
+    fits: shortfall <= 0,
+    allocation: sumAllocation(draft.lines, (l) => l.scenario),
+    currentAllocation: sumAllocation(draft.lines, (l) => l.current ?? 0),
+  };
+}
+
+/** Round a suggested cut down to a clean step (default $10.000). */
+function roundCut(value: number, step = 10000): number {
+  return Math.floor(value / step) * step;
+}
+
+/**
+ * Ranked cut candidates: discretionary lines (wants first, then savings),
+ * largest scenario budget first. Suggested cut = up to half the line.
+ * Relief includes any overspend that disappears when avg3m anchors the line
+ * (cutting a line below avg3m forces real habit change, flagged `demanding`).
+ */
+export function computeCutCandidates(draft: BudgetScenarioDraft): ScenarioCutCandidate[] {
+  const order: Record<ScenarioGroup, number> = { wants: 0, savings: 1, needs: 2 };
+  return draft.lines
+    .filter((l) => !l.isFixed && l.scenario > 0 && l.group !== "needs")
+    .sort((a, b) => order[a.group] - order[b.group] || b.scenario - a.scenario)
+    .map((l) => {
+      const cut = roundCut(l.scenario / 2);
+      if (cut <= 0) return null;
+      const to = l.scenario - cut;
+      return {
+        categoryId: l.categoryId,
+        name: l.name,
+        cut,
+        from: l.scenario,
+        to,
+        avg3m: l.avg3m,
+        relief: cut + lineOverspend(l),
+        // Habit-change warning: only meaningful for spending, not savings transfers
+        demanding: l.group !== "savings" && l.avg3m != null && l.avg3m > to,
+      };
+    })
+    .filter((c): c is ScenarioCutCandidate => c !== null);
+}
+
+/** Defer candidates among startup items: worst verdicts first. */
+export function computeDeferCandidates(
+  draft: BudgetScenarioDraft,
+  cushion: number,
+): ScenarioDeferCandidate[] {
+  const verdictRank: Record<string, number> = {
+    NOT_RECOMMENDED: 0,
+    WAIT: 1,
+    BUY_WITH_CAUTION: 2,
+    BUY: 3,
+  };
+  const before = computeStartupPlan(draft, cushion).reserve;
+  return activeStartupItems(draft)
+    .sort(
+      (a, b) =>
+        (verdictRank[a.verdict ?? "BUY"] ?? 3) - (verdictRank[b.verdict ?? "BUY"] ?? 3) ||
+        b.amount - a.amount,
+    )
+    .map((item) => {
+      const without: BudgetScenarioDraft = {
+        ...draft,
+        startup: {
+          ...draft.startup,
+          items: draft.startup.items.map((i) => (i.id === item.id ? { ...i, deferred: true } : i)),
+        },
+      };
+      const after = computeStartupPlan(without, cushion).reserve;
+      return { itemId: item.id, name: item.name, amount: item.amount, relief: Math.max(0, before - after) };
+    })
+    .filter((c) => c.relief > 0);
+}
+
+/**
+ * Funding timeline: items fund in list order (cumulative need), cushion first,
+ * then monthlyRate per month. readyInMonths 0 = covered by cushion today.
+ */
+export function computeFundingTimeline(
+  draft: BudgetScenarioDraft,
+  cushion: number,
+): ScenarioFundingEntry[] {
+  const rate = draft.startup.monthlyRate;
+  const covered = draft.startup.useCushion ? Math.max(0, cushion) : 0;
+  let cumulative = 0;
+  return draft.startup.items.map((item) => {
+    if (item.deferred) {
+      return { itemId: item.id, name: item.name, amount: item.amount, readyInMonths: null };
+    }
+    cumulative += item.amount;
+    const need = cumulative - covered;
+    const months = need <= 0 ? 0 : rate > 0 ? Math.ceil(need / rate) : null;
+    return { itemId: item.id, name: item.name, amount: item.amount, readyInMonths: months };
+  });
+}
+
+/** Apply a cut candidate to the draft (immutable). */
+export function applyCutToDraft(
+  draft: BudgetScenarioDraft,
+  cut: ScenarioCutCandidate,
+): BudgetScenarioDraft {
+  return {
+    ...draft,
+    lines: draft.lines.map((l) =>
+      l.categoryId === cut.categoryId ? { ...l, scenario: cut.to } : l,
+    ),
+  };
+}

--- a/packages/shared/src/utils/budget-scenario.ts
+++ b/packages/shared/src/utils/budget-scenario.ts
@@ -134,17 +134,24 @@ export function lineOverspend(line: BudgetScenarioLine): number {
   return Math.max(0, line.avg3m - line.scenario);
 }
 
+function planFromTotals(
+  total: number,
+  covered: number,
+  rate: number,
+): { total: number; remaining: number; months: number; reserve: number } {
+  const remaining = Math.max(0, total - covered);
+  const months = remaining > 0 && rate > 0 ? Math.ceil(remaining / rate) : 0;
+  const reserve = months > 0 ? Math.round(remaining / months) : 0;
+  return { total, remaining, months, reserve };
+}
+
 export function computeStartupPlan(
   draft: BudgetScenarioDraft,
   cushion: number,
 ): { total: number; remaining: number; months: number; reserve: number } {
   const total = activeStartupItems(draft).reduce((s, i) => s + i.amount, 0);
   const covered = draft.startup.useCushion ? Math.max(0, cushion) : 0;
-  const remaining = Math.max(0, total - covered);
-  const rate = draft.startup.monthlyRate;
-  const months = remaining > 0 && rate > 0 ? Math.ceil(remaining / rate) : 0;
-  const reserve = months > 0 ? remaining / months : 0;
-  return { total, remaining, months, reserve: Math.round(reserve) };
+  return planFromTotals(total, covered, draft.startup.monthlyRate);
 }
 
 export function computeScenarioSummary(
@@ -180,8 +187,8 @@ export function computeScenarioSummary(
   };
 }
 
-/** Round a suggested cut down to a clean step (default $10.000). */
-function roundCut(value: number, step = 10000): number {
+/** Round a suggested cut down to a clean step. */
+function roundCut(value: number, step: number): number {
   return Math.floor(value / step) * step;
 }
 
@@ -190,14 +197,20 @@ function roundCut(value: number, step = 10000): number {
  * largest scenario budget first. Suggested cut = up to half the line.
  * Relief includes any overspend that disappears when avg3m anchors the line
  * (cutting a line below avg3m forces real habit change, flagged `demanding`).
+ *
+ * `step` is the rounding granularity for suggested cuts — currency-dependent
+ * ($10.000 reads clean in COP; low-nominal currencies need a smaller step).
  */
-export function computeCutCandidates(draft: BudgetScenarioDraft): ScenarioCutCandidate[] {
+export function computeCutCandidates(
+  draft: BudgetScenarioDraft,
+  step = 10_000,
+): ScenarioCutCandidate[] {
   const order: Record<ScenarioGroup, number> = { wants: 0, savings: 1, needs: 2 };
   return draft.lines
     .filter((l) => !l.isFixed && l.scenario > 0 && l.group !== "needs")
     .sort((a, b) => order[a.group] - order[b.group] || b.scenario - a.scenario)
     .map((l) => {
-      const cut = roundCut(l.scenario / 2);
+      const cut = roundCut(l.scenario / 2, step);
       if (cut <= 0) return null;
       const to = l.scenario - cut;
       return {
@@ -226,7 +239,10 @@ export function computeDeferCandidates(
     BUY_WITH_CAUTION: 2,
     BUY: 3,
   };
-  const before = computeStartupPlan(draft, cushion).reserve;
+  const covered = draft.startup.useCushion ? Math.max(0, cushion) : 0;
+  const rate = draft.startup.monthlyRate;
+  const total = activeStartupItems(draft).reduce((s, i) => s + i.amount, 0);
+  const before = planFromTotals(total, covered, rate).reserve;
   return activeStartupItems(draft)
     .sort(
       (a, b) =>
@@ -234,14 +250,7 @@ export function computeDeferCandidates(
         b.amount - a.amount,
     )
     .map((item) => {
-      const without: BudgetScenarioDraft = {
-        ...draft,
-        startup: {
-          ...draft.startup,
-          items: draft.startup.items.map((i) => (i.id === item.id ? { ...i, deferred: true } : i)),
-        },
-      };
-      const after = computeStartupPlan(without, cushion).reserve;
+      const after = planFromTotals(total - item.amount, covered, rate).reserve;
       return { itemId: item.id, name: item.name, amount: item.amount, relief: Math.max(0, before - after) };
     })
     .filter((c) => c.relief > 0);
@@ -280,4 +289,38 @@ export function applyCutToDraft(
       l.categoryId === cut.categoryId ? { ...l, scenario: cut.to } : l,
     ),
   };
+}
+
+// ── Currency-dependent scales ─────────────────────────────────
+// COP nominals are ~4000× USD/EUR — saving rates, rounding steps and
+// labels must scale with the user's currency. Shared so mobile and
+// webapp parameterize the math identically.
+
+export function startupRateOptions(currencyCode: string): number[] {
+  return currencyCode === "COP" ? [300_000, 400_000, 500_000] : [100, 200, 500];
+}
+
+/** Rounding granularity for suggested cuts (pass to computeCutCandidates). */
+export function cutStep(currencyCode: string): number {
+  return currencyCode === "COP" ? 10_000 : 10;
+}
+
+/**
+ * Canonical 50/30/20 group for a budget category. Savings/debt detection is
+ * slug-based (seeded categories); everything else falls back to expense_type
+ * + essential flag, mirroring get503020Allocation's needs/wants split.
+ */
+export function categoryBudgetGroup(category: {
+  slug: string;
+  expense_type?: string | null;
+  is_essential?: boolean;
+}): ScenarioGroup {
+  if (category.slug === "ahorro-e-inversion") return "savings";
+  if (category.expense_type === "fixed" || category.is_essential) return "needs";
+  return "wants";
+}
+
+/** Fixed commitments (not editable, never cut candidates) by category slug. */
+export function isFixedBudgetCategory(slug: string): boolean {
+  return slug === "pagos-de-deuda";
 }

--- a/supabase/migrations/20260610202619_create_budget_scenarios.sql
+++ b/supabase/migrations/20260610202619_create_budget_scenarios.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- Create budget_scenarios table ("Simular cambio" feature)
+--
+-- A budget scenario = an editable clone of the user's current budget, saved as
+-- a named draft to revisit (e.g. "Mudanza": add Arriendo, raise Mercado, attach
+-- one-time startup purchases) and later applied to the real budgets.
+--
+-- Design decisions:
+--   * PLAIN table (no _enc envelope), following the `budgets` table precedent.
+--     Scenario names like "Mudanza" are low-sensitivity. The draft JSONB holds
+--     category UUIDs + amounts and wishlist_item ids / ad-hoc names — no PII
+--     beyond what category/wishlist tables already expose. Keeping this plain
+--     materially simplifies mobile sync (no view / INSTEAD OF triggers).
+--   * user_id -> auth.users(id): `profiles` is now an encrypted view (cannot FK
+--     to a view); recent tables (subscriptions, wishlist_items) all reference
+--     auth.users(id). The draft references category/wishlist ids softly inside
+--     JSONB (no hard FK), so a deleted category degrades gracefully in-app.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- Table
+-- ----------------------------------------------------------------------------
+CREATE TABLE public.budget_scenarios (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL
+    REFERENCES auth.users(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  draft jsonb NOT NULL DEFAULT '{}'::jsonb,
+  applied_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.budget_scenarios IS
+  'Editable budget-scenario drafts for the "Simular cambio" feature. Plain table — low-sensitivity names; draft JSONB softly references category/wishlist ids + amounts. applied_at marks when a scenario was applied to real budgets.';
+
+-- ----------------------------------------------------------------------------
+-- Indexes
+-- ----------------------------------------------------------------------------
+-- List queries are per-user, ordered by updated_at desc.
+CREATE INDEX idx_budget_scenarios_user_updated
+  ON public.budget_scenarios (user_id, updated_at DESC);
+
+-- ----------------------------------------------------------------------------
+-- updated_at maintenance (moddatetime, matching every other core table)
+-- ----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS moddatetime WITH SCHEMA extensions;
+
+DROP TRIGGER IF EXISTS set_updated_at ON public.budget_scenarios;
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.budget_scenarios
+  FOR EACH ROW
+  EXECUTE FUNCTION extensions.moddatetime(updated_at);
+
+-- ----------------------------------------------------------------------------
+-- RLS (fast-path auth pattern; defense-in-depth .eq("user_id", ...) in app)
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.budget_scenarios ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "budget_scenarios_select"
+  ON public.budget_scenarios FOR SELECT
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "budget_scenarios_insert"
+  ON public.budget_scenarios FOR INSERT
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "budget_scenarios_update"
+  ON public.budget_scenarios FOR UPDATE
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "budget_scenarios_delete"
+  ON public.budget_scenarios FOR DELETE
+  USING ((select auth.uid()) = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.budget_scenarios TO authenticated;
+GRANT ALL ON public.budget_scenarios TO postgres, service_role;
+
+COMMIT;

--- a/webapp/src/actions/budget-scenarios.ts
+++ b/webapp/src/actions/budget-scenarios.ts
@@ -152,25 +152,27 @@ export async function applyBudgetScenario(input: {
       is_demo: isDemo,
     }));
 
-  if (upserts.length > 0) {
-    const { error } = await supabase
-      .from("budgets")
-      .upsert(upserts, { onConflict: "user_id,category_id,period" });
-    if (error) return { success: false, error: "No se pudo aplicar el escenario" };
-  }
-
   const removedIds = draft.lines
     .filter((l) => l.scenario === 0 && (l.current ?? 0) > 0)
     .map((l) => l.categoryId);
-  if (removedIds.length > 0) {
-    const { error } = await supabase
-      .from("budgets")
-      .delete()
-      .eq("user_id", user.id)
-      .eq("period", "monthly")
-      .eq("is_demo", isDemo)
-      .in("category_id", removedIds);
-    if (error) return { success: false, error: "No se pudo aplicar el escenario" };
+
+  // Independent writes on disjoint category sets — run in parallel
+  const [upsertResult, deleteResult] = await Promise.all([
+    upserts.length > 0
+      ? supabase.from("budgets").upsert(upserts, { onConflict: "user_id,category_id,period" })
+      : Promise.resolve({ error: null }),
+    removedIds.length > 0
+      ? supabase
+          .from("budgets")
+          .delete()
+          .eq("user_id", user.id)
+          .eq("period", "monthly")
+          .eq("is_demo", isDemo)
+          .in("category_id", removedIds)
+      : Promise.resolve({ error: null }),
+  ]);
+  if (upsertResult.error || deleteResult.error) {
+    return { success: false, error: "No se pudo aplicar el escenario" };
   }
 
   if (id) {

--- a/webapp/src/actions/budget-scenarios.ts
+++ b/webapp/src/actions/budget-scenarios.ts
@@ -1,0 +1,191 @@
+"use server";
+
+import { cacheTag, cacheLife, updateTag } from "next/cache";
+import { getAuthenticatedClient } from "@/lib/supabase/auth";
+import { createCachedClient } from "@/lib/supabase/cached";
+import { getIsDemoFilter } from "@/lib/demo-filter";
+import { saveScenarioSchema } from "@/lib/validators/budget-scenario";
+import { uuidStr } from "@/lib/validators/shared";
+import type { ActionResult } from "@/types/actions";
+import type { BudgetScenarioDraft } from "@zeta/shared";
+
+export interface BudgetScenarioRecord {
+  id: string;
+  name: string;
+  draft: BudgetScenarioDraft;
+  applied_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ─── Cached reads ─────────────────────────────────────────────────────────────
+
+async function getBudgetScenariosCached(
+  userId: string,
+  accessToken: string,
+): Promise<BudgetScenarioRecord[]> {
+  "use cache";
+  cacheTag("budget-scenarios");
+  cacheLife("zeta");
+
+  const supabase = createCachedClient(accessToken);
+  const { data, error } = await supabase
+    .from("budget_scenarios")
+    .select("id, name, draft, applied_at, created_at, updated_at")
+    .eq("user_id", userId)
+    .is("applied_at", null)
+    .order("updated_at", { ascending: false })
+    .limit(10);
+
+  if (error) throw error;
+  return (data ?? []) as unknown as BudgetScenarioRecord[];
+}
+
+export async function getBudgetScenarios(): Promise<BudgetScenarioRecord[]> {
+  const { user, accessToken } = await getAuthenticatedClient();
+  if (!user || !accessToken) return [];
+  try {
+    return await getBudgetScenariosCached(user.id, accessToken);
+  } catch (error) {
+    console.error("Error loading budget scenarios:", error);
+    return [];
+  }
+}
+
+// ─── Mutations ────────────────────────────────────────────────────────────────
+
+export async function saveBudgetScenario(input: {
+  id: string | null;
+  draft: BudgetScenarioDraft;
+}): Promise<ActionResult<{ id: string }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = saveScenarioSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+  const { id, draft } = parsed.data;
+
+  if (id) {
+    const { data, error } = await supabase
+      .from("budget_scenarios")
+      .update({ name: draft.name, draft, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select("id")
+      .single();
+    if (error) return { success: false, error: "No se pudo guardar la simulación" };
+    updateTag("budget-scenarios");
+    return { success: true, data: { id: data.id } };
+  }
+
+  const { data, error } = await supabase
+    .from("budget_scenarios")
+    .insert({ user_id: user.id, name: draft.name, draft })
+    .select("id")
+    .single();
+  if (error) return { success: false, error: "No se pudo guardar la simulación" };
+
+  updateTag("budget-scenarios");
+  return { success: true, data: { id: data.id } };
+}
+
+export async function deleteBudgetScenario(id: string): Promise<ActionResult> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = uuidStr().safeParse(id);
+  if (!parsed.success) return { success: false, error: "Simulación inválida" };
+
+  const { error } = await supabase
+    .from("budget_scenarios")
+    .delete()
+    .eq("id", parsed.data)
+    .eq("user_id", user.id);
+
+  if (error) return { success: false, error: "No se pudo eliminar la simulación" };
+
+  updateTag("budget-scenarios");
+  return { success: true, data: undefined };
+}
+
+/**
+ * Apply a scenario to the real budget: upsert each line's amount as the
+ * standing monthly budget. Lines cut to 0 that had a budget get deleted.
+ * The scenario is then marked applied (it leaves the drafts list).
+ */
+export async function applyBudgetScenario(input: {
+  id: string | null;
+  draft: BudgetScenarioDraft;
+}): Promise<ActionResult<{ updated: number }>> {
+  const { supabase, user } = await getAuthenticatedClient();
+  if (!user) return { success: false, error: "No autenticado" };
+
+  const parsed = saveScenarioSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+  const { id, draft } = parsed.data;
+  const isDemo = await getIsDemoFilter(user.id);
+
+  // Defense-in-depth: every line must reference the user's own or a system category
+  const lineIds = draft.lines.map((l) => l.categoryId);
+  if (lineIds.length > 0) {
+    const { data: owned, error: ownError } = await supabase
+      .from("categories")
+      .select("id")
+      .in("id", lineIds)
+      .or(`user_id.eq.${user.id},user_id.is.null`);
+    if (ownError || (owned ?? []).length !== new Set(lineIds).size) {
+      return { success: false, error: "El escenario tiene categorías inválidas" };
+    }
+  }
+
+  const upserts = draft.lines
+    .filter((l) => l.scenario > 0)
+    .map((l) => ({
+      user_id: user.id,
+      category_id: l.categoryId,
+      amount: l.scenario,
+      period: "monthly" as const,
+      is_demo: isDemo,
+    }));
+
+  if (upserts.length > 0) {
+    const { error } = await supabase
+      .from("budgets")
+      .upsert(upserts, { onConflict: "user_id,category_id,period" });
+    if (error) return { success: false, error: "No se pudo aplicar el escenario" };
+  }
+
+  const removedIds = draft.lines
+    .filter((l) => l.scenario === 0 && (l.current ?? 0) > 0)
+    .map((l) => l.categoryId);
+  if (removedIds.length > 0) {
+    const { error } = await supabase
+      .from("budgets")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("period", "monthly")
+      .eq("is_demo", isDemo)
+      .in("category_id", removedIds);
+    if (error) return { success: false, error: "No se pudo aplicar el escenario" };
+  }
+
+  if (id) {
+    const { error: markError } = await supabase
+      .from("budget_scenarios")
+      .update({ applied_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .eq("user_id", user.id);
+    // Budgets already updated — log instead of failing the whole apply
+    if (markError) console.error("Error marking scenario as applied:", markError);
+  }
+
+  updateTag("budgets");
+  updateTag("dashboard:budgets");
+  updateTag("attention");
+  updateTag("budget-scenarios");
+  return { success: true, data: { updated: upserts.length + removedIds.length } };
+}

--- a/webapp/src/components/budget/scenario/scenario-commit.tsx
+++ b/webapp/src/components/budget/scenario/scenario-commit.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Bookmark } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { StateChip } from "@/components/mobile/v2/state-chip";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import {
+  GHOST_BUTTON_CLASS,
+  BRASS_BUTTON_CLASS,
+  MOBILE_SHEET_SAFE_AREA_CLASS,
+} from "@/lib/constants/styles";
+import { isLineTouched, type BudgetScenarioDraft, type BudgetScenarioSummary } from "@zeta/shared";
+import type { CurrencyCode } from "@/types/domain";
+
+function TotalsCompare({
+  currentTotal,
+  scenarioTotal,
+  income,
+  currency,
+}: {
+  currentTotal: number;
+  scenarioTotal: number;
+  income: number;
+  currency: CurrencyCode;
+}) {
+  const col = (label: string, assigned: number) => {
+    const rest = income - assigned;
+    return (
+      <div className="flex-1 rounded-xl border border-white/6 bg-black/15 px-3 py-2.5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          {label}
+        </p>
+        <p className="mt-1 text-[15px] font-bold tabular-nums">
+          {formatCurrency(assigned, currency)}
+        </p>
+        <p className="mt-0.5 text-[10px] tabular-nums text-z-sage-dark">
+          restante{" "}
+          <span className={cn("font-bold", rest < 0 ? "text-z-debt" : "text-z-income")}>
+            {formatCurrency(rest, currency)}
+          </span>
+        </p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex items-stretch gap-2">
+      {col("Actual", currentTotal)}
+      <ArrowRight className="size-3.5 self-center text-z-sage-dark" strokeWidth={2} />
+      {col("Escenario", scenarioTotal)}
+    </div>
+  );
+}
+
+// ─── E2 · Save as named draft ─────────────────────────────────────────────────
+
+export function ScenarioSaveSheet({
+  open,
+  onOpenChange,
+  draft,
+  summary,
+  currency,
+  saving,
+  onSave,
+  onApplyInstead,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draft: BudgetScenarioDraft;
+  summary: BudgetScenarioSummary;
+  currency: CurrencyCode;
+  saving: boolean;
+  onSave: (name: string) => void;
+  onApplyInstead: () => void;
+}) {
+  const [name, setName] = useState(draft.name);
+
+  const newCount = draft.lines.filter((l) => l.current == null).length;
+  const changedCount = draft.lines.filter((l) => l.current != null && isLineTouched(l)).length;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className={MOBILE_SHEET_SAFE_AREA_CLASS}>
+        <SheetHeader>
+          <SheetTitle>Guardar simulación</SheetTitle>
+          <SheetDescription>Vuelve cuando quieras — no toca tu presupuesto.</SheetDescription>
+        </SheetHeader>
+        <div className="space-y-3 px-4 pb-4">
+          <div className="flex h-11 items-center gap-2 rounded-xl border border-z-sage-light/16 bg-z-surface-2/55 px-3">
+            <Bookmark className="size-3.5 shrink-0 text-z-alert" strokeWidth={1.5} />
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={80}
+              className="w-full bg-transparent text-sm font-semibold outline-none"
+              aria-label="Nombre de la simulación"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-1.5">
+            <StateChip
+              label={
+                summary.fits
+                  ? `sobran ${formatCurrency(-summary.shortfall, currency)}/mes`
+                  : `faltan ${formatCurrency(summary.shortfall, currency)}/mes`
+              }
+              variant={summary.fits ? "sage" : "danger"}
+            />
+            {(newCount > 0 || changedCount > 0) && (
+              <StateChip
+                label={`${newCount} ${newCount === 1 ? "nuevo" : "nuevos"} · ${changedCount} ${changedCount === 1 ? "cambia" : "cambian"}`}
+                variant="brass"
+              />
+            )}
+            {summary.startupTotal > 0 && (
+              <StateChip
+                label={`${formatCurrency(summary.startupTotal, currency)} de arranque`}
+                variant="brass"
+              />
+            )}
+          </div>
+
+          <div className="flex gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onApplyInstead}
+              className={cn(
+                "h-11 flex-1 rounded-md border text-sm font-semibold transition-colors",
+                GHOST_BUTTON_CLASS,
+              )}
+            >
+              Aplicar ahora
+            </button>
+            <button
+              type="button"
+              disabled={saving || name.trim().length === 0}
+              onClick={() => onSave(name.trim())}
+              className={cn(
+                "h-11 flex-1 rounded-md text-sm font-semibold transition-colors disabled:opacity-60",
+                BRASS_BUTTON_CLASS,
+              )}
+            >
+              {saving ? "Guardando…" : "Guardar borrador"}
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── Slim apply confirmation ──────────────────────────────────────────────────
+
+export function ScenarioApplySheet({
+  open,
+  onOpenChange,
+  draft,
+  summary,
+  income,
+  currency,
+  applying,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draft: BudgetScenarioDraft;
+  summary: BudgetScenarioSummary;
+  income: number;
+  currency: CurrencyCode;
+  applying: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className={MOBILE_SHEET_SAFE_AREA_CLASS}>
+        <SheetHeader>
+          <SheetTitle>{draft.name} → presupuesto real</SheetTitle>
+          <SheetDescription>
+            Tus límites mensuales se actualizan de inmediato. Lo gastado este mes no cambia.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="space-y-3 px-4 pb-4">
+          <TotalsCompare
+            currentTotal={summary.currentTotal}
+            scenarioTotal={summary.scenarioTotal}
+            income={income}
+            currency={currency}
+          />
+
+          {!summary.fits && (
+            <p className="rounded-xl border border-z-alert/25 bg-z-alert/8 px-3 py-2 text-[11px] leading-relaxed text-z-sage-light">
+              Al escenario todavía le faltan{" "}
+              <span className="font-bold tabular-nums text-z-debt">
+                {formatCurrency(summary.shortfall, currency)}/mes
+              </span>
+              . Puedes aplicarlo igual y ajustar después.
+            </p>
+          )}
+
+          <div className="flex gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className={cn(
+                "h-11 flex-1 rounded-md border text-sm font-semibold transition-colors",
+                GHOST_BUTTON_CLASS,
+              )}
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              disabled={applying}
+              onClick={onConfirm}
+              className={cn(
+                "h-11 flex-[2] rounded-md text-sm font-semibold transition-colors disabled:opacity-60",
+                BRASS_BUTTON_CLASS,
+              )}
+            >
+              {applying ? "Aplicando…" : "Aplicar al presupuesto"}
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-commit.tsx
+++ b/webapp/src/components/budget/scenario/scenario-commit.tsx
@@ -16,6 +16,7 @@ import {
   GHOST_BUTTON_CLASS,
   BRASS_BUTTON_CLASS,
   MOBILE_SHEET_SAFE_AREA_CLASS,
+  SECTION_EYEBROW_CLASS,
 } from "@/lib/constants/styles";
 import { isLineTouched, type BudgetScenarioDraft, type BudgetScenarioSummary } from "@zeta/shared";
 import type { CurrencyCode } from "@/types/domain";
@@ -35,7 +36,7 @@ function TotalsCompare({
     const rest = income - assigned;
     return (
       <div className="flex-1 rounded-xl border border-white/6 bg-black/15 px-3 py-2.5">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+        <p className={SECTION_EYEBROW_CLASS}>
           {label}
         </p>
         <p className="mt-1 text-[15px] font-bold tabular-nums">

--- a/webapp/src/components/budget/scenario/scenario-editor.tsx
+++ b/webapp/src/components/budget/scenario/scenario-editor.tsx
@@ -12,7 +12,7 @@ import {
 import { CategoryIcon } from "@/components/categories/category-icon";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
+import { MOBILE_SHEET_SAFE_AREA_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
 import { isLineTouched, type BudgetScenarioLine } from "@zeta/shared";
 import { DeltaChip, NuevoBadge, FijoBadge, PromAnchor } from "./scenario-shared";
 import type { ScenarioCategoryOption } from "./scenario-model";
@@ -227,10 +227,10 @@ export function ScenarioEditor({
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
 
-  const friction = lines.filter(
-    (l) => isLineTouched(l) || (l.avg3m != null && l.avg3m > l.scenario),
-  );
-  const calm = lines.filter((l) => !friction.includes(l));
+  const hasFriction = (l: BudgetScenarioLine) =>
+    isLineTouched(l) || (l.avg3m != null && l.avg3m > l.scenario);
+  const friction = lines.filter(hasFriction);
+  const calm = lines.filter((l) => !hasFriction(l));
   const available = categories.filter((c) => !lines.some((l) => l.categoryId === c.id));
 
   return (
@@ -254,7 +254,7 @@ export function ScenarioEditor({
       {calm.length > 0 && (
         <>
           <div className="flex items-center gap-2 pt-1">
-            <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            <span className={SECTION_EYEBROW_CLASS}>
               Sin fricción
             </span>
             <span className="h-px flex-1 bg-white/6" />

--- a/webapp/src/components/budget/scenario/scenario-editor.tsx
+++ b/webapp/src/components/budget/scenario/scenario-editor.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Plus } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { CategoryIcon } from "@/components/categories/category-icon";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
+import { isLineTouched, type BudgetScenarioLine } from "@zeta/shared";
+import { DeltaChip, NuevoBadge, FijoBadge, PromAnchor } from "./scenario-shared";
+import type { ScenarioCategoryOption } from "./scenario-model";
+import type { CurrencyCode } from "@/types/domain";
+
+// ─── Inline amount editing (tap → numeric input) ─────────────────────────────
+
+function EditAmount({
+  value,
+  currency,
+  locked,
+  onChange,
+}: {
+  value: number;
+  currency: CurrencyCode;
+  locked: boolean;
+  onChange: (n: number) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  if (locked) {
+    return (
+      <span className="text-sm font-semibold tabular-nums text-z-sage-light">
+        {formatCurrency(value, currency)}
+      </span>
+    );
+  }
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setDraft(value > 0 ? String(value) : "");
+          setEditing(true);
+        }}
+        className="rounded-md px-1 py-0.5 transition-colors active:bg-white/5"
+        aria-label="Editar monto"
+      >
+        <span className="border-b border-dashed border-z-alert/25 pb-px text-sm font-bold tabular-nums">
+          {formatCurrency(value, currency)}
+        </span>
+      </button>
+    );
+  }
+
+  const commit = () => {
+    const n = parseInt(draft || "0", 10);
+    onChange(Number.isNaN(n) ? value : n);
+    setEditing(false);
+  };
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="inline-flex items-center gap-0.5 rounded-lg border border-z-alert/35 bg-black/35 px-2 py-1">
+        <span className="text-xs text-z-sage-dark">$</span>
+        <input
+          autoFocus
+          inputMode="numeric"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value.replace(/\D/g, ""))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit();
+          }}
+          onBlur={commit}
+          className="w-[88px] bg-transparent text-[13px] font-bold tabular-nums text-foreground outline-none"
+          aria-label="Nuevo monto"
+        />
+      </span>
+      <button
+        type="button"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          commit();
+        }}
+        className="flex size-7 items-center justify-center rounded-lg border border-z-alert/35 bg-z-alert/12 text-z-alert"
+        aria-label="Confirmar monto"
+      >
+        <Check className="size-3" strokeWidth={2.5} />
+      </button>
+    </span>
+  );
+}
+
+// ─── B3 · Reality-anchor row ──────────────────────────────────────────────────
+// Bar fill = real spending (prom 3m) · white marker = scenario budget.
+// If the fill passes the marker, the plan collides with current habits.
+
+function RealityRow({
+  line,
+  currency,
+  onChange,
+}: {
+  line: BudgetScenarioLine;
+  currency: CurrencyCode;
+  onChange: (n: number) => void;
+}) {
+  const max = Math.max(line.avg3m ?? 0, line.scenario, 1) * 1.15;
+  const delta = line.current == null ? null : line.scenario - line.current;
+  const overReal = line.avg3m != null && line.avg3m > line.scenario;
+  const isNew = line.current == null;
+
+  return (
+    <div className="rounded-xl border border-white/6 bg-[#111] px-3 py-2.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate text-[13px] font-semibold">{line.name}</span>
+          {isNew && <NuevoBadge />}
+          {line.isFixed && <FijoBadge />}
+        </span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {delta != null && delta !== 0 && <DeltaChip value={delta} currency={currency} />}
+          {isNew && line.scenario > 0 && <DeltaChip value={line.scenario} currency={currency} />}
+          <EditAmount
+            value={line.scenario}
+            currency={currency}
+            locked={line.isFixed}
+            onChange={onChange}
+          />
+        </span>
+      </div>
+
+      <div className="relative mt-2 h-2 rounded-full bg-white/6">
+        {line.avg3m != null && (
+          <div
+            className={cn(
+              "absolute left-0 top-px h-1.5 rounded-full",
+              overReal ? "bg-z-alert/55" : "bg-z-sage/55",
+            )}
+            style={{ width: `${Math.min(100, (line.avg3m / max) * 100)}%` }}
+          />
+        )}
+        <div
+          className="absolute -top-0.5 h-3 w-0.5 rounded-full bg-foreground"
+          style={{ left: `${Math.min(100, (line.scenario / max) * 100)}%` }}
+        />
+      </div>
+
+      <div className="mt-1.5 flex items-center justify-between gap-2">
+        <PromAnchor avg3m={line.avg3m} scenario={line.scenario} currency={currency} />
+        <span className="text-[9px] text-z-sage-dark">presupuesto │</span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Sticky total footer ──────────────────────────────────────────────────────
+
+export function ScenarioEditorFooter({
+  total,
+  income,
+  currency,
+}: {
+  total: number;
+  income: number;
+  currency: CurrencyCode;
+}) {
+  const diff = income - total;
+  const short = diff < 0;
+  const max = Math.max(total, income, 1);
+
+  return (
+    <div
+      className={cn(
+        "sticky bottom-2 z-10 rounded-xl border bg-[#111]/95 px-3.5 py-2.5 backdrop-blur-sm",
+        short ? "border-z-debt/30" : "border-z-income/30",
+      )}
+    >
+      <div className="flex items-baseline justify-between">
+        <span className="text-[11px] text-z-sage-dark">Total escenario</span>
+        <span className="text-[17px] font-bold tabular-nums">
+          {formatCurrency(total, currency)}
+        </span>
+      </div>
+      <div className="relative mt-1.5 h-1.5 rounded-full bg-white/6">
+        <div
+          className={cn("h-full rounded-full", short ? "bg-z-debt" : "bg-z-income")}
+          style={{ width: `${(total / max) * 100}%` }}
+        />
+        <div
+          className="absolute -top-0.5 h-2.5 w-0.5 rounded-full bg-foreground/55"
+          style={{ left: `${(income / max) * 100}%` }}
+        />
+      </div>
+      <div className="mt-1.5 flex justify-between text-[10px] tabular-nums">
+        <span className="text-z-sage-dark">Ingreso {formatCurrency(income, currency)}</span>
+        <span className={cn("font-bold", short ? "text-z-debt" : "text-z-income")}>
+          {short
+            ? `${formatCurrency(-diff, currency)} sobre tu ingreso`
+            : `${formatCurrency(diff, currency)} libres`}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Editor: friction lines first, calm lines after ──────────────────────────
+
+export function ScenarioEditor({
+  lines,
+  currency,
+  categories,
+  onChangeLine,
+  onAddCategory,
+}: {
+  lines: BudgetScenarioLine[];
+  currency: CurrencyCode;
+  categories: ScenarioCategoryOption[];
+  onChangeLine: (categoryId: string, amount: number) => void;
+  onAddCategory: (cat: ScenarioCategoryOption) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const friction = lines.filter(
+    (l) => isLineTouched(l) || (l.avg3m != null && l.avg3m > l.scenario),
+  );
+  const calm = lines.filter((l) => !friction.includes(l));
+  const available = categories.filter((c) => !lines.some((l) => l.categoryId === c.id));
+
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] leading-relaxed text-z-sage-dark">
+        La barra muestra tu gasto real (prom 3m) contra el presupuesto del escenario (│). Si la
+        barra pasa la marca, el plan choca con tus hábitos.
+      </p>
+
+      <div className="space-y-1.5">
+        {friction.map((l) => (
+          <RealityRow
+            key={l.categoryId}
+            line={l}
+            currency={currency}
+            onChange={(n) => onChangeLine(l.categoryId, n)}
+          />
+        ))}
+      </div>
+
+      {calm.length > 0 && (
+        <>
+          <div className="flex items-center gap-2 pt-1">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+              Sin fricción
+            </span>
+            <span className="h-px flex-1 bg-white/6" />
+          </div>
+          <div className="space-y-1.5">
+            {calm.map((l) => (
+              <RealityRow
+                key={l.categoryId}
+                line={l}
+                currency={currency}
+                onChange={(n) => onChangeLine(l.categoryId, n)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setPickerOpen(true)}
+        className="flex h-10 w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-z-alert/25 text-xs font-semibold text-z-alert transition-colors active:bg-z-alert/8"
+      >
+        <Plus className="size-3.5" strokeWidth={2.5} />
+        Agregar categoría
+      </button>
+
+      <Sheet open={pickerOpen} onOpenChange={setPickerOpen}>
+        <SheetContent side="bottom" className={cn("max-h-[75dvh]", MOBILE_SHEET_SAFE_AREA_CLASS)}>
+          <SheetHeader>
+            <SheetTitle>Agregar categoría al escenario</SheetTitle>
+            <SheetDescription>
+              Las categorías sin presupuesto entran como líneas nuevas.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="space-y-1.5 overflow-y-auto px-4 pb-4">
+            {available.length === 0 && (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                Todas tus categorías ya están en el escenario.
+              </p>
+            )}
+            {available.map((cat) => (
+              <button
+                key={cat.id}
+                type="button"
+                onClick={() => {
+                  onAddCategory(cat);
+                  setPickerOpen(false);
+                }}
+                className="flex w-full items-center gap-3 rounded-xl border border-white/6 bg-[#111] px-3 py-2.5 text-left transition-colors active:bg-white/5"
+              >
+                <span
+                  className="flex size-7 shrink-0 items-center justify-center rounded-md"
+                  style={{ backgroundColor: `${cat.color}20`, color: cat.color }}
+                >
+                  <CategoryIcon icon={cat.icon} className="size-3.5" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">{cat.name}</span>
+                  <span className="block text-[10px] text-z-sage-dark">
+                    {cat.avg3m != null && cat.avg3m > 0
+                      ? `gastas ${formatCurrency(cat.avg3m, currency)} prom 3m`
+                      : "sin historial"}
+                  </span>
+                </span>
+                <NuevoBadge />
+              </button>
+            ))}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-entry.tsx
+++ b/webapp/src/components/budget/scenario/scenario-entry.tsx
@@ -15,6 +15,7 @@ import { formatRelativeDate } from "@/lib/utils/date";
 import {
   BRASS_GHOST_BUTTON_CLASS,
   MOBILE_SHEET_SAFE_AREA_CLASS,
+  SECTION_EYEBROW_CLASS,
 } from "@/lib/constants/styles";
 import { computeScenarioSummary } from "@zeta/shared";
 import type { BudgetScenarioRecord } from "@/actions/budget-scenarios";
@@ -129,7 +130,7 @@ export function SavedScenarios({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
-        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+        <span className={SECTION_EYEBROW_CLASS}>
           Simulaciones guardadas
         </span>
         <span className="h-px flex-1 bg-white/6" />

--- a/webapp/src/components/budget/scenario/scenario-entry.tsx
+++ b/webapp/src/components/budget/scenario/scenario-entry.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo } from "react";
+import { Home, SlidersHorizontal, ChevronRight, Trash2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { formatRelativeDate } from "@/lib/utils/date";
+import {
+  BRASS_GHOST_BUTTON_CLASS,
+  MOBILE_SHEET_SAFE_AREA_CLASS,
+} from "@/lib/constants/styles";
+import { computeScenarioSummary } from "@zeta/shared";
+import type { BudgetScenarioRecord } from "@/actions/budget-scenarios";
+import type { ScenarioTemplate } from "./scenario-model";
+import type { CurrencyCode } from "@/types/domain";
+
+export function ScenarioEntryButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-dashed border-z-alert/35 bg-z-alert/8 text-[13px] font-semibold text-z-alert transition-colors active:bg-z-alert/14"
+    >
+      <SlidersHorizontal className="size-3.5" strokeWidth={2} />
+      Simular un cambio
+    </button>
+  );
+}
+
+function TemplateRow({
+  icon,
+  title,
+  sub,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  sub: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-xl border border-white/6 bg-[#111] p-3 text-left transition-colors active:bg-white/5"
+    >
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-md border border-z-alert/25 bg-z-alert/8 text-z-alert">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[13px] font-semibold">{title}</span>
+        <span className="block text-[10px] text-z-sage-dark">{sub}</span>
+      </span>
+      <ChevronRight className="size-3.5 shrink-0 text-z-sage-dark" strokeWidth={1.5} />
+    </button>
+  );
+}
+
+export function ScenarioEntrySheet({
+  open,
+  onOpenChange,
+  onPickTemplate,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPickTemplate: (template: ScenarioTemplate) => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className={MOBILE_SHEET_SAFE_AREA_CLASS}>
+        <SheetHeader>
+          <SheetTitle>¿Qué cambio quieres probar?</SheetTitle>
+          <SheetDescription>Tu presupuesto real no se toca hasta que apliques.</SheetDescription>
+        </SheetHeader>
+        <div className="space-y-1.5 px-4 pb-4">
+          <TemplateRow
+            icon={<Home className="size-4" strokeWidth={1.5} />}
+            title="Mudanza"
+            sub="Arriendo, servicios, internet"
+            onClick={() => onPickTemplate("mudanza")}
+          />
+          <TemplateRow
+            icon={<SlidersHorizontal className="size-4" strokeWidth={1.5} />}
+            title="Desde cero"
+            sub="Copia tu presupuesto tal cual"
+            onClick={() => onPickTemplate("desde-cero")}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── E2 · Saved drafts on the real view ──────────────────────────────────────
+
+export function SavedScenarios({
+  scenarios,
+  income,
+  cushion,
+  currency,
+  onContinue,
+  onDelete,
+}: {
+  scenarios: BudgetScenarioRecord[];
+  income: number;
+  cushion: number;
+  currency: CurrencyCode;
+  onContinue: (record: BudgetScenarioRecord) => void;
+  onDelete: (id: string) => void;
+}) {
+  const withSummary = useMemo(
+    () =>
+      scenarios.map((record) => ({
+        record,
+        summary: computeScenarioSummary(record.draft, income, cushion),
+      })),
+    [scenarios, income, cushion],
+  );
+
+  if (scenarios.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          Simulaciones guardadas
+        </span>
+        <span className="h-px flex-1 bg-white/6" />
+      </div>
+      {withSummary.map(({ record, summary }) => {
+        return (
+          <div
+            key={record.id}
+            className="flex items-center gap-2.5 rounded-xl border border-dashed border-z-alert/25 bg-z-alert/8 px-3 py-2.5"
+          >
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-z-alert/25 bg-z-alert/12 text-z-alert">
+              <Home className="size-3.5" strokeWidth={1.5} />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline gap-1.5">
+                <span className="truncate text-[13px] font-semibold">{record.name}</span>
+                <span className="shrink-0 text-[10px] text-z-sage-dark">
+                  {formatRelativeDate(record.updated_at)}
+                </span>
+              </div>
+              <p
+                className={cn(
+                  "text-[10.5px] font-semibold tabular-nums",
+                  summary.fits ? "text-z-income" : "text-z-debt",
+                )}
+              >
+                {summary.fits
+                  ? `sobran ${formatCurrency(-summary.shortfall, currency)}/mes`
+                  : `faltan ${formatCurrency(summary.shortfall, currency)}/mes`}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onDelete(record.id)}
+              className="flex size-8 shrink-0 items-center justify-center rounded-lg text-z-sage-dark transition-colors active:bg-white/5"
+              aria-label={`Eliminar ${record.name}`}
+            >
+              <Trash2 className="size-3.5" strokeWidth={1.5} />
+            </button>
+            <button
+              type="button"
+              onClick={() => onContinue(record)}
+              className={cn(
+                "h-11 shrink-0 rounded-md border px-3 text-xs font-semibold transition-colors",
+                BRASS_GHOST_BUTTON_CLASS,
+              )}
+            >
+              Continuar
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-hero.tsx
+++ b/webapp/src/components/budget/scenario/scenario-hero.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import {
+  GHOST_BUTTON_CLASS,
+  BRASS_BUTTON_CLASS,
+  BRASS_GHOST_BUTTON_CLASS,
+} from "@/lib/constants/styles";
+import type { BudgetScenarioSummary } from "@zeta/shared";
+import { SCEN_CARD_CLASS, ScenTag } from "./scenario-shared";
+import type { CurrencyCode } from "@/types/domain";
+
+export function ScenarioHero({
+  name,
+  summary,
+  income,
+  currentTotal,
+  currency,
+  dirty,
+  onDiscard,
+  onSave,
+  onApply,
+}: {
+  name: string;
+  summary: BudgetScenarioSummary;
+  income: number;
+  currentTotal: number;
+  currency: CurrencyCode;
+  dirty: boolean;
+  onDiscard: () => void;
+  onSave: () => void;
+  onApply: () => void;
+}) {
+  const over = summary.scenarioTotal > income;
+  const max = Math.max(summary.scenarioTotal, income, 1);
+  const restante = income - summary.scenarioTotal;
+
+  return (
+    <div className={cn(SCEN_CARD_CLASS, "p-4")}>
+      <div className="flex items-center justify-between gap-2">
+        <ScenTag name={name} />
+        <span className="text-[10px] text-z-sage-dark">{dirty ? "sin guardar" : "guardado"}</span>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <div className="flex-1">
+          <p className="text-[10px] text-z-sage-dark">Ingreso</p>
+          <p className="text-[15px] font-bold tabular-nums text-z-sage-light">
+            {formatCurrency(income, currency)}
+          </p>
+        </div>
+        <div className="flex-1">
+          <p className="text-[10px] text-z-sage-dark">Escenario</p>
+          <p className="text-[15px] font-bold tabular-nums">
+            {formatCurrency(summary.scenarioTotal, currency)}
+          </p>
+        </div>
+        <div className="flex-1 text-right">
+          <p className="text-[10px] text-z-sage-dark">Restante</p>
+          <p
+            className={cn(
+              "text-[15px] font-bold tabular-nums",
+              restante < 0 ? "text-z-debt" : "text-z-income",
+            )}
+          >
+            {formatCurrency(restante, currency)}
+          </p>
+        </div>
+      </div>
+
+      <div className="relative mt-2.5 h-1.5 rounded-full bg-white/6">
+        <div
+          className={cn("h-full rounded-full", over ? "bg-z-debt" : "bg-z-brass")}
+          style={{ width: `${(summary.scenarioTotal / max) * 100}%` }}
+        />
+        <div
+          className="absolute -top-0.5 h-2.5 w-0.5 rounded-full bg-foreground/55"
+          style={{ left: `${(income / max) * 100}%` }}
+        />
+      </div>
+
+      <p className="mt-2 text-[10px] tabular-nums text-z-sage-dark">
+        Real: asignado {formatCurrency(currentTotal, currency)} · restante{" "}
+        <span className="text-z-income">{formatCurrency(income - currentTotal, currency)}</span>
+      </p>
+
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={onDiscard}
+          className={cn(
+            "h-11 flex-1 rounded-md border text-xs font-semibold transition-colors",
+            GHOST_BUTTON_CLASS,
+          )}
+        >
+          Descartar
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          className={cn(
+            "h-11 flex-1 rounded-md border text-xs font-semibold transition-colors",
+            BRASS_GHOST_BUTTON_CLASS,
+          )}
+        >
+          Guardar
+        </button>
+        <button
+          type="button"
+          onClick={onApply}
+          className={cn(
+            "h-11 flex-1 rounded-md text-xs font-semibold transition-colors",
+            BRASS_BUTTON_CLASS,
+          )}
+        >
+          Aplicar…
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-hero.tsx
+++ b/webapp/src/components/budget/scenario/scenario-hero.tsx
@@ -15,7 +15,6 @@ export function ScenarioHero({
   name,
   summary,
   income,
-  currentTotal,
   currency,
   dirty,
   onDiscard,
@@ -25,13 +24,13 @@ export function ScenarioHero({
   name: string;
   summary: BudgetScenarioSummary;
   income: number;
-  currentTotal: number;
   currency: CurrencyCode;
   dirty: boolean;
   onDiscard: () => void;
   onSave: () => void;
   onApply: () => void;
 }) {
+  const { currentTotal } = summary;
   const over = summary.scenarioTotal > income;
   const max = Math.max(summary.scenarioTotal, income, 1);
   const restante = income - summary.scenarioTotal;

--- a/webapp/src/components/budget/scenario/scenario-model.ts
+++ b/webapp/src/components/budget/scenario/scenario-model.ts
@@ -1,9 +1,12 @@
+import { startupRateOptions } from "@zeta/shared";
 import type {
   BudgetScenarioDraft,
   BudgetScenarioLine,
   BudgetScenarioStartupItem,
+  PurchaseDecisionVerdict,
   ScenarioGroup,
 } from "@zeta/shared";
+import type { CurrencyCode } from "@/types/domain";
 
 /** Serializable category option passed from the server component. */
 export interface ScenarioCategoryOption {
@@ -55,6 +58,7 @@ export function lineFromCategory(
 export function createDraft(
   template: ScenarioTemplate,
   categories: ScenarioCategoryOption[],
+  currency: CurrencyCode,
 ): BudgetScenarioDraft {
   const lines = categories.filter((c) => (c.budget ?? 0) > 0).map((c) => lineFromCategory(c));
 
@@ -73,13 +77,17 @@ export function createDraft(
   return {
     name: template === "mudanza" ? "Mudanza" : "Mi escenario",
     lines,
-    startup: { items: [], monthlyRate: 400_000, useCushion: true },
+    startup: { items: [], monthlyRate: startupRateOptions(currency)[1], useCushion: true },
   };
 }
 
-export const STARTUP_RATE_OPTIONS = [300_000, 400_000, 500_000];
+// Currency-dependent scales live in @zeta/shared (mobile parameterizes the
+// same math) — re-exported here for the scenario components.
+export { startupRateOptions, cutStep } from "@zeta/shared";
 
-export const VERDICT_LABELS: Record<string, string> = {
+// Record keyed on the shared verdict type: adding a verdict to
+// purchase-decision.ts breaks this map at compile time instead of silently.
+export const VERDICT_LABELS: Record<PurchaseDecisionVerdict, string> = {
   BUY: "Compra",
   BUY_WITH_CAUTION: "Con cuidado",
   WAIT: "Espera",

--- a/webapp/src/components/budget/scenario/scenario-model.ts
+++ b/webapp/src/components/budget/scenario/scenario-model.ts
@@ -1,0 +1,95 @@
+import type {
+  BudgetScenarioDraft,
+  BudgetScenarioLine,
+  BudgetScenarioStartupItem,
+  ScenarioGroup,
+} from "@zeta/shared";
+
+/** Serializable category option passed from the server component. */
+export interface ScenarioCategoryOption {
+  id: string;
+  slug: string;
+  name: string;
+  icon: string;
+  color: string;
+  /** Current standing monthly budget (null = none). */
+  budget: number | null;
+  /** Real 3-month spending average (null = no history). */
+  avg3m: number | null;
+  group: ScenarioGroup;
+  isFixed: boolean;
+}
+
+/** Wishlist item option for the startup-purchases pool. */
+export interface ScenarioDeseoOption {
+  id: string;
+  name: string;
+  amount: number;
+  verdict: BudgetScenarioStartupItem["verdict"];
+}
+
+export type ScenarioTemplate = "mudanza" | "desde-cero";
+
+/** Slugs the Mudanza template tries to pre-seed as new lines. */
+const MUDANZA_SLUG_GROUPS: string[][] = [
+  ["arriendo-hipoteca", "arriendo", "vivienda"],
+  ["servicios", "servicios-publicos"],
+  ["internet", "internet-y-telefonia", "telefonia"],
+];
+
+export function lineFromCategory(
+  cat: ScenarioCategoryOption,
+  scenario?: number,
+): BudgetScenarioLine {
+  return {
+    categoryId: cat.id,
+    name: cat.name,
+    current: cat.budget,
+    scenario: scenario ?? cat.budget ?? 0,
+    avg3m: cat.avg3m,
+    isFixed: cat.isFixed,
+    group: cat.group,
+  };
+}
+
+export function createDraft(
+  template: ScenarioTemplate,
+  categories: ScenarioCategoryOption[],
+): BudgetScenarioDraft {
+  const lines = categories.filter((c) => (c.budget ?? 0) > 0).map((c) => lineFromCategory(c));
+
+  if (template === "mudanza") {
+    const present = new Set(lines.map((l) => l.categoryId));
+    for (const slugs of MUDANZA_SLUG_GROUPS) {
+      const match = categories.find((c) => slugs.includes(c.slug) && !present.has(c.id));
+      if (match) {
+        // New line: enters at 0 so the user types the real figure
+        lines.unshift(lineFromCategory({ ...match, budget: null }, 0));
+        present.add(match.id);
+      }
+    }
+  }
+
+  return {
+    name: template === "mudanza" ? "Mudanza" : "Mi escenario",
+    lines,
+    startup: { items: [], monthlyRate: 400_000, useCushion: true },
+  };
+}
+
+export const STARTUP_RATE_OPTIONS = [300_000, 400_000, 500_000];
+
+export const VERDICT_LABELS: Record<string, string> = {
+  BUY: "Compra",
+  BUY_WITH_CAUTION: "Con cuidado",
+  WAIT: "Espera",
+  NOT_RECOMMENDED: "No recomendado",
+};
+
+export function normalizeVerdict(
+  verdict: string | null,
+): BudgetScenarioStartupItem["verdict"] {
+  return verdict && verdict in VERDICT_LABELS
+    ? (verdict as BudgetScenarioStartupItem["verdict"])
+    : null;
+}

--- a/webapp/src/components/budget/scenario/scenario-sandbox.tsx
+++ b/webapp/src/components/budget/scenario/scenario-sandbox.tsx
@@ -24,7 +24,7 @@ import {
   type BudgetScenarioDraft,
 } from "@zeta/shared";
 import { saveBudgetScenario, applyBudgetScenario } from "@/actions/budget-scenarios";
-import { lineFromCategory, type ScenarioCategoryOption, type ScenarioDeseoOption } from "./scenario-model";
+import { cutStep, lineFromCategory, type ScenarioCategoryOption, type ScenarioDeseoOption } from "./scenario-model";
 import { ScenarioHero } from "./scenario-hero";
 import { ScenarioEditor, ScenarioEditorFooter } from "./scenario-editor";
 import { ScenarioVerdict } from "./scenario-verdict";
@@ -76,9 +76,15 @@ export function ScenarioSandbox({
     () => computeScenarioSummary(draft, income, cushion),
     [draft, income, cushion],
   );
-  const cuts = useMemo(() => computeCutCandidates(draft), [draft]);
+  const cuts = useMemo(() => computeCutCandidates(draft, cutStep(currency)), [draft, currency]);
   const defers = useMemo(() => computeDeferCandidates(draft, cushion), [draft, cushion]);
-  const appliedSet = useMemo(() => new Set(appliedCutIds), [appliedCutIds]);
+
+  const updateStartup = (patch: Partial<BudgetScenarioDraft["startup"]>) =>
+    onDraftChange({ ...draft, startup: { ...draft.startup, ...patch } });
+  const patchItem = (itemId: string, patch: { deferred: boolean }) =>
+    updateStartup({
+      items: draft.startup.items.map((i) => (i.id === itemId ? { ...i, ...patch } : i)),
+    });
 
   const handleSave = (name: string) => {
     const named = { ...draft, name };
@@ -127,7 +133,6 @@ export function ScenarioSandbox({
           name={draft.name}
           summary={summary}
           income={income}
-          currentTotal={summary.currentTotal}
           currency={currency}
           dirty={dirty}
           onDiscard={() => (dirty ? setDiscardOpen(true) : onExit())}
@@ -140,23 +145,13 @@ export function ScenarioSandbox({
           income={income}
           cuts={cuts}
           defers={defers}
-          appliedCutIds={appliedSet}
+          appliedCutIds={appliedCutIds}
           currency={currency}
           onApplyCut={(cut) => {
             onDraftChange(applyCutToDraft(draft, cut));
             onCutApplied(cut.categoryId);
           }}
-          onDeferItem={(itemId) =>
-            onDraftChange({
-              ...draft,
-              startup: {
-                ...draft.startup,
-                items: draft.startup.items.map((i) =>
-                  i.id === itemId ? { ...i, deferred: true } : i,
-                ),
-              },
-            })
-          }
+          onDeferItem={(itemId) => patchItem(itemId, { deferred: true })}
         />
 
         <ScenarioEditor
@@ -184,45 +179,27 @@ export function ScenarioSandbox({
           cushion={cushion}
           deseos={deseos}
           currency={currency}
-          onSetRate={(rate) =>
-            onDraftChange({ ...draft, startup: { ...draft.startup, monthlyRate: rate } })
-          }
-          onToggleCushion={() =>
-            onDraftChange({
-              ...draft,
-              startup: { ...draft.startup, useCushion: !draft.startup.useCushion },
-            })
-          }
+          onSetRate={(rate) => updateStartup({ monthlyRate: rate })}
+          onToggleCushion={() => updateStartup({ useCushion: !draft.startup.useCushion })}
           onAddItem={({ name, amount, deseo }) =>
-            onDraftChange({
-              ...draft,
-              startup: {
-                ...draft.startup,
-                items: [
-                  ...draft.startup.items,
-                  {
-                    id: crypto.randomUUID(),
-                    name,
-                    amount,
-                    verdict: deseo ? normalizeVerdict(deseo.verdict) : null,
-                    wishlistItemId: deseo?.id ?? null,
-                    deferred: false,
-                  },
-                ],
-              },
+            updateStartup({
+              items: [
+                ...draft.startup.items,
+                {
+                  id: crypto.randomUUID(),
+                  name,
+                  amount,
+                  verdict: deseo ? normalizeVerdict(deseo.verdict) : null,
+                  wishlistItemId: deseo?.id ?? null,
+                  deferred: false,
+                },
+              ],
             })
           }
-          onToggleDefer={(itemId) =>
-            onDraftChange({
-              ...draft,
-              startup: {
-                ...draft.startup,
-                items: draft.startup.items.map((i) =>
-                  i.id === itemId ? { ...i, deferred: !i.deferred } : i,
-                ),
-              },
-            })
-          }
+          onToggleDefer={(itemId) => {
+            const item = draft.startup.items.find((i) => i.id === itemId);
+            if (item) patchItem(itemId, { deferred: !item.deferred });
+          }}
         />
 
         <ScenarioEditorFooter total={summary.scenarioTotal} income={income} currency={currency} />

--- a/webapp/src/components/budget/scenario/scenario-sandbox.tsx
+++ b/webapp/src/components/budget/scenario/scenario-sandbox.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { MobileHeader } from "@/components/mobile/v2/mobile-header";
+import { cn } from "@/lib/utils";
+import { MOBILE_SHEET_SAFE_AREA_CLASS } from "@/lib/constants/styles";
+import {
+  applyCutToDraft,
+  computeCutCandidates,
+  computeDeferCandidates,
+  computeScenarioSummary,
+  type BudgetScenarioDraft,
+} from "@zeta/shared";
+import { saveBudgetScenario, applyBudgetScenario } from "@/actions/budget-scenarios";
+import { lineFromCategory, type ScenarioCategoryOption, type ScenarioDeseoOption } from "./scenario-model";
+import { ScenarioHero } from "./scenario-hero";
+import { ScenarioEditor, ScenarioEditorFooter } from "./scenario-editor";
+import { ScenarioVerdict } from "./scenario-verdict";
+import { ScenarioStartup } from "./scenario-startup";
+import { ScenarioSaveSheet, ScenarioApplySheet } from "./scenario-commit";
+import { normalizeVerdict } from "./scenario-model";
+import type { CurrencyCode } from "@/types/domain";
+
+export interface ScenarioSandboxProps {
+  draft: BudgetScenarioDraft;
+  scenarioId: string | null;
+  dirty: boolean;
+  income: number;
+  cushion: number;
+  currency: CurrencyCode;
+  categories: ScenarioCategoryOption[];
+  deseos: ScenarioDeseoOption[];
+  appliedCutIds: string[];
+  modeToggle: React.ReactNode;
+  onDraftChange: (next: BudgetScenarioDraft) => void;
+  onCutApplied: (categoryId: string) => void;
+  onSaved: (id: string, named: BudgetScenarioDraft) => void;
+  onExit: () => void;
+}
+
+export function ScenarioSandbox({
+  draft,
+  scenarioId,
+  dirty,
+  income,
+  cushion,
+  currency,
+  categories,
+  deseos,
+  appliedCutIds,
+  modeToggle,
+  onDraftChange,
+  onCutApplied,
+  onSaved,
+  onExit,
+}: ScenarioSandboxProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [applyOpen, setApplyOpen] = useState(false);
+  const [discardOpen, setDiscardOpen] = useState(false);
+
+  const summary = useMemo(
+    () => computeScenarioSummary(draft, income, cushion),
+    [draft, income, cushion],
+  );
+  const cuts = useMemo(() => computeCutCandidates(draft), [draft]);
+  const defers = useMemo(() => computeDeferCandidates(draft, cushion), [draft, cushion]);
+  const appliedSet = useMemo(() => new Set(appliedCutIds), [appliedCutIds]);
+
+  const handleSave = (name: string) => {
+    const named = { ...draft, name };
+    startTransition(async () => {
+      const result = await saveBudgetScenario({ id: scenarioId, draft: named });
+      if (result.success) {
+        setSaveOpen(false);
+        onSaved(result.data.id, named);
+        toast.success("Simulación guardada");
+        router.refresh();
+      } else {
+        toast.error(result.error);
+      }
+    });
+  };
+
+  const handleApply = () => {
+    startTransition(async () => {
+      const result = await applyBudgetScenario({ id: scenarioId, draft });
+      if (result.success) {
+        setApplyOpen(false);
+        onExit();
+        toast.success("Escenario aplicado a tu presupuesto");
+        router.refresh();
+      } else {
+        toast.error(result.error);
+      }
+    });
+  };
+
+  return (
+    <div>
+      <div className="lg:hidden">
+        <MobileHeader variant="sub" title="Simulación" backHref="/plan" />
+      </div>
+
+      <div
+        className={cn(
+          "space-y-4 px-4 pt-4 lg:mx-auto lg:max-w-md lg:px-0 lg:pt-0 pb-8",
+          MOBILE_SHEET_SAFE_AREA_CLASS,
+        )}
+      >
+        {modeToggle}
+
+        <ScenarioHero
+          name={draft.name}
+          summary={summary}
+          income={income}
+          currentTotal={summary.currentTotal}
+          currency={currency}
+          dirty={dirty}
+          onDiscard={() => (dirty ? setDiscardOpen(true) : onExit())}
+          onSave={() => setSaveOpen(true)}
+          onApply={() => setApplyOpen(true)}
+        />
+
+        <ScenarioVerdict
+          summary={summary}
+          income={income}
+          cuts={cuts}
+          defers={defers}
+          appliedCutIds={appliedSet}
+          currency={currency}
+          onApplyCut={(cut) => {
+            onDraftChange(applyCutToDraft(draft, cut));
+            onCutApplied(cut.categoryId);
+          }}
+          onDeferItem={(itemId) =>
+            onDraftChange({
+              ...draft,
+              startup: {
+                ...draft.startup,
+                items: draft.startup.items.map((i) =>
+                  i.id === itemId ? { ...i, deferred: true } : i,
+                ),
+              },
+            })
+          }
+        />
+
+        <ScenarioEditor
+          lines={draft.lines}
+          currency={currency}
+          categories={categories}
+          onChangeLine={(categoryId, amount) =>
+            onDraftChange({
+              ...draft,
+              lines: draft.lines.map((l) =>
+                l.categoryId === categoryId ? { ...l, scenario: amount } : l,
+              ),
+            })
+          }
+          onAddCategory={(cat) =>
+            onDraftChange({
+              ...draft,
+              lines: [lineFromCategory({ ...cat, budget: null }, 0), ...draft.lines],
+            })
+          }
+        />
+
+        <ScenarioStartup
+          draft={draft}
+          cushion={cushion}
+          deseos={deseos}
+          currency={currency}
+          onSetRate={(rate) =>
+            onDraftChange({ ...draft, startup: { ...draft.startup, monthlyRate: rate } })
+          }
+          onToggleCushion={() =>
+            onDraftChange({
+              ...draft,
+              startup: { ...draft.startup, useCushion: !draft.startup.useCushion },
+            })
+          }
+          onAddItem={({ name, amount, deseo }) =>
+            onDraftChange({
+              ...draft,
+              startup: {
+                ...draft.startup,
+                items: [
+                  ...draft.startup.items,
+                  {
+                    id: crypto.randomUUID(),
+                    name,
+                    amount,
+                    verdict: deseo ? normalizeVerdict(deseo.verdict) : null,
+                    wishlistItemId: deseo?.id ?? null,
+                    deferred: false,
+                  },
+                ],
+              },
+            })
+          }
+          onToggleDefer={(itemId) =>
+            onDraftChange({
+              ...draft,
+              startup: {
+                ...draft.startup,
+                items: draft.startup.items.map((i) =>
+                  i.id === itemId ? { ...i, deferred: !i.deferred } : i,
+                ),
+              },
+            })
+          }
+        />
+
+        <ScenarioEditorFooter total={summary.scenarioTotal} income={income} currency={currency} />
+      </div>
+
+      <ScenarioSaveSheet
+        open={saveOpen}
+        onOpenChange={setSaveOpen}
+        draft={draft}
+        summary={summary}
+        currency={currency}
+        saving={isPending}
+        onSave={handleSave}
+        onApplyInstead={() => {
+          setSaveOpen(false);
+          setApplyOpen(true);
+        }}
+      />
+      <ScenarioApplySheet
+        open={applyOpen}
+        onOpenChange={setApplyOpen}
+        draft={draft}
+        summary={summary}
+        income={income}
+        currency={currency}
+        applying={isPending}
+        onConfirm={handleApply}
+      />
+
+      <AlertDialog open={discardOpen} onOpenChange={setDiscardOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Descartar la simulación?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {scenarioId
+                ? "Los cambios sin guardar se pierden. El borrador guardado queda como estaba."
+                : "Esta simulación no está guardada — se pierde por completo."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Seguir editando</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setDiscardOpen(false);
+                onExit();
+              }}
+            >
+              Descartar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-section.tsx
+++ b/webapp/src/components/budget/scenario/scenario-section.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { createContext, useContext, useState, useTransition } from "react";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useHideTabBar } from "@/components/mobile/v2/tab-bar-visibility-provider";
+import { cn } from "@/lib/utils";
+import type { BudgetScenarioDraft } from "@zeta/shared";
+import { deleteBudgetScenario, type BudgetScenarioRecord } from "@/actions/budget-scenarios";
+import { createDraft, type ScenarioCategoryOption, type ScenarioDeseoOption, type ScenarioTemplate } from "./scenario-model";
+import { ScenarioEntryButton, ScenarioEntrySheet, SavedScenarios } from "./scenario-entry";
+import type { CurrencyCode } from "@/types/domain";
+
+const ScenarioSandbox = dynamic(
+  () => import("./scenario-sandbox").then((m) => ({ default: m.ScenarioSandbox })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="mx-4 mt-4 h-72 animate-pulse rounded-2xl bg-z-surface-2 lg:mx-auto lg:max-w-md" />
+    ),
+  },
+);
+
+function ModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: "real" | "scen";
+  onChange: (mode: "real" | "scen") => void;
+}) {
+  return (
+    <div className="flex gap-1 rounded-xl border border-white/6 bg-black/25 p-0.5">
+      <button
+        type="button"
+        onClick={() => onChange("real")}
+        className={cn(
+          "h-9 flex-1 rounded-lg text-xs font-semibold transition-colors",
+          mode === "real"
+            ? "border border-z-brass/35 bg-z-surface-3 text-foreground"
+            : "text-z-sage-dark",
+        )}
+      >
+        Real
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("scen")}
+        className={cn(
+          "flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg text-xs font-semibold transition-colors",
+          mode === "scen"
+            ? "border border-z-alert/35 bg-z-alert/12 text-z-alert"
+            : "text-z-sage-dark",
+        )}
+      >
+        <span
+          className={cn("size-1.5 rounded-full", mode === "scen" ? "bg-z-alert" : "bg-z-sage-dark")}
+        />
+        Simulación
+      </button>
+    </div>
+  );
+}
+
+// ─── Context: lets the server layout place the entry point inside its flow ───
+
+interface ScenarioContextValue {
+  hasDraft: boolean;
+  mode: "real" | "scen";
+  scenarios: BudgetScenarioRecord[];
+  income: number;
+  cushion: number;
+  currency: CurrencyCode;
+  openEntry: () => void;
+  setMode: (mode: "real" | "scen") => void;
+  continueSaved: (record: BudgetScenarioRecord) => void;
+  deleteSaved: (id: string) => void;
+}
+
+const ScenarioContext = createContext<ScenarioContextValue | null>(null);
+
+/**
+ * Rendered by the server layout wherever the "Simular un cambio" affordance
+ * belongs (under the hero on mobile, top of content on desktop). Shows the
+ * entry button + saved drafts, or the Real/Simulación toggle once a draft exists.
+ */
+export function ScenarioEntryPoint({ className }: { className?: string }) {
+  const ctx = useContext(ScenarioContext);
+  if (!ctx) return null;
+
+  if (ctx.hasDraft) {
+    return (
+      <div className={className}>
+        <ModeToggle mode={ctx.mode} onChange={ctx.setMode} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <ScenarioEntryButton onClick={ctx.openEntry} />
+      <SavedScenarios
+        scenarios={ctx.scenarios}
+        income={ctx.income}
+        cushion={ctx.cushion}
+        currency={ctx.currency}
+        onContinue={ctx.continueSaved}
+        onDelete={ctx.deleteSaved}
+      />
+    </div>
+  );
+}
+
+// ─── Root orchestrator (single instance for mobile + desktop) ────────────────
+
+export function ScenarioSection({
+  categories,
+  deseos,
+  scenarios,
+  income,
+  cushion,
+  currency,
+  children,
+}: {
+  categories: ScenarioCategoryOption[];
+  deseos: ScenarioDeseoOption[];
+  scenarios: BudgetScenarioRecord[];
+  income: number;
+  cushion: number;
+  currency: CurrencyCode;
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  const [draft, setDraft] = useState<BudgetScenarioDraft | null>(null);
+  const [scenarioId, setScenarioId] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [mode, setMode] = useState<"real" | "scen">("real");
+  const [appliedCutIds, setAppliedCutIds] = useState<string[]>([]);
+  const [entryOpen, setEntryOpen] = useState(false);
+
+  const active = draft != null && mode === "scen";
+  useHideTabBar(active);
+
+  const startTemplate = (template: ScenarioTemplate) => {
+    setDraft(createDraft(template, categories));
+    setScenarioId(null);
+    setDirty(true);
+    setAppliedCutIds([]);
+    setEntryOpen(false);
+    setMode("scen");
+  };
+
+  const continueSaved = (record: BudgetScenarioRecord) => {
+    setDraft(record.draft);
+    setScenarioId(record.id);
+    setDirty(false);
+    setAppliedCutIds([]);
+    setMode("scen");
+  };
+
+  const exitScenario = () => {
+    setDraft(null);
+    setScenarioId(null);
+    setDirty(false);
+    setAppliedCutIds([]);
+    setMode("real");
+  };
+
+  const deleteSaved = (id: string) => {
+    startTransition(async () => {
+      const result = await deleteBudgetScenario(id);
+      if (result.success) {
+        toast.success("Simulación eliminada");
+        router.refresh();
+      } else {
+        toast.error(result.error);
+      }
+    });
+  };
+
+  if (income <= 0) return <>{children}</>;
+
+  return (
+    <ScenarioContext.Provider
+      value={{
+        hasDraft: draft != null,
+        mode,
+        scenarios,
+        income,
+        cushion,
+        currency,
+        openEntry: () => setEntryOpen(true),
+        setMode,
+        continueSaved,
+        deleteSaved,
+      }}
+    >
+      <div className={cn(active && "hidden")}>{children}</div>
+
+      {active && draft && (
+        <ScenarioSandbox
+          draft={draft}
+          scenarioId={scenarioId}
+          dirty={dirty}
+          income={income}
+          cushion={cushion}
+          currency={currency}
+          categories={categories}
+          deseos={deseos}
+          appliedCutIds={appliedCutIds}
+          modeToggle={<ModeToggle mode={mode} onChange={setMode} />}
+          onDraftChange={(next) => {
+            setDraft(next);
+            setDirty(true);
+          }}
+          onCutApplied={(categoryId) => setAppliedCutIds((ids) => [...ids, categoryId])}
+          onSaved={(id, named) => {
+            setScenarioId(id);
+            setDraft(named);
+            setDirty(false);
+          }}
+          onExit={exitScenario}
+        />
+      )}
+
+      <ScenarioEntrySheet
+        open={entryOpen}
+        onOpenChange={setEntryOpen}
+        onPickTemplate={startTemplate}
+      />
+    </ScenarioContext.Provider>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-section.tsx
+++ b/webapp/src/components/budget/scenario/scenario-section.tsx
@@ -144,7 +144,7 @@ export function ScenarioSection({
   useHideTabBar(active);
 
   const startTemplate = (template: ScenarioTemplate) => {
-    setDraft(createDraft(template, categories));
+    setDraft(createDraft(template, categories, currency));
     setScenarioId(null);
     setDirty(true);
     setAppliedCutIds([]);

--- a/webapp/src/components/budget/scenario/scenario-shared.tsx
+++ b/webapp/src/components/budget/scenario/scenario-shared.tsx
@@ -67,6 +67,14 @@ const AFFORD_CHIP_CLASSES: Record<string, string> = {
   NOT_RECOMMENDED: "border-z-debt/35 bg-z-debt/8 text-z-debt",
 };
 
+/** Border-color twin of the chip tones, for the timeline verdict dots. */
+export const VERDICT_DOT: Record<string, string> = {
+  BUY: "border-z-income",
+  BUY_WITH_CAUTION: "border-z-alert",
+  WAIT: "border-z-expense",
+  NOT_RECOMMENDED: "border-z-debt",
+};
+
 export function AffordChip({ verdict }: { verdict: BudgetScenarioStartupItem["verdict"] }) {
   if (!verdict) return null;
   return (

--- a/webapp/src/components/budget/scenario/scenario-shared.tsx
+++ b/webapp/src/components/budget/scenario/scenario-shared.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { SlidersHorizontal, Lock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { VERDICT_LABELS } from "./scenario-model";
+import type { BudgetScenarioStartupItem } from "@zeta/shared";
+import type { CurrencyCode } from "@/types/domain";
+
+/** Gold sandbox accent — the visual signature of scenario mode. */
+export const SCEN_CARD_CLASS =
+  "rounded-2xl border-[1.5px] border-dashed border-z-alert/35 bg-gradient-to-b from-z-alert/8 to-transparent";
+
+export function ScenTag({ name, className }: { name: string; className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-z-alert/35 bg-z-alert/12 px-2.5 py-1 text-[10px] font-bold tracking-[0.06em] text-z-alert",
+        className,
+      )}
+    >
+      <SlidersHorizontal className="size-3" strokeWidth={2} />
+      Simulación · {name}
+    </span>
+  );
+}
+
+export function NuevoBadge() {
+  return (
+    <span className="inline-flex shrink-0 items-center rounded border border-z-alert/25 bg-z-alert/12 px-1.5 py-px text-[9px] font-bold uppercase tracking-[0.1em] text-z-alert">
+      nuevo
+    </span>
+  );
+}
+
+export function FijoBadge() {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-z-sage-dark">
+      <Lock className="size-2.5" strokeWidth={2} />
+      fijo
+    </span>
+  );
+}
+
+/** +$ X (more spending, orange) / −$ X (a cut, green). */
+export function DeltaChip({ value, currency }: { value: number; currency: CurrencyCode }) {
+  const up = value > 0;
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-1.5 py-px text-[10px] font-bold tabular-nums",
+        up
+          ? "border-z-expense/30 bg-z-expense/10 text-z-expense"
+          : "border-z-income/30 bg-z-income/10 text-z-income",
+      )}
+    >
+      {up ? "+" : "−"}
+      {formatCurrency(Math.abs(value), currency)}
+    </span>
+  );
+}
+
+const AFFORD_CHIP_CLASSES: Record<string, string> = {
+  BUY: "border-z-income/35 bg-z-income/8 text-z-income",
+  BUY_WITH_CAUTION: "border-z-alert/35 bg-z-alert/8 text-z-alert",
+  WAIT: "border-z-expense/35 bg-z-expense/8 text-z-expense",
+  NOT_RECOMMENDED: "border-z-debt/35 bg-z-debt/8 text-z-debt",
+};
+
+export function AffordChip({ verdict }: { verdict: BudgetScenarioStartupItem["verdict"] }) {
+  if (!verdict) return null;
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-1.5 py-px text-[9px] font-bold uppercase tracking-[0.08em]",
+        AFFORD_CHIP_CLASSES[verdict],
+      )}
+    >
+      {VERDICT_LABELS[verdict]}
+    </span>
+  );
+}
+
+/** "prom 3m $ 410.000" — the reality anchor under editor rows. */
+export function PromAnchor({
+  avg3m,
+  scenario,
+  currency,
+}: {
+  avg3m: number | null;
+  scenario: number;
+  currency: CurrencyCode;
+}) {
+  if (avg3m == null) {
+    return <span className="text-[10px] text-z-sage-dark">sin historial — estimado</span>;
+  }
+  return (
+    <span
+      className={cn(
+        "whitespace-nowrap text-[10px] tabular-nums",
+        avg3m > scenario ? "text-z-alert" : "text-z-sage-dark",
+      )}
+    >
+      gastas <span className="font-semibold">{formatCurrency(avg3m, currency)}</span> prom 3m
+    </span>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-startup.tsx
+++ b/webapp/src/components/budget/scenario/scenario-startup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Plus, Heart, RotateCcw, CalendarClock } from "lucide-react";
 import {
   Sheet,
@@ -15,18 +15,12 @@ import {
   PANEL_SURFACE_CLASS,
   MOBILE_SHEET_SAFE_AREA_CLASS,
   BRASS_BUTTON_CLASS,
+  SECTION_EYEBROW_CLASS,
 } from "@/lib/constants/styles";
 import { computeFundingTimeline, computeStartupPlan, type BudgetScenarioDraft } from "@zeta/shared";
-import { AffordChip } from "./scenario-shared";
-import { STARTUP_RATE_OPTIONS, type ScenarioDeseoOption } from "./scenario-model";
+import { AffordChip, VERDICT_DOT } from "./scenario-shared";
+import { startupRateOptions, type ScenarioDeseoOption } from "./scenario-model";
 import type { CurrencyCode } from "@/types/domain";
-
-const VERDICT_DOT: Record<string, string> = {
-  BUY: "border-z-income",
-  BUY_WITH_CAUTION: "border-z-alert",
-  WAIT: "border-z-expense",
-  NOT_RECOMMENDED: "border-z-debt",
-};
 
 function monthLabels(count: number): string[] {
   const labels = ["hoy"];
@@ -82,7 +76,7 @@ function AddStartupSheet({
         <div className="space-y-4 overflow-y-auto px-4 pb-4">
           {available.length > 0 && (
             <div>
-              <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+              <p className={cn(SECTION_EYEBROW_CLASS, "mb-1.5")}>
                 Desde tus Deseos
               </p>
               <div className="space-y-1.5">
@@ -109,7 +103,7 @@ function AddStartupSheet({
           )}
 
           <div>
-            <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            <p className={cn(SECTION_EYEBROW_CLASS, "mb-1.5")}>
               Otro gasto
             </p>
             <div className="space-y-2">
@@ -178,7 +172,7 @@ export function ScenarioStartup({
   const timeline = computeFundingTimeline(draft, cushion);
   const maxMonth = Math.max(0, ...timeline.map((e) => e.readyInMonths ?? 0));
   const span = Math.max(maxMonth, 5);
-  const labels = monthLabels(span);
+  const labels = useMemo(() => monthLabels(span), [span]);
   const usedWishlistIds = new Set(
     items.map((i) => i.wishlistItemId).filter((id): id is string => id != null),
   );
@@ -188,7 +182,7 @@ export function ScenarioStartup({
     <div className="space-y-2">
       <div className={cn(PANEL_SURFACE_CLASS, "p-4")}>
         <div className="flex items-center justify-between">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          <p className={SECTION_EYEBROW_CLASS}>
             Gastos de arranque
           </p>
           <span className="text-[10px] text-z-sage-dark">una sola vez</span>
@@ -220,7 +214,7 @@ export function ScenarioStartup({
               aria-label="Ritmo de ahorro mensual"
               className="mt-3 flex gap-1 rounded-xl border border-white/6 bg-black/25 p-0.5"
             >
-              {STARTUP_RATE_OPTIONS.map((rate) => (
+              {startupRateOptions(currency).map((rate) => (
                 <button
                   key={rate}
                   type="button"
@@ -232,7 +226,7 @@ export function ScenarioStartup({
                       : "text-z-sage-dark",
                   )}
                 >
-                  $ {rate / 1000}K/mes
+                  {currency === "COP" ? `$ ${rate / 1000}K` : formatCurrency(rate, currency)}/mes
                 </button>
               ))}
             </div>
@@ -354,18 +348,18 @@ export function ScenarioStartup({
             <span
               className={cn(
                 "w-10 shrink-0 text-right text-[11px] font-bold tabular-nums",
-                item.deferred
+                item.deferred || entry?.readyInMonths == null
                   ? "text-z-sage-dark"
-                  : entry?.readyInMonths === 0
+                  : entry.readyInMonths === 0
                     ? "text-z-income"
                     : "text-z-sage-light",
               )}
             >
-              {item.deferred
+              {item.deferred || entry?.readyInMonths == null
                 ? "—"
-                : entry?.readyInMonths === 0
+                : entry.readyInMonths === 0
                   ? "hoy"
-                  : labels[Math.min(entry?.readyInMonths ?? 0, span)]}
+                  : labels[Math.min(entry.readyInMonths, span)]}
             </span>
             <button
               type="button"

--- a/webapp/src/components/budget/scenario/scenario-startup.tsx
+++ b/webapp/src/components/budget/scenario/scenario-startup.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Heart, RotateCcw, CalendarClock } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import {
+  PANEL_SURFACE_CLASS,
+  MOBILE_SHEET_SAFE_AREA_CLASS,
+  BRASS_BUTTON_CLASS,
+} from "@/lib/constants/styles";
+import { computeFundingTimeline, computeStartupPlan, type BudgetScenarioDraft } from "@zeta/shared";
+import { AffordChip } from "./scenario-shared";
+import { STARTUP_RATE_OPTIONS, type ScenarioDeseoOption } from "./scenario-model";
+import type { CurrencyCode } from "@/types/domain";
+
+const VERDICT_DOT: Record<string, string> = {
+  BUY: "border-z-income",
+  BUY_WITH_CAUTION: "border-z-alert",
+  WAIT: "border-z-expense",
+  NOT_RECOMMENDED: "border-z-debt",
+};
+
+function monthLabels(count: number): string[] {
+  const labels = ["hoy"];
+  const fmt = new Intl.DateTimeFormat("es-CO", { month: "short" });
+  for (let i = 1; i <= count; i++) {
+    const d = new Date();
+    d.setDate(1);
+    d.setMonth(d.getMonth() + i);
+    labels.push(fmt.format(d).replace(".", ""));
+  }
+  return labels;
+}
+
+// ─── Add-item sheet: pull from Deseos or ad hoc ──────────────────────────────
+
+function AddStartupSheet({
+  open,
+  onOpenChange,
+  deseos,
+  usedWishlistIds,
+  currency,
+  onAdd,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deseos: ScenarioDeseoOption[];
+  usedWishlistIds: Set<string>;
+  currency: CurrencyCode;
+  onAdd: (item: { name: string; amount: number; deseo: ScenarioDeseoOption | null }) => void;
+}) {
+  const [name, setName] = useState("");
+  const [amount, setAmount] = useState("");
+  const available = deseos.filter((d) => !usedWishlistIds.has(d.id));
+
+  const addAdhoc = () => {
+    const n = parseInt(amount || "0", 10);
+    if (!name.trim() || Number.isNaN(n) || n <= 0) return;
+    onAdd({ name: name.trim(), amount: n, deseo: null });
+    setName("");
+    setAmount("");
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className={cn("max-h-[80dvh]", MOBILE_SHEET_SAFE_AREA_CLASS)}>
+        <SheetHeader>
+          <SheetTitle>Agregar gasto de arranque</SheetTitle>
+          <SheetDescription>
+            Compras de una sola vez para que el cambio arranque.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="space-y-4 overflow-y-auto px-4 pb-4">
+          {available.length > 0 && (
+            <div>
+              <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+                Desde tus Deseos
+              </p>
+              <div className="space-y-1.5">
+                {available.map((d) => (
+                  <button
+                    key={d.id}
+                    type="button"
+                    onClick={() => {
+                      onAdd({ name: d.name, amount: d.amount, deseo: d });
+                      onOpenChange(false);
+                    }}
+                    className="flex w-full items-center gap-2.5 rounded-xl border border-white/6 bg-[#111] px-3 py-2.5 text-left transition-colors active:bg-white/5"
+                  >
+                    <Heart className="size-3.5 shrink-0 text-z-brass" strokeWidth={1.5} />
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">{d.name}</span>
+                    <AffordChip verdict={d.verdict} />
+                    <span className="shrink-0 text-sm font-semibold tabular-nums">
+                      {formatCurrency(d.amount, currency)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+              Otro gasto
+            </p>
+            <div className="space-y-2">
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Nombre — ej. Nevera"
+                className="h-11 w-full rounded-xl border border-white/6 bg-[#111] px-3 text-sm outline-none placeholder:text-z-sage-dark focus-visible:border-z-alert/35"
+              />
+              <div className="flex gap-2">
+                <div className="flex h-11 flex-1 items-center gap-1 rounded-xl border border-white/6 bg-[#111] px-3">
+                  <span className="text-sm text-z-sage-dark">$</span>
+                  <input
+                    inputMode="numeric"
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value.replace(/\D/g, ""))}
+                    placeholder="0"
+                    className="w-full bg-transparent text-sm font-semibold tabular-nums outline-none placeholder:text-z-sage-dark"
+                    aria-label="Monto del gasto"
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={addAdhoc}
+                  className={cn(
+                    "h-11 rounded-md px-4 text-sm font-semibold transition-colors",
+                    BRASS_BUTTON_CLASS,
+                  )}
+                >
+                  Agregar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── D2 · Funding timeline (interactive) ─────────────────────────────────────
+
+export function ScenarioStartup({
+  draft,
+  cushion,
+  deseos,
+  currency,
+  onSetRate,
+  onToggleCushion,
+  onAddItem,
+  onToggleDefer,
+}: {
+  draft: BudgetScenarioDraft;
+  cushion: number;
+  deseos: ScenarioDeseoOption[];
+  currency: CurrencyCode;
+  onSetRate: (rate: number) => void;
+  onToggleCushion: () => void;
+  onAddItem: (item: { name: string; amount: number; deseo: ScenarioDeseoOption | null }) => void;
+  onToggleDefer: (itemId: string) => void;
+}) {
+  const [addOpen, setAddOpen] = useState(false);
+  const { items, monthlyRate, useCushion } = draft.startup;
+
+  const plan = computeStartupPlan(draft, cushion);
+  const timeline = computeFundingTimeline(draft, cushion);
+  const maxMonth = Math.max(0, ...timeline.map((e) => e.readyInMonths ?? 0));
+  const span = Math.max(maxMonth, 5);
+  const labels = monthLabels(span);
+  const usedWishlistIds = new Set(
+    items.map((i) => i.wishlistItemId).filter((id): id is string => id != null),
+  );
+  const byId = new Map(timeline.map((e) => [e.itemId, e]));
+
+  return (
+    <div className="space-y-2">
+      <div className={cn(PANEL_SURFACE_CLASS, "p-4")}>
+        <div className="flex items-center justify-between">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+            Gastos de arranque
+          </p>
+          <span className="text-[10px] text-z-sage-dark">una sola vez</span>
+        </div>
+
+        <div className="mt-1.5 flex items-baseline gap-2">
+          <span className="text-[22px] font-extrabold tabular-nums">
+            {formatCurrency(plan.total, currency)}
+          </span>
+          {items.length > 0 && (
+            <span
+              className={cn(
+                "text-[11px]",
+                plan.months === 0 ? "text-z-income" : "text-z-sage-light",
+              )}
+            >
+              todo listo{" "}
+              {plan.months === 0
+                ? "hoy"
+                : `en ${plan.months} ${plan.months === 1 ? "mes" : "meses"}`}
+            </span>
+          )}
+        </div>
+
+        {items.length > 0 && (
+          <>
+            <div
+              role="group"
+              aria-label="Ritmo de ahorro mensual"
+              className="mt-3 flex gap-1 rounded-xl border border-white/6 bg-black/25 p-0.5"
+            >
+              {STARTUP_RATE_OPTIONS.map((rate) => (
+                <button
+                  key={rate}
+                  type="button"
+                  onClick={() => onSetRate(rate)}
+                  className={cn(
+                    "h-8 flex-1 rounded-lg text-[11px] font-semibold tabular-nums transition-colors",
+                    monthlyRate === rate
+                      ? "border border-z-brass/35 bg-z-surface-3 text-foreground"
+                      : "text-z-sage-dark",
+                  )}
+                >
+                  $ {rate / 1000}K/mes
+                </button>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={onToggleCushion}
+              role="switch"
+              aria-checked={useCushion}
+              className={cn(
+                "mt-2 flex w-full items-center gap-2 rounded-xl border px-3 py-2 transition-colors",
+                useCushion ? "border-z-income/30 bg-z-income/6" : "border-white/6 bg-black/15",
+              )}
+            >
+              <span
+                className={cn(
+                  "relative h-4 w-7 shrink-0 rounded-full transition-colors",
+                  useCushion ? "bg-z-income" : "bg-white/12",
+                )}
+              >
+                <span
+                  className={cn(
+                    "absolute top-0.5 size-3 rounded-full bg-z-ink transition-all",
+                    useCushion ? "left-3.5" : "left-0.5",
+                  )}
+                />
+              </span>
+              <span
+                className={cn(
+                  "text-[11.5px] font-semibold",
+                  useCushion ? "text-z-income" : "text-z-sage-light",
+                )}
+              >
+                Usar colchón actual · {formatCurrency(cushion, currency)}
+              </span>
+            </button>
+
+            {/* Timeline */}
+            <div className="relative mx-1.5 mt-5 h-0.5 rounded-full bg-white/8">
+              {labels.map((_, m) => (
+                <span
+                  key={m}
+                  className="absolute -top-0.5 h-1.5 w-px bg-white/14"
+                  style={{ left: `${(m / span) * 100}%` }}
+                />
+              ))}
+              {timeline.map((entry) => {
+                if (entry.readyInMonths == null) return null;
+                const item = items.find((i) => i.id === entry.itemId);
+                return (
+                  <span
+                    key={entry.itemId}
+                    title={`${entry.name} · ${entry.readyInMonths === 0 ? "hoy" : labels[Math.min(entry.readyInMonths, span)]}`}
+                    className={cn(
+                      "absolute -top-[7px] size-4 -translate-x-1/2 rounded-full border-2 bg-z-ink transition-[left] duration-200",
+                      VERDICT_DOT[item?.verdict ?? "BUY"],
+                    )}
+                    style={{ left: `${(Math.min(entry.readyInMonths, span) / span) * 100}%` }}
+                  />
+                );
+              })}
+            </div>
+            <div className="mx-1.5 mt-2.5 flex justify-between">
+              {labels.map((label, m) => (
+                <span
+                  key={m}
+                  className="text-[9px] font-semibold uppercase tracking-[0.06em] text-z-sage-dark"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          </>
+        )}
+
+        {items.length === 0 && (
+          <p className="mt-2 text-[11px] leading-relaxed text-z-sage-dark">
+            Agrega las compras que el cambio necesita (nevera, muebles…) y calcula cuándo estarán
+            fondeadas.
+          </p>
+        )}
+      </div>
+
+      {items.map((item) => {
+        const entry = byId.get(item.id);
+        return (
+          <div
+            key={item.id}
+            className={cn(
+              "flex items-center gap-2.5 rounded-xl border border-white/6 bg-[#111] px-3 py-2",
+              item.deferred && "opacity-55",
+            )}
+          >
+            <span
+              className={cn(
+                "size-2.5 shrink-0 rounded-full border-2",
+                VERDICT_DOT[item.verdict ?? "BUY"],
+              )}
+            />
+            <span className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  "block truncate text-[12.5px] font-semibold",
+                  item.deferred && "line-through decoration-z-sage-dark/60",
+                )}
+              >
+                {item.name}
+              </span>
+              {item.wishlistItemId && (
+                <span className="flex items-center gap-1 text-[9px] font-semibold uppercase tracking-[0.06em] text-z-brass">
+                  <Heart className="size-2.5" strokeWidth={2} /> de Deseos
+                </span>
+              )}
+            </span>
+            <AffordChip verdict={item.verdict} />
+            <span className="shrink-0 text-[11.5px] font-semibold tabular-nums text-z-sage-light">
+              {formatCurrency(item.amount, currency)}
+            </span>
+            <span
+              className={cn(
+                "w-10 shrink-0 text-right text-[11px] font-bold tabular-nums",
+                item.deferred
+                  ? "text-z-sage-dark"
+                  : entry?.readyInMonths === 0
+                    ? "text-z-income"
+                    : "text-z-sage-light",
+              )}
+            >
+              {item.deferred
+                ? "—"
+                : entry?.readyInMonths === 0
+                  ? "hoy"
+                  : labels[Math.min(entry?.readyInMonths ?? 0, span)]}
+            </span>
+            <button
+              type="button"
+              onClick={() => onToggleDefer(item.id)}
+              className="flex size-8 shrink-0 items-center justify-center rounded-lg text-z-sage-dark transition-colors active:bg-white/5"
+              aria-label={item.deferred ? `Retomar ${item.name}` : `Aplazar ${item.name}`}
+            >
+              {item.deferred ? (
+                <RotateCcw className="size-3.5" strokeWidth={1.5} />
+              ) : (
+                <CalendarClock className="size-3.5" strokeWidth={1.5} />
+              )}
+            </button>
+          </div>
+        );
+      })}
+
+      <button
+        type="button"
+        onClick={() => setAddOpen(true)}
+        className="flex h-10 w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-z-alert/25 text-xs font-semibold text-z-alert transition-colors active:bg-z-alert/8"
+      >
+        <Plus className="size-3.5" strokeWidth={2.5} />
+        Agregar gasto de arranque
+      </button>
+
+      {items.some((i) => !i.deferred) && (
+        <p className="text-[10px] leading-relaxed text-z-sage-dark">
+          Orden de compra sugerido por el veredicto de Deseos: primero lo que el motor aprueba.
+        </p>
+      )}
+
+      <AddStartupSheet
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        deseos={deseos}
+        usedWishlistIds={usedWishlistIds}
+        currency={currency}
+        onAdd={onAddItem}
+      />
+    </div>
+  );
+}

--- a/webapp/src/components/budget/scenario/scenario-verdict.tsx
+++ b/webapp/src/components/budget/scenario/scenario-verdict.tsx
@@ -3,7 +3,7 @@
 import { Scissors, CalendarClock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { PANEL_SURFACE_CLASS } from "@/lib/constants/styles";
+import { PANEL_SURFACE_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
 import type {
   BudgetScenarioSummary,
   ScenarioCutCandidate,
@@ -89,7 +89,7 @@ export function ScenarioVerdict({
   income: number;
   cuts: ScenarioCutCandidate[];
   defers: ScenarioDeferCandidate[];
-  appliedCutIds: Set<string>;
+  appliedCutIds: string[];
   currency: CurrencyCode;
   onApplyCut: (cut: ScenarioCutCandidate) => void;
   onDeferItem: (itemId: string) => void;
@@ -115,13 +115,13 @@ export function ScenarioVerdict({
     },
   ].filter((r) => r.show);
 
-  const visibleCuts = cuts.filter((c) => !appliedCutIds.has(c.categoryId)).slice(0, 3);
+  const visibleCuts = cuts.filter((c) => !appliedCutIds.includes(c.categoryId)).slice(0, 3);
   const visibleDefers = fits ? [] : defers.slice(0, 1);
 
   return (
     <div className={cn(PANEL_SURFACE_CLASS, "p-4")}>
       <div className="flex items-center justify-between gap-2">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+        <p className={SECTION_EYEBROW_CLASS}>
           Escenario · 50 / 30 / 20
         </p>
         <span

--- a/webapp/src/components/budget/scenario/scenario-verdict.tsx
+++ b/webapp/src/components/budget/scenario/scenario-verdict.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { Scissors, CalendarClock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils/currency";
+import { PANEL_SURFACE_CLASS } from "@/lib/constants/styles";
+import type {
+  BudgetScenarioSummary,
+  ScenarioCutCandidate,
+  ScenarioDeferCandidate,
+} from "@zeta/shared";
+import type { CurrencyCode } from "@/types/domain";
+
+// ─── C2 · Verdict told over the 50/30/20 bars ────────────────────────────────
+// Ghost bar = current allocation · solid bar = scenario · white tick = target.
+
+function AllocBar({
+  label,
+  scenario,
+  current,
+  target,
+  income,
+  colorClass,
+  currency,
+}: {
+  label: string;
+  scenario: number;
+  current: number;
+  target: number;
+  income: number;
+  colorClass: string;
+  currency: CurrencyCode;
+}) {
+  const pct = (v: number) => Math.min(105, (v / income) * 100);
+  const over = scenario > target;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-baseline justify-between">
+        <span className="text-[11px] font-semibold text-z-sage-light">{label}</span>
+        <span className="text-[11px] tabular-nums">
+          <span className={cn("font-bold", over ? "text-z-debt" : colorClass)}>
+            {Math.round((scenario / income) * 100)}%
+          </span>
+          <span className="text-z-sage-dark"> · meta {Math.round((target / income) * 100)}%</span>
+        </span>
+      </div>
+      <div className="relative h-2.5 rounded-full bg-white/6">
+        <div
+          className="absolute left-0 top-0 h-full rounded-full bg-z-sage-light/16"
+          style={{ width: `${pct(current)}%` }}
+        />
+        <div
+          className={cn(
+            "absolute left-0 top-0.5 h-1.5 rounded-full transition-[width] duration-200",
+            over ? "bg-z-debt" : colorClass.replace("text-", "bg-"),
+          )}
+          style={{ width: `${pct(scenario)}%` }}
+        />
+        <div
+          className="absolute -top-0.5 h-3.5 w-0.5 rounded-full bg-foreground/55"
+          style={{ left: `${pct(target)}%` }}
+        />
+      </div>
+      <div className="mt-0.5 flex justify-between text-[9px] tabular-nums text-z-sage-dark">
+        <span>actual {formatCurrency(current, currency)}</span>
+        <span>
+          escenario{" "}
+          <span className={cn("font-semibold", over ? "text-z-debt" : "text-z-sage-light")}>
+            {formatCurrency(scenario, currency)}
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ScenarioVerdict({
+  summary,
+  income,
+  cuts,
+  defers,
+  appliedCutIds,
+  currency,
+  onApplyCut,
+  onDeferItem,
+}: {
+  summary: BudgetScenarioSummary;
+  income: number;
+  cuts: ScenarioCutCandidate[];
+  defers: ScenarioDeferCandidate[];
+  appliedCutIds: Set<string>;
+  currency: CurrencyCode;
+  onApplyCut: (cut: ScenarioCutCandidate) => void;
+  onDeferItem: (itemId: string) => void;
+}) {
+  const { shortfall, fits, allocation, currentAllocation } = summary;
+  const targets = { needs: income * 0.5, wants: income * 0.3, savings: income * 0.2 };
+
+  const breakdown = [
+    {
+      label: "Presupuesto vs ingreso",
+      value: summary.budgetGap,
+      show: summary.budgetGap !== 0,
+    },
+    {
+      label: "Sobregasto real esperado",
+      value: summary.expectedOverspend,
+      show: summary.expectedOverspend > 0,
+    },
+    {
+      label: `Reserva de arranque (${summary.startupMonths} ${summary.startupMonths === 1 ? "mes" : "meses"})`,
+      value: summary.startupReserve,
+      show: summary.startupReserve > 0,
+    },
+  ].filter((r) => r.show);
+
+  const visibleCuts = cuts.filter((c) => !appliedCutIds.has(c.categoryId)).slice(0, 3);
+  const visibleDefers = fits ? [] : defers.slice(0, 1);
+
+  return (
+    <div className={cn(PANEL_SURFACE_CLASS, "p-4")}>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+          Escenario · 50 / 30 / 20
+        </p>
+        <span
+          className={cn(
+            "inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-[10px] font-bold tabular-nums",
+            fits
+              ? "border-z-income/35 bg-z-income/8 text-z-income"
+              : "border-z-debt/35 bg-z-debt/8 text-z-debt",
+          )}
+        >
+          {fits
+            ? `sobran ${formatCurrency(-shortfall, currency)}`
+            : `faltan ${formatCurrency(shortfall, currency)}`}{" "}
+          /mes
+        </span>
+      </div>
+
+      <div className="mt-4 space-y-3.5">
+        <AllocBar
+          label="Necesidades"
+          scenario={allocation.needs}
+          current={currentAllocation.needs}
+          target={targets.needs}
+          income={income}
+          colorClass="text-z-sage"
+          currency={currency}
+        />
+        <AllocBar
+          label="Gustos"
+          scenario={allocation.wants}
+          current={currentAllocation.wants}
+          target={targets.wants}
+          income={income}
+          colorClass="text-z-brass"
+          currency={currency}
+        />
+        <AllocBar
+          label="Ahorro"
+          scenario={allocation.savings}
+          current={currentAllocation.savings}
+          target={targets.savings}
+          income={income}
+          colorClass="text-z-income"
+          currency={currency}
+        />
+      </div>
+
+      {breakdown.length > 0 && (
+        <div className="mt-3 border-t border-white/6 pt-2.5">
+          {breakdown.map((row) => (
+            <div
+              key={row.label}
+              className="flex items-baseline justify-between py-1 text-[11px]"
+            >
+              <span className="text-z-sage-light">{row.label}</span>
+              <span
+                className={cn(
+                  "font-bold tabular-nums",
+                  row.value > 0 ? "text-z-debt" : "text-z-income",
+                )}
+              >
+                {row.value > 0 ? "−" : "+"}
+                {formatCurrency(Math.abs(row.value), currency)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-2 text-[10.5px] leading-relaxed text-z-sage-dark">
+        {fits ? (
+          <>
+            El total cabe en tu ingreso con{" "}
+            <span className="font-semibold text-z-income">
+              {formatCurrency(-shortfall, currency)}
+            </span>{" "}
+            de margen al mes.
+          </>
+        ) : (
+          <>
+            Necesidades pasa de {Math.round((currentAllocation.needs / income) * 100)}% a{" "}
+            <span className="font-semibold text-z-debt">
+              {Math.round((allocation.needs / income) * 100)}%
+            </span>
+            . Para que cierre, recorta gustos o pausa parte del ahorro.
+          </>
+        )}
+      </p>
+
+      {!fits && (visibleCuts.length > 0 || visibleDefers.length > 0) && (
+        <div className="mt-2.5 flex flex-wrap gap-1.5">
+          {visibleCuts.map((cut) => (
+            <button
+              key={cut.categoryId}
+              type="button"
+              onClick={() => onApplyCut(cut)}
+              className="inline-flex items-center gap-1 rounded-full border border-z-alert/25 bg-z-alert/8 px-2.5 py-1.5 text-[10px] font-semibold text-z-alert transition-colors active:bg-z-alert/16"
+            >
+              <Scissors className="size-2.5" strokeWidth={2} />
+              {cut.name} −{formatCurrency(cut.relief, currency)}
+            </button>
+          ))}
+          {visibleDefers.map((d) => (
+            <button
+              key={d.itemId}
+              type="button"
+              onClick={() => onDeferItem(d.itemId)}
+              className="inline-flex items-center gap-1 rounded-full border border-z-alert/25 bg-z-alert/8 px-2.5 py-1.5 text-[10px] font-semibold text-z-alert transition-colors active:bg-z-alert/16"
+            >
+              <CalendarClock className="size-2.5" strokeWidth={2} />
+              Aplazar {d.name} −{formatCurrency(d.relief, currency)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
@@ -5,6 +5,9 @@ import { getCategoriesWithBudgetData, getAllCategoriesForManagement, getCategori
 import { get503020Allocation } from "@/actions/allocation";
 import { getUncategorizedTransactions } from "@/actions/categorize";
 import { getAttentionSnapshot } from "@/actions/attention";
+import { getBudgetScenarios } from "@/actions/budget-scenarios";
+import { getWishlistItems } from "@/actions/wishlist";
+import { getAccounts } from "@/actions/accounts";
 import { BudgetSummaryBar } from "@/components/budget/budget-summary-bar";
 import { BudgetCategoryGrid } from "@/components/budget/budget-category-grid";
 import { TrendComparison } from "@/components/budget/trend-comparison";
@@ -21,6 +24,12 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { parseMonth, formatMonthLabel, getDaysRemainingInMonth } from "@/lib/utils/date";
 import { MOBILE_TAB_BAR_CLEARANCE_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { ScenarioSection, ScenarioEntryPoint } from "@/components/budget/scenario/scenario-section";
+import {
+  normalizeVerdict,
+  type ScenarioCategoryOption,
+  type ScenarioDeseoOption,
+} from "@/components/budget/scenario/scenario-model";
 import type { CurrencyCode, CategoryBudgetData } from "@/types/domain";
 
 const BudgetWizard = dynamic(
@@ -44,6 +53,9 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
     uncategorized,
     categoryTreeResult,
     attentionSnapshot,
+    budgetScenarios,
+    wishlistItems,
+    accountsResult,
   ] = await Promise.all([
     getBudgetMode(),
     getEstimatedIncome(currency, month),
@@ -53,6 +65,9 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
     getUncategorizedTransactions(),
     getCategories(),
     getAttentionSnapshot(),
+    getBudgetScenarios(),
+    getWishlistItems(),
+    getAccounts(),
   ]);
 
   const budgetMode = modeResult.success ? modeResult.data : null;
@@ -66,6 +81,40 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
   const daysRemaining = getDaysRemainingInMonth(target);
   const monthLabel = formatMonthLabel(target);
   const withBudget = outflowCategories.filter((c) => (c.budget ?? 0) > 0).length;
+
+  // ── "Simular cambio" inputs ──
+  const scenarioCategories: ScenarioCategoryOption[] = outflowCategories
+    .filter((c) => c.is_active)
+    .map((c) => ({
+      id: c.id,
+      slug: c.slug,
+      name: c.name_es ?? c.name,
+      icon: c.icon,
+      color: c.color,
+      budget: c.budget,
+      avg3m: c.average3m > 0 ? c.average3m : null,
+      group:
+        c.slug === "ahorro-e-inversion"
+          ? ("savings" as const)
+          : c.expense_type === "fixed" || c.is_essential
+            ? ("needs" as const)
+            : ("wants" as const),
+      isFixed: c.slug === "pagos-de-deuda",
+    }));
+
+  const accounts = accountsResult.success ? accountsResult.data : [];
+  const cushion = accounts
+    .filter((a) => a.account_type === "CHECKING" || a.account_type === "SAVINGS")
+    .reduce((sum, a) => sum + Math.max(0, a.current_balance), 0);
+
+  const scenarioDeseos: ScenarioDeseoOption[] = wishlistItems
+    .filter((w) => w.status === "wishlist" && w.amount > 0)
+    .map((w) => ({
+      id: w.id,
+      name: w.name,
+      amount: w.amount,
+      verdict: normalizeVerdict(w.last_verdict),
+    }));
 
   // If no budget mode configured yet, show wizard
   if (!budgetMode) {
@@ -121,6 +170,14 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
   const chip = chipConfig[pressure];
 
   return (
+    <ScenarioSection
+      categories={scenarioCategories}
+      deseos={scenarioDeseos}
+      scenarios={budgetScenarios}
+      income={income}
+      cushion={cushion}
+      currency={currency}
+    >
     <div className="space-y-6">
       {/* Mobile view */}
       <div className={cn("lg:hidden", MOBILE_TAB_BAR_CLEARANCE_CLASS)}>
@@ -130,7 +187,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
           {/* Budget hero card */}
           <div className={cn(PANEL_INSET_CLASS, "p-4")}>
             <div className="flex items-center justify-between gap-2">
-              <p className="text-[9px] font-bold uppercase tracking-[0.18em] text-z-sage-dark">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
                 Gastado este mes
               </p>
               <StateChip label={chip.label} variant={chip.variant} />
@@ -178,13 +235,16 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
             </div>
           </div>
 
+          {/* Simular cambio — entry / mode toggle */}
+          <ScenarioEntryPoint />
+
           {/* Categories grouped by risk state — D6 */}
           {hasBudgetedCategories && (
             <div className="space-y-5">
               {over.length > 0 && (
                 <section>
                   <div className="mb-2 flex items-center justify-between">
-                    <p className="text-[9px] font-bold uppercase tracking-[0.18em] text-z-expense">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-expense">
                       Sobre límite
                     </p>
                     <span className="text-[10px] text-muted-foreground">{over.length}</span>
@@ -199,7 +259,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               {near.length > 0 && (
                 <section>
                   <div className="mb-2 flex items-center justify-between">
-                    <p className="text-[9px] font-bold uppercase tracking-[0.18em] text-z-brass">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
                       Cerca del límite
                     </p>
                     <span className="text-[10px] text-muted-foreground">{near.length}</span>
@@ -214,7 +274,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               {safe.length > 0 && (
                 <section>
                   <div className="mb-2 flex items-center justify-between">
-                    <p className="text-[9px] font-bold uppercase tracking-[0.18em] text-z-income">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-income">
                       Dentro del límite
                     </p>
                     <span className="text-[10px] text-muted-foreground">{safe.length}</span>
@@ -256,6 +316,9 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
           <MonthPlanner categories={outflowCategories} />
         </div>
 
+        {/* Simular cambio — entry / mode toggle */}
+        <ScenarioEntryPoint className="max-w-md" />
+
         <div className="grid gap-4 lg:grid-cols-2">
           <SummaryCard
             metrics={[
@@ -296,6 +359,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
         </Tabs>
       </div>
     </div>
+    </ScenarioSection>
   );
 }
 

--- a/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
+++ b/webapp/src/components/plan/tabs/plan-tab-presupuesto.tsx
@@ -23,7 +23,8 @@ import { PlanAllocationChip } from "@/components/mobile/v2/plan/plan-allocation-
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { parseMonth, formatMonthLabel, getDaysRemainingInMonth } from "@/lib/utils/date";
-import { MOBILE_TAB_BAR_CLEARANCE_CLASS, PANEL_INSET_CLASS } from "@/lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE_CLASS, PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "@/lib/constants/styles";
+import { categoryBudgetGroup, isFixedBudgetCategory } from "@zeta/shared";
 import { ScenarioSection, ScenarioEntryPoint } from "@/components/budget/scenario/scenario-section";
 import {
   normalizeVerdict,
@@ -93,13 +94,8 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
       color: c.color,
       budget: c.budget,
       avg3m: c.average3m > 0 ? c.average3m : null,
-      group:
-        c.slug === "ahorro-e-inversion"
-          ? ("savings" as const)
-          : c.expense_type === "fixed" || c.is_essential
-            ? ("needs" as const)
-            : ("wants" as const),
-      isFixed: c.slug === "pagos-de-deuda",
+      group: categoryBudgetGroup(c),
+      isFixed: isFixedBudgetCategory(c.slug),
     }));
 
   const accounts = accountsResult.success ? accountsResult.data : [];
@@ -187,7 +183,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
           {/* Budget hero card */}
           <div className={cn(PANEL_INSET_CLASS, "p-4")}>
             <div className="flex items-center justify-between gap-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-sage-dark">
+              <p className={SECTION_EYEBROW_CLASS}>
                 Gastado este mes
               </p>
               <StateChip label={chip.label} variant={chip.variant} />
@@ -244,7 +240,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               {over.length > 0 && (
                 <section>
                   <div className="mb-2 flex items-center justify-between">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-expense">
+                    <p className={cn(SECTION_EYEBROW_CLASS, "text-z-expense")}>
                       Sobre límite
                     </p>
                     <span className="text-[10px] text-muted-foreground">{over.length}</span>
@@ -259,7 +255,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               {near.length > 0 && (
                 <section>
                   <div className="mb-2 flex items-center justify-between">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-brass">
+                    <p className={cn(SECTION_EYEBROW_CLASS, "text-z-brass")}>
                       Cerca del límite
                     </p>
                     <span className="text-[10px] text-muted-foreground">{near.length}</span>
@@ -274,7 +270,7 @@ export async function PlanTabPresupuesto({ month, currency }: PlanTabPresupuesto
               {safe.length > 0 && (
                 <section>
                   <div className="mb-2 flex items-center justify-between">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-z-income">
+                    <p className={cn(SECTION_EYEBROW_CLASS, "text-z-income")}>
                       Dentro del límite
                     </p>
                     <span className="text-[10px] text-muted-foreground">{safe.length}</span>

--- a/webapp/src/lib/validators/budget-scenario.ts
+++ b/webapp/src/lib/validators/budget-scenario.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { uuidStr } from "./shared";
+
+const scenarioLineSchema = z.object({
+  categoryId: uuidStr("Categoría inválida"),
+  name: z.string().min(1).max(120),
+  current: z.number().min(0).nullable(),
+  scenario: z.number().min(0).max(10_000_000_000),
+  avg3m: z.number().min(0).nullable(),
+  isFixed: z.boolean(),
+  group: z.enum(["needs", "wants", "savings"]),
+});
+
+const startupItemSchema = z.object({
+  id: z.string().min(1).max(80),
+  name: z.string().min(1).max(120),
+  amount: z.number().min(0).max(10_000_000_000),
+  verdict: z.enum(["BUY", "BUY_WITH_CAUTION", "WAIT", "NOT_RECOMMENDED"]).nullable(),
+  wishlistItemId: uuidStr("Deseo inválido").nullable(),
+  deferred: z.boolean(),
+});
+
+export const scenarioDraftSchema = z.object({
+  name: z.string().min(1, "Ponle un nombre a la simulación").max(80),
+  lines: z.array(scenarioLineSchema).max(120),
+  startup: z.object({
+    items: z.array(startupItemSchema).max(40),
+    monthlyRate: z.number().min(0).max(10_000_000_000),
+    useCushion: z.boolean(),
+  }),
+});
+
+export const saveScenarioSchema = z.object({
+  id: uuidStr("Simulación inválida").nullable(),
+  draft: scenarioDraftSchema,
+});

--- a/webapp/src/types/database.ts
+++ b/webapp/src/types/database.ts
@@ -317,6 +317,36 @@ export type Database = {
         }
         Relationships: []
       }
+      budget_scenarios: {
+        Row: {
+          applied_at: string | null
+          created_at: string
+          draft: Json
+          id: string
+          name: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          applied_at?: string | null
+          created_at?: string
+          draft?: Json
+          id?: string
+          name: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          applied_at?: string | null
+          created_at?: string
+          draft?: Json
+          id?: string
+          name?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       budgets: {
         Row: {
           amount: number


### PR DESCRIPTION
## What

Implements the **"Simular cambio"** feature from the Claude Design handoff (`claude-ai-design/presupuesto-simular-cambio/`) on the Presupuesto tab. A user planning a life change (canonical case: mudanza) clones their budget into a gold-accented sandbox, edits it against their real 3-month averages, and gets an exact verdict: **funciona / te faltan $X/mes — y dónde recortar**. Nothing touches the live budget until they apply.

Variants implemented (user-selected): **A3** (template entry sheet + Real/Simulación toggle) · **B3** (reality-anchor bar editor) · **C2** (verdict over 50/30/20 ghost bars) · **D2** (interactive startup funding timeline) · **E2** (named drafts + slim apply confirm).

## How it works

- **Math** (`@zeta/shared/budget-scenario.ts`, pure + 11 tests): shortfall decomposes exactly into *budget gap* (escenario vs ingreso) + *expected overspend* (prom 3m over budget, untouched lines only — editing a line is a commitment) + *startup reserve* (arranque restante tras colchón, repartido en meses al ritmo elegido). Cut candidates rank wants→savings with relief = recorte + sobregasto que desaparece; reproduce the design's sample figures (Restaurantes −150k alivia 235k, etc.).
- **Persistence**: new `budget_scenarios` table (JSONB draft, RLS fast-path, migration pushed). Drafts are cross-device; applied scenarios leave the list.
- **Apply**: upserts standing monthly budgets (is_demo-aware, category ownership validated, lines cut to 0 delete their budget), marks `applied_at`, invalidates `budgets`/`dashboard:budgets`/`attention`/`budget-scenarios` via `updateTag`.
- **New lines = existing zero-budget categories** (Mudanza template pre-seeds arriendo/servicios/internet by slug; picker for the rest) — no category creation needed, so applying is a plain budget upsert.
- **Perf**: sandbox lazy-loaded (`next/dynamic`), single `ScenarioSection` instance serves both breakpoints via a context-placed `ScenarioEntryPoint`, cached reads only in the render path.

## Notes / deviations

- "Aplicar desde [mes]" from the design became **apply-immediately** with honest copy ("Tus límites mensuales se actualizan de inmediato") — budgets are standing amounts with no per-month versioning.
- Vehículo template + minor polish deferred to BACKLOG.md (entry added).
- Review gates run: supabase-migrator, server-action-reviewer, zetas-front-guy, perf-auditor — findings fixed in-branch (is_demo partition, cached-client pattern, touch targets, eyebrow typography, double-mount).

## Test plan

- `packages/shared`: `pnpm vitest run budget-scenario` → 11/11 pass (auto-categorize/debt-stats failures pre-exist on main, logged in BACKLOG).
- `webapp`: `pnpm build` clean, `tsc --noEmit` clean, `pnpm audit --audit-level high` clean.
- Manual: Plan → Presupuesto → "Simular un cambio" → Mudanza → edit amounts, apply cuts from the verdict chips, add gastos de arranque from Deseos, save draft, continue from saved list, apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)