### PR TITLE
feat(mobile): ledger mutations + screen wiring for webapp parity

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,6 +10,21 @@
 
 ---
 
+## Mobile ledger parity — Phase 2 follow-ups (2026-06-22)
+
+Mobile got the 4 ledger mutations (`registerPayment`/`createTransfer`/`reconcileBalance`/`recordRecurringOccurrencePayment`) + screen wiring this session. Verified end-to-end on iOS sim: **account Pagar → registerPayment** (balance + tx + refresh all correct). Remaining:
+
+- **Emulator-verify the other 3 wirings.** Pagar is proven; spot-check **Transferir** (createTransfer paired legs), **Ajustar** (reconcileBalance overwrite), and **Recurrentes Confirmar** (recordRecurringOccurrencePayment — the ex-corruption path) on the sim. Same MobileSheet pattern + gate-reviewed repos, so low risk, but confirm balances move.
+- **createTransfer FROM-debt `available_balance` clamp divergence.** Mobile clamps to 0 via `buildDebtBalanceUpdatePayload`; webapp `transfers.ts` allows negative (over-limit). Edge case (transfer FROM a maxed card). Decide canonical behavior and align both sides. (parity gate, 2026-06-22)
+- **Multi-currency reconcile.** Mobile schema migration v17 added only `accounts.currency_balances TEXT` (NO top-level `total_payment_due` — it's a JSON sub-field; remote view lacks the column). Verify `currency_balances` pulls from the remote accounts view correctly and the multi-currency reconcile path works on a real multi-currency account.
+- **`recurring_template_tags` table missing on mobile.** `recordRecurringOccurrencePayment` probes `sqlite_master` and no-ops the tag copy when absent. Add the synced table so recurring payments carry their template tags.
+- **Slash-opacity NativeWind classes** in the new sheets (`bg-z-brass/30`, `bg-z-debt/10`, `active:bg-z-surface-2/5`) — kept for byte-parity with shipping `PaymentSheet.tsx`; rendered fine live, but they're the NativeWind-v3 footgun. Consider migrating PaymentSheet + the new sheets to explicit tokens together.
+- **Sparse Más menu** vs webapp — no Deudas/Deseos/Recurrentes/Categorías/Destinatarios entry points. Confirm whether this is intentional v2 curation; if not, surface them.
+- **Account-detail time-range chips overlap the floating gear** (6M chip under the settings button). Minor header layout fix in `app/account/[id].tsx`.
+- **PlanRoot period chip hardcoded** — `PlanRoot.tsx:257` `periodHasActive={false}`/`periodPercentAssigned={0}`. Wire via `getActivePeriodWithEntries` (needs userId + the webapp assign-% formula). Pairs with the broader Plan/Periodo CRUD (Phase 4).
+- **`confirmOccurrence` deleted** from `recurring.ts` (superseded by `recordRecurringOccurrencePayment`). One doc-comment reference remains; harmless.
+- **iOS Podfile modular-headers fix is local-only** — `mobile/ios/` is gitignored, so the `pod 'GoogleUtilities'/'RecaptchaInterop', :modular_headers => true` lines (needed for the google-signin/AppCheckCore static-lib error) won't survive `expo prebuild` or reach CI/other devs. Make it durable via `expo-build-properties` in `app.json` (`ios.extraPods` or `useModularHeaders`).
+
 ## Bugs
 
 ### `seedPeriodFromRecurring` — reminder dedup is title/amount-fragile

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -192,7 +192,7 @@ export default function LoginScreen() {
         )}
 
         <Text className="text-sm font-medium text-muted-foreground mb-1">
-          Correo electronico
+          Correo electrónico
         </Text>
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
@@ -207,11 +207,11 @@ export default function LoginScreen() {
         />
 
         <Text className="text-sm font-medium text-muted-foreground mb-1">
-          Contrasena
+          Contraseña
         </Text>
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
-          placeholder="Tu contrasena"
+          placeholder="Tu contraseña"
           placeholderTextColor="#938C7E"
           value={password}
           onChangeText={setPassword}
@@ -232,7 +232,7 @@ export default function LoginScreen() {
             <ActivityIndicator color="#121412" />
           ) : (
             <Text className="text-z-ink font-semibold text-base">
-              Iniciar sesion
+              Iniciar sesión
             </Text>
           )}
         </TouchableOpacity>

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -49,8 +49,8 @@ export default function ResetPasswordScreen() {
       return;
     }
 
