### PR TITLE
fix(auth): derive OAuth callback base from runtime Host header

### DIFF
--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -12,14 +12,21 @@ export async function GET(request: Request) {
   // client-controllable, so validate it against an allowlist of trusted public
   // hosts to prevent host-header injection (redirecting the OAuth code off-site).
   // APP_URL (non-public → read at runtime) lets other deployments override.
+  let appUrlHost: string | null = null;
+  if (process.env.APP_URL) {
+    try {
+      appUrlHost = new URL(process.env.APP_URL).host.toLowerCase();
+    } catch {
+      // Ignore a misconfigured APP_URL (e.g. missing scheme) rather than crash.
+    }
+  }
   const allowedHosts = new Set(
-    [
-      process.env.APP_URL ? new URL(process.env.APP_URL).host : null,
-      "pfm.sanson1911.cloud",
-      "localhost:3000",
-    ].filter((h): h is string => Boolean(h))
+    [appUrlHost, "pfm.sanson1911.cloud", "localhost:3000"].filter(
+      (h): h is string => Boolean(h)
+    )
   );
-  const host = request.headers.get("host");
+  // Host headers are case-insensitive; normalize before the allowlist check.
+  const host = request.headers.get("host")?.toLowerCase();
   const proto =
     request.headers.get("x-forwarded-proto") ??
     new URL(request.url).protocol.replace(":", "");

--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -7,8 +7,14 @@ const RECOVERY_REDIRECT = "/reset-password";
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   // ponytail: behind the proxy, request.url resolves to the internal 0.0.0.0:3000
-  // bind, so redirects must use the canonical app URL. Falls back to origin in dev.
-  const base = process.env.NEXT_PUBLIC_APP_URL || origin;
+  // bind, and NEXT_PUBLIC_* is inlined at build time (unreliable at runtime), so
+  // derive the public base from the proxy-forwarded Host header. Falls back to
+  // origin for local dev (no proxy).
+  const host = request.headers.get("host");
+  const proto =
+    request.headers.get("x-forwarded-proto") ??
+    new URL(request.url).protocol.replace(":", "");
+  const base = host ? `${proto}://${host}` : origin;
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;

--- a/webapp/src/app/auth/callback/route.ts
+++ b/webapp/src/app/auth/callback/route.ts
@@ -6,15 +6,24 @@ const RECOVERY_REDIRECT = "/reset-password";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
-  // ponytail: behind the proxy, request.url resolves to the internal 0.0.0.0:3000
-  // bind, and NEXT_PUBLIC_* is inlined at build time (unreliable at runtime), so
-  // derive the public base from the proxy-forwarded Host header. Falls back to
-  // origin for local dev (no proxy).
+  // Behind the proxy, request.url resolves to the internal 0.0.0.0:3000 bind and
+  // NEXT_PUBLIC_* is inlined at build time (empty at runtime), so derive the
+  // public base from the proxy-forwarded Host header. The Host header is
+  // client-controllable, so validate it against an allowlist of trusted public
+  // hosts to prevent host-header injection (redirecting the OAuth code off-site).
+  // APP_URL (non-public → read at runtime) lets other deployments override.
+  const allowedHosts = new Set(
+    [
+      process.env.APP_URL ? new URL(process.env.APP_URL).host : null,
+      "pfm.sanson1911.cloud",
+      "localhost:3000",
+    ].filter((h): h is string => Boolean(h))
+  );
   const host = request.headers.get("host");
   const proto =
     request.headers.get("x-forwarded-proto") ??
     new URL(request.url).protocol.replace(":", "");
-  const base = host ? `${proto}://${host}` : origin;
+  const base = host && allowedHosts.has(host) ? `${proto}://${host}` : origin;
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;


### PR DESCRIPTION
Follow-up to #299. Those redirects used `NEXT_PUBLIC_APP_URL`, but Next inlines `NEXT_PUBLIC_*` at **build time** — in the deployed image it was empty, so `new URL(path, "")` threw → **500 / blank page** on `/auth/callback` (web and the Apple-on-Android web-OAuth fallback).

## Changes
- **Runtime base**: derive the public base from the proxy-forwarded `Host` + `X-Forwarded-Proto` headers (read at runtime), instead of the build-inlined env var.
- **Host-header allowlist** (security): validate `Host` against trusted public hosts (`pfm.sanson1911.cloud`, `localhost:3000`, optional runtime `APP_URL`) before using it — a forged `Host` falls back to the internal origin and cannot redirect the OAuth `code` off-site.

## Notes
- Fixes the 500; turns a failed code exchange into a graceful `/login?error=...` redirect.
- **Does not** fix the separate "PKCE code verifier not found" issue (cookie round-trip) — tracked separately.
- `tsc --noEmit` clean. Host-allowlist logic verified (forged host → internal origin, no off-site redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)