### PR TITLE
fix(email): recognize Bancolombia QR transfers (DD/MM/YYYY) and @-handle Bre-B keys

### DIFF
--- a/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
+++ b/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
@@ -97,6 +97,21 @@ describe("parseBancolombiaEmail", () => {
     expect(result!.pattern_type).toBe("qr_transferencia");
   });
 
+  // Pattern 5b: Transferencia por QR (DD/MM/YYYY date!)
+  it("parses QR transfer (Transferiste por QR) with DD/MM/YYYY date", () => {
+    const line =
+      "Logo Bancolombia [https://example.com/logo.png] yellow-icon [https://example.com/chulo.png] ¡Listo!Todo salió bien con tus movimientos Bancolombia: Transferiste $16,000.00 por QR desde tu cuenta 4398 a la cuenta 6256, el 09/06/2026 03:22. ¿Dudas? Llamanos al 018000931987. Estamos cerca.";
+    const result = parseBancolombiaEmail(line);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("OUTFLOW");
+    expect(result!.amount).toBe(16000);
+    expect(result!.card_last4).toBe("4398");
+    expect(result!.destination).toBe("6256");
+    expect(result!.transaction_date).toBe("2026-06-09");
+    expect(result!.transaction_time).toBe("03:22");
+    expect(result!.pattern_type).toBe("qr_transferencia");
+  });
+
   // Pattern 6: Pago por codigo QR
   it("parses QR llave payment (pagaste por codigo QR)", () => {
     const line =
@@ -139,6 +154,22 @@ describe("parseBancolombiaEmail", () => {
     expect(result!.merchant).toBe("JUAN DIEGO TABORDA LOPEZ");
     expect(result!.card_last4).toBe("4398");
     expect(result!.transaction_date).toBe("2026-03-29");
+    expect(result!.pattern_type).toBe("bre_b");
+  });
+
+  // Pattern 8b: Bre-B transfer with alphanumeric llave (@handle)
+  it("parses Bre-B transfer with alphanumeric llave (@analogicdom)", () => {
+    const line =
+      "Logo Bancolombia [http://example.com/logo.png] yellow-icon [https://example.com/chulo.png] ¡Listo! Todo salió bien con tus movimientos Bancolombia: CRISTIAN, transferiste $129,000.00 a la llave @analogicdom desde tu cuenta *4398 a ANDRES CUARTAS el 16/06/26 a las 16:56. Con Bre-b es de una y gratis. Dudas al 018000912345.";
+    const result = parseBancolombiaEmail(line);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("OUTFLOW");
+    expect(result!.amount).toBe(129000);
+    expect(result!.destination).toBe("@analogicdom");
+    expect(result!.merchant).toBe("ANDRES CUARTAS");
+    expect(result!.card_last4).toBe("4398");
+    expect(result!.transaction_date).toBe("2026-06-16");
+    expect(result!.transaction_time).toBe("16:56");
     expect(result!.pattern_type).toBe("bre_b");
   });
 

--- a/webapp/src/lib/parsers/bancolombia-email.ts
+++ b/webapp/src/lib/parsers/bancolombia-email.ts
@@ -176,6 +176,25 @@ const PATTERNS: PatternDef[] = [
       pattern_type: "qr_transferencia",
     }),
   },
+  // Pattern 5b: Transferencia por QR (DD/MM/YYYY date) — same as 5 but day-first date
+  // "Transferiste $16,000.00 por QR desde tu cuenta 4398 a la cuenta 6256, el 09/06/2026 03:22"
+  {
+    type: "qr_transferencia",
+    regex:
+      /Transferiste \$([\d.,]+) por QR desde tu cuenta \*?(\d+) a la cuenta \*?(\d+),? el (\d{2}\/\d{2}\/\d{4}) (\d{2}:\d{2})/,
+    extract: (m) => ({
+      direction: "OUTFLOW",
+      amount: parseAmount(m[1]),
+      currency: "COP",
+      merchant: null,
+      destination: m[3],
+      card_last4: m[2],
+      card_type: "Cta",
+      transaction_date: parseDateDMY(m[4]),
+      transaction_time: m[5],
+      pattern_type: "qr_transferencia",
+    }),
+  },
   // Pattern 4: Transferencia (plain)
   // "Transferiste $680,000.00 desde tu cuenta 4398 a la cuenta *3196360227 el 27/03/2026 a las 17:19"
   {
@@ -234,11 +253,13 @@ const PATTERNS: PatternDef[] = [
     }),
   },
   // Pattern 8: Bre-B transfer (2-digit year, recipient name after account)
+  // Llave may be numeric (phone) or an alphanumeric Bre-B key (e.g. "@analogicdom")
   // "CRISTIAN, transferiste $100,000.00 a la llave 3013866335 desde tu cuenta *4398 a JUAN DIEGO TABORDA LOPEZ el 29/03/26 a las 20:52"
+  // "CRISTIAN, transferiste $129,000.00 a la llave @analogicdom desde tu cuenta *4398 a ANDRES CUARTAS el 16/06/26 a las 16:56"
   {
     type: "bre_b",
     regex:
-      /transferiste \$([\d.,]+) a la llave (\d+) desde tu cuenta \*?(\d+) a (.+?) el (\d{2}\/\d{2}\/\d{2,4}) a las (\d{2}:\d{2})/,
+      /transferiste \$([\d.,]+) a la llave (\S+) desde tu cuenta \*?(\d+) a (.+?) el (\d{2}\/\d{2}\/\d{2,4}) a las (\d{2}:\d{2})/,
     extract: (m) => ({
       direction: "OUTFLOW",
       amount: parseAmount(m[1]),


### PR DESCRIPTION
Two Bancolombia notification formats were falling through the email parser:

- QR transfers with a day-first date ("Transferiste $16,000.00 por QR ...
  el 09/06/2026 03:22"). The existing qr_transferencia pattern only matched
  the year-first (YYYY/MM/DD) variant. Added a sibling pattern that parses the
  DD/MM/YYYY form via parseDateDMY.
- Bre-B transfers to an alphanumeric llave ("a la llave @analogicdom ..."). The
  bre_b pattern required a numeric llave; broadened it to \S+ so @-handle keys
  match while numeric phone keys still work.

Added regression tests for both formats.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L38DhM9z8UGkR33qpzCxs1