-    if (password.length < 6) {
-      setError("La contraseña debe tener al menos 6 caracteres");
+    if (password.length < 8) {
+      setError("La contraseña debe tener al menos 8 caracteres");
       return;
     }
 
@@ -122,7 +122,7 @@ export default function ResetPasswordScreen() {
         </Text>
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
-          placeholder="Mínimo 6 caracteres"
+          placeholder="Mínimo 8 caracteres"
           placeholderTextColor="#938C7E"
           value={password}
           onChangeText={setPassword}

--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -28,8 +28,8 @@ export default function SignupScreen() {
       return;
     }
 
-    if (password.length < 6) {
-      setError("La contraseña debe tener al menos 6 caracteres");
+    if (password.length < 8) {
+      setError("La contraseña debe tener al menos 8 caracteres");
       return;
     }
 
@@ -100,7 +100,7 @@ export default function SignupScreen() {
         </Text>
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
-          placeholder="Mínimo 6 caracteres"
+          placeholder="Mínimo 8 caracteres"
           placeholderTextColor="#938C7E"
           value={password}
           onChangeText={setPassword}

--- a/mobile/app/(tabs)/accounts.tsx
+++ b/mobile/app/(tabs)/accounts.tsx
@@ -113,7 +113,7 @@ export default function AccountsScreen() {
                   isNegative ? "text-z-debt" : "text-foreground"
                 }`}
               >
-                {formatCurrency(Math.abs(netWorth), "COP" as CurrencyCode)}
+                {(isNegative ? "-" : "") + formatCurrency(Math.abs(netWorth), "COP" as CurrencyCode)}
               </Text>
             </View>
 

--- a/mobile/app/(tabs)/import.tsx
+++ b/mobile/app/(tabs)/import.tsx
@@ -469,15 +469,15 @@ export default function ImportScreen() {
       const stmt = statements[0];
 
       if (!stmt) {
-        throw new Error("No se encontro informacion en el extracto");
+        throw new Error("No se encontró información en el extracto");
       }
 
       if (!stmt.transactions?.length) {
         const typeLabel =
           stmt.statement_type === "loan"
-            ? "prestamo"
+            ? "préstamo"
             : stmt.statement_type === "credit_card"
-              ? "tarjeta de credito"
+              ? "tarjeta de crédito"
               : "extracto";
         throw new Error(
           `Este ${typeLabel} no contiene transacciones para importar`
@@ -617,8 +617,8 @@ export default function ImportScreen() {
     if (!parsedData) return;
     if (!session?.user?.id) {
       Alert.alert(
-        "Inicia sesion",
-        "La importacion de extractos requiere una cuenta autenticada."
+        "Inicia sesión",
+        "La importación de extractos requiere una cuenta autenticada."
       );
       return;
     }

--- a/mobile/app/(tabs)/menu.tsx
+++ b/mobile/app/(tabs)/menu.tsx
@@ -36,7 +36,7 @@ export default function MenuScreen() {
         <HubEntry
           icon={PiggyBank}
           title="Presupuestos"
-          hint="Control mensual por categoria"
+          hint="Control mensual por categoría"
           onPress={() => router.push("/(tabs)/plan" as any)}
         />
         <HubEntry

--- a/mobile/app/account/[id].tsx
+++ b/mobile/app/account/[id].tsx
@@ -7,12 +7,13 @@ import {
   Alert,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { X } from "lucide-react-native";
 import { COLORS } from "../../lib/constants/colors";
 import {
   getAccountById,
+  getAllAccounts,
   deleteAccount,
   type AccountRow,
 } from "../../lib/repositories/accounts";
@@ -28,6 +29,9 @@ import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { isDebtInflow } from "../../lib/transaction-semantics";
 import { AccountHero } from "../../components/accounts/AccountHero";
 import { QuickActionsBar } from "../../components/accounts/QuickActionsBar";
+import { PaymentActionSheet } from "../../components/accounts/PaymentActionSheet";
+import { ReconcileSheet } from "../../components/accounts/ReconcileSheet";
+import { TransferSheet } from "../../components/accounts/TransferSheet";
 import {
   MOBILE_TAB_BAR_CLEARANCE,
   SECTION_EYEBROW_CLASS,
@@ -76,61 +80,63 @@ export default function AccountDetailScreen() {
   const [trendPercent, setTrendPercent] = useState<number | undefined>(undefined);
   const [monthlySpent, setMonthlySpent] = useState(0);
   const [dailyActivity, setDailyActivity] = useState<DailyPoint[]>([]);
+  const [allAccounts, setAllAccounts] = useState<AccountRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [activeSheet, setActiveSheet] = useState<
+    "payment" | "transfer" | "reconcile" | null
+  >(null);
 
-  useEffect(() => {
+  const loadData = useCallback(async () => {
     if (!id) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const now = new Date();
-        const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-        const db = await getDatabase();
-        const [acc, txs, summary] = await Promise.all([
-          getAccountById(id),
-          getTransactions({ accountId: id, limit: 10 }),
-          db.getFirstAsync<{ total_out: number; total_in: number; tx_count: number }>(
-            `SELECT
+    try {
+      const now = new Date();
+      const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+      const db = await getDatabase();
+      const [acc, txs, summary, accountRows] = await Promise.all([
+        getAccountById(id),
+        getTransactions({ accountId: id, limit: 10 }),
+        db.getFirstAsync<{ total_out: number; total_in: number; tx_count: number }>(
+          `SELECT
               COALESCE(SUM(CASE WHEN direction = 'OUTFLOW' THEN amount ELSE 0 END), 0) as total_out,
               COALESCE(SUM(CASE WHEN direction = 'INFLOW' THEN amount ELSE 0 END), 0) as total_in,
               COUNT(*) as tx_count
             FROM transactions
             WHERE account_id = ? AND transaction_date LIKE ? AND is_excluded = 0`,
-            [id, `${month}%`]
-          ),
-        ]);
-        if (cancelled) return;
-        setAccount(acc);
-        setRecentTx(txs as TransactionRow[]);
-        setSpendingSummary(summary);
+          [id, `${month}%`]
+        ),
+        getAllAccounts(),
+      ]);
+      setAccount(acc);
+      setRecentTx(txs as TransactionRow[]);
+      setSpendingSummary(summary);
+      setAllAccounts(accountRows);
 
-        if (acc) {
-          const [history, pulse] = await Promise.all([
-            getBalanceHistory(id, acc.current_balance ?? 0),
-            getSpendingPulse(id),
-          ]);
-          if (cancelled) return;
-          setSnapshotData(history);
-          if (history.length >= 2) {
-            const first = history[0].balance;
-            const last = history[history.length - 1].balance;
-            if (first !== 0) {
-              setTrendPercent(((last - first) / Math.abs(first)) * 100);
-            }
+      if (acc) {
+        const [history, pulse] = await Promise.all([
+          getBalanceHistory(id, acc.current_balance ?? 0),
+          getSpendingPulse(id),
+        ]);
+        setSnapshotData(history);
+        if (history.length >= 2) {
+          const first = history[0].balance;
+          const last = history[history.length - 1].balance;
+          if (first !== 0) {
+            setTrendPercent(((last - first) / Math.abs(first)) * 100);
           }
-          setMonthlySpent(pulse.monthlySpent);
-          setDailyActivity(pulse.dailyActivity);
         }
-      } catch (error) {
-        console.error("Failed to load account:", error);
-      } finally {
-        if (!cancelled) setLoading(false);
+        setMonthlySpent(pulse.monthlySpent);
+        setDailyActivity(pulse.dailyActivity);
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    } catch (error) {
+      console.error("Failed to load account:", error);
+    } finally {
+      setLoading(false);
+    }
   }, [id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const handleDelete = () => {
     if (!id) return;
@@ -226,6 +232,9 @@ export default function AccountDetailScreen() {
             account={account}
             onEdit={() => router.push(`/account/edit/${id}`)}
             onDelete={handleDelete}
+            onPayment={() => setActiveSheet("payment")}
+            onTransfer={() => setActiveSheet("transfer")}
+            onReconcile={() => setActiveSheet("reconcile")}
           />
         </View>
 
@@ -254,7 +263,9 @@ export default function AccountDetailScreen() {
               </View>
             </View>
             <Text className="text-muted-fg-70 font-inter text-xs mt-1.5 text-center">
-              {spendingSummary.tx_count} transacciones este mes
+              {spendingSummary.tx_count}{" "}
+              {spendingSummary.tx_count === 1 ? "transacción" : "transacciones"} este
+              mes
             </Text>
           </View>
         )}
@@ -269,26 +280,26 @@ export default function AccountDetailScreen() {
             <View className="bg-z-surface-2 rounded-xl px-4 border border-white-6">
               {account.credit_limit != null && (
                 <DetailRow
-                  label="Limite de credito"
+                  label="Límite de crédito"
                   value={formatCurrency(account.credit_limit, currency)}
                 />
               )}
               {account.interest_rate != null && (
                 <DetailRow
-                  label="Tasa de interes"
+                  label="Tasa de interés"
                   value={`${account.interest_rate}%`}
                 />
               )}
               {account.cutoff_day != null && (
                 <DetailRow
-                  label="Dia de corte"
-                  value={`Dia ${account.cutoff_day}`}
+                  label="Día de corte"
+                  value={`Día ${account.cutoff_day}`}
                 />
               )}
               {account.payment_day != null && (
                 <DetailRow
-                  label="Dia de pago"
-                  value={`Dia ${account.payment_day}`}
+                  label="Día de pago"
+                  value={`Día ${account.payment_day}`}
                 />
               )}
             </View>
@@ -298,7 +309,7 @@ export default function AccountDetailScreen() {
         {/* Recent transactions */}
         <View className="mx-4 mt-4">
           <Text className={`${SECTION_EYEBROW_CLASS} mb-2`}>
-            Ultimas transacciones
+            Últimas transacciones
           </Text>
           {recentTx.length === 0 ? (
             <View className="bg-z-surface-2 rounded-xl px-4 py-6 border border-white-6 items-center">
@@ -328,7 +339,7 @@ export default function AccountDetailScreen() {
                         className="text-foreground font-inter-medium text-sm"
                         numberOfLines={1}
                       >
-                        {tx.merchant_name ?? tx.description ?? "Sin descripcion"}
+                        {tx.merchant_name ?? tx.description ?? "Sin descripción"}
                       </Text>
                       {(tx.category_name_es || isDebtPayment) && (
                         <Text className="text-muted-fg-70 font-inter text-xs mt-0.5">
@@ -351,6 +362,41 @@ export default function AccountDetailScreen() {
           )}
         </View>
       </ScrollView>
+
+      <PaymentActionSheet
+        visible={activeSheet === "payment"}
+        account={account}
+        allAccounts={allAccounts}
+        onClose={() => setActiveSheet(null)}
+        onSuccess={() => {
+          setActiveSheet(null);
+          Alert.alert("Listo", "El pago se registró correctamente.");
+          loadData();
+        }}
+      />
+
+      <TransferSheet
+        visible={activeSheet === "transfer"}
+        allAccounts={allAccounts}
+        initialFromAccountId={account.id}
+        onClose={() => setActiveSheet(null)}
+        onSuccess={() => {
+          setActiveSheet(null);
+          Alert.alert("Listo", "La transferencia se registró correctamente.");
+          loadData();
+        }}
+      />
+
+      <ReconcileSheet
+        visible={activeSheet === "reconcile"}
+        account={account}
+        onClose={() => setActiveSheet(null)}
+        onSuccess={() => {
+          setActiveSheet(null);
+          Alert.alert("Listo", "El saldo se ajustó correctamente.");
+          loadData();
+        }}
+      />
     </View>
   );
 }

--- a/mobile/app/account/create.tsx
+++ b/mobile/app/account/create.tsx
@@ -64,7 +64,7 @@ export default function CreateAccountScreen() {
     const parsedBalance = parseFloat(balance) || 0;
 
     if (isCreditCard && !creditLimit.trim()) {
-      Alert.alert("Error", "El limite de credito es requerido para tarjetas.");
+      Alert.alert("Error", "El límite de crédito es requerido para tarjetas.");
       return;
     }
 
@@ -163,27 +163,27 @@ export default function CreateAccountScreen() {
         {/* Credit card specific fields */}
         {isCreditCard && (
           <>
-            <FormField label="Limite de credito" required>
+            <FormField label="Límite de crédito" required>
               <NumericInput
                 value={creditLimit}
                 onChangeText={setCreditLimit}
                 placeholder="Ej: 5000000"
               />
             </FormField>
-            <FormField label="Tasa de interes mensual (%)">
+            <FormField label="Tasa de interés mensual (%)">
               <NumericInput
                 value={interestRate}
                 onChangeText={setInterestRate}
                 placeholder="Ej: 2.5"
               />
             </FormField>
-            <FormField label="Dia de corte">
+            <FormField label="Día de corte">
               <DayPicker
                 value={cutoffDay}
                 onSelect={setCutoffDay}
               />
             </FormField>
-            <FormField label="Dia de pago">
+            <FormField label="Día de pago">
               <DayPicker
                 value={paymentDay}
                 onSelect={setPaymentDay}
@@ -195,14 +195,14 @@ export default function CreateAccountScreen() {
         {/* Loan specific fields */}
         {isLoan && (
           <>
-            <FormField label="Tasa de interes mensual (%)">
+            <FormField label="Tasa de interés mensual (%)">
               <NumericInput
                 value={interestRate}
                 onChangeText={setInterestRate}
                 placeholder="Ej: 1.8"
               />
             </FormField>
-            <FormField label="Dia de pago">
+            <FormField label="Día de pago">
               <DayPicker
                 value={paymentDay}
                 onSelect={setPaymentDay}

--- a/mobile/app/account/edit/[id].tsx
+++ b/mobile/app/account/edit/[id].tsx
@@ -99,7 +99,7 @@ export default function EditAccountScreen() {
     }
 
     if (isCreditCard && !creditLimit.trim()) {
-      Alert.alert("Error", "El limite de credito es requerido para tarjetas.");
+      Alert.alert("Error", "El límite de crédito es requerido para tarjetas.");
       return;
     }
 
@@ -206,24 +206,24 @@ export default function EditAccountScreen() {
         {/* Credit card specific */}
         {isCreditCard && (
           <>
-            <FormField label="Limite de credito" required>
+            <FormField label="Límite de crédito" required>
               <NumericInput
                 value={creditLimit}
                 onChangeText={setCreditLimit}
                 placeholder="Ej: 5000000"
               />
             </FormField>
-            <FormField label="Tasa de interes mensual (%)">
+            <FormField label="Tasa de interés mensual (%)">
               <NumericInput
                 value={interestRate}
                 onChangeText={setInterestRate}
                 placeholder="Ej: 2.5"
               />
             </FormField>
-            <FormField label="Dia de corte">
+            <FormField label="Día de corte">
               <DayPicker value={cutoffDay} onSelect={setCutoffDay} />
             </FormField>
-            <FormField label="Dia de pago">
+            <FormField label="Día de pago">
               <DayPicker value={paymentDay} onSelect={setPaymentDay} />
             </FormField>
           </>
@@ -232,14 +232,14 @@ export default function EditAccountScreen() {
         {/* Loan specific */}
         {isLoan && (
           <>
-            <FormField label="Tasa de interes mensual (%)">
+            <FormField label="Tasa de interés mensual (%)">
               <NumericInput
                 value={interestRate}
                 onChangeText={setInterestRate}
                 placeholder="Ej: 1.8"
               />
             </FormField>
-            <FormField label="Dia de pago">
+            <FormField label="Día de pago">
               <DayPicker value={paymentDay} onSelect={setPaymentDay} />
             </FormField>
           </>

--- a/mobile/app/accounts-list.tsx
+++ b/mobile/app/accounts-list.tsx
@@ -77,7 +77,7 @@ export default function AccountsListScreen() {
               isNegative ? "text-z-debt" : "text-foreground"
             }`}
           >
-            {formatCurrency(Math.abs(netWorth), "COP" as CurrencyCode)}
+            {(isNegative ? "-" : "") + formatCurrency(Math.abs(netWorth), "COP" as CurrencyCode)}
           </Text>
         </View>
 

--- a/mobile/app/bug-report.tsx
+++ b/mobile/app/bug-report.tsx
@@ -129,15 +129,15 @@ export default function BugReportScreen() {
     if (!session?.user?.id) {
       Alert.alert(
         "Requiere cuenta",
-        "Debes iniciar sesion para enviar reportes de bug al bucket compartido."
+        "Debes iniciar sesión para enviar reportes de bug al bucket compartido."
       );
       return;
     }
 
     if (!canSubmit) {
       Alert.alert(
-        "Completa la informacion",
-        "Agrega un titulo y una descripcion un poco mas detallada."
+        "Completa la información",
+        "Agrega un título y una descripción un poco más detallada."
       );
       return;
     }
@@ -283,17 +283,17 @@ export default function BugReportScreen() {
           </Text>
 
           <Text className="mt-4 mb-1 text-sm font-inter-medium text-foreground">
-            Titulo del bug
+            Título del bug
           </Text>
           <TextInput
             value={title}
             onChangeText={setTitle}
-            placeholder="Ej: En editar transaccion se solapan fecha y cuenta"
+            placeholder="Ej: En editar transacción se solapan fecha y cuenta"
             className="rounded-xl border border-white-10 bg-z-surface-2-55 px-3 py-2.5 text-foreground"
           />
 
           <Text className="mt-3 mb-1 text-sm font-inter-medium text-foreground">
-            Descripcion
+            Descripción
           </Text>
           <TextInput
             value={description}

--- a/mobile/app/capture.tsx
+++ b/mobile/app/capture.tsx
@@ -60,6 +60,7 @@ import {
   PANEL_INSET_CLASS,
 } from "../lib/constants/styles";
 import { COLORS } from "../lib/constants/colors";
+import { TransferSheet } from "../components/accounts/TransferSheet";
 
 const DEFAULT_ACCOUNT_KEY = "zeta.last_capture_account_id";
 const EXPLICIT_DEFAULT_ACCOUNT_KEY = "zeta.default_capture_account_id";
@@ -230,6 +231,7 @@ export default function CaptureScreen() {
   const [isSubscription, setIsSubscription] = useState(false);
   const [createDestinatario, setCreateDestinatario] = useState(false);
   const [createRecurring, setCreateRecurring] = useState(false);
+  const [showTransferSheet, setShowTransferSheet] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -293,10 +295,10 @@ export default function CaptureScreen() {
 
   function handleTypeChange(next: TxType) {
     if (next === "transfer") {
-      Alert.alert(
-        "Próximamente",
-        "La creación de transferencias llega en la siguiente versión."
-      );
+      // Transfers are a paired OUTFLOW+INFLOW across two accounts — handled by
+      // the dedicated TransferSheet (createTransfer), not the single-account
+      // capture form. Open the sheet and keep the pill on the current type.
+      setShowTransferSheet(true);
       return;
     }
     if (next !== type) {
@@ -772,6 +774,18 @@ export default function CaptureScreen() {
         }}
         selectedId={categoryId}
         categories={filteredCategories as PickerCategoryRow[]}
+      />
+
+      <TransferSheet
+        visible={showTransferSheet}
+        allAccounts={accounts}
+        initialFromAccountId={accountId || undefined}
+        onClose={() => setShowTransferSheet(false)}
+        onSuccess={() => {
+          setShowTransferSheet(false);
+          Alert.alert("Listo", "La transferencia se registró correctamente.");
+          router.back();
+        }}
       />
     </View>
   );

--- a/mobile/app/purchase-decision.tsx
+++ b/mobile/app/purchase-decision.tsx
@@ -580,7 +580,7 @@ export default function PurchaseDecisionScreen() {
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Abrir la lista de deseos"
-                  onPress={() => router.push("/(tabs)/deseos" as never)}
+                  onPress={() => router.push("/deseos" as never)}
                   className="items-center py-2"
                 >
                   <Text className="font-inter-semibold text-sm text-z-brass">

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -321,7 +321,7 @@ export default function TransactionDetailScreen() {
       setTransaction({ ...transaction, is_excluded: isExcluded ? 0 : 1 });
     } catch (err) {
       console.error("Toggle exclude error:", err);
-      Alert.alert("Error", "No se pudo actualizar la transaccion.");
+      Alert.alert("Error", "No se pudo actualizar la transacción.");
     }
   };
 
@@ -449,8 +449,8 @@ export default function TransactionDetailScreen() {
   const handleDelete = () => {
     if (!id) return;
     Alert.alert(
-      "Eliminar transaccion",
-      "Esta accion no se puede deshacer.",
+      "Eliminar transacción",
+      "Esta acción no se puede deshacer.",
       [
         { text: "Cancelar", style: "cancel" },
         {
@@ -462,7 +462,7 @@ export default function TransactionDetailScreen() {
               router.back();
             } catch (err) {
               console.error("Delete failed:", err);
-              Alert.alert("Error", "No se pudo eliminar la transaccion.");
+              Alert.alert("Error", "No se pudo eliminar la transacción.");
             }
           },
         },
@@ -497,7 +497,7 @@ export default function TransactionDetailScreen() {
         </View>
         <View className="flex-1 items-center justify-center px-8">
           <Text className="text-muted-fg-50 font-inter text-base">
-            Transaccion no encontrada
+            Transacción no encontrada
           </Text>
         </View>
       </View>
@@ -665,7 +665,7 @@ export default function TransactionDetailScreen() {
                     Abono a deuda
                   </Text>
                   <Text className="font-inter text-xs text-z-brass">
-                    Categoria fija
+                    Categoría fija
                   </Text>
                 </View>
               ) : (
@@ -804,7 +804,7 @@ export default function TransactionDetailScreen() {
               }
             />
             <DetailRow
-              label="Categoria"
+              label="Categoría"
               value={isDebtPayment ? "Abono a deuda" : transaction.category_name_es}
             />
             <DetailRow
@@ -812,9 +812,9 @@ export default function TransactionDetailScreen() {
               value={transaction.destinatario_name ?? "Sin destinatario"}
             />
             <DetailRow label="Estado" value={statusLabel} />
-            <DetailRow label="Descripcion" value={transaction.description} />
+            <DetailRow label="Descripción" value={transaction.description} />
             <DetailRow
-              label="Descripcion original"
+              label="Descripción original"
               value={transaction.raw_description}
             />
             <DetailRow label="Notas" value={transaction.notes} />

--- a/mobile/components/accounts/AccountBalanceCard.tsx
+++ b/mobile/components/accounts/AccountBalanceCard.tsx
@@ -10,10 +10,10 @@ type Props = {
 const ACCOUNT_TYPE_LABELS: Record<string, string> = {
   CHECKING: "Cuenta corriente",
   SAVINGS: "Ahorros",
-  CREDIT_CARD: "Tarjeta de credito",
-  LOAN: "Prestamo",
+  CREDIT_CARD: "Tarjeta de crédito",
+  LOAN: "Préstamo",
   CASH: "Efectivo",
-  INVESTMENT: "Inversion",
+  INVESTMENT: "Inversión",
   OTHER: "Otro",
 };
 
@@ -84,7 +84,7 @@ export function AccountBalanceCard({ account }: Props) {
         <View className="mt-4">
           <View className="flex-row items-center justify-between mb-1.5">
             <Text className="text-muted-foreground font-inter text-xs">
-              Utilizacion de credito
+              Utilización de crédito
             </Text>
             <Text
               className="font-inter-semibold text-xs"

--- a/mobile/components/accounts/PaymentActionSheet.tsx
+++ b/mobile/components/accounts/PaymentActionSheet.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { X } from "lucide-react-native";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import { registerPayment } from "../../lib/repositories/accounts";
+import { isDebtAccountType, LIQUID_ACCOUNT_TYPES } from "../../lib/constants/accounts";
+import { parseLocalizedAmount } from "../../lib/amount";
+import { COLORS } from "../../lib/constants/colors";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
+import {
+  SheetAccountPicker,
+  SheetAmountInput,
+  SheetError,
+  SheetFieldLabel,
+} from "./account-action-sheet-parts";
+
+interface PaymentActionSheetProps {
+  visible: boolean;
+  /** The account being paid (debt account for the common Pagar case). */
+  account: AccountRow;
+  /** All accounts — used to derive the liquid source-account options. */
+  allAccounts: AccountRow[];
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Quick payment sheet → registerPayment. For a debt account it shows a source
+ * (liquid) account picker; the registerPayment INFLOW reduces the debt and the
+ * paired source OUTFLOW deducts the cash. Mirrors PaymentSheet's amount-input +
+ * source-picker + modal styling.
+ */
+export function PaymentActionSheet({
+  visible,
+  account,
+  allAccounts,
+  onClose,
+  onSuccess,
+}: PaymentActionSheetProps) {
+  const currency = (account.currency_code as CurrencyCode) ?? "COP";
+  const isDebt = isDebtAccountType(account.account_type ?? "OTHER");
+
+  const sourceAccounts = useMemo(
+    () =>
+      allAccounts.filter(
+        (a) =>
+          a.id !== account.id &&
+          LIQUID_ACCOUNT_TYPES.has(a.account_type ?? "OTHER") &&
+          a.currency_code === account.currency_code
+      ),
+    [allAccounts, account.id, account.account_type, account.currency_code]
+  );
+
+  const [amountInput, setAmountInput] = useState("");
+  const [selectedSourceId, setSelectedSourceId] = useState<string>("");
+  const [showSourcePicker, setShowSourcePicker] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setAmountInput("");
+      setSelectedSourceId(sourceAccounts[0]?.id ?? "");
+      setShowSourcePicker(false);
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [visible, sourceAccounts]);
+
+  const parsedAmount = parseLocalizedAmount(amountInput);
+  const hasValidAmount = Number.isFinite(parsedAmount) && parsedAmount > 0;
+  // For debt accounts a source account is required (the paired OUTFLOW). For
+  // non-debt accounts (recording income) the source is optional.
+  const sourceOk = !isDebt || selectedSourceId !== "";
+  const canSubmit = hasValidAmount && sourceOk && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await registerPayment(account.id, {
+        amount: parsedAmount,
+        sourceAccountId: selectedSourceId || undefined,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo registrar el pago.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, account.id, parsedAmount, selectedSourceId, onSuccess]);
+
+  const title = isDebt ? "Registrar pago" : "Registrar ingreso";
+
+  return (
+    <MobileSheet visible={visible} onClose={onClose} hideHandle>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <Text className="text-[15px] font-inter-semibold text-foreground">{title}</Text>
+          <Pressable
+            onPress={onClose}
+            className="h-8 w-8 items-center justify-center rounded-full"
+          >
+            <X size={16} color={COLORS.sageLight} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          className="max-h-[80%]"
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Account info */}
+          <View className={`${PANEL_INSET_CLASS} p-3 mb-4`}>
+            <Text className="text-sm font-inter-semibold text-foreground">{account.name}</Text>
+            <Text className="text-[11px] font-inter text-muted-foreground mt-0.5">
+              {isDebt ? "Deuda actual" : "Saldo"}
+              {" · "}
+              {formatCurrency(Math.abs(account.current_balance ?? 0), currency)}
+            </Text>
+          </View>
+
+          {/* Amount */}
+          <SheetFieldLabel>{isDebt ? "Monto a pagar" : "Monto a registrar"}</SheetFieldLabel>
+          <View className="mb-3">
+            <SheetAmountInput value={amountInput} onChangeText={setAmountInput} autoFocus />
+          </View>
+
+          {/* Source account (debt → required) */}
+          {isDebt && (
+            <>
+              <SheetFieldLabel>Cuenta origen</SheetFieldLabel>
+              <SheetAccountPicker
+                accounts={sourceAccounts}
+                selectedId={selectedSourceId}
+                onSelect={(id) => {
+                  setSelectedSourceId(id);
+                  setShowSourcePicker(false);
+                }}
+                open={showSourcePicker}
+                onToggle={() => setShowSourcePicker((v) => !v)}
+              />
+            </>
+          )}
+
+          {/* Summary */}
+          {hasValidAmount && (
+            <View className="flex-row items-center justify-between mt-2 mb-2">
+              <Text className="text-xs font-inter text-muted-foreground">
+                {isDebt ? "Total a pagar" : "Total"}
+              </Text>
+              <Text className="text-base font-inter-bold text-foreground">
+                {formatCurrency(parsedAmount, currency)}
+              </Text>
+            </View>
+          )}
+
+          {error && <SheetError message={error} />}
+
+          <Pressable
+            onPress={handleSubmit}
+            disabled={!canSubmit}
+            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={COLORS.ink} />
+            ) : (
+              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+                {isDebt ? "Confirmar pago" : "Registrar"}
+              </Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={onClose} className="items-center py-2">
+            <Text className="text-sm font-inter-medium text-muted-foreground">Cancelar</Text>
+          </Pressable>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </MobileSheet>
+  );
+}

--- a/mobile/components/accounts/PaymentActionSheet.tsx
+++ b/mobile/components/accounts/PaymentActionSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -66,14 +66,23 @@ export function PaymentActionSheet({
   const [showSourcePicker, setShowSourcePicker] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hasInitializedRef = useRef(false);
 
+  // Initialize once per open. `sourceAccounts` stays in deps for exhaustive-deps,
+  // but the ref guard prevents a background account reload from wiping the user's
+  // in-progress amount/source selection while the sheet is open.
   useEffect(() => {
     if (visible) {
-      setAmountInput("");
-      setSelectedSourceId(sourceAccounts[0]?.id ?? "");
-      setShowSourcePicker(false);
-      setSubmitting(false);
-      setError(null);
+      if (!hasInitializedRef.current) {
+        setAmountInput("");
+        setSelectedSourceId(sourceAccounts[0]?.id ?? "");
+        setShowSourcePicker(false);
+        setSubmitting(false);
+        setError(null);
+        hasInitializedRef.current = true;
+      }
+    } else {
+      hasInitializedRef.current = false;
     }
   }, [visible, sourceAccounts]);
 

--- a/mobile/components/accounts/QuickActionsBar.tsx
+++ b/mobile/components/accounts/QuickActionsBar.tsx
@@ -86,24 +86,26 @@ type Props = {
   account: AccountRow;
   onEdit: () => void;
   onDelete: () => void;
+  /** Open the payment sheet (registerPayment). */
+  onPayment?: () => void;
+  /** Open the transfer sheet (createTransfer). */
+  onTransfer?: () => void;
+  /** Open the reconcile sheet (reconcileBalance). */
+  onReconcile?: () => void;
 };
 
-const STUB_MESSAGES: Record<string, string> = {
-  payment: "Pagos desde la cuenta llegarán pronto. Por ahora usa 'Agregar' para registrar una transacción.",
-  transfer: "Transferencias entre cuentas llegarán pronto. Por ahora usa 'Agregar' en cada cuenta.",
-  reconcile: "Ajuste de saldo llegará pronto. Por ahora edita la cuenta para corregir el balance manualmente.",
-};
-
-export function QuickActionsBar({ account, onEdit, onDelete }: Props) {
+export function QuickActionsBar({
+  account,
+  onEdit,
+  onDelete,
+  onPayment,
+  onTransfer,
+  onReconcile,
+}: Props) {
   const router = useRouter();
   const accountType = account.account_type ?? "OTHER";
   const accountId = account.id;
   const actions = getActionsForType(accountType);
-
-  function handleStub(type: ActionType) {
-    const msg = STUB_MESSAGES[type];
-    if (msg) Alert.alert("Próximamente", msg);
-  }
 
   function handleMore() {
     Alert.alert("Más opciones", undefined, [
@@ -124,9 +126,13 @@ export function QuickActionsBar({ account, onEdit, onDelete }: Props) {
         handleMore();
         return;
       case "payment":
+        onPayment?.();
+        return;
       case "transfer":
+        onTransfer?.();
+        return;
       case "reconcile":
-        handleStub(action.type);
+        onReconcile?.();
         return;
     }
   }

--- a/mobile/components/accounts/ReconcileSheet.tsx
+++ b/mobile/components/accounts/ReconcileSheet.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { X } from "lucide-react-native";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import { reconcileBalance } from "../../lib/repositories/accounts";
+import { isDebtAccountType } from "../../lib/constants/accounts";
+import { parseLocalizedAmount } from "../../lib/amount";
+import { COLORS } from "../../lib/constants/colors";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
+import {
+  SheetAmountInput,
+  SheetError,
+  SheetFieldLabel,
+} from "./account-action-sheet-parts";
+
+interface ReconcileSheetProps {
+  visible: boolean;
+  account: AccountRow;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Reconcile sheet → reconcileBalance (OVERWRITE). The user enters the real
+ * current balance; reconcileBalance writes the balance directly + records the
+ * adjustment transaction. Pre-fills the current balance.
+ */
+export function ReconcileSheet({ visible, account, onClose, onSuccess }: ReconcileSheetProps) {
+  const currency = (account.currency_code as CurrencyCode) ?? "COP";
+  const isDebt = isDebtAccountType(account.account_type ?? "OTHER");
+  const currentBalance = Math.abs(account.current_balance ?? 0);
+
+  const [amountInput, setAmountInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      // Pre-fill with the current balance (no thousands grouping — the numeric
+      // keypad + parseLocalizedAmount accept a plain integer).
+      setAmountInput(currentBalance ? String(Math.round(currentBalance)) : "");
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [visible, currentBalance]);
+
+  const parsedAmount = parseLocalizedAmount(amountInput);
+  const hasValidAmount = Number.isFinite(parsedAmount) && parsedAmount >= 0;
+  const canSubmit = hasValidAmount && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await reconcileBalance(account.id, { currentBalance: parsedAmount });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo ajustar el saldo.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, account.id, parsedAmount, onSuccess]);
+
+  return (
+    <MobileSheet visible={visible} onClose={onClose} hideHandle>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <Text className="text-[15px] font-inter-semibold text-foreground">Ajustar saldo</Text>
+          <Pressable
+            onPress={onClose}
+            className="h-8 w-8 items-center justify-center rounded-full"
+          >
+            <X size={16} color={COLORS.sageLight} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          className="max-h-[80%]"
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Account info */}
+          <View className={`${PANEL_INSET_CLASS} p-3 mb-4`}>
+            <Text className="text-sm font-inter-semibold text-foreground">{account.name}</Text>
+            <Text className="text-[11px] font-inter text-muted-foreground mt-0.5">
+              {isDebt ? "Deuda actual" : "Saldo actual"}
+              {" · "}
+              {formatCurrency(currentBalance, currency)}
+            </Text>
+          </View>
+
+          <SheetFieldLabel>{isDebt ? "Deuda real" : "Saldo real"}</SheetFieldLabel>
+          <View className="mb-2">
+            <SheetAmountInput value={amountInput} onChangeText={setAmountInput} autoFocus />
+          </View>
+          <Text className="text-[11px] font-inter text-muted-foreground mb-3">
+            Registramos un ajuste por la diferencia y dejamos el saldo en el valor que ingreses.
+          </Text>
+
+          {error && <SheetError message={error} />}
+
+          <Pressable
+            onPress={handleSubmit}
+            disabled={!canSubmit}
+            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={COLORS.ink} />
+            ) : (
+              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+                Guardar ajuste
+              </Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={onClose} className="items-center py-2">
+            <Text className="text-sm font-inter-medium text-muted-foreground">Cancelar</Text>
+          </Pressable>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </MobileSheet>
+  );
+}

--- a/mobile/components/accounts/TransferSheet.tsx
+++ b/mobile/components/accounts/TransferSheet.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { X } from "lucide-react-native";
+import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import { createTransfer } from "../../lib/repositories/transfers";
+import { parseLocalizedAmount } from "../../lib/amount";
+import { toLocalDateString } from "../../lib/utils/date";
+import { COLORS } from "../../lib/constants/colors";
+import { MobileSheet } from "../ui/MobileSheet";
+import {
+  SheetAccountPicker,
+  SheetAmountInput,
+  SheetError,
+  SheetFieldLabel,
+} from "./account-action-sheet-parts";
+
+interface TransferSheetProps {
+  visible: boolean;
+  allAccounts: AccountRow[];
+  /** Optional pre-selected origin account. */
+  initialFromAccountId?: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Transfer sheet → createTransfer. From-account picker + to-account picker
+ * (filtered to the same currency — createTransfer hard-rejects cross-currency)
+ * + amount. Mirrors PaymentSheet's picker + amount-input styling.
+ */
+export function TransferSheet({
+  visible,
+  allAccounts,
+  initialFromAccountId,
+  onClose,
+  onSuccess,
+}: TransferSheetProps) {
+  const [fromId, setFromId] = useState<string>(initialFromAccountId ?? allAccounts[0]?.id ?? "");
+  const [toId, setToId] = useState<string>("");
+  const [amountInput, setAmountInput] = useState("");
+  const [showFromPicker, setShowFromPicker] = useState(false);
+  const [showToPicker, setShowToPicker] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setFromId(initialFromAccountId ?? allAccounts[0]?.id ?? "");
+      setToId("");
+      setAmountInput("");
+      setShowFromPicker(false);
+      setShowToPicker(false);
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [visible, initialFromAccountId, allAccounts]);
+
+  const fromAccount = useMemo(
+    () => allAccounts.find((a) => a.id === fromId) ?? null,
+    [allAccounts, fromId]
+  );
+  const currency = (fromAccount?.currency_code as CurrencyCode) ?? "COP";
+
+  // Destination accounts: any account except the origin, same currency only
+  // (createTransfer rejects cross-currency).
+  const toAccounts = useMemo(
+    () =>
+      allAccounts.filter(
+        (a) => a.id !== fromId && a.currency_code === fromAccount?.currency_code
+      ),
+    [allAccounts, fromId, fromAccount?.currency_code]
+  );
+
+  const parsedAmount = parseLocalizedAmount(amountInput);
+  const hasValidAmount = Number.isFinite(parsedAmount) && parsedAmount > 0;
+  const canSubmit = !!fromId && !!toId && hasValidAmount && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await createTransfer({
+        fromAccountId: fromId,
+        toAccountId: toId,
+        amount: parsedAmount,
+        date: toLocalDateString(),
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo registrar la transferencia.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, fromId, toId, parsedAmount, onSuccess]);
+
+  return (
+    <MobileSheet visible={visible} onClose={onClose} hideHandle>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <Text className="text-[15px] font-inter-semibold text-foreground">
+            Nueva transferencia
+          </Text>
+          <Pressable
+            onPress={onClose}
+            className="h-8 w-8 items-center justify-center rounded-full"
+          >
+            <X size={16} color={COLORS.sageLight} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          className="max-h-[80%]"
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* From */}
+          <SheetFieldLabel>Desde</SheetFieldLabel>
+          <SheetAccountPicker
+            accounts={allAccounts}
+            selectedId={fromId}
+            onSelect={(id) => {
+              setFromId(id);
+              // Origin changed → destination currency filter changes; reset to.
+              setToId("");
+              setShowFromPicker(false);
+            }}
+            open={showFromPicker}
+            onToggle={() => setShowFromPicker((v) => !v)}
+          />
+
+          {/* To */}
+          <SheetFieldLabel>Hacia</SheetFieldLabel>
+          <SheetAccountPicker
+            accounts={toAccounts}
+            selectedId={toId}
+            onSelect={(id) => {
+              setToId(id);
+              setShowToPicker(false);
+            }}
+            open={showToPicker}
+            onToggle={() => setShowToPicker((v) => !v)}
+            placeholder="Seleccionar cuenta destino"
+          />
+
+          {/* Amount */}
+          <SheetFieldLabel>Monto</SheetFieldLabel>
+          <View className="mb-3">
+            <SheetAmountInput value={amountInput} onChangeText={setAmountInput} />
+          </View>
+
+          {/* Summary */}
+          {hasValidAmount && (
+            <View className="flex-row items-center justify-between mt-1 mb-2">
+              <Text className="text-xs font-inter text-muted-foreground">Total a transferir</Text>
+              <Text className="text-base font-inter-bold text-foreground">
+                {formatCurrency(parsedAmount, currency)}
+              </Text>
+            </View>
+          )}
+
+          {error && <SheetError message={error} />}
+
+          <Pressable
+            onPress={handleSubmit}
+            disabled={!canSubmit}
+            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={COLORS.ink} />
+            ) : (
+              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+                Confirmar transferencia
+              </Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={onClose} className="items-center py-2">
+            <Text className="text-sm font-inter-medium text-muted-foreground">Cancelar</Text>
+          </Pressable>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </MobileSheet>
+  );
+}

--- a/mobile/components/accounts/TransferSheet.tsx
+++ b/mobile/components/accounts/TransferSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -51,16 +51,24 @@ export function TransferSheet({
   const [showToPicker, setShowToPicker] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hasInitializedRef = useRef(false);
 
+  // Initialize once per open; the ref guard keeps a background account reload
+  // from wiping in-progress selections/input while the sheet is open.
   useEffect(() => {
     if (visible) {
-      setFromId(initialFromAccountId ?? allAccounts[0]?.id ?? "");
-      setToId("");
-      setAmountInput("");
-      setShowFromPicker(false);
-      setShowToPicker(false);
-      setSubmitting(false);
-      setError(null);
+      if (!hasInitializedRef.current) {
+        setFromId(initialFromAccountId ?? allAccounts[0]?.id ?? "");
+        setToId("");
+        setAmountInput("");
+        setShowFromPicker(false);
+        setShowToPicker(false);
+        setSubmitting(false);
+        setError(null);
+        hasInitializedRef.current = true;
+      }
+    } else {
+      hasInitializedRef.current = false;
     }
   }, [visible, initialFromAccountId, allAccounts]);
 

--- a/mobile/components/accounts/account-action-sheet-parts.tsx
+++ b/mobile/components/accounts/account-action-sheet-parts.tsx
@@ -1,0 +1,119 @@
+import { Check, ChevronDown } from "lucide-react-native";
+import { Pressable, Text, TextInput, View } from "react-native";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import { COLORS } from "../../lib/constants/colors";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+
+/**
+ * Shared building blocks for the account action sheets (Pagar / Transferir /
+ * Ajustar). Mirror PaymentSheet.tsx's source-picker + amount-input patterns so
+ * every sheet looks and behaves identically.
+ */
+
+/** Section eyebrow label used inside the sheets. */
+export function SheetFieldLabel({ children }: { children: string }) {
+  return (
+    <Text className="text-xs font-inter-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+      {children}
+    </Text>
+  );
+}
+
+/** Localized amount text input — mirrors PaymentSheet's custom-amount field. */
+export function SheetAmountInput({
+  value,
+  onChangeText,
+  autoFocus,
+  placeholder = "Ej: 150.000",
+}: {
+  value: string;
+  onChangeText: (next: string) => void;
+  autoFocus?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <TextInput
+      className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-sm font-inter-medium text-foreground"
+      placeholderTextColor={COLORS.sageDark}
+      placeholder={placeholder}
+      keyboardType="numeric"
+      value={value}
+      onChangeText={onChangeText}
+      autoFocus={autoFocus}
+    />
+  );
+}
+
+/**
+ * Collapsible account picker — mirrors PaymentSheet's source-account accordion.
+ * `accounts` is the already-filtered list of selectable accounts.
+ */
+export function SheetAccountPicker({
+  accounts,
+  selectedId,
+  onSelect,
+  open,
+  onToggle,
+  placeholder = "Seleccionar cuenta",
+}: {
+  accounts: AccountRow[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+  open: boolean;
+  onToggle: () => void;
+  placeholder?: string;
+}) {
+  const selected = accounts.find((a) => a.id === selectedId);
+  return (
+    <>
+      <Pressable
+        onPress={onToggle}
+        className={`${PANEL_INSET_CLASS} flex-row items-center justify-between px-3 py-2.5 mb-1`}
+      >
+        <Text className="text-sm font-inter-medium text-foreground" numberOfLines={1}>
+          {selected?.name ?? placeholder}
+        </Text>
+        <ChevronDown
+          size={14}
+          color={COLORS.sageDark}
+          style={{ transform: [{ rotate: open ? "180deg" : "0deg" }] }}
+        />
+      </Pressable>
+
+      {open && (
+        <View className={`${PANEL_INSET_CLASS} overflow-hidden mb-3`}>
+          {accounts.map((acc, i) => (
+            <Pressable
+              key={acc.id}
+              onPress={() => onSelect(acc.id)}
+              className={`flex-row items-center justify-between px-3 py-2.5 active:bg-z-surface-2/5 ${
+                i > 0 ? "border-t border-white-6" : ""
+              }`}
+            >
+              <Text className="text-[13px] font-inter-medium text-foreground" numberOfLines={1}>
+                {acc.name}
+              </Text>
+              {acc.id === selectedId && <Check size={14} color={COLORS.income} />}
+            </Pressable>
+          ))}
+          {accounts.length === 0 && (
+            <View className="px-3 py-3">
+              <Text className="text-[12px] font-inter text-muted-foreground">
+                No hay cuentas disponibles
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
+    </>
+  );
+}
+
+/** Inline error banner — mirrors PaymentSheet's error surface. */
+export function SheetError({ message }: { message: string }) {
+  return (
+    <View className="rounded-xl bg-z-debt/10 px-3 py-2 mb-2">
+      <Text className="text-xs font-inter-medium text-z-debt">{message}</Text>
+    </View>
+  );
+}

--- a/mobile/components/categories/CategoriesRoot.tsx
+++ b/mobile/components/categories/CategoriesRoot.tsx
@@ -297,12 +297,12 @@ export function CategoriesRoot() {
     <View className="flex-1 bg-background">
       <MobileHeader
         variant="sub"
-        title="Categorias"
+        title="Categorías"
         action={
           <Pressable
             onPress={handleCreate}
             className="h-8 w-8 items-center justify-center rounded-full"
-            accessibilityLabel="Nueva categoria"
+            accessibilityLabel="Nueva categoría"
           >
             <Plus size={16} color={COLORS.brass} />
           </Pressable>
@@ -374,10 +374,10 @@ export function CategoriesRoot() {
               <Grid3X3 size={24} color={COLORS.brass} />
             </View>
             <Text className="text-[13px] font-inter-medium text-foreground mb-1">
-              Sin categorias
+              Sin categorías
             </Text>
             <Text className="text-[11px] font-inter text-muted-foreground text-center px-8">
-              Las categorias se sincronizaran cuando te conectes
+              Las categorías se sincronizarán cuando te conectes
             </Text>
           </View>
         )}

--- a/mobile/components/categories/CategoryFormSheet.tsx
+++ b/mobile/components/categories/CategoryFormSheet.tsx
@@ -89,7 +89,7 @@ export function CategoryFormSheet({
   const handleDelete = useCallback(() => {
     if (!category || !onDelete) return;
     Alert.alert(
-      "Eliminar categoria",
+      "Eliminar categoría",
       `Seguro que quieres eliminar "${category.name_es ?? category.name}"?`,
       [
         { text: "Cancelar", style: "cancel" },
@@ -117,7 +117,7 @@ export function CategoryFormSheet({
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
             <Text className="text-[15px] font-inter-semibold text-foreground">
-              {isEditing ? "Editar categoria" : "Nueva categoria"}
+              {isEditing ? "Editar categoría" : "Nueva categoría"}
             </Text>
             <Pressable
               onPress={onClose}
@@ -156,7 +156,7 @@ export function CategoryFormSheet({
             {/* Parent category picker */}
             <View>
               <Text className="text-[11px] font-inter-semibold text-z-sage-dark uppercase tracking-[2px] mb-1.5">
-                Categoria padre (opcional)
+                Categoría padre (opcional)
               </Text>
               <Pressable
                 onPress={() => setParentPickerOpen(!parentPickerOpen)}
@@ -268,7 +268,7 @@ export function CategoryFormSheet({
                 }`}
               >
                 <Text className="text-[13px] font-inter-semibold text-z-ink">
-                  {isEditing ? "Guardar cambios" : "Crear categoria"}
+                  {isEditing ? "Guardar cambios" : "Crear categoría"}
                 </Text>
               </Pressable>
 
@@ -279,7 +279,7 @@ export function CategoryFormSheet({
                 >
                   <Trash2 size={14} color="#E05545" />
                   <Text className="text-[13px] font-inter-semibold text-z-expense">
-                    Eliminar categoria
+                    Eliminar categoría
                   </Text>
                 </Pressable>
               )}

--- a/mobile/components/categorizar/CategorizarRoot.tsx
+++ b/mobile/components/categorizar/CategorizarRoot.tsx
@@ -123,8 +123,8 @@ export function CategorizarRoot() {
             </Text>
             <Text className="text-[11px] font-inter text-muted-foreground">
               {transactions.length === 1
-                ? "transaccion sin categoria"
-                : "transacciones sin categoria"}
+                ? "transacción sin categoría"
+                : "transacciones sin categoría"}
             </Text>
           </View>
         </MCard>

--- a/mobile/components/categorizar/CategoryPickerSheet.tsx
+++ b/mobile/components/categorizar/CategoryPickerSheet.tsx
@@ -81,7 +81,7 @@ export function CategoryPickerSheet({
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
             <Text className="text-[15px] font-inter-semibold text-foreground">
-              Elegir categoria
+              Elegir categoría
             </Text>
             <Pressable
               onPress={onClose}

--- a/mobile/components/categorizar/UncategorizedRow.tsx
+++ b/mobile/components/categorizar/UncategorizedRow.tsx
@@ -13,7 +13,7 @@ export function UncategorizedRow({
   transaction: tx,
   onAssign,
 }: UncategorizedRowProps) {
-  const description = tx.merchant_name ?? tx.description ?? "Sin descripcion";
+  const description = tx.merchant_name ?? tx.description ?? "Sin descripción";
   const isInflow = tx.direction === "INFLOW";
 
   return (
@@ -61,7 +61,7 @@ export function UncategorizedRow({
       <Pressable
         onPress={() => onAssign(tx.id)}
         className="flex-row items-center gap-1 rounded-lg border border-z-brass-20 bg-z-brass-8 px-2 py-1 active:bg-z-brass-15"
-        accessibilityLabel={`Asignar categoria a ${description}`}
+        accessibilityLabel={`Asignar categoría a ${description}`}
       >
         <Tag size={10} color={COLORS.brass} />
         <Text className="text-[10px] font-inter-semibold text-z-brass">

--- a/mobile/components/common/BiometricLockScreen.tsx
+++ b/mobile/components/common/BiometricLockScreen.tsx
@@ -45,7 +45,7 @@ export function BiometricLockScreen({
 
         <Pressable onPress={onFallback} className="px-4 py-2">
           <Text className="text-sm font-inter-medium text-muted-foreground">
-            Usar contrasena
+            Usar contraseña
           </Text>
         </Pressable>
       </View>

--- a/mobile/components/dashboard/CategoryBreakdown.tsx
+++ b/mobile/components/dashboard/CategoryBreakdown.tsx
@@ -22,7 +22,7 @@ export function CategoryBreakdown({
   return (
     <View className="bg-z-surface-2-55 rounded-lg p-4 mx-4 mt-4 mb-6">
       <Text className="text-foreground font-inter-bold text-base mb-4">
-        Gastos por categoria
+        Gastos por categoría
       </Text>
 
       {categories.length === 0 ? (
@@ -46,7 +46,7 @@ export function CategoryBreakdown({
                     className="text-foreground font-inter-medium text-sm"
                     numberOfLines={1}
                   >
-                    {cat.category_name_es || "Sin categoria"}
+                    {cat.category_name_es || "Sin categoría"}
                   </Text>
                 </View>
                 <Text className="text-foreground font-inter-semibold text-sm ml-2">

--- a/mobile/components/destinatarios/DestinatarioDetail.tsx
+++ b/mobile/components/destinatarios/DestinatarioDetail.tsx
@@ -137,7 +137,10 @@ export function DestinatarioDetail({ id }: DestinatarioDetailProps) {
             <View className="flex-row items-center gap-1.5 pt-2">
               <FileText size={12} color={COLORS.sageDark} />
               <Text className="text-[11px] font-inter text-muted-foreground">
-                {destinatario?.transaction_count ?? 0} transacciones
+                {destinatario?.transaction_count ?? 0}{" "}
+                {(destinatario?.transaction_count ?? 0) === 1
+                  ? "transacción"
+                  : "transacciones"}
               </Text>
             </View>
           </View>
@@ -204,7 +207,7 @@ export function DestinatarioDetail({ id }: DestinatarioDetailProps) {
               {transactions.map((tx, idx) => {
                 const isInflow = tx.direction === "INFLOW";
                 const label =
-                  tx.merchant_name ?? tx.description ?? "Sin descripcion";
+                  tx.merchant_name ?? tx.description ?? "Sin descripción";
 
                 return (
                   <MListRow

--- a/mobile/components/destinatarios/DestinatariosRoot.tsx
+++ b/mobile/components/destinatarios/DestinatariosRoot.tsx
@@ -118,8 +118,8 @@ export function DestinatariosRoot() {
             </Text>
             <Text className="text-[11px] font-inter text-muted-foreground text-center px-8">
               {searchQuery.trim()
-                ? "No se encontraron resultados para tu busqueda"
-                : "Los destinatarios se crean automaticamente al importar transacciones"}
+                ? "No se encontraron resultados para tu búsqueda"
+                : "Los destinatarios se crean automáticamente al importar transacciones"}
             </Text>
           </View>
         ) : (

--- a/mobile/components/deudas/DeudasAccountsAccordion.tsx
+++ b/mobile/components/deudas/DeudasAccountsAccordion.tsx
@@ -41,7 +41,7 @@ export function DeudasAccountsAccordion({
                     {account.name}
                   </Text>
                   <Text className="text-[10px] font-inter text-muted-foreground">
-                    {account.type === "CREDIT_CARD" ? "Tarjeta de credito" : "Prestamo"} · {account.interestRate}% EA
+                    {account.type === "CREDIT_CARD" ? "Tarjeta de crédito" : "Préstamo"} · {account.interestRate}% EA
                   </Text>
                 </View>
                 <View className="items-end">

--- a/mobile/components/deudas/DeudasGrid.tsx
+++ b/mobile/components/deudas/DeudasGrid.tsx
@@ -31,7 +31,7 @@ export function DeudasGrid({
           percentage={overallUtilization}
           color={utilizationColor}
           size={56}
-          label="Utilizacion"
+          label="Utilización"
         />
 
         <View className="items-center justify-center">

--- a/mobile/components/deudas/DeudasHero.tsx
+++ b/mobile/components/deudas/DeudasHero.tsx
@@ -53,7 +53,7 @@ export function DeudasHero({
                     {a.name}
                   </Text>
                   <Text className="text-[10px] font-inter text-muted-foreground">
-                    {a.type === "CREDIT_CARD" ? "Tarjeta" : "Prestamo"} · {a.interestRate}% EA
+                    {a.type === "CREDIT_CARD" ? "Tarjeta" : "Préstamo"} · {a.interestRate}% EA
                   </Text>
                 </View>
                 <Text className="text-xs font-inter-semibold text-foreground">

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -11,84 +11,23 @@ import {
   View,
 } from "react-native";
 import { Check, ChevronDown, X, Link2 } from "lucide-react-native";
-import * as Crypto from "expo-crypto";
 import {
-  applyAccountBalanceDelta,
-  computeIdempotencyKey,
   formatCurrency,
   formatDate,
   type CurrencyCode,
-  type TransactionDirection,
 } from "@zeta/shared";
 import { supabase } from "../../lib/supabase";
 import { useAuth } from "../../lib/auth";
 import { COLORS } from "../../lib/constants/colors";
 import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
-import { toLocalDateString, toLocalMonthString } from "../../lib/utils/date";
+import { getDatabase } from "../../lib/db/database";
+import { toLocalMonthString } from "../../lib/utils/date";
 import { parseLocalizedAmount } from "../../lib/amount";
 import { isDebtAccountType } from "../../lib/constants/accounts";
 import { markEntryCompleted } from "../../lib/repositories/planning";
+import { registerPayment } from "../../lib/repositories/accounts";
+import { recordRecurringOccurrencePayment } from "../../lib/repositories/recurring";
 import { computeRecurringGroupUuid } from "../../lib/utils/recurring-group";
-
-const expoHashFn = (payload: string) =>
-  Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, payload);
-
-async function buildIdempotencyKey(params: {
-  txId: string;
-  date: string;
-  amount: number;
-  description: string;
-}): Promise<string> {
-  // Mirrors webapp `cashflow-planner.ts:1283-1292`: same provider name and
-  // providerTransactionId so SHA-256 hash matches across platforms and the
-  // UNIQUE constraint dedups consistently.
-  return computeIdempotencyKey(
-    {
-      provider: "MANUAL_FORM",
-      providerTransactionId: params.txId,
-      transactionDate: params.date,
-      amount: params.amount,
-      rawDescription: params.description,
-    },
-    expoHashFn,
-  );
-}
-
-// Updates accounts.current_balance on Supabase to keep the webapp + dashboard
-// in sync immediately. Local SQLite reconciles on the next pull.
-// Throws on fetch/update errors so the caller's try/catch can surface the
-// failure — silent failure would leave the transaction recorded with the
-// account balance still stale.
-async function updateAccountBalanceRemote(params: {
-  accountId: string;
-  userId: string;
-  direction: TransactionDirection;
-  amount: number;
-}): Promise<void> {
-  const sb = supabase as any;
-  const { data: acct, error: fetchErr } = await sb
-    .from("accounts")
-    .select("current_balance, account_type")
-    .eq("id", params.accountId)
-    .eq("user_id", params.userId)
-    .single();
-  if (fetchErr) throw new Error(fetchErr.message);
-  if (!acct) throw new Error("Cuenta no encontrada");
-
-  const newBalance = applyAccountBalanceDelta({
-    currentBalance: acct.current_balance,
-    accountType: acct.account_type,
-    direction: params.direction,
-    amount: params.amount,
-  });
-
-  const { error: updateErr } = await sb
-    .from("accounts")
-    .update({ current_balance: newBalance })
-    .eq("id", params.accountId)
-    .eq("user_id", params.userId);
-  if (updateErr) throw new Error(updateErr.message);
-}
 
 // ── Types ──
 
@@ -162,7 +101,6 @@ export function PaymentSheet({
   // Search for candidate transactions when sheet opens
   useEffect(() => {
     if (!visible || !session?.user?.id) return;
-    let cancelled = false;
 
     setMode("loading");
     setCandidates([]);
@@ -339,13 +277,19 @@ export function PaymentSheet({
       handleClose();
       onSuccess();
     } catch (err: any) {
-      setError(err?.message ?? "Error al vincular transaccion");
+      setError(err?.message ?? "Error al vincular transacción");
     } finally {
       setSubmitting(false);
     }
   }, [selectedCandidateId, session?.user?.id, entry, handleClose, onSuccess]);
 
   // ── Create new transaction ──
+  // Routes through the offline-first ledger repos (NOT direct Supabase inserts),
+  // so balances clamp at 0, debt available_balance recomputes, and the writes go
+  // through local SQLite + sync_queue:
+  //   · entry has a recurring template → recordRecurringOccurrencePayment
+  //     (real tx[s] + balance + occurrence paid-link + payoff lifecycle).
+  //   · debt account, no template → registerPayment (INFLOW + paired source OUTFLOW).
   const handleCreatePayment = useCallback(async () => {
     if (!canSubmit || !session?.user?.id || resolvedAmount == null) return;
 
@@ -353,152 +297,53 @@ export function PaymentSheet({
     setError(null);
 
     try {
-      const userId = session.user.id;
-      const today = toLocalDateString();
-      const outflowTxId = Crypto.randomUUID();
-      const transferGroupId = debtAccount ? Crypto.randomUUID() : null;
-      const sb = supabase as any;
-      // OUTFLOW shows the entry label in the source ledger ("Netflix"),
-      // INFLOW on the debt account shows "Pago: Netflix". Mirrors webapp
-      // `cashflow-planner.ts:1305-1306` (OUTFLOW) and `:1366-1367` (INFLOW).
-      const outflowDescription = entry.label;
-      const inflowDescription = `Pago: ${entry.label}`;
-
-      // Resolve the matching occurrence up-front so we can stamp
-      // recurrence_group_id on the inserted transactions (mirrors webapp).
-      let occurrenceRow: { id: string; occurrence_date: string } | null = null;
-      let recurrenceGroupId: string | null = null;
       if (entry.recurring_template_id) {
+        // Resolve the matching local pending occurrence so we can pass the
+        // race-free occurrenceId. Fall back to entry.expected_date if the local
+        // occurrence hasn't been pulled yet — the repo tolerates a missing row.
+        const db = await getDatabase();
         const monthPrefix = toLocalMonthString() + "%";
-        const { data: occurrences } = await sb
-          .from("recurring_occurrences")
-          .select("id, occurrence_date")
-          .eq("template_id", entry.recurring_template_id)
-          .eq("user_id", userId)
-          .eq("status", "pending")
-          .like("occurrence_date", monthPrefix)
-          .order("occurrence_date", { ascending: true })
-          .limit(1);
-        if (occurrences && occurrences.length > 0) {
-          const occ = occurrences[0];
-          occurrenceRow = occ;
-          recurrenceGroupId = await computeRecurringGroupUuid(
-            entry.recurring_template_id,
-            occ.occurrence_date,
-          );
+        const occ = await db.getFirstAsync<{ id: string; occurrence_date: string }>(
+          `SELECT id, occurrence_date FROM recurring_occurrences
+           WHERE template_id = ? AND status = 'pending' AND occurrence_date LIKE ?
+           ORDER BY occurrence_date ASC LIMIT 1`,
+          [entry.recurring_template_id, monthPrefix],
+        );
+
+        const result = await recordRecurringOccurrencePayment({
+          templateId: entry.recurring_template_id,
+          occurrenceId: occ?.id,
+          occurrenceDate: occ?.occurrence_date ?? entry.expected_date,
+          actualAmount: resolvedAmount,
+          sourceAccountId: selectedSourceId || undefined,
+        });
+        if (!result.success) {
+          setError(result.error);
+          return;
         }
-      }
-
-      // 1. OUTFLOW from source
-      const outflowKey = await buildIdempotencyKey({
-        txId: outflowTxId,
-        date: today,
-        amount: resolvedAmount,
-        description: outflowDescription,
-      });
-      const { error: outflowErr } = await sb
-        .from("transactions")
-        .insert({
-          id: outflowTxId,
-          user_id: userId,
-          account_id: selectedSourceId,
+      } else if (debtAccount) {
+        // Debt payment with no recurring template — single INFLOW on the debt
+        // account + paired source OUTFLOW.
+        const result = await registerPayment(debtAccount.id, {
           amount: resolvedAmount,
-          currency_code: entry.currency_code,
-          direction: "OUTFLOW",
-          transaction_date: today,
-          raw_description: outflowDescription,
-          clean_description: outflowDescription,
-          merchant_name: entry.label,
-          capture_method: "MANUAL_FORM",
-          category_id: entry.category_id,
-          transfer_group_id: transferGroupId,
-          idempotency_key: outflowKey,
-          is_recurring: !!entry.recurring_template_id,
-          recurrence_group_id: recurrenceGroupId,
+          sourceAccountId: selectedSourceId || undefined,
         });
-
-      if (outflowErr && !outflowErr.message?.includes("23505")) {
-        throw new Error(outflowErr.message);
-      }
-
-      // 2. INFLOW on debt account
-      if (debtAccount && transferGroupId) {
-        const inflowTxId = Crypto.randomUUID();
-        const inflowKey = await buildIdempotencyKey({
-          txId: inflowTxId,
-          date: today,
-          amount: resolvedAmount,
-          description: inflowDescription,
-        });
-        const { error: inflowErr } = await sb
-          .from("transactions")
-          .insert({
-            id: inflowTxId,
-            user_id: userId,
-            account_id: debtAccount.id,
-            amount: resolvedAmount,
-            currency_code: entry.currency_code,
-            direction: "INFLOW",
-            transaction_date: today,
-            raw_description: inflowDescription,
-            clean_description: inflowDescription,
-            merchant_name: entry.label,
-            capture_method: "MANUAL_FORM",
-            category_id: entry.category_id,
-            transfer_group_id: transferGroupId,
-            idempotency_key: inflowKey,
-            is_recurring: !!entry.recurring_template_id,
-            recurrence_group_id: recurrenceGroupId,
-          });
-        if (inflowErr && !inflowErr.message?.includes("23505")) {
-          throw new Error(inflowErr.message);
+        if (!result.success) {
+          setError(result.error);
+          return;
         }
+      } else {
+        setError("No se pudo determinar el destino del pago.");
+        return;
       }
 
-      // 3. Link to recurring occurrence (only after the OUTFLOW persisted).
-      if (occurrenceRow) {
-        const { error: occErr } = await sb
-          .from("recurring_occurrences")
-          .update({
-            status: "paid",
-            transaction_id: outflowTxId,
-            paid_at: new Date().toISOString(),
-          })
-          .eq("id", occurrenceRow.id)
-          .eq("user_id", userId);
-        if (occErr) throw new Error(occErr.message);
-      }
-
-      // 4. Update account balances on Supabase so the webapp reflects the
-      // payment immediately. Local SQLite reconciles on the next pull.
-      await updateAccountBalanceRemote({
-        accountId: selectedSourceId,
-        userId,
-        direction: "OUTFLOW",
-        amount: resolvedAmount,
-      });
-      if (debtAccount) {
-        await updateAccountBalanceRemote({
-          accountId: debtAccount.id,
-          userId,
-          direction: "INFLOW",
-          amount: resolvedAmount,
-        });
-      }
-
-      // 5. Mark planning entry COMPLETED (local + enqueued)
+      // Mark planning entry COMPLETED (local + enqueued).
       await markEntryCompleted(entry.id);
 
       handleClose();
       onSuccess();
     } catch (err: any) {
-      const msg = err?.message ?? "Error al registrar el pago";
-      if (msg.includes("23505") || msg.includes("duplicate")) {
-        handleClose();
-        onSuccess();
-        return;
-      }
-      setError(msg);
+      setError(err?.message ?? "Error al registrar el pago");
     } finally {
       setSubmitting(false);
     }
@@ -559,7 +404,7 @@ export function PaymentSheet({
                     ¿Ya hiciste este pago?
                   </Text>
                   <Text className="text-[11px] font-inter text-muted-fg-50 mb-3">
-                    Encontramos transacciones que podrian ser este pago. Selecciona una para vincularla.
+                    Encontramos transacciones que podrían ser este pago. Selecciona una para vincularla.
                   </Text>
 
                   {candidates.map((tx) => {
@@ -611,7 +456,7 @@ export function PaymentSheet({
                       <>
                         <Link2 size={14} color={COLORS.ink} />
                         <Text className={`text-sm font-inter-semibold ${selectedCandidateId ? "text-z-ink" : "text-z-ink/50"}`}>
-                          Vincular transaccion
+                          Vincular transacción
                         </Text>
                       </>
                     )}

--- a/mobile/components/recurrentes/RecurrentesRoot.tsx
+++ b/mobile/components/recurrentes/RecurrentesRoot.tsx
@@ -8,10 +8,10 @@ import { useSync } from "../../lib/sync/hooks";
 import {
   getOccurrencesForMonth,
   getRecurringSummary,
-  confirmOccurrence,
   skipOccurrence,
   type OccurrenceWithTemplate,
 } from "../../lib/repositories/recurring";
+import { getAllAccounts, type AccountRow } from "../../lib/repositories/accounts";
 import { getPreferredCurrency } from "../../lib/profile";
 import { COLORS } from "../../lib/constants/colors";
 import { MOBILE_TAB_BAR_CLEARANCE, SECTION_EYEBROW_CLASS } from "../../lib/constants/styles";
@@ -20,6 +20,7 @@ import { MonthSelector } from "../common/MonthSelector";
 import { MCard } from "../ui/MCard";
 import { RecurringSummaryCard } from "./RecurringSummaryCard";
 import { OccurrenceRow } from "./OccurrenceRow";
+import { RecurringConfirmSheet } from "./RecurringConfirmSheet";
 
 interface RecurringSummary {
   total_expected: number;
@@ -46,17 +47,22 @@ export function RecurrentesRoot() {
   const [summary, setSummary] = useState<RecurringSummary>(EMPTY_SUMMARY);
   const [completedExpanded, setCompletedExpanded] = useState(false);
   const [currency, setCurrency] = useState<CurrencyCode>("COP");
+  const [accounts, setAccounts] = useState<AccountRow[]>([]);
+  const [confirmingOccurrence, setConfirmingOccurrence] =
+    useState<OccurrenceWithTemplate | null>(null);
 
   const loadData = useCallback(async () => {
     try {
-      const [occ, sum, preferredCurrency] = await Promise.all([
+      const [occ, sum, preferredCurrency, accountRows] = await Promise.all([
         getOccurrencesForMonth(currentMonth),
         getRecurringSummary(currentMonth),
         getPreferredCurrency(),
+        getAllAccounts(),
       ]);
       setOccurrences(occ);
       setSummary(sum);
       setCurrency(preferredCurrency);
+      setAccounts(accountRows);
     } catch (error) {
       console.error("Failed to load recurrentes data:", error);
     }
@@ -79,15 +85,13 @@ export function RecurrentesRoot() {
   }, [sync, loadData]);
 
   const handleConfirm = useCallback(
-    async (occurrenceId: string) => {
-      try {
-        await confirmOccurrence(occurrenceId);
-        await loadData();
-      } catch (error) {
-        console.error("Failed to confirm occurrence:", error);
-      }
+    (occurrenceId: string) => {
+      // Open the confirm sheet — recording the payment (real transaction +
+      // balance + paid-link) happens through recordRecurringOccurrencePayment.
+      const occ = occurrences.find((o) => o.id === occurrenceId);
+      if (occ) setConfirmingOccurrence(occ);
     },
-    [loadData]
+    [occurrences]
   );
 
   const handleSkip = useCallback(
@@ -216,6 +220,18 @@ export function RecurrentesRoot() {
           </View>
         )}
       </ScrollView>
+
+      <RecurringConfirmSheet
+        visible={confirmingOccurrence != null}
+        occurrence={confirmingOccurrence}
+        accounts={accounts}
+        currency={currency}
+        onClose={() => setConfirmingOccurrence(null)}
+        onSuccess={() => {
+          setConfirmingOccurrence(null);
+          loadData();
+        }}
+      />
     </View>
   );
 }

--- a/mobile/components/recurrentes/RecurringConfirmSheet.tsx
+++ b/mobile/components/recurrentes/RecurringConfirmSheet.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { X } from "lucide-react-native";
+import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
+import type { AccountRow } from "../../lib/repositories/accounts";
+import { recordRecurringOccurrencePayment } from "../../lib/repositories/recurring";
+import type { OccurrenceWithTemplate } from "../../lib/repositories/recurring";
+import { isDebtAccountType, LIQUID_ACCOUNT_TYPES } from "../../lib/constants/accounts";
+import { parseLocalizedAmount } from "../../lib/amount";
+import { COLORS } from "../../lib/constants/colors";
+import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
+import {
+  SheetAccountPicker,
+  SheetAmountInput,
+  SheetError,
+  SheetFieldLabel,
+} from "../accounts/account-action-sheet-parts";
+
+interface RecurringConfirmSheetProps {
+  visible: boolean;
+  occurrence: OccurrenceWithTemplate | null;
+  /** All accounts — used to resolve the template's account type + liquid sources. */
+  accounts: AccountRow[];
+  currency: CurrencyCode;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Confirm-a-recurring-payment sheet → recordRecurringOccurrencePayment. Pre-fills
+ * the expected amount (editable). If the template's account is a debt account
+ * (CREDIT_CARD/LOAN) a source (liquid) account picker is required; otherwise the
+ * user can confirm one-tap with the expected amount.
+ */
+export function RecurringConfirmSheet({
+  visible,
+  occurrence,
+  accounts,
+  currency,
+  onClose,
+  onSuccess,
+}: RecurringConfirmSheetProps) {
+  const templateAccount = useMemo(
+    () => (occurrence ? accounts.find((a) => a.id === occurrence.account_id) ?? null : null),
+    [occurrence, accounts]
+  );
+  const isDebt = isDebtAccountType(templateAccount?.account_type ?? "OTHER");
+
+  const sourceAccounts = useMemo(
+    () =>
+      accounts.filter(
+        (a) =>
+          a.id !== occurrence?.account_id &&
+          LIQUID_ACCOUNT_TYPES.has(a.account_type ?? "OTHER") &&
+          a.currency_code === (templateAccount?.currency_code ?? a.currency_code)
+      ),
+    [accounts, occurrence?.account_id, templateAccount?.currency_code]
+  );
+
+  const [amountInput, setAmountInput] = useState("");
+  const [selectedSourceId, setSelectedSourceId] = useState<string>("");
+  const [showSourcePicker, setShowSourcePicker] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible && occurrence) {
+      setAmountInput(String(Math.round(occurrence.expected_amount)));
+      setSelectedSourceId(sourceAccounts[0]?.id ?? "");
+      setShowSourcePicker(false);
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [visible, occurrence, sourceAccounts]);
+
+  const parsedAmount = parseLocalizedAmount(amountInput);
+  const hasValidAmount = Number.isFinite(parsedAmount) && parsedAmount > 0;
+  const sourceOk = !isDebt || selectedSourceId !== "";
+  const canSubmit = !!occurrence && hasValidAmount && sourceOk && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit || !occurrence) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await recordRecurringOccurrencePayment({
+        templateId: occurrence.template_id,
+        occurrenceId: occurrence.id,
+        occurrenceDate: occurrence.occurrence_date,
+        actualAmount: parsedAmount,
+        sourceAccountId: isDebt ? selectedSourceId : undefined,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo registrar el pago.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, occurrence, parsedAmount, isDebt, selectedSourceId, onSuccess]);
+
+  if (!occurrence) return null;
+
+  const label = occurrence.merchant_name || occurrence.description || "Pago recurrente";
+
+  return (
+    <MobileSheet visible={visible} onClose={onClose} hideHandle>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <Text className="text-[15px] font-inter-semibold text-foreground">Confirmar pago</Text>
+          <Pressable
+            onPress={onClose}
+            className="h-8 w-8 items-center justify-center rounded-full"
+          >
+            <X size={16} color={COLORS.sageLight} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          className="max-h-[80%]"
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Occurrence info */}
+          <View className={`${PANEL_INSET_CLASS} p-3 mb-4`}>
+            <Text className="text-sm font-inter-semibold text-foreground">{label}</Text>
+            <Text className="text-[11px] font-inter text-muted-foreground mt-0.5">
+              {formatDate(occurrence.occurrence_date, "dd MMM yyyy")}
+              {templateAccount ? ` · ${templateAccount.name}` : ""}
+              {" · "}
+              {formatCurrency(occurrence.expected_amount, currency)}
+            </Text>
+          </View>
+
+          {/* Amount */}
+          <SheetFieldLabel>Monto pagado</SheetFieldLabel>
+          <View className="mb-3">
+            <SheetAmountInput value={amountInput} onChangeText={setAmountInput} />
+          </View>
+
+          {/* Source account (debt → required) */}
+          {isDebt && (
+            <>
+              <SheetFieldLabel>Cuenta origen</SheetFieldLabel>
+              <SheetAccountPicker
+                accounts={sourceAccounts}
+                selectedId={selectedSourceId}
+                onSelect={(id) => {
+                  setSelectedSourceId(id);
+                  setShowSourcePicker(false);
+                }}
+                open={showSourcePicker}
+                onToggle={() => setShowSourcePicker((v) => !v)}
+              />
+            </>
+          )}
+
+          {error && <SheetError message={error} />}
+
+          <Pressable
+            onPress={handleSubmit}
+            disabled={!canSubmit}
+            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+          >
+            {submitting ? (
+              <ActivityIndicator size="small" color={COLORS.ink} />
+            ) : (
+              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+                Confirmar pago
+              </Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={onClose} className="items-center py-2">
+            <Text className="text-sm font-inter-medium text-muted-foreground">Cancelar</Text>
+          </Pressable>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </MobileSheet>
+  );
+}

--- a/mobile/components/recurrentes/RecurringConfirmSheet.tsx
+++ b/mobile/components/recurrentes/RecurringConfirmSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -71,14 +71,22 @@ export function RecurringConfirmSheet({
   const [showSourcePicker, setShowSourcePicker] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hasInitializedRef = useRef(false);
 
+  // Initialize once per open; the ref guard keeps a background account reload
+  // from wiping the user's in-progress amount/source while the sheet is open.
   useEffect(() => {
     if (visible && occurrence) {
-      setAmountInput(String(Math.round(occurrence.expected_amount)));
-      setSelectedSourceId(sourceAccounts[0]?.id ?? "");
-      setShowSourcePicker(false);
-      setSubmitting(false);
-      setError(null);
+      if (!hasInitializedRef.current) {
+        setAmountInput(String(Math.round(occurrence.expected_amount)));
+        setSelectedSourceId(sourceAccounts[0]?.id ?? "");
+        setShowSourcePicker(false);
+        setSubmitting(false);
+        setError(null);
+        hasInitializedRef.current = true;
+      }
+    } else if (!visible) {
+      hasInitializedRef.current = false;
     }
   }, [visible, occurrence, sourceAccounts]);
 

--- a/mobile/components/transactions/TransactionRow.tsx
+++ b/mobile/components/transactions/TransactionRow.tsx
@@ -29,7 +29,7 @@ export function TransactionRow({
   account_type,
 }: TransactionRowProps) {
   const router = useRouter();
-  const displayName = merchant_name || description || "Sin descripcion";
+  const displayName = merchant_name || description || "Sin descripción";
   const isInflow = direction === "INFLOW";
   const isDebtPayment = isDebtInflow({ direction, accountType: account_type });
   const semanticCategory = isDebtPayment ? "Abono a deuda" : category_name_es;

--- a/mobile/lib/db/schema.ts
+++ b/mobile/lib/db/schema.ts
@@ -557,6 +557,21 @@ export const DB_MIGRATIONS: DbMigration[] = [
       `CREATE INDEX IF NOT EXISTS idx_transactions_personal_debt ON transactions(personal_debt_id)`,
     ],
   },
+  {
+    version: 17,
+    statements: [
+      // ── accounts: multi-currency debt balances (ledger mutation layer) ────
+      // Webapp persists per-currency debt detail in `currency_balances` (JSONB
+      // on the Supabase accounts view). Each entry carries its own
+      // total_payment_due / available_balance — there is NO top-level
+      // total_payment_due column on accounts (that column belongs to
+      // statement_snapshots). Mirror only the JSON column locally so the ledger
+      // mutations (registerPayment, createTransfer, reconcileBalance,
+      // recordRecurringOccurrencePayment) can write the shared debt payload and
+      // pull/push round-trips don't drop it. Stored as TEXT (SQLite has no JSON).
+      `ALTER TABLE accounts ADD COLUMN currency_balances TEXT`,
+    ],
+  },
 ];
 
 export const LATEST_DB_VERSION =

--- a/mobile/lib/demo-data.ts
+++ b/mobile/lib/demo-data.ts
@@ -136,7 +136,7 @@ export async function seedDemoData(): Promise<void> {
     [
       loanId,
       DEMO_USER_ID,
-      "Credito Vehiculo Demo",
+      "Crédito Vehículo Demo",
       "LOAN",
       "Banco Demo",
       6800000,
@@ -207,7 +207,7 @@ export async function seedDemoData(): Promise<void> {
       accountId: loanId,
       amount: 510000,
       direction: "INFLOW",
-      description: "Cuota credito vehiculo",
+      description: "Cuota crédito vehículo",
       date: dateShift(-2),
       categoryId: CATEGORY_OBLIGACIONES,
     },

--- a/mobile/lib/repositories/accounts-detail.ts
+++ b/mobile/lib/repositories/accounts-detail.ts
@@ -10,7 +10,7 @@ export interface DailyPoint {
   amount: number;
 }
 
-function toColombiaDateString(d: Date): string {
+export function toColombiaDateString(d: Date): string {
   return d.toLocaleDateString("en-CA", { timeZone: "America/Bogota" });
 }
 

--- a/mobile/lib/repositories/accounts.ts
+++ b/mobile/lib/repositories/accounts.ts
@@ -1,6 +1,17 @@
 import { getDatabase } from "../db/database";
 import * as Crypto from "expo-crypto";
+import { getDirectionForBalanceDelta } from "@zeta/shared";
 import { setPdfPasswordForAccount } from "../pdf-passwords";
+import {
+  applyLocalBalanceDelta,
+  buildLedgerTxPayload,
+  computeIdempotencyKey,
+  enqueueAccountUpdateCoalesced,
+  insertLedgerTransaction,
+  parseCurrencyBalances,
+  setLocalBalanceOverwrite,
+  type LedgerAccountRow,
+} from "./ledger-helpers";
 
 export type AccountRow = {
   id: string;
@@ -156,57 +167,23 @@ export async function updateAccount(
     ]
   );
 
-  // Check if there's a pending INSERT that hasn't synced yet
-  const pendingInsert = await db.getFirstAsync<{ id: number; payload: string }>(
-    `SELECT id, payload FROM sync_queue
-     WHERE table_name = 'accounts' AND record_id = ? AND operation = 'INSERT' AND synced_at IS NULL`,
-    [id]
-  );
-
-  if (pendingInsert) {
-    // Update the INSERT payload instead of queuing a separate UPDATE
-    const existing = JSON.parse(pendingInsert.payload);
-    const updated = {
-      ...existing,
-      name: params.name,
-      institution_name: params.institution_name ?? null,
-      currency_code: params.currency_code ?? "COP",
-      current_balance: params.current_balance ?? 0,
-      credit_limit: params.credit_limit ?? null,
-      interest_rate: params.interest_rate ?? null,
-      icon: params.icon ?? null,
-      color: params.color ?? null,
-      monthly_payment: params.monthly_payment ?? null,
-      payment_day: params.payment_day ?? null,
-      cutoff_day: params.cutoff_day ?? null,
-      updated_at: now,
-    };
-    await db.runAsync(
-      "UPDATE sync_queue SET payload = ? WHERE id = ?",
-      [JSON.stringify(updated), pendingInsert.id]
-    );
-  } else {
-    // Already synced — queue an UPDATE
-    const syncPayload = {
-      name: params.name,
-      institution_name: params.institution_name ?? null,
-      currency_code: params.currency_code ?? "COP",
-      current_balance: params.current_balance ?? 0,
-      credit_limit: params.credit_limit ?? null,
-      interest_rate: params.interest_rate ?? null,
-      icon: params.icon ?? null,
-      color: params.color ?? null,
-      monthly_payment: params.monthly_payment ?? null,
-      payment_day: params.payment_day ?? null,
-      cutoff_day: params.cutoff_day ?? null,
-      updated_at: now,
-    };
-    await db.runAsync(
-      `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
-       VALUES ('accounts', ?, 'UPDATE', ?, ?)`,
-      [id, JSON.stringify(syncPayload), now]
-    );
-  }
+  // Queue the field UPDATE, coalescing into a still-unsynced INSERT if present
+  // (shared with the ledger mutations via enqueueAccountUpdateCoalesced).
+  const syncPayload = {
+    name: params.name,
+    institution_name: params.institution_name ?? null,
+    currency_code: params.currency_code ?? "COP",
+    current_balance: params.current_balance ?? 0,
+    credit_limit: params.credit_limit ?? null,
+    interest_rate: params.interest_rate ?? null,
+    icon: params.icon ?? null,
+    color: params.color ?? null,
+    monthly_payment: params.monthly_payment ?? null,
+    payment_day: params.payment_day ?? null,
+    cutoff_day: params.cutoff_day ?? null,
+    updated_at: now,
+  };
+  await enqueueAccountUpdateCoalesced(db, id, syncPayload, now);
 }
 
 export async function deleteAccount(id: string): Promise<void> {
@@ -251,4 +228,323 @@ export async function deleteAccount(id: string): Promise<void> {
       [id, JSON.stringify({ id }), now]
     );
   }
+}
+
+// ─── Quick Payment ───────────────────────────────────────────────────────────
+
+export type RegisterPaymentResult =
+  | { success: true }
+  | { success: false; error: string };
+
+/**
+ * Offline-first mirror of webapp accounts.ts `registerPayment`.
+ *
+ * Records a payment/income against a target account as a single INFLOW
+ * transaction, then updates the target balance (debt → clamp at 0 + recompute
+ * available_balance via the shared debt payload; non-debt → +amount). When a
+ * source account is given, deducts from it with OUTFLOW semantics — but the
+ * source is NOT clamped and its available_balance is NOT recomputed
+ * (asymmetric, matching the webapp exactly). The whole mutation is wrapped in
+ * one withTransactionAsync so a throw rolls back the tx + both balance writes.
+ *
+ * Idempotency input (matches webapp): provider "MANUAL", transactionDate =
+ * now.slice(0,10), amount, rawDescription = the embedded-ISO "Pago/Ingreso"
+ * description (the timestamp is part of the webapp key — preserved verbatim).
+ */
+export async function registerPayment(
+  accountId: string,
+  input: { amount: number; sourceAccountId?: string; notes?: string }
+): Promise<RegisterPaymentResult> {
+  const db = await getDatabase();
+
+  const account = await db.getFirstAsync<LedgerAccountRow>(
+    "SELECT * FROM accounts WHERE id = ?",
+    [accountId]
+  );
+  if (!account) return { success: false, error: "Cuenta no encontrada" };
+  // Fail fast on a missing user_id — an empty-string user_id produces rows that
+  // fail Supabase RLS and stick in sync_queue forever.
+  if (!account.user_id) return { success: false, error: "Sesión inválida" };
+
+  const isDebt = account.account_type === "CREDIT_CARD" || account.account_type === "LOAN";
+  const now = new Date().toISOString();
+  const transactionDate = now.slice(0, 10);
+
+  let sourceAccount: LedgerAccountRow | null = null;
+  if (input.sourceAccountId) {
+    sourceAccount = await db.getFirstAsync<LedgerAccountRow>(
+      "SELECT * FROM accounts WHERE id = ?",
+      [input.sourceAccountId]
+    );
+  }
+  const sourceAccountName = sourceAccount?.name ?? "";
+
+  const merchantName = isDebt
+    ? `Pago - ${account.name}`
+    : `Ingreso - ${account.name}`;
+  const rawDescription = isDebt
+    ? sourceAccountName
+      ? `Pago manual registrado desde ${sourceAccountName} (${now})`
+      : `Pago manual registrado (${now})`
+    : `Ingreso manual registrado (${now})`;
+
+  const idempotencyKey = await computeIdempotencyKey({
+    provider: "MANUAL",
+    transactionDate,
+    amount: input.amount,
+    rawDescription,
+  });
+
+  // Debt INFLOW → payment received → balance decreases.
+  // Savings INFLOW → money received → balance increases. Always INFLOW.
+  const txPayload = buildLedgerTxPayload(
+    {
+      userId: account.user_id,
+      accountId,
+      amount: input.amount,
+      currencyCode: account.currency_code,
+      direction: "INFLOW",
+      transactionDate,
+      rawDescription,
+      merchantName,
+      notes: input.notes ?? null,
+      idempotencyKey,
+    },
+    now
+  );
+
+  let duplicate = false;
+  await db.withTransactionAsync(async () => {
+    const { inserted } = await insertLedgerTransaction(db, txPayload, now);
+    if (!inserted) {
+      duplicate = true;
+      return;
+    }
+
+    // Target account balance — debt uses the shared clamp + available recompute.
+    await applyLocalBalanceDelta(db, account, "INFLOW", input.amount, account.currency_code, now);
+
+    // Source account: OUTFLOW semantics, NOT clamped, available NOT recomputed
+    // (asymmetric — matches webapp registerPayment).
+    if (sourceAccount) {
+      const isDebtSource =
+        sourceAccount.account_type === "CREDIT_CARD" || sourceAccount.account_type === "LOAN";
+      const nextSource = isDebtSource
+        ? sourceAccount.current_balance + input.amount
+        : sourceAccount.current_balance - input.amount;
+      await db.runAsync(
+        "UPDATE accounts SET current_balance = ?, updated_at = ? WHERE id = ?",
+        [nextSource, now, sourceAccount.id]
+      );
+      await enqueueAccountUpdateCoalesced(
+        db,
+        sourceAccount.id,
+        { current_balance: nextSource, updated_at: now },
+        now
+      );
+    }
+  });
+
+  if (duplicate) return { success: false, error: "Este pago ya fue registrado" };
+  return { success: true };
+}
+
+// ─── Reconcile balance (manual adjustment) ───────────────────────────────────
+
+export type ReconcileBalanceInput = {
+  currentBalance?: number;
+  currencyBalances?: Record<string, number>;
+  notes?: string;
+};
+
+export type ReconcileBalanceResult =
+  | { success: true; delta: number; currencyDeltas: Record<string, number> }
+  | { success: false; error: string };
+
+/**
+ * Offline-first mirror of webapp accounts.ts `reconcileBalance` — OVERWRITE
+ * semantics. For each requested currency it computes delta = new - previous,
+ * derives the adjustment direction (debt-inverted) via getDirectionForBalanceDelta,
+ * and for every NON-ZERO delta inserts an "Ajuste manual de saldo" transaction
+ * (amount = |delta|). It then OVERWRITES the balance with setLocalBalanceOverwrite
+ * (never applyLocalBalanceDelta — the adjustment tx already represents the move;
+ * a delta-apply would double-count). Single-currency works before the
+ * currency_balances column exists; multi-currency persists currency_balances
+ * when present. All writes are wrapped in one withTransactionAsync.
+ */
+export async function reconcileBalance(
+  accountId: string,
+  input: ReconcileBalanceInput
+): Promise<ReconcileBalanceResult> {
+  const db = await getDatabase();
+
+  const account = await db.getFirstAsync<LedgerAccountRow>(
+    "SELECT * FROM accounts WHERE id = ?",
+    [accountId]
+  );
+  if (!account) return { success: false, error: "Cuenta no encontrada" };
+
+  const requestedBalances =
+    input.currencyBalances && Object.keys(input.currencyBalances).length > 0
+      ? input.currencyBalances
+      : input.currentBalance != null
+        ? { [account.currency_code]: input.currentBalance }
+        : {};
+
+  // Validate EVERY requested balance before any write (matches webapp).
+  for (const [currency, newBalance] of Object.entries(requestedBalances)) {
+    if (!Number.isFinite(newBalance) || newBalance < 0) {
+      return { success: false, error: `Saldo invalido para ${currency}` };
+    }
+  }
+
+  const existingCurrencyBalances = parseCurrencyBalances(account.currency_balances) ?? {};
+  const shouldPersistCurrencyBalances =
+    account.currency_balances != null ||
+    Object.keys(requestedBalances).some((currency) => currency !== account.currency_code);
+
+  const now = new Date().toISOString();
+  const transactionDate = now.slice(0, 10);
+  const currencyDeltas: Record<string, number> = {};
+
+  // Build per-currency adjustment transactions + next currency_balances map.
+  type AdjustmentTx = {
+    currency: string;
+    direction: "INFLOW" | "OUTFLOW";
+    amount: number;
+    idempotencyKey: string;
+    rawDescription: string;
+  };
+  const adjustments: AdjustmentTx[] = [];
+
+  for (const [currency, newBalance] of Object.entries(requestedBalances)) {
+    const previousBalance =
+      currency === account.currency_code
+        ? account.current_balance ?? 0
+        : resolveCurrencyCurrentValue(existingCurrencyBalances[currency]);
+    const delta = newBalance - previousBalance;
+    currencyDeltas[currency] = delta;
+
+    if (shouldPersistCurrencyBalances) {
+      const baseEntry: Record<string, unknown> =
+        currency === account.currency_code
+          ? {
+              current_balance: account.current_balance ?? 0,
+              credit_limit: account.credit_limit,
+              available_balance: account.available_balance ?? null,
+              interest_rate: account.interest_rate ?? null,
+              minimum_payment: account.monthly_payment ?? null,
+              total_payment_due: null,
+              ...(existingCurrencyBalances[currency] ?? {}),
+            }
+          : (existingCurrencyBalances[currency] ?? {
+              current_balance: null,
+              credit_limit: null,
+              available_balance: null,
+              interest_rate: null,
+              minimum_payment: null,
+              total_payment_due: null,
+            });
+
+      const nextEntry: Record<string, unknown> = { ...baseEntry, current_balance: newBalance };
+
+      if (account.account_type === "CREDIT_CARD") {
+        const creditLimit =
+          (nextEntry.credit_limit as number | null) ??
+          (currency === account.currency_code ? account.credit_limit : null);
+        nextEntry.total_payment_due = newBalance;
+        if (creditLimit != null) {
+          nextEntry.credit_limit = creditLimit;
+          nextEntry.available_balance = Math.max(creditLimit - newBalance, 0);
+        }
+      }
+
+      existingCurrencyBalances[currency] = nextEntry;
+    }
+
+    if (delta === 0) continue;
+
+    const adjustmentDirection = getDirectionForBalanceDelta({
+      accountType: account.account_type,
+      delta,
+    });
+    if (!adjustmentDirection) {
+      return { success: false, error: "No se pudo determinar el ajuste de saldo." };
+    }
+
+    const rawDescription = `Ajuste manual de saldo ${currency} (${now})`;
+    const idempotencyKey = await computeIdempotencyKey({
+      provider: "MANUAL",
+      transactionDate,
+      amount: Math.abs(delta),
+      rawDescription,
+    });
+
+    adjustments.push({
+      currency,
+      direction: adjustmentDirection,
+      amount: Math.abs(delta),
+      idempotencyKey,
+      rawDescription,
+    });
+  }
+
+  const primaryBalance =
+    requestedBalances[account.currency_code] ?? account.current_balance ?? 0;
+
+  await db.withTransactionAsync(async () => {
+    for (const adj of adjustments) {
+      const txPayload = buildLedgerTxPayload(
+        {
+          userId: account.user_id ?? "",
+          accountId,
+          amount: adj.amount,
+          currencyCode: adj.currency,
+          direction: adj.direction,
+          transactionDate,
+          rawDescription: adj.rawDescription,
+          // Webapp sets merchant_name = null + a distinct clean_description.
+          // rawDescription stays byte-matched to the webapp idempotency string.
+          merchantName: null,
+          cleanDescription: "Ajuste manual de saldo",
+          categoryId: null,
+          categorizationSource: "SYSTEM_DEFAULT",
+          notes: input.notes ?? null,
+          idempotencyKey: adj.idempotencyKey,
+        },
+        now
+      );
+      await insertLedgerTransaction(db, txPayload, now);
+    }
+
+    // OVERWRITE the balance (NOT a delta — the adjustment tx already moved it).
+    await setLocalBalanceOverwrite(
+      db,
+      account,
+      primaryBalance,
+      shouldPersistCurrencyBalances ? existingCurrencyBalances : null,
+      now
+    );
+  });
+
+  return {
+    success: true,
+    delta: currencyDeltas[account.currency_code] ?? 0,
+    currencyDeltas,
+  };
+}
+
+/**
+ * Mirror of resolveCurrencyBalanceCurrentValue (webapp currency-balances.ts):
+ * total_payment_due → (credit_limit - available_balance) → current_balance → 0.
+ */
+function resolveCurrencyCurrentValue(entry: Record<string, unknown> | undefined): number {
+  if (!entry) return 0;
+  const tpd = entry.total_payment_due;
+  if (typeof tpd === "number" && Number.isFinite(tpd)) return tpd;
+  const cl = entry.credit_limit;
+  const ab = entry.available_balance;
+  if (typeof cl === "number" && typeof ab === "number") return Math.max(cl - ab, 0);
+  const cb = entry.current_balance;
+  return typeof cb === "number" ? cb : 0;
 }

--- a/mobile/lib/repositories/ledger-helpers.ts
+++ b/mobile/lib/repositories/ledger-helpers.ts
@@ -1,0 +1,457 @@
+import * as Crypto from "expo-crypto";
+import type { SQLiteDatabase } from "expo-sqlite";
+import {
+  applyAccountBalanceDelta,
+  buildDebtBalanceUpdatePayload,
+  computeIdempotencyKey as sharedComputeIdempotencyKey,
+  isDebtAccountType,
+  type HashFn,
+  type TransactionDirection,
+} from "@zeta/shared";
+
+/**
+ * Ledger mutation substrate — the shared write primitives the 4 money-moving
+ * mobile mutations (registerPayment, createTransfer, reconcileBalance,
+ * recordRecurringOccurrencePayment) compose.
+ *
+ * INVARIANT: every helper here receives the active `db` handle and a frozen
+ * `now` ISO timestamp from the CALLER, and the caller wraps all of its writes
+ * in a single `db.withTransactionAsync(...)`. Helpers therefore NEVER open a
+ * transaction of their own — that would nest and break atomic rollback. A throw
+ * from any helper rolls back the entire mutation (this replaces the webapp's
+ * manual outflow-delete rollback path).
+ *
+ * Idempotency, recurrence_group_id and transfer_group_id are computed with the
+ * exact same inputs as the webapp Server Actions so cross-platform rows dedup
+ * by construction (DB UNIQUE(idempotency_key) catches re-imports).
+ */
+
+/** expo-crypto SHA256 hashFn — the mobile equivalent of webapp's WebCrypto. */
+export const expoHashFn: HashFn = (payload: string) =>
+  Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, payload);
+
+export const computeIdempotencyKey = (
+  params: Parameters<typeof sharedComputeIdempotencyKey>[0]
+) => sharedComputeIdempotencyKey(params, expoHashFn);
+
+/** Account columns the ledger mutations read. `currency_balances` (a JSON map
+ * whose per-currency entries hold total_payment_due/available_balance — there is
+ * no top-level total_payment_due column) may be absent on older installs — see
+ * schema migration. */
+export type LedgerAccountRow = {
+  id: string;
+  user_id?: string;
+  name: string;
+  account_type: string;
+  currency_code: string;
+  current_balance: number;
+  available_balance?: number | null;
+  credit_limit: number | null;
+  interest_rate?: number | null;
+  monthly_payment?: number | null;
+  currency_balances?: unknown;
+};
+
+// ─── sync_queue: account UPDATE coalesce ─────────────────────────────────────
+
+/**
+ * Queue an account-balance UPDATE, coalescing into a still-unsynced INSERT when
+ * one exists (factored out of accounts.ts updateAccount L159-209). If the row
+ * has never synced, merge the partial payload into the pending INSERT payload
+ * so Supabase receives one consistent INSERT; otherwise queue a standalone
+ * UPDATE (further coalescing into a pending UPDATE if present, mirroring the
+ * transactions repo's enqueueTransactionUpdate).
+ *
+ * Caller must run inside its own withTransactionAsync.
+ */
+export async function enqueueAccountUpdateCoalesced(
+  db: SQLiteDatabase,
+  accountId: string,
+  partialPayload: Record<string, unknown>,
+  now: string
+): Promise<void> {
+  const pendingInsert = await db.getFirstAsync<{ id: number; payload: string }>(
+    `SELECT id, payload FROM sync_queue
+     WHERE table_name = 'accounts' AND record_id = ? AND operation = 'INSERT' AND synced_at IS NULL`,
+    [accountId]
+  );
+
+  if (pendingInsert) {
+    const existing = JSON.parse(pendingInsert.payload);
+    await db.runAsync("UPDATE sync_queue SET payload = ? WHERE id = ?", [
+      JSON.stringify({ ...existing, ...partialPayload }),
+      pendingInsert.id,
+    ]);
+    return;
+  }
+
+  const pendingUpdate = await db.getFirstAsync<{ id: number; payload: string }>(
+    `SELECT id, payload FROM sync_queue
+     WHERE table_name = 'accounts' AND record_id = ? AND operation = 'UPDATE' AND synced_at IS NULL`,
+    [accountId]
+  );
+
+  if (pendingUpdate) {
+    const existing = JSON.parse(pendingUpdate.payload);
+    await db.runAsync("UPDATE sync_queue SET payload = ? WHERE id = ?", [
+      JSON.stringify({ ...existing, ...partialPayload }),
+      pendingUpdate.id,
+    ]);
+    return;
+  }
+
+  await db.runAsync(
+    `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+     VALUES ('accounts', ?, 'UPDATE', ?, ?)`,
+    [accountId, JSON.stringify(partialPayload), now]
+  );
+}
+
+// ─── Ledger transaction payload ──────────────────────────────────────────────
+
+export type LedgerTxInput = {
+  userId: string;
+  accountId: string;
+  amount: number;
+  currencyCode: string;
+  direction: TransactionDirection;
+  transactionDate: string;
+  rawDescription: string;
+  /** merchant / human label. Defaults clean_description = merchantName ?? rawDescription. */
+  merchantName?: string | null;
+  /** Override for clean_description. When set, used verbatim (e.g. reconcile sets
+   * a distinct clean label while keeping merchant_name = null). Defaults to
+   * merchantName || rawDescription. */
+  cleanDescription?: string | null;
+  categoryId?: string | null;
+  /** Override; defaults USER_CREATED when categoryId present, else SYSTEM_DEFAULT. */
+  categorizationSource?: string | null;
+  notes?: string | null;
+  idempotencyKey: string;
+  transferGroupId?: string | null;
+  recurrenceGroupId?: string | null;
+  isRecurring?: boolean;
+  /** Defaults "MANUAL". registerPayment / transfers / reconcile use MANUAL. */
+  provider?: string;
+  /** Defaults "MANUAL_FORM". */
+  captureMethod?: string;
+};
+
+type LedgerTxPayload = {
+  id: string;
+  user_id: string;
+  account_id: string;
+  category_id: string | null;
+  categorization_source: string;
+  amount: number;
+  currency_code: string;
+  direction: TransactionDirection;
+  clean_description: string;
+  merchant_name: string | null;
+  raw_description: string;
+  transaction_date: string;
+  status: string;
+  idempotency_key: string;
+  is_excluded: boolean;
+  is_recurring: boolean;
+  notes: string | null;
+  provider: string;
+  capture_method: string;
+  transfer_group_id: string | null;
+  recurrence_group_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+/**
+ * Single source of the standard transaction field set for the ledger mutations,
+ * matching webapp persistTransaction + the mobile `transactions` table column
+ * set (transactions.ts buildInsertPayload). `clean_description` falls back to
+ * `merchant_name || raw_description`, exactly like the webapp's persisted rows.
+ */
+export function buildLedgerTxPayload(
+  input: LedgerTxInput,
+  now: string
+): LedgerTxPayload {
+  const cleanDescription =
+    input.cleanDescription ?? (input.merchantName || input.rawDescription);
+  return {
+    id: Crypto.randomUUID(),
+    user_id: input.userId,
+    account_id: input.accountId,
+    category_id: input.categoryId ?? null,
+    categorization_source:
+      input.categorizationSource ??
+      (input.categoryId ? "USER_CREATED" : "SYSTEM_DEFAULT"),
+    amount: input.amount,
+    currency_code: input.currencyCode,
+    direction: input.direction,
+    clean_description: cleanDescription,
+    merchant_name: input.merchantName ?? null,
+    raw_description: input.rawDescription,
+    transaction_date: input.transactionDate,
+    status: "POSTED",
+    idempotency_key: input.idempotencyKey,
+    is_excluded: false,
+    is_recurring: input.isRecurring ?? false,
+    notes: input.notes ?? null,
+    provider: input.provider ?? "MANUAL",
+    capture_method: input.captureMethod ?? "MANUAL_FORM",
+    transfer_group_id: input.transferGroupId ?? null,
+    recurrence_group_id: input.recurrenceGroupId ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+/**
+ * INSERT one ledger transaction row + enqueue its `transactions` INSERT for
+ * sync. Returns `{ inserted: false }` on a local UNIQUE(idempotency_key)
+ * conflict (the mobile equivalent of Postgres 23505) so callers skip balance
+ * application + occurrence marking for duplicates — never throwing, so the
+ * caller's withTransactionAsync isn't rolled back by an expected dupe.
+ *
+ * Sync payload uses the Supabase VIEW column names + real booleans (the local
+ * row uses `description` for clean text and 0/1 booleans; push.ts sends the
+ * payload object verbatim, so it must already be view-shaped).
+ */
+export async function insertLedgerTransaction(
+  db: SQLiteDatabase,
+  payload: LedgerTxPayload,
+  now: string
+): Promise<{ inserted: boolean; id: string }> {
+  try {
+    await db.runAsync(
+      `INSERT INTO transactions
+        (id, user_id, account_id, category_id, categorization_source,
+         amount, currency_code, direction,
+         description, merchant_name, raw_description, transaction_date, status, idempotency_key,
+         is_excluded, is_recurring, notes, provider, capture_method,
+         transfer_group_id, recurrence_group_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        payload.id,
+        payload.user_id,
+        payload.account_id,
+        payload.category_id,
+        payload.categorization_source,
+        payload.amount,
+        payload.currency_code,
+        payload.direction,
+        payload.clean_description,
+        payload.merchant_name,
+        payload.raw_description,
+        payload.transaction_date,
+        payload.status,
+        payload.idempotency_key,
+        payload.is_excluded ? 1 : 0,
+        payload.is_recurring ? 1 : 0,
+        payload.notes,
+        payload.provider,
+        payload.capture_method,
+        payload.transfer_group_id,
+        payload.recurrence_group_id,
+        payload.created_at,
+        payload.updated_at,
+      ]
+    );
+  } catch (err) {
+    if (isUniqueConstraintError(err)) {
+      return { inserted: false, id: payload.id };
+    }
+    throw err;
+  }
+
+  // Sync payload: Supabase view columns + real booleans (mirror push.ts intent).
+  await db.runAsync(
+    `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+     VALUES ('transactions', ?, 'INSERT', ?, ?)`,
+    [payload.id, JSON.stringify(payload), now]
+  );
+
+  return { inserted: true, id: payload.id };
+}
+
+/** True for a SQLite UNIQUE constraint violation (idempotency_key collision). */
+function isUniqueConstraintError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /UNIQUE constraint failed|constraint failed: transactions\.idempotency_key/i.test(
+    message
+  );
+}
+
+// ─── Balance application ──────────────────────────────────────────────────────
+
+/**
+ * Apply a signed balance DELTA to an account (the webapp's
+ * applyAccountBalanceDelta + buildDebtBalanceUpdatePayload path). Debt accounts
+ * get current_balance + available_balance + currency_balances written together;
+ * non-debt accounts get only current_balance. Bumps updated_at and coalesces
+ * the sync UPDATE. Returns the new balance.
+ *
+ * Multi-currency degrades gracefully: buildDebtBalanceUpdatePayload only writes
+ * `currency_balances` when the column holds a map with the currency key — when
+ * absent (older installs / unparsed column) only top-level balances are written
+ * (matches the webapp's "currency_balances missing key" warning path).
+ */
+export async function applyLocalBalanceDelta(
+  db: SQLiteDatabase,
+  account: LedgerAccountRow,
+  direction: TransactionDirection,
+  amount: number,
+  currencyCode: string,
+  now: string
+): Promise<number> {
+  const isDebt = isDebtAccountType(account.account_type);
+  const nextBalance = applyAccountBalanceDelta({
+    currentBalance: account.current_balance,
+    accountType: account.account_type,
+    direction,
+    amount,
+  });
+
+  const currencyBalances = parseCurrencyBalances(account.currency_balances);
+
+  const payload: Record<string, unknown> = isDebt
+    ? buildDebtBalanceUpdatePayload(
+        { credit_limit: account.credit_limit, currency_balances: currencyBalances },
+        nextBalance,
+        currencyCode
+      )
+    : { current_balance: nextBalance };
+  payload.updated_at = now;
+
+  await runAccountBalanceUpdate(db, account.id, payload, now);
+
+  // Keep the in-memory row consistent for callers that hit the same account
+  // twice in one mutation (e.g. a debt leg pair).
+  account.current_balance = nextBalance;
+  if (typeof payload.available_balance === "number") {
+    account.available_balance = payload.available_balance as number;
+  }
+  if (payload.currency_balances !== undefined) {
+    account.currency_balances = payload.currency_balances;
+  }
+
+  return nextBalance;
+}
+
+/**
+ * Reconcile-only OVERWRITE of an account's balance. Unlike applyLocalBalanceDelta
+ * this sets current_balance directly (NO delta — calling applyAccountBalanceDelta
+ * here would double-count the adjustment transactions). Recomputes
+ * available_balance for CREDIT_CARD when credit_limit is known, persists the
+ * currency_balances JSON when provided, bumps updated_at, coalesces the sync
+ * UPDATE.
+ */
+export async function setLocalBalanceOverwrite(
+  db: SQLiteDatabase,
+  account: LedgerAccountRow,
+  primaryBalance: number,
+  currencyBalances: Record<string, unknown> | null,
+  now: string
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    current_balance: primaryBalance,
+    updated_at: now,
+  };
+
+  if (account.account_type === "CREDIT_CARD" && account.credit_limit != null) {
+    payload.available_balance = Math.max(account.credit_limit - primaryBalance, 0);
+  }
+
+  if (currencyBalances !== null) {
+    payload.currency_balances = currencyBalances;
+  }
+
+  await runAccountBalanceUpdate(db, account.id, payload, now);
+
+  account.current_balance = primaryBalance;
+  if (typeof payload.available_balance === "number") {
+    account.available_balance = payload.available_balance as number;
+  }
+  if (currencyBalances !== null) {
+    account.currency_balances = currencyBalances;
+  }
+}
+
+// ─── Internal: write the account row + coalesce sync ─────────────────────────
+
+/**
+ * Apply a balance payload to the local accounts row (only the columns the
+ * payload actually carries) and enqueue/coalesce the sync UPDATE.
+ *
+ * Multi-currency degrades gracefully: `currency_balances` (a JSON column whose
+ * entries carry per-currency total_payment_due/available_balance) is written to
+ * the local row ONLY when that column exists (added in the schema migration). On
+ * older installs the column write is skipped silently and only top-level
+ * current_balance/available_balance land — matching the webapp's documented
+ * warning path. The sync payload carries the same view-shaped fields.
+ */
+async function runAccountBalanceUpdate(
+  db: SQLiteDatabase,
+  accountId: string,
+  payload: Record<string, unknown>,
+  now: string
+): Promise<void> {
+  const hasCurrencyBalancesColumn = await accountsHasColumn(db, "currency_balances");
+
+  const setClauses: string[] = [];
+  const values: (string | number | null)[] = [];
+
+  if ("current_balance" in payload) {
+    setClauses.push("current_balance = ?");
+    values.push(payload.current_balance as number);
+  }
+  if ("available_balance" in payload) {
+    setClauses.push("available_balance = ?");
+    values.push(payload.available_balance as number);
+  }
+  if ("currency_balances" in payload && hasCurrencyBalancesColumn) {
+    setClauses.push("currency_balances = ?");
+    const cb = payload.currency_balances;
+    values.push(cb == null ? null : JSON.stringify(cb));
+  }
+  setClauses.push("updated_at = ?");
+  values.push(now);
+  values.push(accountId);
+
+  await db.runAsync(
+    `UPDATE accounts SET ${setClauses.join(", ")} WHERE id = ?`,
+    values
+  );
+
+  await enqueueAccountUpdateCoalesced(db, accountId, payload, now);
+}
+
+const accountsColumnCache = new Map<string, boolean>();
+
+/** Cheap PRAGMA-backed check so balance writes degrade gracefully before the
+ * currency_balances column exists on older installs. */
+async function accountsHasColumn(db: SQLiteDatabase, column: string): Promise<boolean> {
+  const cached = accountsColumnCache.get(column);
+  if (cached !== undefined) return cached;
+  const cols = await db.getAllAsync<{ name: string }>("PRAGMA table_info(accounts)");
+  const present = cols.some((c) => c.name === column);
+  accountsColumnCache.set(column, present);
+  return present;
+}
+
+/** Parse the stored currency_balances (JSON string or object) into a map, or
+ * null when absent — so buildDebtBalanceUpdatePayload only touches the JSON when
+ * it actually has the currency key. */
+export function parseCurrencyBalances(
+  raw: unknown
+): Record<string, Record<string, unknown>> | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw === "object") return raw as Record<string, Record<string, unknown>>;
+  return null;
+}

--- a/mobile/lib/repositories/recurring.ts
+++ b/mobile/lib/repositories/recurring.ts
@@ -1,7 +1,22 @@
 import * as Crypto from "expo-crypto";
-import type { RecurrenceFrequency, TransactionDirection } from "@zeta/shared";
+import {
+  getDebtPaymentCategoryId,
+  getOccurrencesBetween,
+  isDebtAccountType,
+  TRANSFER_CATEGORY_ID,
+  type RecurrenceFrequency,
+  type TransactionDirection,
+} from "@zeta/shared";
 import { getDatabase } from "../db/database";
 import { enqueueInsert, enqueueUpdate } from "../sync/queue";
+import { toColombiaDateString } from "./accounts-detail";
+import {
+  applyLocalBalanceDelta,
+  buildLedgerTxPayload,
+  computeIdempotencyKey,
+  insertLedgerTransaction,
+  type LedgerAccountRow,
+} from "./ledger-helpers";
 
 /** Convert a recurring amount to its monthly equivalent based on frequency. */
 export function toMonthlyAmount(amount: number, frequency: string): number {
@@ -283,26 +298,6 @@ export async function createRecurringTemplate(
   });
 
   return id;
-}
-
-/** Mark an occurrence as paid and enqueue for sync. */
-export async function confirmOccurrence(occurrenceId: string): Promise<void> {
-  const db = await getDatabase();
-  const now = new Date().toISOString();
-  await db.runAsync(
-    "UPDATE recurring_occurrences SET status = 'paid', paid_at = ? WHERE id = ?",
-    [now, occurrenceId]
-  );
-  await db.runAsync(
-    `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at) VALUES (?, ?, ?, ?, ?)`,
-    [
-      "recurring_occurrences",
-      occurrenceId,
-      "UPDATE",
-      JSON.stringify({ status: "paid", paid_at: now }),
-      now,
-    ]
-  );
 }
 
 /** True when a `recurring_occurrences` row already points to this transaction. */
@@ -630,4 +625,420 @@ export async function skipOccurrence(occurrenceId: string): Promise<void> {
       now,
     ]
   );
+}
+
+// ─── Record a recurring occurrence payment (full ledger mutation) ────────────
+
+export type RecordRecurringOccurrencePaymentInput = {
+  templateId: string;
+  /** Local `recurring_occurrences.id` of the occurrence being paid. When the
+   * UI caller has it (it does), pass it so the occurrence UPDATE is keyed by id
+   * — no template+date guess, no missing-sync-row race. */
+  occurrenceId?: string;
+  /** YYYY-MM-DD — the scheduled occurrence date (drives idempotency + matching). */
+  occurrenceDate: string;
+  /** YYYY-MM-DD — when the payment actually happened. Defaults to occurrenceDate. */
+  paymentDate?: string;
+  actualAmount: number;
+  sourceAccountId?: string | null;
+};
+
+export type RecordRecurringOccurrencePaymentResult =
+  | { success: true; created: number; alreadyRecorded: number }
+  | { success: false; error: string };
+
+type RecurringLeg = {
+  accountId: string;
+  amount: number;
+  direction: TransactionDirection;
+  rawDescription: string;
+  merchantName: string;
+  categoryId: string | null;
+  notes: string;
+};
+
+/**
+ * Offline-first mirror of webapp recurring-templates.ts
+ * `recordRecurringOccurrencePayment`. Replaces the old confirmOccurrence stub's
+ * logic for the "marcar como pagada con monto" path.
+ *
+ * - Validates `occurrenceDate` matches the template via getOccurrencesBetween.
+ * - Debt template → TWO legs: OUTFLOW from the source account
+ *   (category TRANSFER_CATEGORY_ID) + INFLOW on the debt account
+ *   (category template.category_id ?? getDebtPaymentCategoryId(account_type)).
+ *   Non-debt → ONE leg on the template account.
+ * - recurrence_group_id = computeRecurringGroupUuid(templateId, occurrenceDate)
+ *   (reused existing local impl — byte-identical to webapp).
+ * - PER-LEG idempotency: provider "RECURRING_CHECKLIST", providerTransactionId
+ *   = `${templateId}|${occurrenceDate}|${accountId}|${direction}` (uses
+ *   occurrenceDate, NOT paymentDate — distinct per leg).
+ * - On created > 0: occurrence → status 'paid', transaction_id = firstCreated,
+ *   paid_at = now (does NOT set linked_manually). Copies recurring_template_tags
+ *   → transaction_tags (soft-fail).
+ * - Applies the balance delta per CREATED tx only (skips dupes → no double
+ *   debit) against an in-memory accountMap, so a debt account hit by both legs
+ *   accumulates correctly. If a debt nextBalance <= 0 → deactivate templates +
+ *   delete pending occurrences (payoff lifecycle).
+ * - All writes wrapped in ONE withTransactionAsync.
+ */
+export async function recordRecurringOccurrencePayment(
+  input: RecordRecurringOccurrencePaymentInput
+): Promise<RecordRecurringOccurrencePaymentResult> {
+  if (!(input.actualAmount > 0)) {
+    return { success: false, error: "El monto debe ser mayor que cero." };
+  }
+
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+
+  const template = await db.getFirstAsync<{
+    id: string;
+    user_id: string;
+    account_id: string;
+    category_id: string | null;
+    currency_code: string;
+    direction: TransactionDirection;
+    frequency: string;
+    start_date: string;
+    end_date: string | null;
+    merchant_name: string | null;
+    description: string | null;
+    transfer_source_account_id: string | null;
+    account_type: string | null;
+  }>(
+    `SELECT t.id, t.user_id, t.account_id, t.category_id, t.currency_code, t.direction,
+            t.frequency, t.start_date, t.end_date, t.merchant_name, t.description,
+            t.transfer_source_account_id, a.account_type
+     FROM recurring_transaction_templates t
+     LEFT JOIN accounts a ON t.account_id = a.id
+     WHERE t.id = ?`,
+    [input.templateId]
+  );
+  if (!template) {
+    return { success: false, error: "No se encontró la plantilla recurrente." };
+  }
+  // Fail fast on a missing user_id — an empty-string user_id produces rows that
+  // fail Supabase RLS and stick in sync_queue forever.
+  if (!template.user_id) {
+    return { success: false, error: "Sesión inválida" };
+  }
+
+  // Validate occurrence matches the template's recurrence.
+  const targetDate = new Date(`${input.occurrenceDate}T12:00:00`);
+  const occurrences = getOccurrencesBetween(
+    template.start_date,
+    template.frequency as RecurrenceFrequency,
+    template.end_date,
+    targetDate,
+    targetDate
+  );
+  if (!occurrences.includes(input.occurrenceDate)) {
+    return { success: false, error: "La fecha no coincide con la recurrencia de la plantilla." };
+  }
+
+  const isDebtPaymentTemplate = !!template.account_type && isDebtAccountType(template.account_type);
+  const effectiveSourceAccountId =
+    input.sourceAccountId ?? template.transfer_source_account_id ?? null;
+
+  if (isDebtPaymentTemplate && !effectiveSourceAccountId) {
+    return { success: false, error: "Debes indicar la cuenta origen para registrar el pago de deuda." };
+  }
+  if (isDebtPaymentTemplate && effectiveSourceAccountId === template.account_id) {
+    return { success: false, error: "La cuenta origen no puede ser la misma cuenta de deuda." };
+  }
+
+  // Load involved accounts into a mutable map (balance deltas mutate it).
+  const accountIds = [
+    template.account_id,
+    ...(effectiveSourceAccountId ? [effectiveSourceAccountId] : []),
+  ];
+  const placeholders = accountIds.map(() => "?").join(", ");
+  const accountRows = await db.getAllAsync<LedgerAccountRow>(
+    `SELECT * FROM accounts WHERE id IN (${placeholders})`,
+    accountIds
+  );
+  const accountMap = new Map(accountRows.map((a) => [a.id, a]));
+  const targetAccount = accountMap.get(template.account_id);
+  if (!targetAccount) {
+    return { success: false, error: "No se encontró la cuenta destino del pago." };
+  }
+
+  // Build legs (mirror buildRecurringPaymentTransactions).
+  const baseLabel = template.merchant_name || template.description || "Pago recurrente";
+  let legs: RecurringLeg[];
+  if (isDebtPaymentTemplate) {
+    const sourceAccount = effectiveSourceAccountId ? accountMap.get(effectiveSourceAccountId) : null;
+    if (!sourceAccount) {
+      return { success: false, error: "No se encontró la cuenta origen para esta transferencia." };
+    }
+    legs = [
+      {
+        accountId: sourceAccount.id,
+        amount: input.actualAmount,
+        direction: "OUTFLOW",
+        rawDescription: `Transferencia a ${targetAccount.name} - ${baseLabel}`,
+        merchantName: `Transferencia a ${targetAccount.name}`,
+        categoryId: TRANSFER_CATEGORY_ID,
+        notes: "Pago recurrente marcado desde checklist",
+      },
+      {
+        accountId: targetAccount.id,
+        amount: input.actualAmount,
+        direction: "INFLOW",
+        rawDescription: `Abono deuda desde ${sourceAccount.name} - ${baseLabel}`,
+        merchantName: baseLabel,
+        categoryId: template.category_id ?? getDebtPaymentCategoryId(targetAccount.account_type),
+        notes: "Abono de deuda marcado desde checklist recurrente",
+      },
+    ];
+  } else {
+    legs = [
+      {
+        accountId: template.account_id,
+        amount: input.actualAmount,
+        direction: template.direction,
+        rawDescription: baseLabel,
+        merchantName: baseLabel,
+        categoryId: template.category_id,
+        notes: "Transacción recurrente marcada desde checklist",
+      },
+    ];
+  }
+
+  const effectivePaymentDate = input.paymentDate ?? input.occurrenceDate;
+  const recurrenceGroupId = await computeRecurringGroupUuid(template.id, input.occurrenceDate);
+
+  let created = 0;
+  let alreadyRecorded = 0;
+  const createdTxIds: string[] = [];
+  const createdLegs: { accountId: string; amount: number; direction: TransactionDirection }[] = [];
+
+  await db.withTransactionAsync(async () => {
+    // Persist the resolved source account on the template if it changed (debt).
+    // Inside the transaction so it rolls back atomically with the payment.
+    if (
+      isDebtPaymentTemplate &&
+      effectiveSourceAccountId &&
+      effectiveSourceAccountId !== template.transfer_source_account_id
+    ) {
+      await db.runAsync(
+        "UPDATE recurring_transaction_templates SET transfer_source_account_id = ?, updated_at = ? WHERE id = ?",
+        [effectiveSourceAccountId, now, template.id]
+      );
+      await enqueueUpdate(
+        db,
+        "recurring_transaction_templates",
+        template.id,
+        { transfer_source_account_id: effectiveSourceAccountId, updated_at: now },
+        now
+      );
+    }
+
+    for (const leg of legs) {
+      // PER-LEG idempotency: providerTransactionId uses occurrenceDate (NOT
+      // paymentDate), so the key is stable regardless of when paid.
+      const recurrenceIdentity = `${template.id}|${input.occurrenceDate}|${leg.accountId}|${leg.direction}`;
+      const idempotencyKey = await computeIdempotencyKey({
+        provider: "RECURRING_CHECKLIST",
+        providerTransactionId: recurrenceIdentity,
+        transactionDate: input.occurrenceDate,
+        amount: leg.amount,
+        rawDescription: leg.rawDescription,
+      });
+
+      const txPayload = buildLedgerTxPayload(
+        {
+          userId: template.user_id,
+          accountId: leg.accountId,
+          amount: leg.amount,
+          currencyCode: template.currency_code,
+          direction: leg.direction,
+          transactionDate: effectivePaymentDate,
+          rawDescription: leg.rawDescription,
+          merchantName: leg.merchantName,
+          categoryId: leg.categoryId,
+          categorizationSource: leg.categoryId ? "USER_CREATED" : "SYSTEM_DEFAULT",
+          notes: leg.notes,
+          idempotencyKey,
+          isRecurring: true,
+          recurrenceGroupId,
+        },
+        now
+      );
+
+      const { inserted, id } = await insertLedgerTransaction(db, txPayload, now);
+      if (!inserted) {
+        alreadyRecorded++;
+        continue;
+      }
+      created++;
+      createdTxIds.push(id);
+      createdLegs.push({ accountId: leg.accountId, amount: leg.amount, direction: leg.direction });
+    }
+
+    if (created > 0) {
+      // Mark the matching occurrence paid (does NOT set linked_manually).
+      const occPayload = {
+        status: "paid",
+        transaction_id: createdTxIds[0],
+        paid_at: now,
+      };
+      if (input.occurrenceId) {
+        // Caller supplied the occurrence id — key the UPDATE + sync row by it.
+        // No template+date guess, no missing-row race.
+        await db.runAsync(
+          `UPDATE recurring_occurrences
+             SET status = 'paid', transaction_id = ?, paid_at = ?
+             WHERE id = ? AND status = 'pending'`,
+          [createdTxIds[0], now, input.occurrenceId]
+        );
+        await enqueueUpdate(
+          db,
+          "recurring_occurrences",
+          input.occurrenceId,
+          occPayload,
+          now
+        );
+      } else {
+        // Fallback: template + date. If no local occurrence row exists yet
+        // (not pulled), the UPDATE is a no-op — never enqueue a guessed row,
+        // or Supabase would receive a stale UPDATE keyed by the wrong id.
+        const res = await db.runAsync(
+          `UPDATE recurring_occurrences
+             SET status = 'paid', transaction_id = ?, paid_at = ?
+             WHERE template_id = ? AND occurrence_date = ? AND status = 'pending'`,
+          [createdTxIds[0], now, template.id, input.occurrenceDate]
+        );
+        if (res.changes === 0) {
+          console.warn(
+            `recordRecurringOccurrencePayment: no local pending occurrence for template ${template.id} @ ${input.occurrenceDate}; skipping occurrence sync enqueue (it will be reconciled on next pull).`
+          );
+        } else {
+          const occRow = await db.getFirstAsync<{ id: string }>(
+            `SELECT id FROM recurring_occurrences
+               WHERE template_id = ? AND occurrence_date = ? LIMIT 1`,
+            [template.id, input.occurrenceDate]
+          );
+          if (occRow) {
+            await enqueueUpdate(
+              db,
+              "recurring_occurrences",
+              occRow.id,
+              occPayload,
+              now
+            );
+          }
+        }
+      }
+
+      // Copy template tags onto every created transaction (soft-fail). The
+      // `recurring_template_tags` table may not exist on mobile yet (webapp-only
+      // for now) — probe first so a missing table is a silent no-op rather than
+      // a mid-transaction error that would roll back the whole payment.
+      const tagTableExists = await db.getFirstAsync<{ name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'recurring_template_tags'"
+      );
+      if (tagTableExists) {
+        const tagRows = await db.getAllAsync<{ tag_id: string }>(
+          "SELECT tag_id FROM recurring_template_tags WHERE recurring_template_id = ?",
+          [template.id]
+        );
+        const tagIds = tagRows.map((r) => r.tag_id);
+        if (tagIds.length > 0) {
+          for (const txId of createdTxIds) {
+            for (const tagId of tagIds) {
+              await db.runAsync(
+                "INSERT OR IGNORE INTO transaction_tags (transaction_id, tag_id) VALUES (?, ?)",
+                [txId, tagId]
+              );
+            }
+            await db.runAsync(
+              `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+               VALUES ('transaction_tags', ?, 'REPLACE', ?, ?)`,
+              [
+                txId,
+                JSON.stringify({
+                  transaction_id: txId,
+                  tag_ids: tagIds,
+                  // transaction_tags has a NOT-NULL user_id (webapp inserts it).
+                  user_id: template.user_id,
+                }),
+                now,
+              ]
+            );
+          }
+        }
+      }
+    }
+
+    // Apply balance delta per CREATED leg only (skip dupes → no double debit).
+    // accountMap rows are mutated by applyLocalBalanceDelta so a debt account
+    // hit by both legs accumulates.
+    for (const leg of createdLegs) {
+      const account = accountMap.get(leg.accountId);
+      if (!account) continue;
+      const nextBalance = await applyLocalBalanceDelta(
+        db,
+        account,
+        leg.direction,
+        leg.amount,
+        template.currency_code,
+        now
+      );
+      // Payoff lifecycle: a debt that reached 0 stops generating cuotas.
+      if (isDebtAccountType(account.account_type) && nextBalance <= 0) {
+        await deactivateTemplatesForPaidOffAccountLocal(db, account.id, now);
+      }
+    }
+  });
+
+  return { success: true, created, alreadyRecorded };
+}
+
+/**
+ * Local port of webapp `deactivateTemplatesForPaidOffAccount`: when a debt
+ * account reaches 0, deactivate its active templates (is_active = 0,
+ * end_date = today) and DELETE only its PENDING occurrences (paid/skipped stay
+ * as history). Enqueues all changes for sync. Caller runs inside a transaction.
+ */
+async function deactivateTemplatesForPaidOffAccountLocal(
+  db: Awaited<ReturnType<typeof getDatabase>>,
+  accountId: string,
+  now: string
+): Promise<void> {
+  // Colombia-timezone date for end_date, matching webapp (toColombiaDateString).
+  // `now.slice(0,10)` would be UTC — wrong day late-evening in Colombia (UTC-5).
+  const today = toColombiaDateString(new Date(now));
+  const templates = await db.getAllAsync<{ id: string }>(
+    "SELECT id FROM recurring_transaction_templates WHERE account_id = ? AND is_active = 1",
+    [accountId]
+  );
+  if (templates.length === 0) return;
+
+  for (const t of templates) {
+    await db.runAsync(
+      "UPDATE recurring_transaction_templates SET is_active = 0, end_date = ?, updated_at = ? WHERE id = ?",
+      [today, now, t.id]
+    );
+    await enqueueUpdate(
+      db,
+      "recurring_transaction_templates",
+      t.id,
+      { is_active: false, end_date: today, updated_at: now },
+      now
+    );
+
+    const pendingOccs = await db.getAllAsync<{ id: string }>(
+      "SELECT id FROM recurring_occurrences WHERE template_id = ? AND status = 'pending'",
+      [t.id]
+    );
+    for (const occ of pendingOccs) {
+      await db.runAsync("DELETE FROM recurring_occurrences WHERE id = ?", [occ.id]);
+      await db.runAsync(
+        `INSERT INTO sync_queue (table_name, record_id, operation, payload, created_at)
+         VALUES ('recurring_occurrences', ?, 'DELETE', ?, ?)`,
+        [occ.id, JSON.stringify({ id: occ.id }), now]
+      );
+    }
+  }
 }

--- a/mobile/lib/repositories/transfers.ts
+++ b/mobile/lib/repositories/transfers.ts
@@ -1,0 +1,163 @@
+import * as Crypto from "expo-crypto";
+import { getDatabase } from "../db/database";
+import {
+  applyLocalBalanceDelta,
+  buildLedgerTxPayload,
+  computeIdempotencyKey,
+  insertLedgerTransaction,
+  type LedgerAccountRow,
+} from "./ledger-helpers";
+
+export type CreateTransferInput = {
+  fromAccountId: string;
+  toAccountId: string;
+  amount: number;
+  /** YYYY-MM-DD */
+  date: string;
+  notes?: string;
+};
+
+export type CreateTransferResult =
+  | { success: true; outflowId: string; inflowId: string }
+  | { success: false; error: string };
+
+/**
+ * Offline-first mirror of webapp transfers.ts `createTransfer`.
+ *
+ * Inserts a paired OUTFLOW (on `from`) + INFLOW (on `to`) sharing one
+ * `transfer_group_id`, then updates both balances (from = OUTFLOW, to = INFLOW)
+ * via applyLocalBalanceDelta — so debt legs clamp at 0 and recompute
+ * available_balance through the shared debt payload. All 4 writes are wrapped in
+ * ONE withTransactionAsync, so any throw rolls back the whole transfer (this
+ * replaces the webapp's manual outflow-delete rollback).
+ *
+ * Guards (match webapp): from !== to, amount > 0, SAME currency (hard reject —
+ * no FX). Idempotency rawDescription is byte-identical:
+ *   `${desc}|${fromId}→${toId}|${groupId}` — so the two legs never collide and
+ * legitimate same-day transfers don't dedup against each other.
+ */
+export async function createTransfer(
+  input: CreateTransferInput
+): Promise<CreateTransferResult> {
+  if (input.fromAccountId === input.toAccountId) {
+    return { success: false, error: "No puedes transferir a la misma cuenta." };
+  }
+  if (!(input.amount > 0)) {
+    return { success: false, error: "El monto debe ser mayor que cero." };
+  }
+
+  const db = await getDatabase();
+
+  const fromAccount = await db.getFirstAsync<LedgerAccountRow>(
+    "SELECT * FROM accounts WHERE id = ?",
+    [input.fromAccountId]
+  );
+  if (!fromAccount) return { success: false, error: "Cuenta de origen no encontrada" };
+
+  const toAccount = await db.getFirstAsync<LedgerAccountRow>(
+    "SELECT * FROM accounts WHERE id = ?",
+    [input.toAccountId]
+  );
+  if (!toAccount) return { success: false, error: "Cuenta de destino no encontrada" };
+
+  // Fail fast on a missing/mismatched user_id — an empty-string user_id produces
+  // rows that fail Supabase RLS and stick in sync_queue forever. Both legs share
+  // one owner; validate both and use the verified id for the ledger payloads.
+  const userId = fromAccount.user_id;
+  if (!userId || !toAccount.user_id || toAccount.user_id !== userId) {
+    return { success: false, error: "Sesión inválida" };
+  }
+
+  // Reject cross-currency transfers (no FX support yet) — matches webapp.
+  if (fromAccount.currency_code !== toAccount.currency_code) {
+    return {
+      success: false,
+      error:
+        "No se pueden hacer transferencias entre cuentas con diferente moneda. Ambas deben ser " +
+        fromAccount.currency_code +
+        ".",
+    };
+  }
+
+  const now = new Date().toISOString();
+  const transferGroupId = Crypto.randomUUID();
+  const currencyCode = fromAccount.currency_code;
+
+  const outflowDescription = `Transferencia a ${toAccount.name}`;
+  const inflowDescription = `Transferencia desde ${fromAccount.name}`;
+
+  // Account IDs + transferGroupId in the rawDescription so two legitimate
+  // same-day transfers don't collide, and the legs differ from one another.
+  const outflowKey = await computeIdempotencyKey({
+    provider: "MANUAL",
+    transactionDate: input.date,
+    amount: input.amount,
+    rawDescription: `${outflowDescription}|${input.fromAccountId}→${input.toAccountId}|${transferGroupId}`,
+  });
+  const inflowKey = await computeIdempotencyKey({
+    provider: "MANUAL",
+    transactionDate: input.date,
+    amount: input.amount,
+    rawDescription: `${inflowDescription}|${input.fromAccountId}→${input.toAccountId}|${transferGroupId}`,
+  });
+
+  const outflowPayload = buildLedgerTxPayload(
+    {
+      userId,
+      accountId: input.fromAccountId,
+      amount: input.amount,
+      currencyCode,
+      direction: "OUTFLOW",
+      transactionDate: input.date,
+      rawDescription: outflowDescription,
+      merchantName: toAccount.name,
+      notes: input.notes ?? null,
+      idempotencyKey: outflowKey,
+      transferGroupId,
+    },
+    now
+  );
+  const inflowPayload = buildLedgerTxPayload(
+    {
+      userId,
+      accountId: input.toAccountId,
+      amount: input.amount,
+      currencyCode,
+      direction: "INFLOW",
+      transactionDate: input.date,
+      rawDescription: inflowDescription,
+      merchantName: fromAccount.name,
+      notes: input.notes ?? null,
+      idempotencyKey: inflowKey,
+      transferGroupId,
+    },
+    now
+  );
+
+  let duplicate = false;
+  await db.withTransactionAsync(async () => {
+    const outflowRes = await insertLedgerTransaction(db, outflowPayload, now);
+    if (!outflowRes.inserted) {
+      duplicate = true;
+      return;
+    }
+    const inflowRes = await insertLedgerTransaction(db, inflowPayload, now);
+    if (!inflowRes.inserted) {
+      // Throw to roll back the outflow + its sync row in one atomic step
+      // (replaces webapp's manual outflow-delete rollback).
+      duplicate = true;
+      throw new Error("__TRANSFER_DUPLICATE__");
+    }
+
+    // FROM: OUTFLOW · TO: INFLOW. Both clamp/recompute as applicable (debt).
+    await applyLocalBalanceDelta(db, fromAccount, "OUTFLOW", input.amount, currencyCode, now);
+    await applyLocalBalanceDelta(db, toAccount, "INFLOW", input.amount, currencyCode, now);
+  }).catch((err) => {
+    if (err instanceof Error && err.message === "__TRANSFER_DUPLICATE__") return;
+    throw err;
+  });
+
+  if (duplicate) return { success: false, error: "Esta transferencia ya fue registrada" };
+
+  return { success: true, outflowId: outflowPayload.id, inflowId: inflowPayload.id };
+}

--- a/mobile/lib/sync/push.ts
+++ b/mobile/lib/sync/push.ts
@@ -148,6 +148,9 @@ export async function pushPendingChanges(): Promise<number> {
             const rows = payload.tag_ids.map((tagId: string) => ({
               transaction_id: item.record_id,
               tag_id: tagId,
+              // transaction_tags has a NOT-NULL user_id (RLS-scoped). The
+              // enqueuer now carries it; without it the insert fails NOT-NULL/RLS.
+              user_id: payload.user_id,
             }));
             const { error: insError } = await sb
               .from(tableName)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -25,6 +25,7 @@ export * from "./utils/extra-payment";
 export * from "./utils/cc-projection";
 export * from "./utils/dashboard-layout";
 export * from "./utils/account-balance";
+export * from "./utils/debt-balance";
 export * from "./utils/monthly-aggregates";
 export * from "./utils/ritmo";
 export * from "./utils/subscription-detector";

--- a/packages/shared/src/utils/debt-balance.ts
+++ b/packages/shared/src/utils/debt-balance.ts
@@ -1,0 +1,41 @@
+/**
+ * Build the accounts-row update payload for a debt account whose balance just
+ * changed: current_balance, available_balance, and the currency_balances
+ * JSONB that /deudas reads via extractDebtAccounts. Single source of truth —
+ * every debt-payment path (checklist, extra payment, auto-linked companion
+ * leg, mobile ledger mutations) must write these fields together or the page
+ * shows stale debt.
+ *
+ * Pure function — no Supabase / no I/O. Lives in @zeta/shared so both the
+ * webapp Server Actions and the mobile offline-first repositories produce a
+ * byte-identical payload.
+ */
+export function buildDebtBalanceUpdatePayload(
+  account: {
+    credit_limit: number | null;
+    currency_balances: unknown;
+  },
+  nextBalance: number,
+  currencyCode: string
+): Record<string, unknown> {
+  const nextAvailable =
+    account.credit_limit != null ? Math.max(account.credit_limit - nextBalance, 0) : undefined;
+
+  const updatePayload: Record<string, unknown> = { current_balance: nextBalance };
+  if (nextAvailable !== undefined) updatePayload.available_balance = nextAvailable;
+
+  const cb = account.currency_balances as Record<string, Record<string, unknown>> | null;
+  if (cb && cb[currencyCode]) {
+    updatePayload.currency_balances = {
+      ...cb,
+      [currencyCode]: {
+        ...cb[currencyCode],
+        current_balance: nextBalance,
+        total_payment_due: Math.max(nextBalance, 0),
+        ...(nextAvailable !== undefined ? { available_balance: nextAvailable } : {}),
+      },
+    };
+  }
+
+  return updatePayload;
+}

--- a/webapp/src/lib/debt/payoff.ts
+++ b/webapp/src/lib/debt/payoff.ts
@@ -2,43 +2,12 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 import { toColombiaDateString } from "@/lib/utils/date";
 import { applyAccountBalanceDelta, isDebtAccountType } from "@/lib/utils/account-balance";
+import { buildDebtBalanceUpdatePayload } from "@zeta/shared";
 
-/**
- * Build the accounts-row update payload for a debt account whose balance just
- * changed: current_balance, available_balance, and the currency_balances
- * JSONB that /deudas reads via extractDebtAccounts. Single source of truth —
- * every debt-payment path (checklist, extra payment, auto-linked companion
- * leg) must write these fields together or the page shows stale debt.
- */
-export function buildDebtBalanceUpdatePayload(
-  account: {
-    credit_limit: number | null;
-    currency_balances: unknown;
-  },
-  nextBalance: number,
-  currencyCode: string
-): Record<string, unknown> {
-  const nextAvailable =
-    account.credit_limit != null ? Math.max(account.credit_limit - nextBalance, 0) : undefined;
-
-  const updatePayload: Record<string, unknown> = { current_balance: nextBalance };
-  if (nextAvailable !== undefined) updatePayload.available_balance = nextAvailable;
-
-  const cb = account.currency_balances as Record<string, Record<string, unknown>> | null;
-  if (cb && cb[currencyCode]) {
-    updatePayload.currency_balances = {
-      ...cb,
-      [currencyCode]: {
-        ...cb[currencyCode],
-        current_balance: nextBalance,
-        total_payment_due: Math.max(nextBalance, 0),
-        ...(nextAvailable !== undefined ? { available_balance: nextAvailable } : {}),
-      },
-    };
-  }
-
-  return updatePayload;
-}
+// Pure payload builder now lives in @zeta/shared so the webapp Server Actions
+// and the mobile offline-first repositories produce a byte-identical update.
+// Re-exported here to preserve the existing webapp import surface.
+export { buildDebtBalanceUpdatePayload };
 
 /**
  * Apply a payment (INFLOW) to a debt account's stored balances. Deactivates


### PR DESCRIPTION
## What

Closes the mobile **write-side** parity gap with the webapp. The money-moving buttons were dead "Próximamente" stubs and the recurrentes confirm corrupted balances (marked paid, created no transaction). They now work — verified on the iOS simulator.

## Phase 1 — ledger mutation layer (gate-reviewed)

Four mobile repo mutations mirroring the webapp Server Actions byte-for-byte: `registerPayment` + `reconcileBalance` (`accounts.ts`), `createTransfer` (new `transfers.ts`), `recordRecurringOccurrencePayment` (`recurring.ts`). Plus shared `ledger-helpers.ts`, `buildDebtBalanceUpdatePayload` promoted to `@zeta/shared`, and mobile schema v17 (`accounts.currency_balances`).

Reviewed by `mobile-webapp-parity` + `mobile-sync-doctor`; blockers fixed:
- `user_id` fail-fast guards (no RLS-failing empty-string rows)
- recurring occurrence-id race → race-free `occurrenceId` path
- `transaction_tags.user_id` added to the sync push payload
- multi-write atomicity via `withTransactionAsync`
- reconcile `merchant_name=null`, payoff `end_date` Colombia TZ

## Phase 2 — screen wiring

Pagar / Transferir / Ajustar (account detail + QuickActionsBar), capture **Transferencia**, and recurrentes **Confirmar** now call the new repos via new bottom-sheets. The plan `PaymentSheet` is rerouted off its direct-to-Supabase path (it missed the debt clamp + bypassed local SQLite/sync). `confirmOccurrence` stub deleted.

## Phase 0 + polish

Dead route `/(tabs)/deseos`→`/deseos`, signup/reset password min 6→8, 56 accent/grammar fixes (22 files), negative net-worth `−` sign.

## Verified on iOS sim (demo mode)

**Pagar → registerPayment** end-to-end: loan $6.800.000 → $6.300.000 (−500k), real "Abono a deuda" tx, Ingresos del mes +500k, screen refreshed. Ajustar sheet confirmed. Gates green: mobile + webapp + shared `tsc` clean, webapp `pnpm build` passes.

## Not yet done (tracked in BACKLOG.md)

- Emulator-verify Transferir / Reconcile / **Recurrentes Confirmar** (demo seeds no recurring occurrences — needs a real account)
- transfer FROM-debt `available_balance` clamp divergence; multi-currency reconcile; `recurring_template_tags` table
- iOS Podfile modular-headers fix is gitignored/local-only → make durable via `expo-build-properties`

🤖 Generated with [Claude Code](https://claude.com/claude-code)