### PR TITLE
feat(mobile): picker polish + email import queue + sync-stall fix

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,6 +10,14 @@
 
 ---
 
+## Mobile design-system follow-ups (2026-06-22, post PR #302)
+
+PR #302 fixed the inline-tx picker bugs (panel opacity / see-through scrim / flex-collapse) + a 36-file design-system sweep (MobileSheet conversion ×4, safe-area, brand colors, button classes, hex→COLORS). Remaining:
+
+- **Slash-opacity className sweep.** NativeWind v3 (this project) does NOT compile `bg-color/opacity` in `className` — it renders transparent (for `bg-`) or no-op (for `border-`). The scrims were the worst case (fixed). But many `className` tints/borders/pressed-states still use slash-opacity and render wrong: `bg-z-income/10`, `bg-z-brass/10`, `bg-z-surface-2/5`, `active:bg-z-surface-2/5`, `active:bg-z-surface-2/10`, `border-white/10`, `border-white/20`, `bg-z-debt/10` (e.g. periodo.tsx, PaymentSheet RadioOption, CategoryFormSheet/PaymentSheet pressed states). Sweep: grep `/[0-9]` inside className strings → replace with the dash token (`bg-z-income-10` etc.). Some tokens don't exist yet (`white-20`, `z-debt-10`, `surface-2-5`) and must be added to `tailwind.config.js` first.
+- **Verify the 4 MobileSheet conversions on device** (AddWidgetSheet, plan PaymentSheet, ReassignSheet, CategoryFormSheet) — tsc-clean structural refactors, worth a visual check (esp. PaymentSheet's KeyboardAvoidingView + link/create modes).
+- **Off-token colors needing NEW tokens** (audit fix #9): `#0EA5E9` debt-blue, `#6366f1` account-seed default — propose tokens in colors.ts/TOKENS.md rather than approximating.
+
 ## Mobile ledger parity — Phase 2 follow-ups (2026-06-22)
 
 Mobile got the 4 ledger mutations (`registerPayment`/`createTransfer`/`reconcileBalance`/`recordRecurringOccurrencePayment`) + screen wiring this session. Verified end-to-end on iOS sim: **account Pagar → registerPayment** (balance + tx + refresh all correct). Remaining:

--- a/mobile/app/(auth)/forgot-password.tsx
+++ b/mobile/app/(auth)/forgot-password.tsx
@@ -85,7 +85,7 @@ export default function ForgotPasswordScreen() {
             <TextInput
               className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
               placeholder="correo@ejemplo.com"
-              placeholderTextColor="#938C7E"
+              placeholderTextColor={COLORS.sageDark}
               value={email}
               onChangeText={setEmail}
               autoCapitalize="none"
@@ -103,7 +103,7 @@ export default function ForgotPasswordScreen() {
               activeOpacity={0.8}
             >
               {loading ? (
-                <ActivityIndicator color="#121412" />
+                <ActivityIndicator color={COLORS.ink} />
               ) : (
                 <Text className="text-z-ink font-semibold text-base">
                   Enviar enlace

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -174,7 +174,7 @@ export default function LoginScreen() {
             activeOpacity={0.7}
           >
             <View className="bg-z-brass-12 border border-z-brass-25 rounded-full p-4">
-              <Fingerprint size={36} color="#937844" />
+              <Fingerprint size={36} color={COLORS.brass} />
             </View>
             <Text className="text-z-brass font-inter-medium text-sm">
               Ingresar con biometría
@@ -197,7 +197,7 @@ export default function LoginScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="correo@ejemplo.com"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -212,7 +212,7 @@ export default function LoginScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
           placeholder="Tu contraseña"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -229,7 +229,7 @@ export default function LoginScreen() {
           activeOpacity={0.8}
         >
           {loading ? (
-            <ActivityIndicator color="#121412" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
             <Text className="text-z-ink font-semibold text-base">
               Iniciar sesión
@@ -246,7 +246,7 @@ export default function LoginScreen() {
           activeOpacity={0.8}
         >
           {demoLoading ? (
-            <ActivityIndicator color="#938C7E" />
+            <ActivityIndicator color={COLORS.sageDark} />
           ) : (
             <Text className="text-foreground font-semibold text-base">
               Probar demo sin cuenta

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -123,7 +123,7 @@ export default function ResetPasswordScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="Mínimo 8 caracteres"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -137,7 +137,7 @@ export default function ResetPasswordScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
           placeholder="Repite tu nueva contraseña"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={confirmPassword}
           onChangeText={setConfirmPassword}
           secureTextEntry
@@ -154,7 +154,7 @@ export default function ResetPasswordScreen() {
           activeOpacity={0.8}
         >
           {loading ? (
-            <ActivityIndicator color="#121412" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
             <Text className="text-z-ink font-semibold text-base">
               Guardar contraseña

--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -86,7 +86,7 @@ export default function SignupScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="correo@ejemplo.com"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -101,7 +101,7 @@ export default function SignupScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-4 text-base text-foreground bg-black-10"
           placeholder="Mínimo 8 caracteres"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -115,7 +115,7 @@ export default function SignupScreen() {
         <TextInput
           className="border border-white-6 rounded-lg px-4 py-3 mb-6 text-base text-foreground bg-black-10"
           placeholder="Repite tu contraseña"
-          placeholderTextColor="#938C7E"
+          placeholderTextColor={COLORS.sageDark}
           value={confirmPassword}
           onChangeText={setConfirmPassword}
           secureTextEntry
@@ -132,7 +132,7 @@ export default function SignupScreen() {
           activeOpacity={0.8}
         >
           {loading ? (
-            <ActivityIndicator color="#121412" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
             <Text className="text-z-ink font-semibold text-base">
               Crear cuenta

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -41,6 +41,7 @@ import {
   reschedulePaymentReminders,
 } from "../lib/services/notifications";
 import { trackProductEvent } from "../lib/analytics/product-events";
+import { COLORS } from "../lib/constants/colors";
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -378,7 +379,7 @@ function RootLayoutNav() {
         )}
         {isLoading && (
           <View style={styles.loadingOverlay}>
-            <ActivityIndicator size="large" color="#937844" />
+            <ActivityIndicator size="large" color={COLORS.brass} />
           </View>
         )}
         </OnboardingStatusContext.Provider>
@@ -391,7 +392,7 @@ function RootLayoutNav() {
 const styles = StyleSheet.create({
   loadingOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "#121412",
+    backgroundColor: COLORS.ink,
     alignItems: "center",
     justifyContent: "center",
   },

--- a/mobile/app/bug-report.tsx
+++ b/mobile/app/bug-report.tsx
@@ -13,7 +13,8 @@ import {
 import { useRouter } from "expo-router";
 import Constants from "expo-constants";
 import * as DocumentPicker from "expo-document-picker";
-import { MOBILE_TAB_BAR_CLEARANCE } from "../lib/constants/styles";
+import { MOBILE_TAB_BAR_CLEARANCE, BRASS_BUTTON_CLASS } from "../lib/constants/styles";
+import { COLORS } from "../lib/constants/colors";
 import { ArrowLeft, Paperclip, Send } from "lucide-react-native";
 import { supabase } from "../lib/supabase";
 import { useAuth } from "../lib/auth";
@@ -260,7 +261,7 @@ export default function BugReportScreen() {
           onPress={() => router.back()}
           className="w-8 h-8 items-center justify-center rounded-full bg-z-surface-2 active:bg-z-surface-3"
         >
-          <ArrowLeft size={18} color="#6B7280" />
+          <ArrowLeft size={18} color={COLORS.sageDark} />
         </Pressable>
         <Text className="text-foreground font-inter-bold text-base">
           Quick Capture de Bug
@@ -336,10 +337,10 @@ export default function BugReportScreen() {
               disabled={picking || submitting}
             >
               {picking ? (
-                <ActivityIndicator color="#6B7280" />
+                <ActivityIndicator color={COLORS.sageDark} />
               ) : (
                 <>
-                  <Paperclip size={16} color="#6B7280" />
+                  <Paperclip size={16} color={COLORS.sageDark} />
                   <Text className="ml-2 text-foreground font-inter-medium text-sm">
                     Adjuntar captura o PDF
                   </Text>
@@ -349,7 +350,7 @@ export default function BugReportScreen() {
           )}
 
           {!pendingScreenshotUri && attachment && (
-            <View className="mt-2 rounded-lg bg-sky-50 border border-sky-200 px-3 py-2">
+            <View className="mt-2 rounded-lg bg-z-brass-8 border border-z-brass-20 px-3 py-2">
               <Text className="text-z-brass font-inter text-xs" numberOfLines={2}>
                 Archivo: {attachment.name}
               </Text>
@@ -360,7 +361,7 @@ export default function BugReportScreen() {
               )}
               <Pressable
                 onPress={() => setAttachment(null)}
-                className="mt-2 self-start rounded-md border border-sky-300 px-2 py-1 active:bg-sky-100"
+                className="mt-2 self-start rounded-md border border-z-brass-30 px-2 py-1 active:bg-z-brass-10"
                 disabled={submitting}
               >
                 <Text className="text-z-brass font-inter-medium text-xs">
@@ -371,18 +372,18 @@ export default function BugReportScreen() {
           )}
         </View>
         <Pressable
-          className={`mt-5 rounded-xl py-3.5 items-center flex-row justify-center ${
-            canSubmit && !submitting ? "bg-primary" : "bg-z-surface-3"
+          className={`${BRASS_BUTTON_CLASS} mt-5 rounded-xl py-3.5 items-center flex-row justify-center ${
+            canSubmit && !submitting ? "" : "opacity-40"
           }`}
           onPress={handleSubmit}
           disabled={!canSubmit || submitting}
         >
           {submitting ? (
-            <ActivityIndicator color="#FFFFFF" />
+            <ActivityIndicator color={COLORS.ink} />
           ) : (
             <>
-              <Send size={16} color="#FFFFFF" />
-              <Text className="ml-2 text-white font-inter-bold text-base">
+              <Send size={16} color={COLORS.ink} />
+              <Text className="ml-2 text-z-ink font-inter-bold text-base">
                 Enviar ticket
               </Text>
             </>

--- a/mobile/app/capture-screenshot.tsx
+++ b/mobile/app/capture-screenshot.tsx
@@ -251,7 +251,7 @@ export default function CaptureScreenshotScreen() {
         >
           <ArrowLeft size={18} color={COLORS.foreground} />
         </Pressable>
-        <Text className="text-lg font-semibold text-z-white">
+        <Text className="text-lg font-semibold text-foreground">
           Capturar extracto
         </Text>
       </View>
@@ -285,7 +285,7 @@ export default function CaptureScreenshotScreen() {
               className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-4`}
             >
               <ImageIcon size={18} color={COLORS.foreground} />
-              <Text className="text-base font-medium text-z-white">
+              <Text className="text-base font-medium text-foreground">
                 Elegir de galería
               </Text>
             </Pressable>
@@ -297,7 +297,8 @@ export default function CaptureScreenshotScreen() {
             <Image
               source={{ uri: imageUri }}
               resizeMode="contain"
-              style={{ width: "100%", height: 420, borderRadius: 16, backgroundColor: "rgba(255,255,255,0.06)" }}
+              className="bg-white-6"
+              style={{ width: "100%", height: 420, borderRadius: 16 }}
             />
             {error ? (
               <Text className="text-sm text-z-expense">{error}</Text>
@@ -326,7 +327,7 @@ export default function CaptureScreenshotScreen() {
                   className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-3`}
                 >
                   <RefreshCw size={16} color={COLORS.foreground} />
-                  <Text className="text-sm font-medium text-z-white">
+                  <Text className="text-sm font-medium text-foreground">
                     Cambiar imagen
                   </Text>
                 </Pressable>
@@ -341,7 +342,7 @@ export default function CaptureScreenshotScreen() {
               <Text className="text-xs uppercase tracking-[0.14em] text-z-sage-dark">
                 {parsed.bank ?? "Extracto"}
               </Text>
-              <Text className="mt-1 text-base font-semibold text-z-white">
+              <Text className="mt-1 text-base font-semibold text-foreground">
                 {parsed.transactions.length} transacciones detectadas
               </Text>
             </View>
@@ -371,7 +372,7 @@ export default function CaptureScreenshotScreen() {
                         >
                           <Text
                             className={`text-xs ${
-                              isSelected ? "font-semibold text-z-brass" : "text-z-white"
+                              isSelected ? "font-semibold text-z-brass" : "text-foreground"
                             }`}
                           >
                             {a.name}
@@ -391,7 +392,7 @@ export default function CaptureScreenshotScreen() {
                   className="flex-row items-center justify-between rounded-2xl bg-z-surface-2-55 px-4 py-3"
                 >
                   <View className="flex-1 pr-3">
-                    <Text className="text-sm text-z-white" numberOfLines={1}>
+                    <Text className="text-sm text-foreground" numberOfLines={1}>
                       {t.description || "Sin descripción"}
                     </Text>
                     <Text className="text-xs text-z-sage-dark">{t.date}</Text>
@@ -442,7 +443,7 @@ export default function CaptureScreenshotScreen() {
         {step === "done" && (
           <View className="mt-6 items-center gap-4">
             <CheckCircle size={48} color={COLORS.income} />
-            <Text className="text-lg font-semibold text-z-white">
+            <Text className="text-lg font-semibold text-foreground">
               {importedCount} transacciones importadas
             </Text>
             <View className="w-full gap-3">
@@ -451,7 +452,7 @@ export default function CaptureScreenshotScreen() {
                 accessibilityRole="button"
                 className={`${GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-2xl px-4 py-4`}
               >
-                <Text className="text-base font-medium text-z-white">
+                <Text className="text-base font-medium text-foreground">
                   Capturar otra
                 </Text>
               </Pressable>

--- a/mobile/app/periodo.tsx
+++ b/mobile/app/periodo.tsx
@@ -6,12 +6,12 @@ import {
   Text,
   View,
 } from "react-native";
-import { useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
-import { ArrowLeft, Check, ChevronDown, Banknote } from "lucide-react-native";
+import { Check, ChevronDown, Banknote } from "lucide-react-native";
 import { formatCurrency, formatDate, type CurrencyCode } from "@zeta/shared";
 import { useAuth } from "../lib/auth";
 import { COLORS } from "../lib/constants/colors";
+import { MobileHeader } from "../components/ui/MobileHeader";
 import { isDebtAccountType } from "../lib/constants/accounts";
 import { MOBILE_TAB_BAR_CLEARANCE, PANEL_INSET_CLASS, SECTION_EYEBROW_CLASS } from "../lib/constants/styles";
 import { getActivePeriodWithEntries } from "../lib/repositories/planning";
@@ -87,7 +87,6 @@ interface PeriodoData {
 }
 
 export default function PeriodoScreen() {
-  const router = useRouter();
   const { session } = useAuth();
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<PeriodoData | null>(null);
@@ -244,7 +243,7 @@ export default function PeriodoScreen() {
   if (!data) {
     return (
       <View className="flex-1 bg-background">
-        <Header onBack={() => router.back()} />
+        <MobileHeader variant="sub" title="Plan del periodo" />
         <View className="flex-1 items-center justify-center px-8">
           <Text className="text-foreground font-inter-semibold text-base text-center">
             No hay periodo activo
@@ -262,7 +261,7 @@ export default function PeriodoScreen() {
 
   return (
     <View className="flex-1 bg-background">
-      <Header onBack={() => router.back()} />
+      <MobileHeader variant="sub" title="Plan del periodo" />
       <ScrollView
         className="flex-1"
         contentContainerStyle={{ padding: 16, gap: 12, paddingBottom: MOBILE_TAB_BAR_CLEARANCE }}
@@ -421,18 +420,6 @@ export default function PeriodoScreen() {
           loadData();
         }}
       />
-    </View>
-  );
-}
-
-// ── Header ──
-function Header({ onBack }: { onBack: () => void }) {
-  return (
-    <View className="flex-row items-center px-4 pt-14 pb-2">
-      <Pressable onPress={onBack} className="mr-3 p-1">
-        <ArrowLeft size={20} color={COLORS.sageLight} />
-      </Pressable>
-      <Text className="text-lg font-inter-bold text-foreground">Plan del periodo</Text>
     </View>
   );
 }

--- a/mobile/app/subscriptions.tsx
+++ b/mobile/app/subscriptions.tsx
@@ -19,6 +19,8 @@ import { supabase } from "../lib/supabase";
 import { parseLocalizedAmount } from "../lib/amount";
 import { useAuth } from "../lib/auth";
 import { KeyboardScreen } from "../components/common/KeyboardScreen";
+import { BRASS_BUTTON_CLASS } from "../lib/constants/styles";
+import { COLORS } from "../lib/constants/colors";
 const SUGGESTED_NAMES = [
   "Gym",
   "Netflix",
@@ -335,16 +337,14 @@ export default function SubscriptionsScreen() {
           <Pressable
             onPress={handleSave}
             disabled={saving || loading}
-            className={`flex-1 rounded-xl py-3 items-center ${
-              saving || loading
-                ? "bg-primary-light"
-                : "bg-primary active:bg-primary-dark"
+            className={`${BRASS_BUTTON_CLASS} flex-1 rounded-xl py-3 items-center ${
+              saving || loading ? "opacity-40" : ""
             }`}
           >
             {saving ? (
-              <ActivityIndicator color="#FFFFFF" />
+              <ActivityIndicator color={COLORS.ink} />
             ) : (
-              <Text className="text-white font-inter-bold text-sm">
+              <Text className="text-z-ink font-inter-bold text-sm">
                 {editingId ? "Guardar cambios" : "Agregar suscripción"}
               </Text>
             )}
@@ -364,7 +364,7 @@ export default function SubscriptionsScreen() {
     >
       {loading ? (
         <View className="flex-1 items-center justify-center py-16">
-          <ActivityIndicator size="large" color="#C5BFAE" />
+          <ActivityIndicator size="large" color={COLORS.sageLight} />
         </View>
       ) : (
         <>
@@ -381,7 +381,7 @@ export default function SubscriptionsScreen() {
                 <Pressable
                   key={name}
                   onPress={() => useSuggestedName(name)}
-                  className="rounded-full border border-z-brass/30 bg-z-brass/10 px-3 py-1.5 active:bg-z-brass/20"
+                  className="rounded-full border border-z-brass-30 bg-z-brass-10 px-3 py-1.5 active:bg-z-brass-20"
                 >
                   <Text className="text-z-brass font-inter-medium text-xs">{name}</Text>
                 </Pressable>
@@ -395,7 +395,7 @@ export default function SubscriptionsScreen() {
               value={merchantName}
               onChangeText={setMerchantName}
               placeholder="Ej: Netflix"
-              placeholderTextColor="#938C7E"
+              placeholderTextColor={COLORS.sageDark}
               className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
@@ -405,7 +405,7 @@ export default function SubscriptionsScreen() {
               onChangeText={setAmountInput}
               keyboardType="decimal-pad"
               placeholder="Ej: 49900"
-              placeholderTextColor="#938C7E"
+              placeholderTextColor={COLORS.sageDark}
               className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
@@ -413,7 +413,7 @@ export default function SubscriptionsScreen() {
               Cuenta de cobro
             </Text>
             {accounts.length === 0 ? (
-              <View className="rounded-xl border border-amber-700/30 bg-amber-900/20 px-3 py-2.5">
+              <View className="rounded-xl border border-z-alert-25 bg-z-alert-12 px-3 py-2.5">
                 <Text className="text-z-alert font-inter text-xs">
                   Crea una cuenta primero para registrar suscripciones.
                 </Text>
@@ -428,13 +428,13 @@ export default function SubscriptionsScreen() {
                       onPress={() => setAccountId(account.id)}
                       className={`rounded-xl border px-3 py-2 ${
                         selected
-                          ? "border-primary bg-primary-light"
+                          ? "border-z-brass bg-z-brass-15"
                           : "border-white-6 bg-black-10"
                       }`}
                     >
                       <Text
                         className={`font-inter-medium text-xs ${
-                          selected ? "text-primary-dark" : "text-foreground"
+                          selected ? "text-z-brass" : "text-foreground"
                         }`}
                       >
                         {account.name}
@@ -454,12 +454,12 @@ export default function SubscriptionsScreen() {
                     key={option.value}
                     onPress={() => setFrequency(option.value)}
                     className={`rounded-xl border px-3 py-2 ${
-                      selected ? "border-primary bg-primary-light" : "border-white-6 bg-black-10"
+                      selected ? "border-z-brass bg-z-brass-15" : "border-white-6 bg-black-10"
                     }`}
                   >
                     <Text
                       className={`font-inter-medium text-xs ${
-                        selected ? "text-primary-dark" : "text-foreground"
+                        selected ? "text-z-brass" : "text-foreground"
                       }`}
                     >
                       {option.label}
@@ -475,7 +475,7 @@ export default function SubscriptionsScreen() {
               onChangeText={setDayOfMonthInput}
               keyboardType="number-pad"
               placeholder="1 - 31"
-              placeholderTextColor="#938C7E"
+              placeholderTextColor={COLORS.sageDark}
               className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
@@ -486,7 +486,7 @@ export default function SubscriptionsScreen() {
               value={description}
               onChangeText={setDescription}
               placeholder="Ej: Plan familiar"
-              placeholderTextColor="#938C7E"
+              placeholderTextColor={COLORS.sageDark}
               className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-foreground"
             />
 
@@ -523,7 +523,7 @@ export default function SubscriptionsScreen() {
 
                       <View
                         className={`rounded-full px-2.5 py-1 ${
-                          item.is_active ? "bg-z-income/10" : "bg-black-10"
+                          item.is_active ? "bg-z-income-10" : "bg-black-10"
                         }`}
                       >
                         <Text
@@ -541,7 +541,7 @@ export default function SubscriptionsScreen() {
                         {formatCurrency(item.amount, item.currency_code as CurrencyCode)}
                       </Text>
                       <View className="flex-row items-center">
-                        <Repeat size={14} color="#938C7E" />
+                        <Repeat size={14} color={COLORS.sageDark} />
                         <Text className="ml-1 text-muted-foreground font-inter text-xs">
                           {getScheduleLabel(item)}
                         </Text>
@@ -565,11 +565,11 @@ export default function SubscriptionsScreen() {
 
                       <Pressable
                         onPress={() => toggleActive(item)}
-                        className="rounded-xl border border-sky-700/30 px-3 py-2 active:bg-sky-900/20"
+                        className="rounded-xl border border-z-brass-20 px-3 py-2 active:bg-z-brass-8"
                         disabled={isBusy || saving}
                       >
                         {togglingId === item.id ? (
-                          <ActivityIndicator size="small" color="#0284C7" />
+                          <ActivityIndicator size="small" color={COLORS.brass} />
                         ) : (
                           <Text className="text-z-brass font-inter-medium text-xs">
                             {item.is_active ? "Pausar" : "Activar"}
@@ -579,14 +579,14 @@ export default function SubscriptionsScreen() {
 
                       <Pressable
                         onPress={() => handleDelete(item)}
-                        className="rounded-xl border border-z-debt/30 px-3 py-2 active:bg-z-debt/10"
+                        className="rounded-xl border border-z-debt-30 px-3 py-2 active:bg-z-debt-12"
                         disabled={isBusy || saving}
                       >
                         {deletingId === item.id ? (
-                          <ActivityIndicator size="small" color="#DC2626" />
+                          <ActivityIndicator size="small" color={COLORS.expense} />
                         ) : (
                           <View className="flex-row items-center">
-                            <Trash2 size={12} color="#DC2626" />
+                            <Trash2 size={12} color={COLORS.expense} />
                             <Text className="ml-1 text-z-expense font-inter-medium text-xs">
                               Eliminar
                             </Text>

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -969,7 +969,7 @@ export default function TransactionDetailScreen() {
       {showDatePicker && Platform.OS === "ios" ? (
         <Modal transparent animationType="slide">
           <View className="flex-1 justify-end bg-black/40">
-            <View className="bg-z-surface-2-55 rounded-t-2xl pt-2 pb-6">
+            <View className="border-t border-white-6 bg-background rounded-t-2xl pt-2 pb-6">
               <View className="flex-row justify-end px-4 pb-2">
                 <Pressable
                   onPress={() => setShowDatePicker(false)}

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -972,7 +972,7 @@ export default function TransactionDetailScreen() {
             className="flex-1 justify-end"
             style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
           >
-            <View className="border-t border-white-6 bg-background rounded-t-2xl pt-2 pb-6">
+            <View className="border border-white-6 bg-background rounded-t-2xl pt-2 pb-6">
               <View className="flex-row justify-end px-4 pb-2">
                 <Pressable
                   onPress={() => setShowDatePicker(false)}

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -488,7 +488,7 @@ export default function TransactionDetailScreen() {
             accessibilityRole="button"
             className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-black-20"
           >
-            <X size={18} color="#938C7E" />
+            <X size={18} color={COLORS.sageDark} />
           </Pressable>
           <Text className="text-foreground font-inter-bold text-base">
             Detalle
@@ -543,7 +543,7 @@ export default function TransactionDetailScreen() {
               {saving ? (
                 <ActivityIndicator size="small" color={COLORS.income} />
               ) : (
-                <Text className="text-primary font-inter-bold text-sm">
+                <Text className="text-z-brass font-inter-bold text-sm">
                   Guardar
                 </Text>
               )}
@@ -557,7 +557,7 @@ export default function TransactionDetailScreen() {
               accessibilityRole="button"
               className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-black-20"
             >
-              <X size={18} color="#938C7E" />
+              <X size={18} color={COLORS.sageDark} />
             </Pressable>
             <Text className="text-foreground font-inter-bold text-base">
               Detalle
@@ -569,7 +569,7 @@ export default function TransactionDetailScreen() {
                 accessibilityRole="button"
                 className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-black-20"
               >
-                <Pencil size={16} color="#938C7E" />
+                <Pencil size={16} color={COLORS.sageDark} />
               </Pressable>
               <Pressable
                 onPress={handleDelete}
@@ -612,7 +612,7 @@ export default function TransactionDetailScreen() {
                 value={editMerchantName}
                 onChangeText={setEditMerchantName}
                 placeholder="Nombre del comercio"
-                placeholderTextColor="#938C7E"
+                placeholderTextColor={COLORS.sageDark}
                 autoCapitalize="words"
               />
             </FormField>
@@ -624,7 +624,7 @@ export default function TransactionDetailScreen() {
                 value={editDescription}
                 onChangeText={setEditDescription}
                 placeholder="Descripción de la transacción"
-                placeholderTextColor="#938C7E"
+                placeholderTextColor={COLORS.sageDark}
               />
             </FormField>
 
@@ -635,7 +635,7 @@ export default function TransactionDetailScreen() {
                 value={editAmount}
                 onChangeText={setEditAmount}
                 placeholder="0"
-                placeholderTextColor="#938C7E"
+                placeholderTextColor={COLORS.sageDark}
                 keyboardType="decimal-pad"
               />
             </FormField>
@@ -653,14 +653,14 @@ export default function TransactionDetailScreen() {
                     day: "numeric",
                   })}
                 </Text>
-                <Calendar size={16} color="#938C7E" />
+                <Calendar size={16} color={COLORS.sageDark} />
               </Pressable>
             </FormField>
 
             {/* Category */}
             <FormField label="Categoría">
               {isDebtPayment ? (
-                <View className="bg-sky-900/20 border border-sky-700/30 rounded-xl px-4 py-3 flex-row items-center justify-between">
+                <View className="bg-z-brass-8 border border-z-brass-20 rounded-xl px-4 py-3 flex-row items-center justify-between">
                   <Text className="font-inter-medium text-sm text-z-brass">
                     Abono a deuda
                   </Text>
@@ -680,7 +680,7 @@ export default function TransactionDetailScreen() {
                   >
                     {editCategoryName ?? "Sin categoría"}
                   </Text>
-                  <Tag size={16} color="#938C7E" />
+                  <Tag size={16} color={COLORS.sageDark} />
                 </Pressable>
               )}
             </FormField>
@@ -700,7 +700,7 @@ export default function TransactionDetailScreen() {
                 >
                   {editDestinatarioName ?? "Sin destinatario"}
                 </Text>
-                <UserRound size={16} color="#938C7E" />
+                <UserRound size={16} color={COLORS.sageDark} />
               </Pressable>
             </FormField>
 
@@ -711,7 +711,7 @@ export default function TransactionDetailScreen() {
                 value={editNotes}
                 onChangeText={setEditNotes}
                 placeholder="Agregar nota..."
-                placeholderTextColor="#938C7E"
+                placeholderTextColor={COLORS.sageDark}
                 multiline
                 style={{ minHeight: 72, textAlignVertical: "top" }}
               />
@@ -735,9 +735,9 @@ export default function TransactionDetailScreen() {
               <Switch
                 value={editIsExcluded}
                 onValueChange={setEditIsExcluded}
-                trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                trackColor={{ false: COLORS.switchTrack, true: COLORS.income }}
                 thumbColor={COLORS.foreground}
-                ios_backgroundColor="#3A3A3A"
+                ios_backgroundColor={COLORS.switchTrack}
               />
             </View>
           </ScrollView>
@@ -754,7 +754,7 @@ export default function TransactionDetailScreen() {
               })}
             </Text>
             {isExcluded && (
-              <View className="flex-row items-center bg-amber-900/20 px-3 py-1 rounded-full mb-2">
+              <View className="flex-row items-center bg-z-alert-12 px-3 py-1 rounded-full mb-2">
                 <Text className="text-z-alert font-inter-medium text-xs">
                   Excluido de totales
                 </Text>
@@ -853,9 +853,9 @@ export default function TransactionDetailScreen() {
               <Switch
                 value={isExcluded}
                 onValueChange={handleToggleExclude}
-                trackColor={{ false: "#3A3A3A", true: COLORS.income }}
+                trackColor={{ false: COLORS.switchTrack, true: COLORS.income }}
                 thumbColor={COLORS.foreground}
-                ios_backgroundColor="#3A3A3A"
+                ios_backgroundColor={COLORS.switchTrack}
               />
             </View>
 
@@ -978,7 +978,7 @@ export default function TransactionDetailScreen() {
                   onPress={() => setShowDatePicker(false)}
                   className="h-8 px-3 items-center justify-center"
                 >
-                  <Text className="text-primary font-inter-bold text-sm">
+                  <Text className="text-z-brass font-inter-bold text-sm">
                     Listo
                   </Text>
                 </Pressable>

--- a/mobile/app/transaction/[id].tsx
+++ b/mobile/app/transaction/[id].tsx
@@ -968,7 +968,10 @@ export default function TransactionDetailScreen() {
       {/* Date picker — iOS: spinner in bottom sheet; Android: native dialog */}
       {showDatePicker && Platform.OS === "ios" ? (
         <Modal transparent animationType="slide">
-          <View className="flex-1 justify-end bg-black/40">
+          <View
+            className="flex-1 justify-end"
+            style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+          >
             <View className="border-t border-white-6 bg-background rounded-t-2xl pt-2 pb-6">
               <View className="flex-row justify-end px-4 pb-2">
                 <Pressable

--- a/mobile/components/accounts/AccountBalanceCard.tsx
+++ b/mobile/components/accounts/AccountBalanceCard.tsx
@@ -2,6 +2,7 @@ import { View, Text } from "react-native";
 import { ACCOUNT_TYPES } from "../../lib/constants/accounts";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import type { AccountRow } from "../../lib/repositories/accounts";
+import { COLORS } from "../../lib/constants/colors";
 
 type Props = {
   account: AccountRow;
@@ -24,7 +25,7 @@ export function AccountBalanceCard({ account }: Props) {
     account.account_type === "LOAN";
   const typeDef = ACCOUNT_TYPES.find((t) => t.value === account.account_type);
   const Icon = typeDef?.icon;
-  const color = account.color ?? "#6B7280";
+  const color = account.color ?? COLORS.sageDark;
 
   // Credit utilization: balance / credit_limit (only for credit cards)
   const showUtilization =
@@ -38,9 +39,9 @@ export function AccountBalanceCard({ account }: Props) {
 
   // Utilization severity color
   const getUtilizationColor = (pct: number) => {
-    if (pct >= 80) return "#EF4444"; // red
-    if (pct >= 50) return "#F59E0B"; // amber
-    return "#10B981"; // green
+    if (pct >= 80) return COLORS.debt; // high
+    if (pct >= 50) return COLORS.alert; // medium
+    return COLORS.income; // low
   };
 
   return (

--- a/mobile/components/accounts/AccountCard.tsx
+++ b/mobile/components/accounts/AccountCard.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable } from "react-native";
 import { ACCOUNT_TYPES } from "../../lib/constants/accounts";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import type { AccountRow } from "../../lib/repositories/accounts";
+import { COLORS } from "../../lib/constants/colors";
 
 type Props = {
   account: AccountRow;
@@ -14,7 +15,7 @@ export function AccountCard({ account, onPress }: Props) {
   const typeDef = ACCOUNT_TYPES.find((t) => t.value === account.account_type);
   const Icon = typeDef?.icon;
   const shortLabel = typeDef?.shortLabel ?? account.account_type;
-  const color = account.color ?? "#6B7280";
+  const color = account.color ?? COLORS.sageDark;
   const isDebt = DEBT_TYPES.has(account.account_type);
 
   return (

--- a/mobile/components/accounts/CardFace.tsx
+++ b/mobile/components/accounts/CardFace.tsx
@@ -15,6 +15,16 @@ const INSTITUTION_GRADIENTS: Record<string, [string, string, string]> = {
 
 const FALLBACK_GRADIENT: [string, string, string] = ["#1a1a1a", "#252525", "#333333"];
 
+// Card-art text overlays sit on top of the institution gradient, so they use
+// translucent-white ink (not a brand token). Derived from a single white base
+// to keep the opacity ramp consistent.
+const CARD_INK = "255,255,255";
+const CARD_INK_PRIMARY = "#FFFFFF";
+const CARD_INK_70 = `rgba(${CARD_INK},0.7)`;
+const CARD_INK_60 = `rgba(${CARD_INK},0.6)`;
+const CARD_INK_50 = `rgba(${CARD_INK},0.5)`;
+const CARD_INK_40 = `rgba(${CARD_INK},0.4)`;
+
 const TYPE_LABELS: Record<string, string> = {
   CREDIT_CARD: "CRÉDITO",
   SAVINGS: "AHORROS",
@@ -54,14 +64,14 @@ export function CardFace({ account }: Props) {
       <View className="flex-1 p-4 justify-between">
         <View className="flex-row items-start justify-between">
           <Text
-            style={{ color: "rgba(255,255,255,0.7)" }}
+            style={{ color: CARD_INK_70 }}
             className="font-inter-medium text-xs uppercase"
             numberOfLines={1}
           >
             {account.institution_name ?? ""}
           </Text>
           <Text
-            style={{ color: "rgba(255,255,255,0.5)", letterSpacing: 1.5 }}
+            style={{ color: CARD_INK_50, letterSpacing: 1.5 }}
             className="font-inter-semibold text-[10px] uppercase"
           >
             {typeLabel}
@@ -69,7 +79,7 @@ export function CardFace({ account }: Props) {
         </View>
         <View className="flex-1 justify-center">
           <Text
-            style={{ color: "#FFFFFF" }}
+            style={{ color: CARD_INK_PRIMARY }}
             className="font-inter-bold text-xl tabular-nums"
           >
             {formatCurrency(account.current_balance ?? 0, cc)}
@@ -77,13 +87,13 @@ export function CardFace({ account }: Props) {
         </View>
         <View className="flex-row items-end justify-between">
           <Text
-            style={{ color: "rgba(255,255,255,0.6)", letterSpacing: 2 }}
+            style={{ color: CARD_INK_60, letterSpacing: 2 }}
             className="font-inter-medium text-sm"
           >
             {mask ? `•••• ${mask}` : "••••"}
           </Text>
           <Text
-            style={{ color: "rgba(255,255,255,0.4)" }}
+            style={{ color: CARD_INK_40 }}
             className="font-inter-medium text-xs"
           >
             {account.currency_code}

--- a/mobile/components/accounts/PaymentActionSheet.tsx
+++ b/mobile/components/accounts/PaymentActionSheet.tsx
@@ -15,7 +15,7 @@ import { registerPayment } from "../../lib/repositories/accounts";
 import { isDebtAccountType, LIQUID_ACCOUNT_TYPES } from "../../lib/constants/accounts";
 import { parseLocalizedAmount } from "../../lib/amount";
 import { COLORS } from "../../lib/constants/colors";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "../../lib/constants/styles";
 import { MobileSheet } from "../ui/MobileSheet";
 import {
   SheetAccountPicker,
@@ -185,12 +185,12 @@ export function PaymentActionSheet({
           <Pressable
             onPress={handleSubmit}
             disabled={!canSubmit}
-            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+            className={`${BRASS_BUTTON_CLASS} rounded-xl py-3 items-center mt-2 ${canSubmit ? "" : "opacity-40"}`}
           >
             {submitting ? (
               <ActivityIndicator size="small" color={COLORS.ink} />
             ) : (
-              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+              <Text className="text-sm font-inter-semibold text-z-ink">
                 {isDebt ? "Confirmar pago" : "Registrar"}
               </Text>
             )}

--- a/mobile/components/accounts/ReconcileSheet.tsx
+++ b/mobile/components/accounts/ReconcileSheet.tsx
@@ -15,7 +15,7 @@ import { reconcileBalance } from "../../lib/repositories/accounts";
 import { isDebtAccountType } from "../../lib/constants/accounts";
 import { parseLocalizedAmount } from "../../lib/amount";
 import { COLORS } from "../../lib/constants/colors";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "../../lib/constants/styles";
 import { MobileSheet } from "../ui/MobileSheet";
 import {
   SheetAmountInput,
@@ -118,12 +118,12 @@ export function ReconcileSheet({ visible, account, onClose, onSuccess }: Reconci
           <Pressable
             onPress={handleSubmit}
             disabled={!canSubmit}
-            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+            className={`${BRASS_BUTTON_CLASS} rounded-xl py-3 items-center mt-2 ${canSubmit ? "" : "opacity-40"}`}
           >
             {submitting ? (
               <ActivityIndicator size="small" color={COLORS.ink} />
             ) : (
-              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+              <Text className="text-sm font-inter-semibold text-z-ink">
                 Guardar ajuste
               </Text>
             )}

--- a/mobile/components/accounts/TransferSheet.tsx
+++ b/mobile/components/accounts/TransferSheet.tsx
@@ -15,6 +15,7 @@ import { createTransfer } from "../../lib/repositories/transfers";
 import { parseLocalizedAmount } from "../../lib/amount";
 import { toLocalDateString } from "../../lib/utils/date";
 import { COLORS } from "../../lib/constants/colors";
+import { BRASS_BUTTON_CLASS } from "../../lib/constants/styles";
 import { MobileSheet } from "../ui/MobileSheet";
 import {
   SheetAccountPicker,
@@ -186,12 +187,12 @@ export function TransferSheet({
           <Pressable
             onPress={handleSubmit}
             disabled={!canSubmit}
-            className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+            className={`${BRASS_BUTTON_CLASS} rounded-xl py-3 items-center mt-2 ${canSubmit ? "" : "opacity-40"}`}
           >
             {submitting ? (
               <ActivityIndicator size="small" color={COLORS.ink} />
             ) : (
-              <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+              <Text className="text-sm font-inter-semibold text-z-ink">
                 Confirmar transferencia
               </Text>
             )}

--- a/mobile/components/categories/CategoryFormSheet.tsx
+++ b/mobile/components/categories/CategoryFormSheet.tsx
@@ -4,14 +4,17 @@ import {
   Text,
   TextInput,
   Pressable,
-  Modal,
   ScrollView,
   type ViewStyle,
   Alert,
 } from "react-native";
 import { X, Trash2, ChevronDown } from "lucide-react-native";
 import { COLORS } from "../../lib/constants/colors";
-import { BRASS_BUTTON_CLASS } from "../../lib/constants/styles";
+import {
+  BRASS_BUTTON_CLASS,
+  DESTRUCTIVE_GHOST_BUTTON_CLASS,
+} from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
 import type { CategoryRow } from "../../lib/repositories/categories";
 
 /** Preset colors that read well on the dark background */
@@ -106,16 +109,11 @@ export function CategoryFormSheet({
   }, [category, onDelete, onClose]);
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-    >
-      <View className="flex-1 justify-end bg-black/60">
-        <View className="max-h-[80%] rounded-t-3xl border-t border-white-6 bg-background">
+    <MobileSheet visible={visible} onClose={onClose} maxHeightClass="max-h-[80%]" hideHandle>
+      <View>
+        <View>
           {/* Header */}
-          <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <View className="flex-row items-center justify-between px-4 pt-2 pb-2">
             <Text className="text-[15px] font-inter-semibold text-foreground">
               {isEditing ? "Editar categoría" : "Nueva categoría"}
             </Text>
@@ -129,10 +127,10 @@ export function CategoryFormSheet({
           </View>
 
           <ScrollView
-            className="flex-1"
+            style={{ flexShrink: 1 }}
             contentContainerStyle={{
               paddingHorizontal: 16,
-              paddingBottom: 40,
+              paddingBottom: 16,
               gap: 16,
             }}
             keyboardShouldPersistTaps="handled"
@@ -275,9 +273,9 @@ export function CategoryFormSheet({
               {isEditing && onDelete && (
                 <Pressable
                   onPress={handleDelete}
-                  className="flex-row items-center justify-center gap-2 rounded-xl border border-red-500/20 bg-red-500/8 py-3 active:opacity-80"
+                  className={`${DESTRUCTIVE_GHOST_BUTTON_CLASS} flex-row items-center justify-center gap-2 rounded-xl py-3 active:opacity-80`}
                 >
-                  <Trash2 size={14} color="#E05545" />
+                  <Trash2 size={14} color={COLORS.debt} />
                   <Text className="text-[13px] font-inter-semibold text-z-expense">
                     Eliminar categoría
                   </Text>
@@ -287,6 +285,6 @@ export function CategoryFormSheet({
           </ScrollView>
         </View>
       </View>
-    </Modal>
+    </MobileSheet>
   );
 }

--- a/mobile/components/categorizar/CategoryPickerSheet.tsx
+++ b/mobile/components/categorizar/CategoryPickerSheet.tsx
@@ -10,6 +10,7 @@ import {
 import { X } from "lucide-react-native";
 import { COLORS } from "../../lib/constants/colors";
 import type { CategoryRow } from "../../lib/repositories/categories";
+import { MODAL_SCRIM_COLOR } from "../ui/MobileSheet";
 
 interface CategoryPickerSheetProps {
   categories: CategoryRow[];
@@ -76,8 +77,11 @@ export function CategoryPickerSheet({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <View className="flex-1 justify-end bg-black/60">
-        <View className="max-h-[70%] rounded-t-3xl border-t border-white-6 bg-background">
+      <View
+        className="flex-1 justify-end"
+        style={{ backgroundColor: MODAL_SCRIM_COLOR }}
+      >
+        <View className="max-h-[70%] min-h-[320px] rounded-t-3xl border-t border-white-6 bg-background">
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
             <Text className="text-[15px] font-inter-semibold text-foreground">
@@ -93,7 +97,7 @@ export function CategoryPickerSheet({
           </View>
 
           <ScrollView
-            className="flex-1"
+            style={{ flexShrink: 1 }}
             contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40 }}
           >
             {/* Grouped sections */}

--- a/mobile/components/common/BiometricLockScreen.tsx
+++ b/mobile/components/common/BiometricLockScreen.tsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Fingerprint } from "lucide-react-native";
 import { authenticateWithBiometrics } from "../../lib/biometrics";
+import { COLORS } from "../../lib/constants/colors";
+import { BRASS_BUTTON_CLASS } from "../../lib/constants/styles";
 
 export function BiometricLockScreen({
   onUnlock,
@@ -25,7 +27,7 @@ export function BiometricLockScreen({
     <View style={styles.container}>
       <View className="items-center">
         <View className="h-20 w-20 rounded-full bg-z-brass-10 items-center justify-center mb-6">
-          <Fingerprint size={40} color="#937844" />
+          <Fingerprint size={40} color={COLORS.brass} />
         </View>
         <Text className="text-2xl font-inter-bold text-foreground mb-2">
           Zeta
@@ -36,7 +38,7 @@ export function BiometricLockScreen({
 
         <Pressable
           onPress={attemptUnlock}
-          className="rounded-xl bg-z-brass px-8 py-3.5 mb-4"
+          className={`${BRASS_BUTTON_CLASS} rounded-xl px-8 py-3.5 mb-4`}
         >
           <Text className="text-z-ink font-inter-bold text-base">
             Desbloquear
@@ -56,7 +58,7 @@ export function BiometricLockScreen({
 const styles = StyleSheet.create({
   container: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "#121412",
+    backgroundColor: COLORS.ink,
     alignItems: "center",
     justifyContent: "center",
     zIndex: 999,

--- a/mobile/components/common/KeyboardScreen.tsx
+++ b/mobile/components/common/KeyboardScreen.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from "react";
 import { Pressable, Text, View } from "react-native";
 import { ArrowLeft } from "lucide-react-native";
 import { KeyboardAvoidingView } from "react-native-keyboard-controller";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppKeyboardAwareScrollView } from "./AppKeyboardAwareScrollView";
 import { MOBILE_TAB_BAR_CLEARANCE } from "../../lib/constants/styles";
+import { COLORS } from "../../lib/constants/colors";
 
 export function KeyboardScreen({
   title,
@@ -16,17 +18,21 @@ export function KeyboardScreen({
   children: ReactNode;
   footer?: ReactNode;
 }) {
+  const insets = useSafeAreaInsets();
   return (
     <KeyboardAvoidingView
       className="flex-1 bg-background"
       behavior="padding"
     >
-      <View className="flex-row items-center justify-between border-b border-white-6 bg-z-surface-2-55 px-4 pb-2 pt-4">
+      <View
+        className="flex-row items-center justify-between border-b border-white-6 bg-z-surface-2-55 px-4 pb-2"
+        style={{ paddingTop: insets.top }}
+      >
         <Pressable
           onPress={onBack}
           className="h-8 w-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
         >
-          <ArrowLeft size={18} color="#938C7E" />
+          <ArrowLeft size={18} color={COLORS.sageDark} />
         </Pressable>
         <Text className="text-base font-inter-bold text-foreground">{title}</Text>
         <View className="w-8" />

--- a/mobile/components/common/MonthSelector.tsx
+++ b/mobile/components/common/MonthSelector.tsx
@@ -1,6 +1,7 @@
 import { Pressable, Text, View } from "react-native";
 import { ChevronLeft, ChevronRight } from "lucide-react-native";
 import { formatMonthLabel } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
 
 function parseMonth(month: string): Date {
   const [year, monthIndex] = month.split("-").map(Number);
@@ -36,7 +37,7 @@ export function MonthSelector({
         onPress={() => onChange(shiftMonth(month, -1))}
         className="h-8 w-8 items-center justify-center rounded-full bg-black-10"
       >
-        <ChevronLeft size={16} color="#938C7E" />
+        <ChevronLeft size={16} color={COLORS.sageDark} />
       </Pressable>
 
       <Text className="text-foreground font-inter-semibold text-sm capitalize">
@@ -56,7 +57,7 @@ export function MonthSelector({
           onPress={() => onChange(shiftMonth(month, 1))}
           className="h-8 w-8 items-center justify-center rounded-full bg-black-10"
         >
-          <ChevronRight size={16} color="#938C7E" />
+          <ChevronRight size={16} color={COLORS.sageDark} />
         </Pressable>
       </View>
     </View>

--- a/mobile/components/dashboard/BalanceCard.tsx
+++ b/mobile/components/dashboard/BalanceCard.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import { Wallet } from "lucide-react-native";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
 
 type BalanceCardProps = {
   totalBalance: number;
@@ -16,7 +17,7 @@ export function BalanceCard({
   return (
     <View className="bg-z-surface-2-55 rounded-lg p-5 mx-4 mt-4">
       <View className="flex-row items-center mb-2">
-        <Wallet size={18} color="#938C7E" />
+        <Wallet size={18} color={COLORS.sageDark} />
         <Text className="text-muted-foreground font-inter-medium text-sm ml-2">
           Balance total
         </Text>

--- a/mobile/components/dashboard/CategoryBreakdown.tsx
+++ b/mobile/components/dashboard/CategoryBreakdown.tsx
@@ -1,5 +1,6 @@
 import { View, Text } from "react-native";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
 
 export type CategorySpend = {
   category_id: string | null;
@@ -32,7 +33,7 @@ export function CategoryBreakdown({
       ) : (
         categories.map((cat, index) => {
           const percentage = maxTotal > 0 ? (cat.total / maxTotal) * 100 : 0;
-          const color = cat.category_color || "#6B7280";
+          const color = cat.category_color || COLORS.sageDark;
 
           return (
             <View key={cat.category_id ?? `unknown-${index}`} className="mb-3">

--- a/mobile/components/dashboard/MonthSummary.tsx
+++ b/mobile/components/dashboard/MonthSummary.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import { TrendingUp, TrendingDown } from "lucide-react-native";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
+import { COLORS } from "../../lib/constants/colors";
 
 type MonthSummaryProps = {
   income: number;
@@ -19,7 +20,7 @@ export function MonthSummary({
       <View className="flex-1 bg-z-surface-2-55 rounded-lg p-4">
         <View className="flex-row items-center mb-2">
           <View className="bg-z-income/10 rounded-full p-1.5">
-            <TrendingUp size={14} color="#22C55E" />
+            <TrendingUp size={14} color={COLORS.income} />
           </View>
           <Text className="text-muted-foreground font-inter text-xs ml-2">
             Ingresos
@@ -34,7 +35,7 @@ export function MonthSummary({
       <View className="flex-1 bg-z-surface-2-55 rounded-lg p-4">
         <View className="flex-row items-center mb-2">
           <View className="bg-z-expense/10 rounded-full p-1.5">
-            <TrendingDown size={14} color="#EF4444" />
+            <TrendingDown size={14} color={COLORS.expense} />
           </View>
           <Text className="text-muted-foreground font-inter text-xs ml-2">
             Gastos

--- a/mobile/components/dashboard/PurchaseDecisionCard.tsx
+++ b/mobile/components/dashboard/PurchaseDecisionCard.tsx
@@ -1,6 +1,7 @@
 import { Pressable, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 import { Brain } from "lucide-react-native";
+import { COLORS } from "../../lib/constants/colors";
 
 export function PurchaseDecisionCard() {
   const router = useRouter();
@@ -12,7 +13,7 @@ export function PurchaseDecisionCard() {
     >
       <View className="flex-row items-center gap-3">
         <View className="h-10 w-10 rounded-full bg-z-brass/10 items-center justify-center">
-          <Brain size={20} color="#C5BFAE" />
+          <Brain size={20} color={COLORS.sageLight} />
         </View>
         <View className="flex-1">
           <Text className="text-sm font-inter-semibold text-foreground">

--- a/mobile/components/deseos/DeseosEnrichDrawer.tsx
+++ b/mobile/components/deseos/DeseosEnrichDrawer.tsx
@@ -139,7 +139,7 @@ export function DeseosEnrichDrawer({ visible, item, userId, onClose, onSaved }: 
               <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-sage-dark">
                 Completar
               </Text>
-              <Text className="font-inter-bold text-base text-z-white mt-0.5" numberOfLines={1}>
+              <Text className="font-inter-bold text-base text-foreground mt-0.5" numberOfLines={1}>
                 {item.name}
               </Text>
             </View>
@@ -163,7 +163,7 @@ export function DeseosEnrichDrawer({ visible, item, userId, onClose, onSaved }: 
                 maxLength={500}
                 placeholder="Describe tu motivación..."
                 placeholderTextColor={COLORS.sageDark}
-                className="rounded-xl border border-white-6 bg-z-surface-2 px-3 py-2.5 font-inter text-sm text-z-white min-h-[60px]"
+                className="rounded-xl border border-white-6 bg-z-surface-2 px-3 py-2.5 font-inter text-sm text-foreground min-h-[60px]"
                 style={{ textAlignVertical: "top" }}
               />
             </FieldGroup>
@@ -204,7 +204,7 @@ export function DeseosEnrichDrawer({ visible, item, userId, onClose, onSaved }: 
                   keyboardType="numeric"
                   placeholder="12"
                   placeholderTextColor={COLORS.sageDark}
-                  className="rounded-xl border border-white-6 bg-z-surface-2 px-3 py-2.5 font-inter-semibold text-sm text-z-white tabular-nums w-32"
+                  className="rounded-xl border border-white-6 bg-z-surface-2 px-3 py-2.5 font-inter-semibold text-sm text-foreground tabular-nums w-32"
                 />
               </FieldGroup>
             )}
@@ -229,7 +229,7 @@ export function DeseosEnrichDrawer({ visible, item, userId, onClose, onSaved }: 
                       >
                         <Text
                           className={`font-inter-semibold text-xs ${
-                            isSelected ? "text-z-white" : "text-z-sage-light"
+                            isSelected ? "text-foreground" : "text-z-sage-light"
                           }`}
                         >
                           {a.name}
@@ -247,7 +247,7 @@ export function DeseosEnrichDrawer({ visible, item, userId, onClose, onSaved }: 
                 onPress={() => setPickerOpen(true)}
                 className="flex-row items-center justify-between rounded-xl border border-white-6 bg-z-surface-2 px-3 py-3"
               >
-                <Text className="font-inter-semibold text-sm text-z-white">
+                <Text className="font-inter-semibold text-sm text-foreground">
                   {categoryLabel}
                 </Text>
                 <ChevronRight size={16} color={COLORS.sageDark} />

--- a/mobile/components/deseos/DeseosRoot.tsx
+++ b/mobile/components/deseos/DeseosRoot.tsx
@@ -398,7 +398,7 @@ function NudgeBanner({
         <Text className="text-[10px] font-inter-semibold uppercase tracking-[0.18em] text-z-brass">
           {nudge.type === "score_transition" ? "Pasó a verde" : "Llegó la hora"}
         </Text>
-        <Text className="font-inter text-xs text-z-white mt-0.5">
+        <Text className="font-inter text-xs text-foreground mt-0.5">
           {nudge.message}
         </Text>
       </View>
@@ -470,7 +470,7 @@ const DeseosRow = memo(function DeseosRow({
                 </Text>
               </View>
               {score != null && (
-                <Text className="text-[14px] font-inter-bold text-z-white tabular-nums">
+                <Text className="text-[14px] font-inter-bold text-foreground tabular-nums">
                   {Math.round(score)}
                   <Text className="text-[10px] text-muted-foreground"> /100</Text>
                 </Text>

--- a/mobile/components/inicio/AddWidgetSheet.tsx
+++ b/mobile/components/inicio/AddWidgetSheet.tsx
@@ -1,7 +1,7 @@
-import { View, Text, Pressable, Modal, ScrollView } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { View, Text, Pressable, ScrollView } from "react-native";
 import { X, Plus } from "lucide-react-native";
 import { COLORS } from "../../lib/constants/colors";
+import { MobileSheet } from "../ui/MobileSheet";
 import {
   WIDGET_CATALOG,
   type CatalogEntry,
@@ -21,55 +21,45 @@ export function AddWidgetSheet({
   onAdd,
   existingTypes,
 }: AddWidgetSheetProps) {
-  const insets = useSafeAreaInsets();
-
   return (
-    <Modal
-      visible={open}
-      animationType="slide"
-      transparent
-      onRequestClose={onClose}
-    >
-      <Pressable className="flex-1 bg-black-40" onPress={onClose} />
-      <View
-        className="rounded-t-2xl border-t border-white-6 bg-z-surface-2"
-        style={{ paddingBottom: insets.bottom + 8, maxHeight: "70%" }}
-      >
-        <View className="flex-row items-center justify-between px-4 pb-3 pt-4">
-          <View>
-            <Text className="text-sm font-inter-semibold text-foreground">
-              Añadir widget
-            </Text>
-            <Text className="mt-0.5 text-[11px] font-inter text-muted-foreground">
-              Personaliza tu inicio
-            </Text>
-          </View>
-          <Pressable
-            onPress={onClose}
-            accessibilityLabel="Cerrar"
-            className="h-8 w-8 items-center justify-center rounded-full"
-          >
-            <X size={18} color={COLORS.sageDark} />
-          </Pressable>
+    <MobileSheet visible={open} onClose={onClose} maxHeightClass="max-h-[70%]">
+      <View className="flex-row items-center justify-between px-4 pb-3 pt-1">
+        <View>
+          <Text className="text-sm font-inter-semibold text-foreground">
+            Añadir widget
+          </Text>
+          <Text className="mt-0.5 text-[11px] font-inter text-muted-foreground">
+            Personaliza tu inicio
+          </Text>
         </View>
-
-        <View className="h-px bg-z-surface-2-6 mx-4" />
-
-        <ScrollView contentContainerStyle={{ paddingVertical: 8 }}>
-          {WIDGET_CATALOG.map((entry) => (
-            <CatalogRow
-              key={entry.type}
-              entry={entry}
-              disabled={!entry.available || existingTypes.has(entry.type)}
-              onPress={() => {
-                onAdd(entry.type);
-                onClose();
-              }}
-            />
-          ))}
-        </ScrollView>
+        <Pressable
+          onPress={onClose}
+          accessibilityLabel="Cerrar"
+          className="h-8 w-8 items-center justify-center rounded-full"
+        >
+          <X size={18} color={COLORS.sageDark} />
+        </Pressable>
       </View>
-    </Modal>
+
+      <View className="h-px bg-z-surface-2-6 mx-4" />
+
+      <ScrollView
+        style={{ flexShrink: 1 }}
+        contentContainerStyle={{ paddingVertical: 8 }}
+      >
+        {WIDGET_CATALOG.map((entry) => (
+          <CatalogRow
+            key={entry.type}
+            entry={entry}
+            disabled={!entry.available || existingTypes.has(entry.type)}
+            onPress={() => {
+              onAdd(entry.type);
+              onClose();
+            }}
+          />
+        ))}
+      </ScrollView>
+    </MobileSheet>
   );
 }
 

--- a/mobile/components/inicio/HybridHero.tsx
+++ b/mobile/components/inicio/HybridHero.tsx
@@ -53,6 +53,13 @@ const TONE_COLOR: Record<RitmoStatusTone, string> = {
   debt: COLORS.debt,
 };
 
+// Heatmap legend swatch colors. SVG/inline backgrounds can't take a className,
+// so derive translucent tints from the brand COLORS tokens (matches the
+// bucket-tone opacities used in BUCKET_TONE).
+const LEGEND_LOW_COLOR = `${COLORS.income}4D`; // 0.30
+const LEGEND_MED_COLOR = `${COLORS.alert}66`; // 0.40
+const LEGEND_HIGH_COLOR = `${COLORS.debt}80`; // 0.50
+
 function dayOfMonth(iso: string): number {
   return parseInt(iso.slice(8, 10), 10);
 }
@@ -596,9 +603,9 @@ const PatternView = memo(function PatternView(props: {
 
       {/* Legend */}
       <View className="mt-3 flex-row flex-wrap gap-3">
-        <LegendDot color="rgba(92,184,138,0.30)" label={BUCKET_LABEL.low} />
-        <LegendDot color="rgba(212,168,67,0.40)" label={BUCKET_LABEL.med} />
-        <LegendDot color="rgba(224,85,69,0.50)" label={BUCKET_LABEL.high} />
+        <LegendDot color={LEGEND_LOW_COLOR} label={BUCKET_LABEL.low} />
+        <LegendDot color={LEGEND_MED_COLOR} label={BUCKET_LABEL.med} />
+        <LegendDot color={LEGEND_HIGH_COLOR} label={BUCKET_LABEL.high} />
       </View>
 
       {selectedEntry && (

--- a/mobile/components/plan/PaymentSheet.tsx
+++ b/mobile/components/plan/PaymentSheet.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
-  Modal,
   Platform,
   Pressable,
   ScrollView,
@@ -19,7 +18,8 @@ import {
 import { supabase } from "../../lib/supabase";
 import { useAuth } from "../../lib/auth";
 import { COLORS } from "../../lib/constants/colors";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
 import { getDatabase } from "../../lib/db/database";
 import { toLocalMonthString } from "../../lib/utils/date";
 import { parseLocalizedAmount } from "../../lib/amount";
@@ -358,12 +358,12 @@ export function PaymentSheet({
   }, [sourceAccounts, debtAccount]);
 
   return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
-      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
-        <View className="flex-1 justify-end bg-black/60">
-          <View className="rounded-t-3xl border-t border-white-6 bg-background">
+    <MobileSheet visible={visible} onClose={handleClose} maxHeightClass="max-h-[88%]" hideHandle>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"}>
+        <View>
+          <View>
             {/* Header */}
-            <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+            <View className="flex-row items-center justify-between px-4 pt-2 pb-2">
               <Text className="text-[15px] font-inter-semibold text-foreground">
                 {mode === "link" ? "Vincular pago existente" : "Registrar pago"}
               </Text>
@@ -373,8 +373,8 @@ export function PaymentSheet({
             </View>
 
             <ScrollView
-              className="max-h-[80%]"
-              contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40 }}
+              style={{ flexShrink: 1 }}
+              contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
               keyboardShouldPersistTaps="handled"
             >
               {/* Entry info */}
@@ -439,7 +439,7 @@ export function PaymentSheet({
 
                   {/* Error */}
                   {error && (
-                    <View className="rounded-xl bg-z-debt/10 px-3 py-2 mb-2">
+                    <View className="rounded-xl bg-z-debt-12 px-3 py-2 mb-2">
                       <Text className="text-xs font-inter-medium text-z-debt">{error}</Text>
                     </View>
                   )}
@@ -448,14 +448,14 @@ export function PaymentSheet({
                   <Pressable
                     onPress={handleLinkTransaction}
                     disabled={!selectedCandidateId || submitting}
-                    className={`rounded-xl py-3 items-center mt-2 flex-row justify-center gap-2 ${selectedCandidateId ? "bg-z-brass" : "bg-z-brass/30"}`}
+                    className={`${BRASS_BUTTON_CLASS} rounded-xl py-3 items-center mt-2 flex-row justify-center gap-2 ${selectedCandidateId ? "" : "opacity-40"}`}
                   >
                     {submitting ? (
                       <ActivityIndicator size="small" color={COLORS.ink} />
                     ) : (
                       <>
                         <Link2 size={14} color={COLORS.ink} />
-                        <Text className={`text-sm font-inter-semibold ${selectedCandidateId ? "text-z-ink" : "text-z-ink/50"}`}>
+                        <Text className="text-sm font-inter-semibold text-z-ink">
                           Vincular transacción
                         </Text>
                       </>
@@ -503,7 +503,7 @@ export function PaymentSheet({
                     <View className="ml-8 mb-3">
                       <TextInput
                         className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-sm font-inter-medium text-foreground"
-                        placeholderTextColor="#938C7E"
+                        placeholderTextColor={COLORS.sageDark}
                         placeholder="Ej: 150.000"
                         keyboardType="numeric"
                         value={customAmount}
@@ -562,7 +562,7 @@ export function PaymentSheet({
 
                   {/* Error */}
                   {error && (
-                    <View className="rounded-xl bg-z-debt/10 px-3 py-2 mb-2">
+                    <View className="rounded-xl bg-z-debt-12 px-3 py-2 mb-2">
                       <Text className="text-xs font-inter-medium text-z-debt">{error}</Text>
                     </View>
                   )}
@@ -571,12 +571,12 @@ export function PaymentSheet({
                   <Pressable
                     onPress={handleCreatePayment}
                     disabled={!canSubmit}
-                    className={`rounded-xl py-3 items-center mt-2 ${canSubmit ? "bg-z-brass" : "bg-z-brass/30"}`}
+                    className={`${BRASS_BUTTON_CLASS} rounded-xl py-3 items-center mt-2 ${canSubmit ? "" : "opacity-40"}`}
                   >
                     {submitting ? (
                       <ActivityIndicator size="small" color={COLORS.ink} />
                     ) : (
-                      <Text className={`text-sm font-inter-semibold ${canSubmit ? "text-z-ink" : "text-z-ink/50"}`}>
+                      <Text className="text-sm font-inter-semibold text-z-ink">
                         Confirmar pago
                       </Text>
                     )}
@@ -600,7 +600,7 @@ export function PaymentSheet({
           </View>
         </View>
       </KeyboardAvoidingView>
-    </Modal>
+    </MobileSheet>
   );
 }
 

--- a/mobile/components/plan/PlanNetHero.tsx
+++ b/mobile/components/plan/PlanNetHero.tsx
@@ -31,6 +31,11 @@ interface PlanNetHeroProps {
   onToggle: () => void;
 }
 
+// Gridline tints. SVG strokes can't take a className, so derive translucent
+// foreground tints from the brand COLORS token instead of hardcoded RGB.
+const ZERO_LINE_COLOR = `${COLORS.foreground}1F`; // ~0.12
+const TODAY_LINE_COLOR = `${COLORS.foreground}26`; // ~0.15
+
 // Mini chart geometry (balance-only, non-interactive)
 const CHART_VB_W = 320;
 const CHART_VB_H = 54;
@@ -154,9 +159,9 @@ function PlanNetHeroBase({
           <View className="mt-3">
             <Svg viewBox={`0 0 ${CHART_VB_W} ${CHART_VB_H}`} style={{ width: "100%", height: CHART_VB_H }}>
               {chart.zeroY !== null && (
-                <Line x1={CHART_PAD_L} y1={chart.zeroY} x2={CHART_VB_W - CHART_PAD_R} y2={chart.zeroY} stroke="rgba(234,229,218,0.12)" strokeWidth={0.8} strokeDasharray="2,2" />
+                <Line x1={CHART_PAD_L} y1={chart.zeroY} x2={CHART_VB_W - CHART_PAD_R} y2={chart.zeroY} stroke={ZERO_LINE_COLOR} strokeWidth={0.8} strokeDasharray="2,2" />
               )}
-              <Line x1={chart.todayX} y1={CHART_PAD_T} x2={chart.todayX} y2={CHART_VB_H - CHART_PAD_B} stroke="rgba(234,229,218,0.15)" strokeWidth={0.8} strokeDasharray="2,2" />
+              <Line x1={chart.todayX} y1={CHART_PAD_T} x2={chart.todayX} y2={CHART_VB_H - CHART_PAD_B} stroke={TODAY_LINE_COLOR} strokeWidth={0.8} strokeDasharray="2,2" />
               {chart.pastPath !== "" && (
                 <Path d={chart.pastPath} fill="none" stroke={COLORS.brass} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" />
               )}

--- a/mobile/components/plan/ReassignSheet.tsx
+++ b/mobile/components/plan/ReassignSheet.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from "react";
 import {
   ActivityIndicator,
-  Modal,
   Pressable,
   ScrollView,
   Text,
@@ -12,7 +11,8 @@ import { Check, X } from "lucide-react-native";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { useAuth } from "../../lib/auth";
 import { COLORS } from "../../lib/constants/colors";
-import { PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { BRASS_BUTTON_CLASS, PANEL_INSET_CLASS } from "../../lib/constants/styles";
+import { MobileSheet } from "../ui/MobileSheet";
 import { parseLocalizedAmount } from "../../lib/amount";
 import {
   createAssignment,
@@ -122,11 +122,11 @@ export function ReassignSheet({
   );
 
   return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
-      <View className="flex-1 justify-end bg-black/60">
-        <View className="rounded-t-3xl border-t border-white-6 bg-background">
+    <MobileSheet visible={visible} onClose={handleClose} maxHeightClass="max-h-[70%]" hideHandle>
+      <View>
+        <View>
           {/* Header */}
-          <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <View className="flex-row items-center justify-between px-4 pt-2 pb-2">
             <Text className="text-[15px] font-inter-semibold text-foreground">Reasignar gasto</Text>
             <Pressable onPress={handleClose} className="h-8 w-8 items-center justify-center rounded-full">
               <X size={16} color={COLORS.sageLight} />
@@ -134,8 +134,8 @@ export function ReassignSheet({
           </View>
 
           <ScrollView
-            className="max-h-[70%]"
-            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40 }}
+            style={{ flexShrink: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
           >
             {/* Current assignment info */}
             <View className={`${PANEL_INSET_CLASS} p-3 mb-4`}>
@@ -193,7 +193,7 @@ export function ReassignSheet({
                 </Text>
                 <TextInput
                   className="rounded-xl border border-white-6 bg-black-10 px-3 py-2.5 text-sm font-inter-medium text-foreground"
-                  placeholderTextColor="#938C7E"
+                  placeholderTextColor={COLORS.sageDark}
                   placeholder="Monto"
                   keyboardType="numeric"
                   value={amountInput}
@@ -203,7 +203,7 @@ export function ReassignSheet({
             )}
 
             {error && (
-              <View className="rounded-xl bg-z-debt/10 px-3 py-2 mt-2">
+              <View className="rounded-xl bg-z-debt-12 px-3 py-2 mt-2">
                 <Text className="text-xs font-inter-medium text-z-debt">{error}</Text>
               </View>
             )}
@@ -212,12 +212,12 @@ export function ReassignSheet({
             <Pressable
               onPress={handleReassign}
               disabled={!selectedIncomeId || submitting}
-              className={`rounded-xl py-3 items-center mt-4 ${selectedIncomeId ? "bg-z-brass" : "bg-z-brass/30"}`}
+              className={`${BRASS_BUTTON_CLASS} rounded-xl py-3 items-center mt-4 ${selectedIncomeId ? "" : "opacity-40"}`}
             >
               {submitting ? (
                 <ActivityIndicator size="small" color={COLORS.ink} />
               ) : (
-                <Text className={`text-sm font-inter-semibold ${selectedIncomeId ? "text-z-ink" : "text-z-ink/50"}`}>
+                <Text className="text-sm font-inter-semibold text-z-ink">
                   Reasignar
                 </Text>
               )}
@@ -229,6 +229,6 @@ export function ReassignSheet({
           </ScrollView>
         </View>
       </View>
-    </Modal>
+    </MobileSheet>
   );
 }

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -109,7 +109,7 @@ export function CategoryPicker({
       onRequestClose={handleClose}
     >
       <View className="flex-1 justify-end bg-black/35">
-        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl bg-z-surface-2-55">
+        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border-t border-white-6 bg-background">
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
             <Text className="text-foreground font-inter-bold text-base">

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -114,7 +114,7 @@ export function CategoryPicker({
         className="flex-1 justify-end"
         style={{ backgroundColor: MODAL_SCRIM_COLOR }}
       >
-        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border-t border-white-6 bg-background">
+        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border border-white-6 bg-background">
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
             <Text className="text-foreground font-inter-bold text-base">

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from "react-native";
 import { Check, X } from "lucide-react-native";
+import { MODAL_SCRIM_COLOR } from "../ui/MobileSheet";
 
 export type CategoryRow = {
   id: string;
@@ -108,7 +109,10 @@ export function CategoryPicker({
       transparent
       onRequestClose={handleClose}
     >
-      <View className="flex-1 justify-end bg-black/35">
+      <View
+        className="flex-1 justify-end"
+        style={{ backgroundColor: MODAL_SCRIM_COLOR }}
+      >
         <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border-t border-white-6 bg-background">
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">

--- a/mobile/components/transactions/CategoryPicker.tsx
+++ b/mobile/components/transactions/CategoryPicker.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { Check, X } from "lucide-react-native";
 import { MODAL_SCRIM_COLOR } from "../ui/MobileSheet";
+import { COLORS } from "../../lib/constants/colors";
 
 export type CategoryRow = {
   id: string;
@@ -121,9 +122,9 @@ export function CategoryPicker({
             </Text>
             <Pressable
               onPress={handleClose}
-              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-z-surface-2/10"
+              className="w-8 h-8 items-center justify-center rounded-full bg-black-10 active:bg-black-10"
             >
-              <X size={18} color="#938C7E" />
+              <X size={18} color={COLORS.sageDark} />
             </Pressable>
           </View>
 
@@ -132,7 +133,7 @@ export function CategoryPicker({
             <TextInput
               className="bg-black-10 rounded-xl px-4 py-2.5 text-foreground font-inter text-sm"
               placeholder="Buscar categoría..."
-              placeholderTextColor="#938C7E"
+              placeholderTextColor={COLORS.sageDark}
               value={search}
               onChangeText={setSearch}
               autoCorrect={false}
@@ -143,13 +144,13 @@ export function CategoryPicker({
           {/* "None" option */}
           <Pressable
             onPress={() => handleSelect(null, null)}
-            className="flex-row items-center px-4 py-3.5 border-b border-white-6 active:bg-z-surface-2/5"
+            className="flex-row items-center px-4 py-3.5 border-b border-white-6 active:bg-black-10"
           >
-            <View className="w-3 h-3 rounded-full bg-z-surface-2/15 mr-3" />
+            <View className="w-3 h-3 rounded-full bg-white-6 mr-3" />
             <Text className="text-muted-foreground font-inter text-sm flex-1">
               Sin categoría
             </Text>
-            {selectedId === null && <Check size={16} color="#10B981" />}
+            {selectedId === null && <Check size={16} color={COLORS.income} />}
           </Pressable>
 
           <FlatList
@@ -175,7 +176,7 @@ export function CategoryPicker({
                   onPress={() =>
                     handleSelect(item.item.id, displayName(item.item))
                   }
-                  className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-z-surface-2/5`}
+                  className={`flex-row items-center ${paddingLeft} pr-4 py-3.5 active:bg-black-10`}
                 >
                   {item.item.color ? (
                     <View
@@ -183,21 +184,21 @@ export function CategoryPicker({
                       style={{ backgroundColor: item.item.color }}
                     />
                   ) : (
-                    <View className="w-3 h-3 rounded-full bg-z-surface-2/15 mr-3" />
+                    <View className="w-3 h-3 rounded-full bg-white-6 mr-3" />
                   )}
                   <Text
                     className={`font-inter text-sm flex-1 ${
-                      isSelected ? "text-primary font-inter-medium" : "text-foreground"
+                      isSelected ? "text-z-brass font-inter-medium" : "text-foreground"
                     }`}
                   >
                     {displayName(item.item)}
                   </Text>
-                  {isSelected && <Check size={16} color="#10B981" />}
+                  {isSelected && <Check size={16} color={COLORS.income} />}
                 </Pressable>
               );
             }}
             ItemSeparatorComponent={() => (
-              <View className="h-px bg-z-surface-2-6 ml-4" />
+              <View className="h-px bg-white-6 ml-4" />
             )}
           />
         </View>

--- a/mobile/components/transactions/DestinatarioPicker.tsx
+++ b/mobile/components/transactions/DestinatarioPicker.tsx
@@ -98,7 +98,7 @@ export function DestinatarioPicker({
       onRequestClose={handleClose}
     >
       <View className="flex-1 justify-end bg-black-40">
-        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl bg-z-surface-2-55">
+        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border-t border-white-6 bg-background">
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
             <Text className="text-foreground font-inter-bold text-base">

--- a/mobile/components/transactions/DestinatarioPicker.tsx
+++ b/mobile/components/transactions/DestinatarioPicker.tsx
@@ -98,7 +98,7 @@ export function DestinatarioPicker({
       onRequestClose={handleClose}
     >
       <View className="flex-1 justify-end bg-black-40">
-        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border-t border-white-6 bg-background">
+        <View className="max-h-[72%] min-h-[320px] rounded-t-2xl border border-white-6 bg-background">
           {/* Header */}
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
             <Text className="text-foreground font-inter-bold text-base">

--- a/mobile/components/transactions/SearchBar.tsx
+++ b/mobile/components/transactions/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { View, TextInput } from "react-native";
 import { Search, X } from "lucide-react-native";
 import { useCallback, useRef, useState } from "react";
+import { COLORS } from "../../lib/constants/colors";
 
 type SearchBarProps = {
   onSearch: (query: string) => void;
@@ -32,18 +33,18 @@ export function SearchBar({
 
   return (
     <View className="flex-row items-center bg-z-surface-2 rounded-lg px-3 py-2.5 border border-white-6">
-      <Search size={18} color="#938C7E" />
+      <Search size={18} color={COLORS.sageDark} />
       <TextInput
         className="flex-1 ml-2 text-foreground font-inter text-sm"
         placeholder={placeholder}
-        placeholderTextColor="#938C7E"
+        placeholderTextColor={COLORS.sageDark}
         value={value}
         onChangeText={handleChange}
         autoCapitalize="none"
         autoCorrect={false}
       />
       {value.length > 0 && (
-        <X size={18} color="#9CA3AF" onPress={handleClear} />
+        <X size={18} color={COLORS.sageDark} onPress={handleClear} />
       )}
     </View>
   );

--- a/mobile/components/transactions/TagPickerSheet.tsx
+++ b/mobile/components/transactions/TagPickerSheet.tsx
@@ -3,6 +3,7 @@ import { Modal, Pressable, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { X } from "lucide-react-native";
 import { COLORS } from "../../lib/constants/colors";
+import { BRASS_BUTTON_CLASS } from "../../lib/constants/styles";
 import { MODAL_SCRIM_COLOR } from "../ui/MobileSheet";
 import { TagSelector } from "./TagSelector";
 import { getTagsForTransaction } from "../../lib/repositories/tags";
@@ -110,7 +111,7 @@ export function TagPickerSheet({ visible, transactionId, onClose, onSave }: Prop
               disabled={saving || loading}
               accessibilityLabel="Guardar etiquetas"
               accessibilityRole="button"
-              className={`items-center rounded-full bg-z-brass py-3 ${saving || loading ? "opacity-60" : "active:bg-z-brass-12"}`}
+              className={`items-center rounded-full py-3 ${BRASS_BUTTON_CLASS} ${saving || loading ? "opacity-40" : ""}`}
             >
               <Text className="text-sm font-inter-semibold text-z-ink">
                 {saving ? "Guardando…" : "Guardar"}

--- a/mobile/components/transactions/TagPickerSheet.tsx
+++ b/mobile/components/transactions/TagPickerSheet.tsx
@@ -65,7 +65,7 @@ export function TagPickerSheet({ visible, transactionId, onClose, onSave }: Prop
     >
       <View className="flex-1 justify-end bg-black-40">
         <View
-          className="max-h-[80%] rounded-t-2xl bg-z-surface-2-55"
+          className="max-h-[80%] rounded-t-2xl border-t border-white-6 bg-background"
           style={{ paddingBottom: insets.bottom }}
         >
           <View className="flex-row items-center justify-between px-4 pb-2 pt-4">

--- a/mobile/components/transactions/TagPickerSheet.tsx
+++ b/mobile/components/transactions/TagPickerSheet.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Modal, Pressable, Text, View } from "react-native";
+import { Modal, Pressable, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { X } from "lucide-react-native";
 import { COLORS } from "../../lib/constants/colors";
+import { MODAL_SCRIM_COLOR } from "../ui/MobileSheet";
 import { TagSelector } from "./TagSelector";
 import { getTagsForTransaction } from "../../lib/repositories/tags";
 
@@ -63,9 +64,12 @@ export function TagPickerSheet({ visible, transactionId, onClose, onSave }: Prop
       transparent
       onRequestClose={onClose}
     >
-      <View className="flex-1 justify-end bg-black-40">
+      <View
+        className="flex-1 justify-end"
+        style={{ backgroundColor: MODAL_SCRIM_COLOR }}
+      >
         <View
-          className="max-h-[80%] rounded-t-2xl border-t border-white-6 bg-background"
+          className="max-h-[80%] min-h-[420px] rounded-t-2xl border-t border-white-6 bg-background"
           style={{ paddingBottom: insets.bottom }}
         >
           <View className="flex-row items-center justify-between px-4 pb-2 pt-4">
@@ -82,7 +86,10 @@ export function TagPickerSheet({ visible, transactionId, onClose, onSave }: Prop
             </Pressable>
           </View>
 
-          <View className="flex-1 px-4 pb-2">
+          <ScrollView
+            className="flex-1"
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 8 }}
+          >
             {loading ? (
               <View className="py-12 items-center">
                 <Text className="text-sm font-inter text-muted-foreground">
@@ -95,7 +102,7 @@ export function TagPickerSheet({ visible, transactionId, onClose, onSave }: Prop
                 onChange={setSelectedTagIds}
               />
             )}
-          </View>
+          </ScrollView>
 
           <View className="px-4 pb-4 pt-2">
             <Pressable

--- a/mobile/components/transactions/TagPickerSheet.tsx
+++ b/mobile/components/transactions/TagPickerSheet.tsx
@@ -70,7 +70,7 @@ export function TagPickerSheet({ visible, transactionId, onClose, onSave }: Prop
         style={{ backgroundColor: MODAL_SCRIM_COLOR }}
       >
         <View
-          className="max-h-[80%] min-h-[420px] rounded-t-2xl border-t border-white-6 bg-background"
+          className="max-h-[80%] min-h-[420px] rounded-t-2xl border border-white-6 bg-background"
           style={{ paddingBottom: insets.bottom }}
         >
           <View className="flex-row items-center justify-between px-4 pb-2 pt-4">

--- a/mobile/components/transactions/TagSelector.tsx
+++ b/mobile/components/transactions/TagSelector.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import { View, Text, Pressable, ActivityIndicator } from "react-native";
 import { getAllTags, type TagWithGroup } from "../../lib/repositories/tags";
+import { COLORS } from "../../lib/constants/colors";
+
+/** Brass tint background for the selected tag pill (brass at ~6% alpha). */
+const SELECTED_TAG_BG = `${COLORS.brass}10`;
 
 type Props = {
   selectedTagIds: string[];
@@ -57,7 +61,7 @@ export function TagSelector({ selectedTagIds, onChange }: Props) {
   if (loading) {
     return (
       <View className="py-3 items-center">
-        <ActivityIndicator size="small" color="#937844" />
+        <ActivityIndicator size="small" color={COLORS.brass} />
       </View>
     );
   }
@@ -85,27 +89,26 @@ export function TagSelector({ selectedTagIds, onChange }: Props) {
           <View className="flex-row flex-wrap gap-1.5">
             {group.tags.map((tag) => {
               const isSelected = selected.has(tag.id);
-              const tagColor = tag.color ?? group.groupColor ?? "#6B7280";
               return (
                 <Pressable
                   key={tag.id}
                   onPress={() => toggleTag(tag.id)}
                   className={`rounded-full px-2.5 py-1 border ${
                     isSelected
-                      ? "border-amber-600 bg-amber-50"
+                      ? "border-z-brass-20 bg-z-brass-8"
                       : "border-white-8 bg-z-surface-2-55"
                   }`}
                   style={
                     isSelected
-                      ? { borderColor: "#937844", backgroundColor: "#93784410" }
+                      ? { borderColor: COLORS.brass, backgroundColor: SELECTED_TAG_BG }
                       : undefined
                   }
                 >
                   <Text
                     className={`font-inter-medium text-xs ${
-                      isSelected ? "text-z-alert" : "text-muted-foreground"
+                      isSelected ? "text-z-brass" : "text-muted-foreground"
                     }`}
-                    style={isSelected ? { color: "#937844" } : undefined}
+                    style={isSelected ? { color: COLORS.brass } : undefined}
                   >
                     {tag.name}
                   </Text>

--- a/mobile/components/transactions/TransactionRow.tsx
+++ b/mobile/components/transactions/TransactionRow.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { formatCurrency, type CurrencyCode } from "@zeta/shared";
 import { isDebtInflow } from "../../lib/transaction-semantics";
+import { COLORS } from "../../lib/constants/colors";
 
 type TransactionRowProps = {
   id: string;
@@ -33,7 +34,7 @@ export function TransactionRow({
   const isInflow = direction === "INFLOW";
   const isDebtPayment = isDebtInflow({ direction, accountType: account_type });
   const semanticCategory = isDebtPayment ? "Abono a deuda" : category_name_es;
-  const color = isDebtPayment ? "#0EA5E9" : (category_color || "#6B7280");
+  const color = isDebtPayment ? COLORS.debt : (category_color || COLORS.sageDark);
   const initial = isDebtPayment ? "AB" : category_icon || (semanticCategory?.[0] ?? "?");
 
   return (

--- a/mobile/components/transactions/VincularPicker.tsx
+++ b/mobile/components/transactions/VincularPicker.tsx
@@ -49,7 +49,7 @@ export function VincularPicker({
       onRequestClose={onClose}
     >
       <View className="flex-1 justify-end bg-black-40">
-        <View className="max-h-[72%] min-h-[280px] rounded-t-2xl bg-z-surface-2-55">
+        <View className="max-h-[72%] min-h-[280px] rounded-t-2xl border-t border-white-6 bg-background">
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
             <View>
               <Text className="text-foreground font-inter-bold text-base">

--- a/mobile/components/transactions/VincularPicker.tsx
+++ b/mobile/components/transactions/VincularPicker.tsx
@@ -49,7 +49,7 @@ export function VincularPicker({
       onRequestClose={onClose}
     >
       <View className="flex-1 justify-end bg-black-40">
-        <View className="max-h-[72%] min-h-[280px] rounded-t-2xl border-t border-white-6 bg-background">
+        <View className="max-h-[72%] min-h-[280px] rounded-t-2xl border border-white-6 bg-background">
           <View className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-white-6">
             <View>
               <Text className="text-foreground font-inter-bold text-base">

--- a/mobile/components/transactions/VincularPicker.tsx
+++ b/mobile/components/transactions/VincularPicker.tsx
@@ -89,7 +89,7 @@ export function VincularPicker({
             </View>
           ) : (
             <ScrollView
-              className="flex-1"
+              style={{ flexShrink: 1 }}
               contentContainerStyle={{ paddingBottom: 24 }}
             >
               {candidates.map((c) => (

--- a/mobile/components/ui/MobileSheet.tsx
+++ b/mobile/components/ui/MobileSheet.tsx
@@ -44,7 +44,7 @@ export function MobileSheet({
       >
         <Pressable
           onPress={(e) => e.stopPropagation()}
-          className={`${maxHeightClass} rounded-t-2xl border-t border-white-6 bg-background`}
+          className={`${maxHeightClass} rounded-t-2xl border border-white-6 bg-background`}
           style={{ paddingBottom: insets.bottom + 16 }}
         >
           {!hideHandle && (


### PR DESCRIPTION
Mobile polish batch.

## Email import queue (webapp parity)
- Embedded in Movimientos **Importar** tool tile (shows "N correos").
- Pending email-parsed txs: inline **Importar**, expand row to reassign account / discard, **Subir PDF** entry, **Importar todas**.
- Repo mirrors webapp `email-ingest` Server Actions directly against Supabase (`pending_email_transactions` is remote-only).
- After a mutation: `syncAll()` → re-read feed, so the new row shows without a manual pull-to-refresh.

## Sync-stall fix (`pull.ts`) — was hiding the entire Movimientos list
- `accounts.currency_balances` (JSONB) + boolean columns can't bind in expo-sqlite; `JSON_FIELDS` omitted `accounts`, so the raw object **crashed the accounts pull and stalled the sync cursor** → transactions never downloaded.
- Fix: add `accounts.currency_balances` to `JSON_FIELDS` + coerce any object/boolean at bind time (defense-in-depth).

## Avatar menu
- Opaque surface + scrim backdrop (was see-through); fix two dead tokens (`z-surface-2-6`, slash-opacity).

## Destinatario picker
- Inline **"Crear «query»"** quick-create when no match (name-only; full-wizard parity tracked in BACKLOG).

## Earlier on this branch
- Picker sheet opacity/collapse/border fixes (original #302 scope).

Verified live on iOS sim: empty-list fixed (133 movimientos), import → feed updates, inline-create affordance renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)