### PR TITLE
feat(import): saved passwords in PDF queue, suppress browser autofill

### DIFF
--- a/webapp/src/actions/email-pdf-ingest.ts
+++ b/webapp/src/actions/email-pdf-ingest.ts
@@ -89,10 +89,26 @@ export async function dismissEmailPdfStatement(
   return { success: true, data: null };
 }
 
+/**
+ * Result of a manual re-parse. On a parse failure we surface the new terminal
+ * status (`needs_password` vs `parse_failed`) so the caller can re-sync its
+ * optimistic UI — otherwise a corrupted-file failure leaves the row stuck on
+ * the password prompt even though the DB has moved it to `parse_failed`.
+ * `status` is omitted for transient/guard failures (auth, download) that don't
+ * change the stored status.
+ */
+export type RetryPdfParsingResult =
+  | { success: true }
+  | {
+      success: false;
+      error: string;
+      status?: "needs_password" | "parse_failed";
+    };
+
 export async function retryPdfParsing(
   id: string,
   password: string,
-): Promise<ActionResult<null>> {
+): Promise<RetryPdfParsingResult> {
   const { supabase, user } = await getAuthenticatedClient();
   if (!user) return { success: false, error: "No autenticado" };
 
@@ -169,21 +185,22 @@ export async function retryPdfParsing(
       }
     }
   } else {
+    const nextStatus = result.needsPassword ? "needs_password" : "parse_failed";
     await supabase
       .from("pending_email_statements")
       .update({
-        status: result.needsPassword ? "needs_password" : "parse_failed",
+        status: nextStatus,
         error_message: result.error,
         updated_at: new Date().toISOString(),
       })
       .eq("id", id)
       .eq("user_id", user.id);
 
-    return { success: false, error: result.error };
+    return { success: false, error: result.error, status: nextStatus };
   }
 
   updateTag("email-ingest");
