### PR TITLE
fix(auth): use canonical app URL for OAuth callback redirects

### DIFF
--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -6,6 +6,9 @@ const RECOVERY_REDIRECT = "/reset-password";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
+  // ponytail: behind the proxy, request.url resolves to the internal 0.0.0.0:3000
+  // bind, so redirects must use the canonical app URL. Falls back to origin in dev.
+  const base = process.env.NEXT_PUBLIC_APP_URL ?? origin;
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
@@ -21,22 +24,22 @@ export async function GET(request: Request) {
   if (tokenHash && type) {
     const { error } = await supabase.auth.verifyOtp({ type, token_hash: tokenHash });
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      return NextResponse.redirect(`${base}${next}`);
     }
     return NextResponse.redirect(
-      `${origin}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
+      `${base}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
     );
   }
 
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      return NextResponse.redirect(`${base}${next}`);
     }
     return NextResponse.redirect(
-      `${origin}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
+      `${base}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
     );
   }
 
-  return NextResponse.redirect(`${origin}/login?error=auth_callback_missing_params`);
+  return NextResponse.redirect(`${base}/login?error=auth_callback_missing_params`);
 }

--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   // ponytail: behind the proxy, request.url resolves to the internal 0.0.0.0:3000
   // bind, so redirects must use the canonical app URL. Falls back to origin in dev.
-  const base = process.env.NEXT_PUBLIC_APP_URL ?? origin;
+  const base = process.env.NEXT_PUBLIC_APP_URL || origin;
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
@@ -24,22 +24,22 @@ export async function GET(request: Request) {
   if (tokenHash && type) {
     const { error } = await supabase.auth.verifyOtp({ type, token_hash: tokenHash });
     if (!error) {
-      return NextResponse.redirect(`${base}${next}`);
+      return NextResponse.redirect(new URL(next, base));
     }
     return NextResponse.redirect(
-      `${base}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
+      new URL(`/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`, base)
     );
   }
 
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${base}${next}`);
+      return NextResponse.redirect(new URL(next, base));
     }
     return NextResponse.redirect(
-      `${base}/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`
+      new URL(`/login?error=auth_callback_failed&reason=${encodeURIComponent(error.message)}`, base)
     );
   }
 
-  return NextResponse.redirect(`${base}/login?error=auth_callback_missing_params`);
+  return NextResponse.redirect(new URL(`/login?error=auth_callback_missing_params`, base));
 }

--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -13,8 +13,13 @@ export async function GET(request: Request) {
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const nextParam = searchParams.get("next");
+  // Block protocol-relative ("//host") and backslash ("/\host") forms — both
+  // normalize to an off-origin URL via new URL(next, base) → open redirect.
   const safeNext =
-    nextParam && nextParam.startsWith("/") && !nextParam.startsWith("//")
+    nextParam &&
+    nextParam.startsWith("/") &&
+    !nextParam.startsWith("//") &&
+    !nextParam.startsWith("/\\")
       ? nextParam
       : null;
   const next = safeNext ?? (type === "recovery" ? RECOVERY_REDIRECT : "/dashboard");


### PR DESCRIPTION
## Problem
OAuth (Google/Apple) and password-recovery callbacks redirected to `https://0.0.0.0:3000/dashboard`, which the browser refuses (`Not allowed to use restricted network port`).

## Cause
Behind the reverse proxy, the Next.js standalone server binds `0.0.0.0:3000`, so `new URL(request.url).origin` inside `/auth/callback` resolves to the **internal** address, not the public host. Every redirect built from `origin` pointed at `0.0.0.0:3000`.

## Fix
Derive the redirect base from `NEXT_PUBLIC_APP_URL` (canonical public URL, set per-env), falling back to `origin` for local dev. One file, 5 redirect sites.

## Notes
- Production also needed two infra fixes already applied: corrected `NEXT_PUBLIC_APP_URL` (was missing scheme + subdomain) and an nginx `proxy_buffer_size` bump (Supabase session cookies overflowed the 8k default → 502). This PR is the code half.
- Verified: `pnpm build` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)