### PR TITLE
feat(email): support "Botón Bancolombia" transfer notification format

### DIFF
--- a/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
+++ b/webapp/src/components/mobile/v2/movimientos/movimientos-herramientas.tsx
@@ -452,6 +452,7 @@ const PATTERN_LABELS: Record<string, { label: string; icon: typeof Mail }> = {
   compra_debito: { label: "Compra débito", icon: CreditCard },
   compra_credito: { label: "Compra crédito", icon: CreditCard },
   transferencia: { label: "Transferencia", icon: TransferIcon },
+  boton_bancolombia: { label: "Botón Bancolombia", icon: Building },
   qr_transferencia: { label: "Transferencia QR", icon: QrCode },
   qr_pago: { label: "Pago QR", icon: QrCode },
   pago_pse: { label: "Pago PSE", icon: Building },

--- a/webapp/src/components/transactions/pending-email-transactions.tsx
+++ b/webapp/src/components/transactions/pending-email-transactions.tsx
@@ -53,6 +53,7 @@ const PATTERN_LABELS: Record<string, { label: string; icon: typeof Mail }> = {
   compra_debito: { label: "Compra débito", icon: CreditCard },
   compra_credito: { label: "Compra crédito", icon: CreditCard },
   transferencia: { label: "Transferencia", icon: ArrowUpRight },
+  boton_bancolombia: { label: "Botón Bancolombia", icon: Building },
   qr_transferencia: { label: "Transferencia QR", icon: QrCode },
   qr_pago: { label: "Pago QR", icon: QrCode },
   pago_pse: { label: "Pago PSE", icon: Building },

--- a/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
+++ b/webapp/src/lib/parsers/__tests__/bancolombia-email.test.ts
@@ -83,6 +83,26 @@ describe("parseBancolombiaEmail", () => {
     expect(result!.destination).toBe("10382409401");
   });
 
+  // Pattern: Transferencia por Boton Bancolombia (PSE-style button payment)
+  it("parses Boton Bancolombia transfer (Transferiste por Boton Bancolombia)", () => {
+    const line =
+      "header-logo [http://bancolombia-email-wsuite.s3.amazonaws.com/templates/60712c2057ad717760ad6b6c/img/header-logo.png]yellow-icon [http://bancolombia-email-wsuite.s3.amazonaws.com/templates/60712c2057ad717760ad6b6c/img/yellow-icon.png] NotificaciónTransaccionalBancolombia: Transferiste $126,750.00 por Boton Bancolombia a MUNICIPIO DE BELLO desde producto *4398. 19/06/2026 12:04:49 ¿Dudas? 018000931987.Este es una notificación automática, por favor no respondas este mensaje.";
+    const result = parseBancolombiaEmail(line);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("OUTFLOW");
+    expect(result!.amount).toBe(126750);
+    expect(result!.merchant).toBe("MUNICIPIO DE BELLO");
+    expect(result!.destination).toBeNull();
+    expect(result!.card_last4).toBe("4398");
+    expect(result!.card_type).toBe("producto");
+    expect(result!.transaction_date).toBe("2026-06-19");
+    expect(result!.transaction_time).toBe("12:04");
+    expect(result!.pattern_type).toBe("boton_bancolombia");
+    expect(result!.raw_line).toBe(
+      "Transferiste $126,750.00 por Boton Bancolombia a MUNICIPIO DE BELLO desde producto *4398. 19/06/2026 12:04:49"
+    );
+  });
+
   // Pattern 5: Transferencia por QR (YYYY/MM/DD date!)
   it("parses QR transfer (Transferiste por QR) with YYYY/MM/DD date", () => {
     const line =

--- a/webapp/src/lib/parsers/bancolombia-email.ts
+++ b/webapp/src/lib/parsers/bancolombia-email.ts
@@ -440,7 +440,7 @@ export function parseBancolombiaEmail(
       const parsed = pattern.extract(match);
       if (parsed) {
         // Extract raw_line from the alert segment only, excluding trailing support/marketing copy.
-        const rawLineMatch = normalized.match(/Bancolombia:\s*([\s\S]+?)(?:\.?\s*(?:Si tienes dudas|¿Dudas|¿Tienes dudas|Encuentranos aqui|Con codigo QR|Con Bre-b|A tu lado|Estamos cerca)|$)/);
+        const rawLineMatch = normalized.match(/Bancolombia:\s*([\s\S]+?)(?:\.\s*(?:Si tienes dudas|Encuentranos aqui|Con codigo QR|Con Bre-b|A tu lado|Estamos cerca)|\.?\s*(?:¿Dudas|¿Tienes dudas)|$)/);
         const raw_line = rawLineMatch ? rawLineMatch[1].trim() : normalized;
         return { ...parsed, raw_line };
       }

--- a/webapp/src/lib/parsers/bancolombia-email.ts
+++ b/webapp/src/lib/parsers/bancolombia-email.ts
@@ -14,6 +14,7 @@ export interface ParsedEmailTransaction {
     | "compra_debito"
     | "compra_credito"
     | "transferencia"
+    | "boton_bancolombia"
     | "qr_transferencia"
     | "qr_pago"
     | "pago_pse"
@@ -155,6 +156,27 @@ const PATTERNS: PatternDef[] = [
       transaction_date: parseDateDMY(m[5]),
       transaction_time: m[6],
       pattern_type: "compra_debito",
+    }),
+  },
+  // Pattern: Transferencia por Boton Bancolombia (PSE-style button payment to a merchant)
+  // "Transferiste $126,750.00 por Boton Bancolombia a MUNICIPIO DE BELLO desde producto *4398. 19/06/2026 12:04:49"
+  // Note: date+time follow a period (no "el"/"a las"); time may include seconds.
+  // Must come before the plain "transferencia"/"qr_transferencia" patterns.
+  {
+    type: "boton_bancolombia",
+    regex:
+      /Transferiste \$([\d.,]+) por Boton Bancolombia a (.+?) desde producto \*?(\d+)\.? (\d{2}\/\d{2}\/\d{4}) (\d{2}:\d{2})(?::\d{2})?/,
+    extract: (m) => ({
+      direction: "OUTFLOW",
+      amount: parseAmount(m[1]),
+      currency: "COP",
+      merchant: m[2].trim(),
+      destination: null,
+      card_last4: m[3],
+      card_type: "producto",
+      transaction_date: parseDateDMY(m[4]),
+      transaction_time: m[5],
+      pattern_type: "boton_bancolombia",
     }),
   },
   // Pattern 5: Transferencia por QR (YYYY/MM/DD date) — must come before plain transferencia
@@ -418,7 +440,7 @@ export function parseBancolombiaEmail(
       const parsed = pattern.extract(match);
       if (parsed) {
         // Extract raw_line from the alert segment only, excluding trailing support/marketing copy.
-        const rawLineMatch = normalized.match(/Bancolombia:\s*([\s\S]+?)(?:\.\s*(?:Si tienes dudas|¿Dudas|¿Tienes dudas|Encuentranos aqui|Con codigo QR|Con Bre-b|A tu lado|Estamos cerca)|$)/);
+        const rawLineMatch = normalized.match(/Bancolombia:\s*([\s\S]+?)(?:\.?\s*(?:Si tienes dudas|¿Dudas|¿Tienes dudas|Encuentranos aqui|Con codigo QR|Con Bre-b|A tu lado|Estamos cerca)|$)/);
         const raw_line = rawLineMatch ? rawLineMatch[1].trim() : normalized;
         return { ...parsed, raw_line };
       }


### PR DESCRIPTION
Add a new email parser pattern for Bancolombia "Botón Bancolombia"
(PSE-style button payment) notifications, e.g.:

  "Transferiste $126,750.00 por Boton Bancolombia a MUNICIPIO DE BELLO
   desde producto *4398. 19/06/2026 12:04:49"

This format is distinct from existing transfers: the recipient follows
"a", the source is "desde producto *XXXX", and the date+time trail a
period (no "el"/"a las") with seconds in the time.

- Add `boton_bancolombia` pattern_type + regex (OUTFLOW, card_type
  "producto", merchant = recipient), ordered before the QR/plain
  transferencia patterns.
- Make the period before the trailing-copy boundary optional in the
  raw_line extractor so "...HH:MM:SS ¿Dudas?" trims cleanly.
- Map the new pattern_type label/icon in the web and mobile pending
  email transaction lists.
- Add a parser test using the real notification body.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lmd7w9K9kBYhVV9onqG4Tf