-  return { success: true, data: null };
+  return { success: true };
 }
 
 /**

--- a/webapp/src/components/import/import-page-client.tsx
+++ b/webapp/src/components/import/import-page-client.tsx
@@ -102,6 +102,7 @@ export function ImportPageClient({
             key={selectedId ?? "none"}
             statements={visiblePending}
             onReviewStatement={handleReviewStatement}
+            vaultSuggestions={initialVaultSuggestions}
           />
           {mobileAboutPanel}
         </>

--- a/webapp/src/components/import/pending-email-statements.tsx
+++ b/webapp/src/components/import/pending-email-statements.tsx
@@ -11,16 +11,25 @@ import {
   X,
   RefreshCw,
   Clock,
+  KeyRound,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { BRASS_BUTTON_CLASS } from "@/lib/constants/styles";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { NO_PASSWORD_AUTOFILL_PROPS } from "@/lib/constants/forms";
 import {
   dismissEmailPdfStatement,
   retryPdfParsing,
 } from "@/actions/email-pdf-ingest";
+import type { PdfPasswordSuggestion } from "@/actions/pdf-passwords";
 import type { PendingEmailStatement } from "@/types/domain";
 import { formatRelativeDate } from "@/lib/utils/date";
 import { cn } from "@/lib/utils";
@@ -73,11 +82,13 @@ function formatFileSize(bytes: number | null): string {
 interface PendingEmailStatementsProps {
   statements: PendingEmailStatement[];
   onReviewStatement?: (statement: PendingEmailStatement) => void;
+  vaultSuggestions?: PdfPasswordSuggestion[];
 }
 
 export function PendingEmailStatements({
   statements: initialStatements,
   onReviewStatement,
+  vaultSuggestions = [],
 }: PendingEmailStatementsProps) {
   const [statements, setStatements] = useState(initialStatements);
   const [isPending, startTransition] = useTransition();
@@ -104,8 +115,8 @@ export function PendingEmailStatements({
     });
   }
 
-  function handleRetryWithPassword(id: string) {
-    const password = passwordInputs[id]?.trim();
+  function handleRetryWithPassword(id: string, explicitPassword?: string) {
+    const password = (explicitPassword ?? passwordInputs[id])?.trim();
     if (!password) {
       toast.error("Ingresa la contraseña del PDF");
       return;
@@ -274,7 +285,7 @@ export function PendingEmailStatements({
 
                 {/* Password input for encrypted PDFs */}
                 {stmt.status === "needs_password" && (
-                  <div className="flex items-center gap-2 pl-12">
+                  <div className="flex flex-wrap items-center gap-2 pl-12">
                     <Input
                       type="password"
                       placeholder="Contraseña del PDF"
@@ -289,8 +300,47 @@ export function PendingEmailStatements({
                       onKeyDown={(e) => {
                         if (e.key === "Enter") handleRetryWithPassword(stmt.id);
                       }}
-                      autoComplete="off"
+                      {...NO_PASSWORD_AUTOFILL_PROPS}
                     />
+                    {vaultSuggestions.length > 0 && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className={cn(GHOST_BUTTON_CLASS, "h-8 gap-1.5 text-xs")}
+                            disabled={isLoading}
+                          >
+                            <KeyRound className="size-3.5" />
+                            Usar guardada
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="start">
+                          {vaultSuggestions.map((sug) => (
+                            <DropdownMenuItem
+                              key={sug.id}
+                              onSelect={() => {
+                                setPasswordInputs((prev) => ({
+                                  ...prev,
+                                  [stmt.id]: sug.password,
+                                }));
+                                handleRetryWithPassword(stmt.id, sug.password);
+                              }}
+                            >
+                              <span className="truncate">{sug.alias}</span>
+                              <span className="ml-2 text-xs text-muted-foreground">
+                                {sug.scope === "account"
+                                  ? "cuenta"
+                                  : sug.scope === "bank"
+                                  ? sug.bank_key
+                                  : "global"}
+                              </span>
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                     <Button
                       size="sm"
                       className={cn(BRASS_BUTTON_CLASS, "h-8 gap-1.5 text-xs")}

--- a/webapp/src/components/import/pending-email-statements.tsx
+++ b/webapp/src/components/import/pending-email-statements.tsx
@@ -133,6 +133,18 @@ export function PendingEmailStatements({
           );
           toast.success("PDF procesado correctamente");
         } else {
+          // Re-sync the row when the retry moved it to a new terminal status
+          // (e.g. a non-password failure flips it to `parse_failed`) so the UI
+          // doesn't stay stuck on the password prompt.
+          if (result.status) {
+            setStatements((prev) =>
+              prev.map((s) =>
+                s.id === id
+                  ? { ...s, status: result.status!, error_message: result.error }
+                  : s,
+              ),
+            );
+          }
           toast.error(result.error);
         }
       } catch {

--- a/webapp/src/components/import/step-upload.tsx
+++ b/webapp/src/components/import/step-upload.tsx
@@ -5,6 +5,7 @@ import { Upload, FileText, Loader2, Lock, HelpCircle, CheckCircle2, ImageIcon, K
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { BRASS_BUTTON_CLASS, GHOST_BUTTON_CLASS } from "@/lib/constants/styles";
+import { NO_PASSWORD_AUTOFILL_PROPS } from "@/lib/constants/forms";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -538,7 +539,7 @@ export function StepUpload({
                       setPasswordFromVault(false);
                     }}
                     className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                    autoComplete="off"
+                    {...NO_PASSWORD_AUTOFILL_PROPS}
                   />
                 </div>
                 {vaultSuggestions.length > 0 && (

--- a/webapp/src/lib/constants/forms.ts
+++ b/webapp/src/lib/constants/forms.ts
@@ -1,0 +1,18 @@
+/**
+ * Props that suppress the browser's saved-password autofill on a password
+ * field. `autoComplete="off"` is silently ignored by Chrome for inputs of
+ * `type="password"`, so we use `new-password` (the only value Chrome honors as
+ * "do not offer saved credentials") plus the opt-out attributes recognized by
+ * the major password managers.
+ *
+ * Use for PDF-password fields and similar one-off secrets that are NOT the
+ * user's site credentials — offering site logins there is noise, and saving
+ * the typed value into the browser's password store is wrong.
+ */
+export const NO_PASSWORD_AUTOFILL_PROPS = {
+  autoComplete: "new-password",
+  "data-1p-ignore": true,
+  "data-lpignore": true,
+  "data-bwignore": true,
+  "data-form-type": "other",
+} as const;


### PR DESCRIPTION
The import queue ("Cola de importación") for emailed encrypted PDFs only
offered a manual password field. Wire the saved-password vault into it so
needs-password entries get the same "Usar guardada" picker as the main
upload flow — selecting a saved password fills the field and retries
parsing in one tap. The page already loads every saved password as
`vaultSuggestions`; it's now passed through to the queue.

Also stop browsers from offering site-credential autofill (and from
saving the typed value) on PDF-password fields. `autoComplete="off"` is
ignored by Chrome for password inputs, so introduce a shared
`NO_PASSWORD_AUTOFILL_PROPS` constant (autoComplete="new-password" plus
the password-manager opt-out attributes) and apply it to both the queue
and main upload password fields.