### PR TITLE
fix(transferencia): wire FAB transfer tab to createTransfer (paired outflow+inflow)

### DIFF
--- a/webapp/src/actions/transfers.ts
+++ b/webapp/src/actions/transfers.ts
@@ -148,8 +148,20 @@ export async function createTransfer(
     .single();
 
   if (inflowError) {
-    // Rollback: delete the outflow transaction
-    await supabase.from("transactions").delete().eq("id", outflow.id).eq("user_id", user.id);
+    // Rollback: delete the outflow transaction (balances not yet touched, so a
+    // failed rollback only leaves an orphaned outflow — log it for cleanup).
+    const { error: rollbackError } = await supabase
+      .from("transactions")
+      .delete()
+      .eq("id", outflow.id)
+      .eq("user_id", user.id);
+    if (rollbackError) {
+      console.error("Transfer rollback failed — orphaned outflow", {
+        transferGroupId,
+        outflowId: outflow.id,
+        rollbackError,
+      });
+    }
     if (inflowError.code === "23505") {
       return { success: false, error: "Esta transferencia ya fue registrada" };
     }
@@ -173,9 +185,11 @@ export async function createTransfer(
     fromUpdate.available_balance = fromAccount.credit_limit - newFromBalance;
   }
 
-  // TO account: INFLOW → debt decreases balance, non-debt increases balance
+  // TO account: INFLOW → debt decreases balance, non-debt increases balance.
+  // Clamp debt payments at 0 (matches registerPayment) so overpaying a credit
+  // card / loan doesn't drive the owed balance negative.
   const newToBalance = isToDebt
-    ? toAccount.current_balance - amount
+    ? Math.max(0, toAccount.current_balance - amount)
     : toAccount.current_balance + amount;
 
   const toUpdate: Record<string, unknown> = {
@@ -191,17 +205,24 @@ export async function createTransfer(
     supabase.from("accounts").update(toUpdate).eq("id", toAccountId).eq("user_id", user.id),
   ]);
 
+  // 7. Revalidate caches (do this even on balance failure so the new
+  // transactions are reflected immediately).
+  revalidateFinancialViews();
+
   if (fromBalRes.error || toBalRes.error) {
-    // Transactions exist but balances may be inconsistent — log for investigation
+    // Transactions exist but balances may be inconsistent — surface a warning
+    // so the user can reconcile (matches registerPayment's behavior).
     console.error("Balance update failed after transfer", {
       transferGroupId,
       fromError: fromBalRes.error,
       toError: toBalRes.error,
     });
+    return {
+      success: false,
+      error:
+        "Transferencia registrada, pero un saldo no se actualizó. Revísalo manualmente.",
+    };
   }
-
-  // 7. Revalidate caches
-  revalidateFinancialViews();
 
   return {
     success: true,

--- a/webapp/src/components/accounts/transfer-dialog.tsx
+++ b/webapp/src/components/accounts/transfer-dialog.tsx
@@ -22,8 +22,6 @@ import { cn } from "@/lib/utils";
 import { createTransfer } from "@/actions/transfers";
 import type { Account } from "@/types/domain";
 
-const EXCLUDED_DESTINATION_TYPES = new Set(["LOAN", "INVESTMENT"]);
-
 interface TransferDialogProps {
   account: Account;
   accounts: Account[];
@@ -37,11 +35,9 @@ export function TransferDialog({
   open,
   onOpenChange,
 }: TransferDialogProps) {
-  const destinationAccounts = accounts.filter(
-    (a) =>
-      a.id !== account.id &&
-      !EXCLUDED_DESTINATION_TYPES.has(a.account_type ?? "")
-  );
+  // Any other account is a valid destination — transferring to a CREDIT_CARD or
+  // LOAN registers a payment (inflow reduces the owed balance).
+  const destinationAccounts = accounts.filter((a) => a.id !== account.id);
 
   const today = new Date().toISOString().slice(0, 10);
 

--- a/webapp/src/components/accounts/transfer-dialog.tsx
+++ b/webapp/src/components/accounts/transfer-dialog.tsx
@@ -35,9 +35,12 @@ export function TransferDialog({
   open,
   onOpenChange,
 }: TransferDialogProps) {
-  // Any other account is a valid destination — transferring to a CREDIT_CARD or
-  // LOAN registers a payment (inflow reduces the owed balance).
-  const destinationAccounts = accounts.filter((a) => a.id !== account.id);
+  // Any other same-currency account is a valid destination — transferring to a
+  // CREDIT_CARD or LOAN registers a payment (inflow reduces the owed balance).
+  // createTransfer rejects cross-currency, so filter those out up front.
+  const destinationAccounts = accounts.filter(
+    (a) => a.id !== account.id && a.currency_code === account.currency_code
+  );
 
   const today = new Date().toISOString().slice(0, 10);
 

--- a/webapp/src/components/accounts/transfer-dialog.tsx
+++ b/webapp/src/components/accounts/transfer-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -8,6 +8,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -43,6 +46,7 @@ export function TransferDialog({
   );
 
   const today = new Date().toISOString().slice(0, 10);
+  const [date, setDate] = useState<string>(today);
 
   const [state, formAction, isPending] = useActionState(createTransfer, {
     success: false as const,
@@ -84,12 +88,9 @@ export function TransferDialog({
           {/* Amount */}
           <div className="space-y-2">
             <Label htmlFor="transfer-amount">Monto</Label>
-            <Input
+            <CurrencyInput
               id="transfer-amount"
               name="amount"
-              type="number"
-              step="0.01"
-              min="0.01"
               required
               autoFocus
               placeholder="0"
@@ -98,12 +99,13 @@ export function TransferDialog({
 
           {/* Date */}
           <div className="space-y-2">
-            <Label htmlFor="transfer-date">Fecha</Label>
-            <Input
-              id="transfer-date"
+            <Label>Fecha</Label>
+            <DatePicker
               name="date"
-              type="date"
-              defaultValue={today}
+              value={date}
+              onChange={(v) => setDate(v ?? today)}
+              className="w-full"
+              placeholder="Seleccionar fecha"
             />
           </div>
 
@@ -126,16 +128,13 @@ export function TransferDialog({
           )}
 
           {/* Submit */}
-          <button
+          <Button
             type="submit"
             disabled={isPending}
-            className={cn(
-              BRASS_BUTTON_CLASS,
-              "w-full rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50"
-            )}
+            className={cn(BRASS_BUTTON_CLASS, "w-full")}
           >
             {isPending ? "Transfiriendo..." : "Transferir"}
-          </button>
+          </Button>
         </form>
       </DialogContent>
     </Dialog>

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -11,6 +11,7 @@ import {
   Repeat,
 } from "lucide-react";
 import { createTransaction } from "@/actions/transactions";
+import { createTransfer } from "@/actions/transfers";
 import { Button } from "@/components/ui/button";
 import { CategoryZonePicker } from "@/components/categories/category-zone-picker";
 import { DestinatarioZonePicker } from "@/components/destinatarios/destinatario-zone-picker";
@@ -94,10 +95,23 @@ export function MobileTransactionForm({
 
   const direction = defaultDirection ?? directionFromType(transactionType);
 
-  const [state, formAction, pending] = useActionState(createTransaction, {
+  const isTransferMode = transactionType === "transfer";
+
+  // Two action states: regular transactions vs. paired account transfers.
+  // Transfers go through createTransfer (outflow + inflow + balance updates);
+  // everything else through createTransaction.
+  const [txState, txFormAction, txPending] = useActionState(createTransaction, {
     success: false,
     error: "",
   });
+  const [transferState, transferFormAction, transferPending] = useActionState(
+    createTransfer,
+    { success: false, error: "" }
+  );
+
+  const state = isTransferMode ? transferState : txState;
+  const formAction = isTransferMode ? transferFormAction : txFormAction;
+  const pending = isTransferMode ? transferPending : txPending;
 
   // Close form after action transition commits (route already revalidated)
   useEffect(() => {
@@ -119,6 +133,13 @@ export function MobileTransactionForm({
       localStorage.setItem(STORAGE_KEY, selectedAccountId);
     }
   }, [selectedAccountId]);
+
+  // Transfer destination account (only used in transfer mode)
+  const [destinationAccountId, setDestinationAccountId] = useState<string>("");
+  const destinationAccounts = useMemo(
+    () => accounts.filter((a) => a.id !== selectedAccountId),
+    [accounts, selectedAccountId]
+  );
 
   const [categoryId, setCategoryId] = useState<string | null>(null);
 
@@ -233,6 +254,14 @@ export function MobileTransactionForm({
         value={recurringTransferSourceAccountId}
       />
 
+      {/* Transfer-only fields consumed by createTransfer */}
+      {isTransferMode && (
+        <>
+          <input type="hidden" name="currencyCode" value={currencyCode} />
+          <input type="hidden" name="date" value={transactionDate} />
+        </>
+      )}
+
       {/* Direction selector — only shown when no preset */}
       {showTypeSelector && (
         <div className="flex gap-1 rounded-lg bg-muted p-1">
@@ -264,28 +293,35 @@ export function MobileTransactionForm({
       {/* ── DETALLES ────────────────────────────────────────── */}
       <SectionEyebrow>Detalles</SectionEyebrow>
 
-      {/* Description — full width */}
-      <div className="space-y-2">
-        <Label htmlFor="mobile-merchant">Descripción</Label>
-        <Input
-          id="mobile-merchant"
-          name="merchant_name"
-          value={merchantName}
-          onChange={(event) => setMerchantName(event.target.value)}
-          placeholder="Ej: Almuerzo, Uber, Arriendo..."
-        />
-      </div>
+      {/* Description — full width (not used for transfers) */}
+      {!isTransferMode && (
+        <div className="space-y-2">
+          <Label htmlFor="mobile-merchant">Descripción</Label>
+          <Input
+            id="mobile-merchant"
+            name="merchant_name"
+            value={merchantName}
+            onChange={(event) => setMerchantName(event.target.value)}
+            placeholder="Ej: Almuerzo, Uber, Arriendo..."
+          />
+        </div>
+      )}
 
-      {/* Cuenta */}
+      {/* Cuenta (origen for transfers) */}
       <div className="space-y-2">
-        <Label htmlFor="mobile-account">Cuenta</Label>
+        <Label htmlFor="mobile-account">
+          {isTransferMode ? "Cuenta origen" : "Cuenta"}
+        </Label>
         <Select
-          name="account_id"
+          name={isTransferMode ? "fromAccountId" : "account_id"}
           value={selectedAccountId}
           onValueChange={(value) => {
             setSelectedAccountId(value);
             if (recurringTransferSourceAccountId === value) {
               setRecurringTransferSourceAccountId("");
+            }
+            if (destinationAccountId === value) {
+              setDestinationAccountId("");
             }
           }}
         >
@@ -302,6 +338,34 @@ export function MobileTransactionForm({
         </Select>
       </div>
 
+      {/* Cuenta destino — transfers only */}
+      {isTransferMode && (
+        <div className="space-y-2">
+          <Label htmlFor="mobile-destination-account">Cuenta destino</Label>
+          <Select
+            name="toAccountId"
+            required
+            value={destinationAccountId}
+            onValueChange={setDestinationAccountId}
+          >
+            <SelectTrigger id="mobile-destination-account">
+              <SelectValue placeholder="Seleccionar cuenta" />
+            </SelectTrigger>
+            <SelectContent>
+              {destinationAccounts.map((acc) => (
+                <SelectItem key={acc.id} value={acc.id}>
+                  {acc.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Se registrará una salida en la cuenta origen y una entrada en la
+            cuenta destino.
+          </p>
+        </div>
+      )}
+
       {/* Fecha */}
       <div className="space-y-2">
         <Label>Fecha</Label>
@@ -312,18 +376,34 @@ export function MobileTransactionForm({
         />
       </div>
 
-      {/* Category — full width */}
-      <div className="space-y-2">
-        <Label>Categoría</Label>
-        <CategoryZonePicker
-          variant="popover"
-          categories={categories}
-          value={categoryId}
-          onValueChange={setCategoryId}
-          direction={direction}
-          name="category_id"
-        />
-      </div>
+      {/* Category — full width (not used for transfers) */}
+      {!isTransferMode && (
+        <div className="space-y-2">
+          <Label>Categoría</Label>
+          <CategoryZonePicker
+            variant="popover"
+            categories={categories}
+            value={categoryId}
+            onValueChange={setCategoryId}
+            direction={direction}
+            name="category_id"
+          />
+        </div>
+      )}
+
+      {/* Notas — transfers only (other modes have it under "Más opciones") */}
+      {isTransferMode && (
+        <div className="space-y-2">
+          <Label htmlFor="mobile-transfer-notes">Notas (opcional)</Label>
+          <Input
+            id="mobile-transfer-notes"
+            name="notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            placeholder="Ej: Pago cuota préstamo"
+          />
+        </div>
+      )}
 
       {/* ── ASIGNAR ─────────────────────────────────────────── */}
       {allowRelatedSetup && (

--- a/webapp/src/components/mobile/mobile-transaction-form.tsx
+++ b/webapp/src/components/mobile/mobile-transaction-form.tsx
@@ -134,11 +134,16 @@ export function MobileTransactionForm({
     }
   }, [selectedAccountId]);
 
-  // Transfer destination account (only used in transfer mode)
+  // Transfer destination account (only used in transfer mode). Only same-currency
+  // accounts are valid destinations — createTransfer rejects cross-currency.
   const [destinationAccountId, setDestinationAccountId] = useState<string>("");
-  const destinationAccounts = useMemo(
-    () => accounts.filter((a) => a.id !== selectedAccountId),
-    [accounts, selectedAccountId]
+  const transferSourceCurrency = accounts.find(
+    (a) => a.id === selectedAccountId
+  )?.currency_code;
+  const destinationAccounts = accounts.filter(
+    (a) =>
+      a.id !== selectedAccountId &&
+      a.currency_code === transferSourceCurrency
   );
 
   const [categoryId, setCategoryId] = useState<string | null>(null);
@@ -320,7 +325,15 @@ export function MobileTransactionForm({
             if (recurringTransferSourceAccountId === value) {
               setRecurringTransferSourceAccountId("");
             }
-            if (destinationAccountId === value) {
+            // Clear a destination that's no longer valid for the new source
+            // (same account, or a now-mismatched currency).
+            const dest = accounts.find((a) => a.id === destinationAccountId);
+            const newSource = accounts.find((a) => a.id === value);
+            if (
+              dest &&
+              (dest.id === value ||
+                dest.currency_code !== newSource?.currency_code)
+            ) {
               setDestinationAccountId("");
             }
           }}


### PR DESCRIPTION
The 'Transferencia' tab in /transactions/new submitted to createTransaction
with no destination account, creating a single outflow — an incomplete 'gasto'.

- Wire the transfer tab to the existing createTransfer action (paired
  outflow + inflow sharing a transfer_group_id, both balances updated).
- Add a 'Cuenta destino' picker; relabel source as 'Cuenta origen'; hide
  Descripción/Categoría/Destinatario and add a Notas field in transfer mode.
- Allow debt accounts (CREDIT_CARD/LOAN) as transfer destinations so paying
  a credit/loan from savings works; clamp debt destination balance at 0.
- Surface a warning instead of silent success when a balance write fails,
  and log a failed rollback delete (orphaned outflow).